### PR TITLE
docs: comprehensive overhaul — 8 pages rewritten, 3,300+ lines added

### DIFF
--- a/apps/website/content/docs-v2/api/fetch-stream-transport.mdx
+++ b/apps/website/content/docs-v2/api/fetch-stream-transport.mdx
@@ -6,7 +6,7 @@ You rarely need to interact with `FetchStreamTransport` directly — simply prov
 
 ```ts
 import { inject } from '@angular/core';
-import { streamResource, FetchStreamTransport } from '@ngxp/stream-resource';
+import { streamResource, FetchStreamTransport } from '@cacheplane/stream-resource';
 
 // Override transport for a single resource
 const events = streamResource<Event>({

--- a/apps/website/content/docs-v2/api/mock-stream-transport.mdx
+++ b/apps/website/content/docs-v2/api/mock-stream-transport.mdx
@@ -7,7 +7,7 @@ import { TestBed } from '@angular/core/testing';
 import {
   provideStreamResource,
   MockStreamTransport,
-} from '@ngxp/stream-resource';
+} from '@cacheplane/stream-resource';
 
 beforeEach(() => {
   TestBed.configureTestingModule({

--- a/apps/website/content/docs-v2/api/provide-stream-resource.mdx
+++ b/apps/website/content/docs-v2/api/provide-stream-resource.mdx
@@ -7,7 +7,7 @@ import { bootstrapApplication } from '@angular/platform-browser';
 import {
   provideStreamResource,
   FetchStreamTransport,
-} from '@ngxp/stream-resource';
+} from '@cacheplane/stream-resource';
 import { AppComponent } from './app/app.component';
 
 bootstrapApplication(AppComponent, {

--- a/apps/website/content/docs-v2/api/stream-resource.mdx
+++ b/apps/website/content/docs-v2/api/stream-resource.mdx
@@ -3,7 +3,7 @@
 `streamResource` is the core primitive of the library. It creates a reactive resource that opens a server-sent event stream, tracks loading and error states, and exposes the latest emitted value — all within Angular's signal-based reactivity model.
 
 ```ts
-import { streamResource } from '@ngxp/stream-resource';
+import { streamResource } from '@cacheplane/stream-resource';
 
 // Inside a component or service with injection context
 const repo = streamResource<Repository>({

--- a/apps/website/content/docs-v2/concepts/agent-architecture.mdx
+++ b/apps/website/content/docs-v2/concepts/agent-architecture.mdx
@@ -529,7 +529,7 @@ export class AgentComponent {
 | Transport error (network) | N/A | `error()` fires, `status()` becomes `'error'` |
 | Agent exceeds recursion limit | Graph raises `GraphRecursionError` | `error()` fires with recursion message |
 
-<Callout type="warn" title="Recursion limits">
+<Callout type="warning" title="Recursion limits">
 LangGraph defaults to 25 recursion steps. If your agent loops between `model` and `tools` more than 25 times, it stops with a `GraphRecursionError`. Increase the limit in production with `graph.compile(recursion_limit=50)` or redesign the agent to converge faster.
 </Callout>
 

--- a/apps/website/content/docs-v2/concepts/agent-architecture.mdx
+++ b/apps/website/content/docs-v2/concepts/agent-architecture.mdx
@@ -1,69 +1,701 @@
 # Agent Architecture
 
-How AI agents work — the planning, execution, and tool-calling lifecycle that streamResource() connects your Angular app to.
+How AI agents work — the planning, execution, and tool-calling lifecycle that streamResource() connects your Angular app to. This page shows you the Python patterns that power modern agents and exactly how each pattern surfaces in Angular through `@cacheplane/stream-resource`.
 
-## The agent loop
+<Callout type="info" title="Python + Angular, both sides">
+Every section below shows the Python backend code first, then the Angular frontend code that consumes it. You need both halves to build a production agent application — LangGraph handles the intelligence, streamResource() handles the reactivity.
+</Callout>
 
-An AI agent follows a cycle:
+## The Agent Loop
+
+Every agent follows a five-phase cycle. Understanding this cycle is critical because each phase maps to a specific streamResource() signal in your Angular app.
 
 <Steps>
-<Step title="Receive input">
-The user sends a message via `submit()`. streamResource() posts it to LangGraph Platform.
+<Step title="Receive">
+The user sends a message. On the Angular side, `submit()` posts input to LangGraph Platform. On the Python side, the message lands in the graph's `messages` state key.
+
+```python
+class AgentState(TypedDict):
+    messages: Annotated[list, add]
+    plan: list[str]
+    tool_results: dict
+```
+
 </Step>
 <Step title="Plan">
-The LLM decides what to do next — respond directly, call a tool, or delegate to a subagent.
+The LLM examines the full message history plus any accumulated state. It decides what to do next — respond directly, call one or more tools, or delegate to a subagent.
+
+```python
+def plan(state: AgentState, config: RunnableConfig) -> dict:
+    system = """You are a research assistant. Given the conversation,
+    decide whether to respond directly, search for information,
+    or analyze data. Use tools when the user needs factual answers."""
+
+    response = llm.bind_tools(tools).invoke([
+        {"role": "system", "content": system},
+        *state["messages"],
+    ])
+    return {"messages": [response]}
+```
+
 </Step>
 <Step title="Execute">
-Tools run (database queries, API calls, code execution). Results feed back into state.
+If the LLM decided to call tools, LangGraph routes to the tool node. Tools run — database queries, API calls, code execution — and their results feed back into state as `ToolMessage` entries.
+
+```python
+from langgraph.prebuilt import ToolNode
+
+tool_node = ToolNode(tools)
+# LangGraph automatically calls each tool the LLM requested
+# and appends ToolMessage results to state["messages"]
+```
+
 </Step>
 <Step title="Respond">
-The agent streams its response token-by-token. streamResource() updates the `messages()` signal in real-time.
+After tools finish (or if no tools were needed), the agent streams its final response token by token. streamResource() updates the `messages()` signal in real time so your Angular template re-renders incrementally.
+
+```typescript
+// Angular side — messages update as tokens arrive
+@if (agent.isLoading()) {
+  <app-typing-indicator />
+}
+@for (msg of agent.messages(); track msg.id) {
+  <app-message [message]="msg" />
+}
+```
+
 </Step>
 <Step title="Checkpoint">
-State is checkpointed. The agent may loop back to Plan, or finish.
+LangGraph checkpoints the full state — messages, tool results, plan, everything. The agent may loop back to Plan (if tools returned data that needs further reasoning) or finish. The checkpoint is what enables time-travel debugging via `history()`.
+
+```python
+from langgraph.checkpoint.postgres import PostgresSaver
+
+checkpointer = PostgresSaver.from_connection_string(DATABASE_URL)
+graph = builder.compile(checkpointer=checkpointer)
+```
+
 </Step>
 </Steps>
 
-## Tool calling
+## ReAct Pattern
 
-Agents extend their capabilities through tools. streamResource() tracks tool execution:
+ReAct (Reason + Act) is the most common agent pattern. The agent reasons about the user's question, decides to call a tool, observes the result, and loops until it has enough information to answer.
+
+<Tabs>
+<Tab label="Python agent">
+
+```python
+from langgraph.graph import END, START, StateGraph
+from langgraph.prebuilt import ToolNode
+from langchain_openai import ChatOpenAI
+from langchain_core.tools import tool
+from typing_extensions import TypedDict, Annotated
+from operator import add
+
+# --- State ---
+class AgentState(TypedDict):
+    messages: Annotated[list, add]
+
+# --- Tools ---
+@tool
+def search_docs(query: str) -> str:
+    """Search the knowledge base for relevant documents."""
+    results = vector_store.similarity_search(query, k=3)
+    return "\n\n".join(doc.page_content for doc in results)
+
+@tool
+def query_database(sql: str) -> str:
+    """Run a read-only SQL query against the analytics database."""
+    rows = db.execute(text(sql)).fetchall()
+    return json.dumps([dict(r) for r in rows])
+
+@tool
+def get_weather(city: str) -> str:
+    """Get current weather for a city."""
+    resp = httpx.get(f"https://api.weather.com/v1/{city}")
+    return resp.json()["summary"]
+
+tools = [search_docs, query_database, get_weather]
+
+# --- LLM with tools bound ---
+llm = ChatOpenAI(model="gpt-5-mini")
+
+def call_model(state: AgentState) -> dict:
+    response = llm.bind_tools(tools).invoke(state["messages"])
+    return {"messages": [response]}
+
+# --- Routing ---
+def should_continue(state: AgentState) -> str:
+    last_message = state["messages"][-1]
+    if last_message.tool_calls:
+        return "tools"
+    return END
+
+# --- Graph ---
+builder = StateGraph(AgentState)
+builder.add_node("model", call_model)
+builder.add_node("tools", ToolNode(tools))
+
+builder.add_edge(START, "model")
+builder.add_conditional_edges("model", should_continue)
+builder.add_edge("tools", "model")  # After tools, reason again
+
+graph = builder.compile()
+```
+
+</Tab>
+<Tab label="Angular component">
+
+```typescript
+import { ChangeDetectionStrategy, Component, computed } from '@angular/core';
+import { streamResource } from '@cacheplane/stream-resource';
+
+interface AgentState {
+  messages: BaseMessage[];
+}
+
+@Component({
+  selector: 'app-react-agent',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    @for (msg of messages(); track msg.id) {
+      <app-message [message]="msg" />
+    }
+
+    @if (activeTools().length) {
+      <app-tool-progress [tools]="activeTools()" />
+    }
+
+    @for (result of completedTools(); track result.id) {
+      <app-tool-result [call]="result" />
+    }
+  `,
+})
+export class ReactAgentComponent {
+  agent = streamResource<AgentState>({
+    assistantId: 'react_agent',
+  });
+
+  messages = this.agent.messages;
+
+  // Tools currently executing (spinner, progress bar)
+  activeTools = computed(() => this.agent.toolProgress());
+
+  // Tools that finished with results (expandable cards)
+  completedTools = computed(() => this.agent.toolCalls());
+
+  send(text: string) {
+    this.agent.submit({
+      messages: [{ role: 'human', content: text }],
+    });
+  }
+}
+```
+
+</Tab>
+</Tabs>
+
+The key insight: `should_continue` is the decision point. If the LLM's response contains `tool_calls`, the graph routes to the `tools` node. If not, it ends. After tools execute, the graph loops back to `model` so the LLM can reason about the tool results. This loop continues until the LLM responds without requesting any tools.
+
+## Tool Calling Deep Dive
+
+Tools are how agents interact with the outside world. Understanding both the Python definition and the Angular consumption is essential.
+
+### Defining Tools in Python
+
+Every tool is a Python function decorated with `@tool`. LangGraph converts the function signature and docstring into the JSON schema that the LLM uses to decide when and how to call it:
+
+```python
+from langchain_core.tools import tool
+from pydantic import BaseModel, Field
+
+# Simple tool — args inferred from function signature
+@tool
+def calculate(expression: str) -> str:
+    """Evaluate a mathematical expression and return the result."""
+    return str(eval(expression))  # Use a sandbox in production
+
+# Structured tool — explicit schema with validation
+class EmailInput(BaseModel):
+    to: str = Field(description="Recipient email address")
+    subject: str = Field(description="Email subject line")
+    body: str = Field(description="Email body content")
+
+@tool(args_schema=EmailInput)
+def send_email(to: str, subject: str, body: str) -> str:
+    """Send an email to the specified recipient."""
+    mail_service.send(to=to, subject=subject, body=body)
+    return f"Email sent to {to}"
+```
+
+<Callout type="tip" title="Docstrings matter">
+The LLM reads the docstring to decide when to call a tool. A vague docstring like "does stuff" means the LLM will not know when to use it. Be specific: what the tool does, what it returns, when to use it.
+</Callout>
+
+### How Tools Surface in Angular
+
+When the agent calls a tool, streamResource() exposes the execution lifecycle through two signals:
+
+<Tabs>
+<Tab label="toolProgress()">
+
+```typescript
+// toolProgress() — tools currently executing
+// Updates in real time as tools start and complete
+
+const agent = streamResource<AgentState>({
+  assistantId: 'react_agent',
+});
+
+// Each entry has: name, args, status
+const activeTools = computed(() => agent.toolProgress());
+
+// Template usage
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    @for (tool of activeTools(); track tool.id) {
+      <div class="tool-executing">
+        <app-spinner />
+        <span>Running {{ tool.name }}...</span>
+        <pre>{{ tool.args | json }}</pre>
+      </div>
+    }
+  `,
+})
+export class ToolProgressComponent {
+  activeTools = computed(() => this.agent.toolProgress());
+}
+```
+
+</Tab>
+<Tab label="toolCalls()">
+
+```typescript
+// toolCalls() — completed tool calls with results
+// Available after each tool finishes
+
+const completedTools = computed(() => agent.toolCalls());
+
+// Each entry has: name, args, result, duration
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    @for (call of completedTools(); track call.id) {
+      <details>
+        <summary>
+          {{ call.name }}
+          <span class="duration">{{ call.duration }}ms</span>
+        </summary>
+        <div class="args">
+          <h4>Input</h4>
+          <pre>{{ call.args | json }}</pre>
+        </div>
+        <div class="result">
+          <h4>Output</h4>
+          <pre>{{ call.result }}</pre>
+        </div>
+      </details>
+    }
+  `,
+})
+export class ToolResultsComponent {
+  completedTools = computed(() => this.agent.toolCalls());
+}
+```
+
+</Tab>
+</Tabs>
+
+### Tool Execution Flow
+
+The full lifecycle from Python tool definition to Angular UI update:
+
+<Steps>
+<Step title="LLM requests tool">
+The model returns an `AIMessage` with a `tool_calls` array. Each entry specifies the tool name and arguments.
+</Step>
+<Step title="LangGraph routes to ToolNode">
+The `should_continue` conditional edge detects `tool_calls` and routes to the `tools` node.
+</Step>
+<Step title="Tool executes">
+`ToolNode` calls the Python function. The result is wrapped in a `ToolMessage` and appended to state.
+</Step>
+<Step title="SSE event streams">
+LangGraph Platform streams the tool call and result as SSE events to the Angular client.
+</Step>
+<Step title="streamResource() updates signals">
+`toolProgress()` updates during execution. `toolCalls()` updates when the tool completes. Both trigger OnPush change detection.
+</Step>
+</Steps>
+
+## Multi-Agent Architecture
+
+When a single agent with tools is not enough, you can compose multiple agents into a supervisor-worker architecture. A supervisor agent receives the user's request, decides which specialist to delegate to, and synthesizes the final answer.
+
+<Tabs>
+<Tab label="Python supervisor">
+
+```python
+from langgraph.graph import END, START, StateGraph
+from langchain_openai import ChatOpenAI
+from typing import Literal
+from typing_extensions import TypedDict, Annotated
+from operator import add
+
+class OrchestratorState(TypedDict):
+    messages: Annotated[list, add]
+    next_agent: str
+    research_output: str
+    analysis_output: str
+
+llm = ChatOpenAI(model="gpt-5-mini")
+
+# --- Supervisor ---
+def supervisor(state: OrchestratorState) -> dict:
+    response = llm.bind_tools([route_tool]).invoke([
+        {"role": "system", "content": """You are a supervisor.
+        Route to 'researcher' for fact-finding,
+        'analyst' for data analysis,
+        'writer' for drafting content,
+        or 'finish' if the task is complete."""},
+        *state["messages"],
+    ])
+    destination = response.tool_calls[0]["args"]["agent"]
+    return {"next_agent": destination, "messages": [response]}
+
+# --- Specialist subagents (each is its own compiled graph) ---
+researcher_graph = build_researcher_agent()
+analyst_graph = build_analyst_agent()
+writer_graph = build_writer_agent()
+
+# --- Routing ---
+def route_to_agent(state: OrchestratorState) -> str:
+    return state["next_agent"]
+
+# --- Orchestrator graph ---
+builder = StateGraph(OrchestratorState)
+builder.add_node("supervisor", supervisor)
+builder.add_node("researcher", researcher_graph)
+builder.add_node("analyst", analyst_graph)
+builder.add_node("writer", writer_graph)
+
+builder.add_edge(START, "supervisor")
+builder.add_conditional_edges("supervisor", route_to_agent, {
+    "researcher": "researcher",
+    "analyst": "analyst",
+    "writer": "writer",
+    "finish": END,
+})
+# After each specialist, return to supervisor
+builder.add_edge("researcher", "supervisor")
+builder.add_edge("analyst", "supervisor")
+builder.add_edge("writer", "supervisor")
+
+graph = builder.compile()
+```
+
+</Tab>
+<Tab label="Angular component">
+
+```typescript
+import { ChangeDetectionStrategy, Component, computed } from '@angular/core';
+import { streamResource } from '@cacheplane/stream-resource';
+
+interface OrchestratorState {
+  messages: BaseMessage[];
+  next_agent: string;
+  research_output: string;
+  analysis_output: string;
+}
+
+@Component({
+  selector: 'app-multi-agent',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <app-chat [messages]="messages()" />
+
+    <aside class="agent-panel">
+      <h3>Active Agents</h3>
+      @for (sub of activeWorkers(); track sub.name) {
+        <app-agent-card
+          [name]="sub.name"
+          [status]="sub.status"
+          [messages]="sub.messages" />
+      }
+    </aside>
+
+    <footer class="all-agents">
+      <h3>All Subagents</h3>
+      @for (entry of allSubagents(); track entry[0]) {
+        <app-subagent-summary
+          [name]="entry[0]"
+          [state]="entry[1]" />
+      }
+    </footer>
+  `,
+})
+export class MultiAgentComponent {
+  orchestrator = streamResource<OrchestratorState>({
+    assistantId: 'orchestrator',
+    subagentToolNames: ['researcher', 'analyst', 'writer'],
+  });
+
+  messages = this.orchestrator.messages;
+
+  // Currently running subagents with live status
+  activeWorkers = computed(() => this.orchestrator.activeSubagents());
+
+  // Full map of all subagents (active + completed)
+  allSubagents = computed(() =>
+    Array.from(this.orchestrator.subagents().entries())
+  );
+
+  send(text: string) {
+    this.orchestrator.submit({
+      messages: [{ role: 'human', content: text }],
+    });
+  }
+}
+```
+
+</Tab>
+</Tabs>
+
+<Callout type="tip" title="subagentToolNames is the key">
+The `subagentToolNames` option tells streamResource() which graph nodes are subagents. Without it, subagent execution looks like regular tool calls. With it, `activeSubagents()` and `subagents()` provide dedicated tracking with isolated message histories.
+</Callout>
+
+## Error Handling and Recovery
+
+Agents fail. Tools throw exceptions, APIs time out, LLMs hallucinate invalid tool arguments. A robust architecture handles all of these gracefully.
+
+### Python-Side Error Handling
+
+```python
+from langchain_core.tools import tool, ToolException
+
+@tool(handle_tool_error=True)
+def query_database(sql: str) -> str:
+    """Run a read-only SQL query against the analytics database."""
+    if "DROP" in sql.upper() or "DELETE" in sql.upper():
+        raise ToolException("Destructive queries are not allowed.")
+    try:
+        rows = db.execute(text(sql)).fetchall()
+        return json.dumps([dict(r) for r in rows])
+    except Exception as e:
+        raise ToolException(f"Query failed: {str(e)}")
+```
+
+When `handle_tool_error=True` is set, LangGraph catches `ToolException` and feeds the error message back to the LLM as a `ToolMessage`. The LLM sees the error and can retry with corrected arguments or explain the failure to the user.
+
+### How Errors Surface in Angular
 
 ```typescript
 const agent = streamResource<AgentState>({
-  assistantId: 'research_agent',
+  assistantId: 'react_agent',
 });
 
-// Currently executing tools
-const tools = computed(() => agent.toolProgress());
+// The error() signal captures both transport and agent errors
+const error = computed(() => agent.error());
 
-// Completed tool calls with results
-const completedTools = computed(() => agent.toolCalls());
+// In your template
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    @if (error()) {
+      <app-error-banner [error]="error()" (retry)="retry()" />
+    }
+  `,
+})
+export class AgentComponent {
+  error = computed(() => this.agent.error());
+
+  retry() {
+    // Re-submit the last message to retry
+    this.agent.submit(this.lastInput);
+  }
+}
 ```
 
-## Multi-agent patterns
+### Error Recovery Strategies
 
-Complex tasks use multiple agents working together:
+| Error type | Python behavior | Angular signal |
+|---|---|---|
+| Tool throws `ToolException` | Error fed back to LLM, agent retries | `toolCalls()` shows error in result |
+| Tool throws unexpected error | LangGraph catches it, marks tool as failed | `error()` fires with details |
+| LLM returns invalid tool args | ToolNode validation fails, error fed to LLM | `toolProgress()` shows failed status |
+| Transport error (network) | N/A | `error()` fires, `status()` becomes `'error'` |
+| Agent exceeds recursion limit | Graph raises `GraphRecursionError` | `error()` fires with recursion message |
 
-- **Orchestrator** — one agent delegates to specialized subagents
-- **Pipeline** — agents process sequentially, each refining the output
-- **Debate** — agents review each other's work
+<Callout type="warn" title="Recursion limits">
+LangGraph defaults to 25 recursion steps. If your agent loops between `model` and `tools` more than 25 times, it stops with a `GraphRecursionError`. Increase the limit in production with `graph.compile(recursion_limit=50)` or redesign the agent to converge faster.
+</Callout>
 
-streamResource() supports these patterns through the `subagents()` and `activeSubagents()` signals.
+## Checkpointing and Debugging
+
+Every time a node completes, LangGraph saves a checkpoint — a full snapshot of the agent's state at that moment. streamResource() exposes this checkpoint timeline to Angular, giving you time-travel debugging for free.
+
+### How Checkpoints Work
+
+```python
+from langgraph.checkpoint.postgres import PostgresSaver
+
+checkpointer = PostgresSaver.from_connection_string(DATABASE_URL)
+graph = builder.compile(checkpointer=checkpointer)
+
+# Every node execution creates a checkpoint:
+# checkpoint_1: after "model" (LLM decided to call search_docs)
+# checkpoint_2: after "tools" (search_docs returned results)
+# checkpoint_3: after "model" (LLM responded with final answer)
+```
+
+### Exposing Checkpoints in Angular
+
+```typescript
+const agent = streamResource<AgentState>({
+  assistantId: 'react_agent',
+  threadId: signal('thread_abc123'),
+});
+
+// Full checkpoint timeline — every state snapshot
+const timeline = computed(() => agent.history());
+
+// Current branch (for time-travel)
+const branch = computed(() => agent.branch());
+```
+
+### Building a Debug Timeline
+
+```typescript
+@Component({
+  selector: 'app-debug-timeline',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="timeline">
+      @for (checkpoint of history(); track checkpoint.id) {
+        <button
+          [class.active]="checkpoint.id === currentCheckpoint()"
+          (click)="timeTravel(checkpoint.id)">
+          <span class="node">{{ checkpoint.node }}</span>
+          <span class="time">{{ checkpoint.timestamp | date:'medium' }}</span>
+        </button>
+      }
+    </div>
+
+    <div class="state-inspector">
+      <h3>State at checkpoint</h3>
+      <pre>{{ selectedState() | json }}</pre>
+    </div>
+  `,
+})
+export class DebugTimelineComponent {
+  history = computed(() => this.agent.history());
+  currentCheckpoint = signal<string | null>(null);
+
+  selectedState = computed(() => {
+    const id = this.currentCheckpoint();
+    return this.history().find(c => c.id === id)?.state;
+  });
+
+  timeTravel(checkpointId: string) {
+    this.currentCheckpoint.set(checkpointId);
+    this.agent.submit(null, { checkpoint: checkpointId });
+  }
+}
+```
+
+<Callout type="tip" title="Time-travel is branching">
+When you submit from a previous checkpoint, LangGraph creates a new branch from that point. The original timeline is preserved. The `branch()` signal tells you which branch is currently active. See the [Time Travel guide](/docs/guides/time-travel) for the full walkthrough.
+</Callout>
+
+## Choosing an Architecture
+
+Not every application needs a multi-agent swarm. Here is a decision guide for picking the right level of complexity.
+
+### Single Agent with Tools
+
+**Use when:** Most applications. The user has a conversation, the agent calls tools as needed, and responds.
+
+```python
+# Simple, powerful, covers 80% of use cases
+builder = StateGraph(AgentState)
+builder.add_node("model", call_model)
+builder.add_node("tools", ToolNode(tools))
+builder.add_edge(START, "model")
+builder.add_conditional_edges("model", should_continue)
+builder.add_edge("tools", "model")
+graph = builder.compile()
+```
+
+**Angular signals used:** `messages()`, `toolCalls()`, `toolProgress()`, `status()`
+
+### Single Agent with Human-in-the-Loop
+
+**Use when:** The agent takes high-stakes actions (sending emails, modifying data, making purchases) that need human approval.
+
+```python
+from langgraph.types import Interrupt
+
+def propose_action(state: AgentState) -> dict:
+    plan = llm.invoke(state["messages"])
+    raise Interrupt(value={"action": plan.content, "requires_approval": True})
+
+def execute_action(state: AgentState) -> dict:
+    # Only runs after human approves
+    return perform_action(state["pending_action"])
+```
+
+**Angular signals used:** `messages()`, `interrupt()`, `status()` plus `submit(null, { resume })` to approve
+
+### Multi-Agent Supervisor
+
+**Use when:** The task naturally decomposes into specialist roles (researcher, analyst, writer), and each specialist needs its own tools, prompts, and reasoning chain.
+
+```python
+builder = StateGraph(OrchestratorState)
+builder.add_node("supervisor", supervisor)
+builder.add_node("researcher", researcher_subgraph)
+builder.add_node("analyst", analyst_subgraph)
+builder.add_conditional_edges("supervisor", route_to_agent)
+```
+
+**Angular signals used:** `messages()`, `subagents()`, `activeSubagents()`, `toolCalls()`, `status()`
+
+### Decision Matrix
+
+| Factor | Single agent | Single + approval | Multi-agent |
+|---|---|---|---|
+| Tool count | 1-10 | 1-10 | 10+ across specialists |
+| Task complexity | Single domain | Single domain, high stakes | Cross-domain |
+| Latency budget | Low | Medium (human wait) | Higher (multiple LLM calls) |
+| State isolation | Shared | Shared + interrupt | Isolated per subagent |
+| Angular complexity | Low | Medium | Higher |
 
 <Callout type="tip" title="Start simple">
-Most applications only need a single agent with tools. Add subagents when you need true task delegation with isolated state.
+Begin with a single agent and tools. Add human-in-the-loop when you need approval flows. Graduate to multi-agent only when a single agent's context window cannot hold all the tools and instructions it needs.
 </Callout>
 
 ## What's Next
 
 <CardGroup cols={2}>
   <Card title="LangGraph Basics" href="/docs/concepts/langgraph-basics">
-    Learn the graph, node, and edge model that agents are built on.
+    Learn the graph, node, and edge primitives that agents are built on.
   </Card>
-  <Card title="Subgraphs" href="/docs/guides/subgraphs">
-    Compose agents into multi-agent pipelines using subgraphs.
+  <Card title="Streaming" href="/docs/guides/streaming">
+    Stream token-by-token responses with multiple stream modes.
   </Card>
   <Card title="Interrupts" href="/docs/guides/interrupts">
-    Pause agent execution and wait for human approval mid-run.
+    Build human-in-the-loop approval flows that pause and resume agents.
+  </Card>
+  <Card title="Subgraphs" href="/docs/guides/subgraphs">
+    Compose multi-agent systems with orchestrators and specialist workers.
+  </Card>
+  <Card title="Time Travel" href="/docs/guides/time-travel">
+    Debug agents by stepping through checkpoint history and branching.
+  </Card>
+  <Card title="Angular Signals" href="/docs/concepts/angular-signals">
+    How Signals power the reactive model behind streamResource().
   </Card>
 </CardGroup>

--- a/apps/website/content/docs-v2/concepts/angular-signals.mdx
+++ b/apps/website/content/docs-v2/concepts/angular-signals.mdx
@@ -249,7 +249,7 @@ effect(() => {
 });
 ```
 
-<Callout type="warn" title="Avoid writing to Signals inside effect()">
+<Callout type="warning" title="Avoid writing to Signals inside effect()">
 Writing to a Signal inside an `effect()` can create infinite loops. If you need to transform one Signal into another, use `computed()` instead. Reserve `effect()` for side effects that leave the reactive graph — DOM manipulation, logging, analytics, network calls.
 </Callout>
 

--- a/apps/website/content/docs-v2/concepts/angular-signals.mdx
+++ b/apps/website/content/docs-v2/concepts/angular-signals.mdx
@@ -1,75 +1,559 @@
 # Angular Signals
 
-streamResource() is built on Angular Signals — the reactive primitive introduced in Angular 16+. Every property on a StreamResourceRef is a Signal, making it work seamlessly with OnPush change detection, computed values, and effect callbacks.
+Angular Signals are the reactive primitive that powers streamResource(). If you're coming from a Python AI/agent background and wondering how Angular handles real-time streaming data, this page is your guide. Every property on a StreamResourceRef is a Signal, which means your templates update automatically as tokens arrive — no manual subscriptions, no async pipes, no RxJS boilerplate.
 
-## Signals primer
+<Callout type="info" title="For Python developers">
+Think of Signals like a Python property with built-in change notification. When the value changes, every consumer — templates, computed values, effects — re-evaluates automatically. If you've used Pydantic models with validators that react to field changes, Signals are the Angular equivalent but deeply integrated into the rendering engine.
+</Callout>
 
-A Signal is a reactive value container. When a Signal's value changes, Angular automatically re-renders any template that reads it.
+## What Are Angular Signals?
 
-```typescript
-// streamResource returns Signals, not Observables
-const chat = streamResource<ChatState>({ assistantId: 'agent' });
-
-chat.messages()    // Signal<BaseMessage[]> — call to read
-chat.status()      // Signal<ResourceStatus>
-chat.error()       // Signal<unknown>
-chat.isLoading()   // Signal<boolean> (computed)
-```
-
-## Computed values
-
-Use `computed()` to derive new Signals from streamResource signals.
+A Signal is a reactive value container introduced in Angular 16+. You create one, read it by calling it like a function, and Angular tracks which templates and computations depend on it.
 
 ```typescript
-const lastMessage = computed(() =>
-  chat.messages().at(-1)?.content ?? ''
-);
+import { signal, computed } from '@angular/core';
 
-const messageCount = computed(() =>
-  chat.messages().length
-);
+// Create a writable signal
+const count = signal(0);
 
-const isIdle = computed(() =>
-  chat.status() === 'idle'
-);
+// Read the current value — call it like a function
+console.log(count()); // 0
+
+// Update the value
+count.set(1);
+count.update(prev => prev + 1);
+
+// Derive new values with computed()
+const doubled = computed(() => count() * 2);
+console.log(doubled()); // 4
 ```
 
-## OnPush change detection
+The key insight: Angular knows which Signals a template reads. When those Signals change, Angular re-renders only the affected parts of the DOM. No diffing the entire tree, no zone.js overhead.
 
-Because Signals trigger change detection automatically, streamResource works perfectly with `ChangeDetectionStrategy.OnPush`.
+## How streamResource Uses Signals Internally
+
+Under the hood, streamResource() receives Server-Sent Events (SSE) over HTTP and feeds them into RxJS BehaviorSubjects. It then converts those BehaviorSubjects into Angular Signals using `toSignal()`. This is the bridge between the async streaming world and Angular's synchronous reactivity model.
+
+<Tabs>
+<Tab label="Internal flow">
+
+```typescript
+// Simplified view of what streamResource does internally:
+
+// 1. SSE events arrive as an observable stream
+const messages$ = new BehaviorSubject<BaseMessage[]>([]);
+const status$ = new BehaviorSubject<ResourceStatus>('idle');
+
+// 2. Each SSE chunk updates the BehaviorSubject
+transport.onChunk(chunk => {
+  messages$.next([...messages$.getValue(), chunk.message]);
+});
+
+// 3. BehaviorSubjects become Signals via toSignal()
+const messages = toSignal(messages$, { initialValue: [] });
+const status = toSignal(status$, { initialValue: 'idle' });
+
+// 4. Your component reads pure Signals — no RxJS knowledge needed
+```
+
+</Tab>
+<Tab label="What you see">
+
+```typescript
+import { streamResource } from '@cacheplane/stream-resource';
+
+// You never touch BehaviorSubjects or toSignal() yourself.
+// streamResource() hands you clean Signals:
+const chat = streamResource<ChatState>({
+  assistantId: 'chat_agent',
+});
+
+chat.messages();   // Signal<BaseMessage[]>
+chat.status();     // Signal<ResourceStatus>
+chat.error();      // Signal<unknown>
+chat.isLoading();  // Signal<boolean>
+chat.value();      // Signal<ChatState>
+```
+
+</Tab>
+</Tabs>
+
+<Callout type="tip" title="Why this matters">
+The BehaviorSubject-to-Signal conversion means you get the best of both worlds: RxJS handles the async SSE transport (reconnection, backpressure, error recovery), while Signals handle the synchronous UI reactivity (change detection, template binding, computed derivations). You only interact with the Signal side.
+</Callout>
+
+## The Streaming Lifecycle as Signals
+
+Every streamResource() instance moves through a lifecycle: **idle**, **loading**, tokens arriving, then **resolved** (or **error**). The `status()` Signal reflects each transition in real time.
+
+<Steps>
+<Step title="idle — Waiting for input">
+The resource has been created but no request has been submitted yet. All Signals hold their initial values.
+
+```typescript
+const chat = streamResource<ChatState>({
+  assistantId: 'chat_agent',
+});
+
+console.log(chat.status());     // 'idle'
+console.log(chat.messages());   // []
+console.log(chat.isLoading());  // false
+```
+</Step>
+
+<Step title="loading — Request in flight">
+After calling `submit()`, the status transitions to `'loading'`. The SSE connection is open and the agent is processing.
+
+```typescript
+chat.submit({ messages: [{ role: 'user', content: 'Explain quantum computing' }] });
+
+console.log(chat.status());     // 'loading'
+console.log(chat.isLoading());  // true
+console.log(chat.messages());   // [] (no tokens yet)
+```
+</Step>
+
+<Step title="loading — Tokens streaming">
+As the agent generates tokens, the `messages()` Signal updates with each chunk. The status remains `'loading'` throughout.
+
+```typescript
+// After first few tokens arrive:
+console.log(chat.status());     // 'loading' (still streaming)
+console.log(chat.messages());   // [AIMessageChunk("Quantum computing uses...")]
+
+// After more tokens:
+console.log(chat.messages());   // [AIMessageChunk("Quantum computing uses qubits...")]
+// The message content grows as tokens stream in
+```
+</Step>
+
+<Step title="resolved — Stream complete">
+The agent has finished. All tokens have arrived. The status transitions to `'resolved'`.
+
+```typescript
+console.log(chat.status());     // 'resolved'
+console.log(chat.isLoading());  // false
+console.log(chat.messages());   // [AIMessage("Quantum computing uses qubits to...")]
+```
+</Step>
+
+<Step title="error — Something went wrong">
+If the agent fails or the connection drops, the status transitions to `'error'` and the `error()` Signal contains the failure details.
+
+```typescript
+console.log(chat.status());     // 'error'
+console.log(chat.error());      // HttpErrorResponse { status: 500, ... }
+console.log(chat.isLoading());  // false
+```
+</Step>
+</Steps>
+
+## Composing Derived State with computed()
+
+`computed()` lets you derive new Signals from streamResource Signals. These derived Signals update automatically whenever their dependencies change — during streaming, that means every time a new token arrives.
+
+```typescript
+import { computed } from '@angular/core';
+import { streamResource } from '@cacheplane/stream-resource';
+
+const chat = streamResource<ChatState>({
+  assistantId: 'chat_agent',
+});
+
+// Count all messages in the conversation
+const messageCount = computed(() => chat.messages().length);
+
+// Get the last message (useful for showing the latest response)
+const lastMessage = computed(() => chat.messages().at(-1));
+
+// Extract just the assistant's messages
+const assistantMessages = computed(() =>
+  chat.messages().filter(m => m._getType() === 'ai')
+);
+
+// Track which tools the agent is actively calling
+const activeTools = computed(() =>
+  chat.messages()
+    .filter(m => m._getType() === 'ai')
+    .flatMap(m => m.tool_calls ?? [])
+    .filter(tc => !tc.result)
+);
+
+// Build a user-facing error message
+const errorDisplay = computed(() => {
+  const err = chat.error();
+  if (!err) return null;
+  if (err instanceof HttpErrorResponse) {
+    return err.status === 429
+      ? 'Rate limited. Please wait a moment.'
+      : `Server error (${err.status})`;
+  }
+  return 'An unexpected error occurred.';
+});
+
+// Combine multiple signals into a single view model
+const viewModel = computed(() => ({
+  messages: chat.messages(),
+  isStreaming: chat.isLoading(),
+  canSend: chat.status() !== 'loading',
+  messageCount: messageCount(),
+  error: errorDisplay(),
+}));
+```
+
+<Callout type="tip" title="computed() is lazy and cached">
+A `computed()` only re-evaluates when one of its dependencies actually changes, and it caches the result. If `chat.messages()` emits the same reference, downstream computeds skip their work entirely. This matters for high-frequency streaming where tokens arrive rapidly.
+</Callout>
+
+## Side Effects with effect()
+
+Use `effect()` when a Signal change should trigger work that lives outside the template — logging, analytics, scrolling, persisting state. Effects run in the injection context and are automatically cleaned up when the component is destroyed.
+
+```typescript
+import { effect } from '@angular/core';
+
+// Log errors for observability
+effect(() => {
+  const err = chat.error();
+  if (err) {
+    console.error('[StreamResource] Agent error:', err);
+    this.analytics.track('agent_error', { error: err });
+  }
+});
+
+// Auto-scroll to bottom when new messages arrive
+effect(() => {
+  const msgs = chat.messages();
+  if (msgs.length > 0) {
+    // Schedule after Angular renders the new message
+    setTimeout(() => {
+      this.chatContainer.nativeElement.scrollTo({
+        top: this.chatContainer.nativeElement.scrollHeight,
+        behavior: 'smooth',
+      });
+    });
+  }
+});
+
+// Track streaming duration for performance monitoring
+effect(() => {
+  const status = chat.status();
+  if (status === 'loading') {
+    this.streamStart = performance.now();
+  }
+  if (status === 'resolved' && this.streamStart) {
+    const duration = performance.now() - this.streamStart;
+    this.analytics.track('stream_duration_ms', { duration });
+    this.streamStart = null;
+  }
+});
+```
+
+<Callout type="warn" title="Avoid writing to Signals inside effect()">
+Writing to a Signal inside an `effect()` can create infinite loops. If you need to transform one Signal into another, use `computed()` instead. Reserve `effect()` for side effects that leave the reactive graph — DOM manipulation, logging, analytics, network calls.
+</Callout>
+
+## Template Patterns
+
+Angular's new control flow syntax (`@if`, `@for`, `@switch`) works naturally with Signals. Here's a complete chat template that handles every lifecycle state.
+
+```typescript
+import { ChangeDetectionStrategy, Component, computed, effect, ElementRef, ViewChild } from '@angular/core';
+import { streamResource } from '@cacheplane/stream-resource';
+
+@Component({
+  selector: 'app-chat',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <!-- Status bar -->
+    @switch (chat.status()) {
+      @case ('loading') {
+        <div class="status-bar streaming">
+          Agent is responding...
+        </div>
+      }
+      @case ('error') {
+        <div class="status-bar error">
+          {{ errorDisplay() }}
+          <button (click)="retry()">Retry</button>
+        </div>
+      }
+    }
+
+    <!-- Message list -->
+    <div class="messages" #chatContainer>
+      @for (message of chat.messages(); track $index) {
+        @switch (message._getType()) {
+          @case ('human') {
+            <div class="message user">
+              {{ message.content }}
+            </div>
+          }
+          @case ('ai') {
+            <div class="message assistant">
+              {{ message.content }}
+
+              <!-- Show tool calls if the assistant invoked any -->
+              @for (tool of message.tool_calls ?? []; track tool.id) {
+                <div class="tool-call">
+                  Called: {{ tool.name }}
+                </div>
+              }
+            </div>
+          }
+          @case ('tool') {
+            <div class="message tool-result">
+              {{ message.name }}: {{ message.content }}
+            </div>
+          }
+        }
+      } @empty {
+        <div class="empty-state">
+          Send a message to start the conversation.
+        </div>
+      }
+    </div>
+
+    <!-- Input area -->
+    <form (submit)="send($event)">
+      <input
+        #input
+        type="text"
+        placeholder="Type a message..."
+        [disabled]="chat.isLoading()"
+      />
+      <button type="submit" [disabled]="chat.isLoading()">
+        @if (chat.isLoading()) { Streaming... } @else { Send }
+      </button>
+    </form>
+  `,
+})
+export class ChatComponent {
+  @ViewChild('chatContainer') chatContainer!: ElementRef<HTMLElement>;
+
+  chat = streamResource<ChatState>({
+    assistantId: 'chat_agent',
+  });
+
+  errorDisplay = computed(() => {
+    const err = this.chat.error();
+    if (!err) return '';
+    return err instanceof HttpErrorResponse
+      ? `Error ${err.status}: ${err.statusText}`
+      : 'Connection lost. Please retry.';
+  });
+
+  scrollEffect = effect(() => {
+    const msgs = this.chat.messages();
+    if (msgs.length) {
+      setTimeout(() =>
+        this.chatContainer?.nativeElement.scrollTo({
+          top: this.chatContainer.nativeElement.scrollHeight,
+          behavior: 'smooth',
+        })
+      );
+    }
+  });
+
+  send(event: Event) {
+    event.preventDefault();
+    const input = (event.target as HTMLFormElement).querySelector('input')!;
+    const content = input.value.trim();
+    if (!content) return;
+
+    this.chat.submit({
+      messages: [{ role: 'user', content }],
+    });
+    input.value = '';
+  }
+
+  retry() {
+    this.chat.submit({
+      messages: [{ role: 'user', content: 'Please try again.' }],
+    });
+  }
+}
+```
+
+## OnPush Change Detection
+
+Every component using streamResource() should use `ChangeDetectionStrategy.OnPush`. Here's why it works and why it's efficient.
+
+With the default change detection strategy, Angular checks every component in the tree on every browser event — clicks, timers, HTTP responses. For a streaming agent emitting dozens of tokens per second, that means hundreds of unnecessary checks across your entire app.
+
+With OnPush, Angular only checks a component when:
+
+1. An `@Input()` reference changes
+2. An event fires inside the component's template
+3. A **Signal** that the template reads changes
+
+Since streamResource() exposes Signals, condition 3 handles everything. When a new token arrives and `messages()` updates, Angular marks only the components reading that Signal for check — not the entire tree.
 
 ```typescript
 @Component({
+  // Always use OnPush with streamResource
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    @for (msg of chat.messages(); track $index) {
-      <p>{{ msg.content }}</p>
+    <p>{{ chat.messages().length }} messages</p>
+    @if (chat.isLoading()) {
+      <app-typing-indicator />
     }
   `,
 })
 export class ChatComponent {
-  chat = streamResource<ChatState>({ assistantId: 'agent' });
+  chat = streamResource<ChatState>({ assistantId: 'chat_agent' });
 }
 ```
 
-## No RxJS required
+<Callout type="info" title="No markForCheck() needed">
+With older Observable-based patterns, you had to call `ChangeDetectorRef.markForCheck()` or use the `async` pipe to trigger OnPush updates. Signals do this automatically. When a Signal's value changes, Angular's internal notification system marks the component dirty — zero manual intervention.
+</Callout>
 
-Unlike traditional Angular HTTP patterns, streamResource doesn't use Observables. There are no subscriptions to manage, no async pipes needed, and no memory leak risks.
+## Python Agent to Angular Signals
 
-<Callout type="tip" title="Why Signals over RxJS?">
-Signals are simpler for UI state. They synchronously read the latest value, compose with computed(), and integrate with Angular's template syntax. streamResource handles the async SSE connection internally and surfaces results as Signals.
+The real power of streamResource() is how it pairs a Python LangGraph agent with Angular Signals. The agent defines the logic; Signals surface the results in real time.
+
+<Tabs>
+<Tab label="agent.py">
+
+```python
+from langgraph.graph import END, START, MessagesState, StateGraph
+from langchain_openai import ChatOpenAI
+from langchain_core.tools import tool
+
+llm = ChatOpenAI(model="gpt-5-mini", streaming=True)
+
+@tool
+def search_knowledge_base(query: str) -> str:
+    """Search internal documentation for relevant information."""
+    results = vector_store.similarity_search(query, k=3)
+    return "\n".join(r.page_content for r in results)
+
+tools = [search_knowledge_base]
+
+def call_model(state: MessagesState) -> dict:
+    response = llm.bind_tools(tools).invoke(state["messages"])
+    return {"messages": [response]}
+
+def should_continue(state: MessagesState) -> str:
+    last_msg = state["messages"][-1]
+    if last_msg.tool_calls:
+        return "tools"
+    return END
+
+# Build the graph
+builder = StateGraph(MessagesState)
+builder.add_node("model", call_model)
+builder.add_node("tools", ToolNode(tools))
+builder.add_edge(START, "model")
+builder.add_conditional_edges("model", should_continue)
+builder.add_edge("tools", "model")
+
+graph = builder.compile()
+```
+
+</Tab>
+<Tab label="chat.component.ts">
+
+```typescript
+import { ChangeDetectionStrategy, Component, computed, effect } from '@angular/core';
+import { streamResource } from '@cacheplane/stream-resource';
+
+@Component({
+  selector: 'app-chat',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    @for (msg of chat.messages(); track $index) {
+      @switch (msg._getType()) {
+        @case ('human') {
+          <div class="user">{{ msg.content }}</div>
+        }
+        @case ('ai') {
+          <div class="assistant">
+            {{ msg.content }}
+            @for (tc of msg.tool_calls ?? []; track tc.id) {
+              <span class="tool-badge">{{ tc.name }}</span>
+            }
+          </div>
+        }
+        @case ('tool') {
+          <div class="tool-result">{{ msg.name }}: {{ msg.content }}</div>
+        }
+      }
+    }
+
+    @if (chat.isLoading()) {
+      <div class="typing-indicator">Agent is thinking...</div>
+    }
+  `,
+})
+export class ChatComponent {
+  chat = streamResource<ChatState>({
+    assistantId: 'chat_agent',
+  });
+
+  // Derived state from the Python agent's output
+  toolsUsed = computed(() =>
+    this.chat.messages()
+      .filter(m => m._getType() === 'tool')
+      .map(m => m.name)
+  );
+
+  hasError = computed(() => this.chat.status() === 'error');
+
+  sendMessage(content: string) {
+    this.chat.submit({
+      messages: [{ role: 'user', content }],
+    });
+  }
+}
+```
+
+</Tab>
+</Tabs>
+
+When the Python agent calls `search_knowledge_base`, the tool call streams to Angular as a message. When the tool returns, the result streams as another message. The agent's final response streams token by token. Every one of these events updates the `messages()` Signal, and your template re-renders the new content automatically.
+
+## Performance: Signals vs Alternatives
+
+High-frequency token streaming puts unique pressure on a frontend framework. Here's why Signals with OnPush outperform the alternatives.
+
+| Approach | Token update cost | Memory overhead | Cleanup required |
+|---|---|---|---|
+| **Signals + OnPush** | Marks only reading components | None beyond Signal | Automatic |
+| Observable + async pipe | Creates/destroys subscriptions per `@if` block | Subscription objects | Pipe handles it |
+| Observable + manual subscribe | Full component check if you forget `markForCheck()` | Subscription tracking | Manual unsubscribe |
+| Default change detection | Checks entire component tree | None | None |
+
+For a typical chat UI receiving 30-50 tokens per second:
+
+- **Signals + OnPush**: Only the message list component and its direct ancestors are checked. The sidebar, header, settings panel — all skipped.
+- **Default strategy**: Every component in the tree is checked 30-50 times per second, even components with no streaming data.
+- **Observable + async pipe**: Works correctly but creates and destroys subscriptions each time an `@if` or `@for` block re-evaluates, adding GC pressure during rapid streaming.
+
+<Callout type="tip" title="Signal equality checks">
+Signals use referential equality (`===`) by default. streamResource() creates new array references for `messages()` only when the array actually changes (a new token arrives). Between updates, reading `messages()` returns the same reference and skips downstream recomputation. For custom equality, pass an `equal` function when creating a `computed()`.
 </Callout>
 
 ## What's Next
 
 <CardGroup cols={2}>
   <Card title="State Management" href="/docs/concepts/state-management">
-    Understand how LangGraph agent state flows into Angular Signals.
+    How LangGraph agent state flows into Angular Signals and how to structure complex state.
   </Card>
   <Card title="Streaming" href="/docs/guides/streaming">
-    See Signals in action with token-by-token streaming responses.
+    Configure stream modes, handle token-by-token rendering, and manage concurrent streams.
+  </Card>
+  <Card title="LangGraph Basics" href="/docs/concepts/langgraph-basics">
+    Understand the Python agent patterns that produce the events Signals consume.
   </Card>
   <Card title="API Reference" href="/docs/api/stream-resource">
-    Full reference for every Signal exposed by streamResource.
+    Full reference for every Signal, method, and option on StreamResourceRef.
+  </Card>
+  <Card title="Interrupts" href="/docs/guides/interrupts">
+    Build human-in-the-loop approval flows that pause and resume the agent.
+  </Card>
+  <Card title="OnPush Guide" href="/docs/guides/change-detection">
+    Deep dive into change detection optimization for streaming applications.
   </Card>
 </CardGroup>

--- a/apps/website/content/docs-v2/concepts/state-management.mdx
+++ b/apps/website/content/docs-v2/concepts/state-management.mdx
@@ -1,84 +1,541 @@
 # State Management
 
-How state flows through streamResource() — from LangGraph's server-side state machine to Angular Signals in your templates.
+How agent state flows from LangGraph's server-side state machine into Angular Signals — and why the separation between server state and UI state makes your app simpler, not more complex.
 
-## State lives on the server
+<Callout type="info" title="Mental model">
+LangGraph Platform owns the state. Angular owns the view. `streamResource()` is the read-only bridge between them. You never manually sync, serialize, or manage agent state in your Angular code.
+</Callout>
 
-Unlike traditional Angular state management (NgRx, signals stores), agent state lives on the LangGraph Platform. Your Angular app is a stateless view layer.
+## State Lives on the Server
 
+In a traditional Angular app, state lives in an NgRx store or a signals-based service. In a LangGraph app, **the agent's state lives on the server** — in LangGraph Platform's checkpoint store. Your Angular app is a stateless view layer that reads state through signals as the agent streams it back.
+
+This inversion is intentional. Agent state can span multiple LLM calls, tool executions, and human-in-the-loop interrupts. It needs to survive browser refreshes, reconnections, and even server deployments. A server-side checkpoint store handles all of that automatically. Your Angular app just calls `.submit()` and reads signals.
+
+<Steps>
+<Step title="User submits input">
+Your Angular component calls `agent.submit({ messages: [userMsg] })`. No state is stored in the component.
+</Step>
+<Step title="streamResource() sends the request">
+`@cacheplane/stream-resource` forwards the input to `FetchStreamTransport`, which opens an HTTP POST and SSE connection to LangGraph Platform.
+</Step>
+<Step title="LangGraph Platform executes the graph">
+The agent runs its nodes — calling the LLM, invoking tools, checking conditions — and streams SSE events back with incremental state updates.
+</Step>
+<Step title="FetchStreamTransport parses the stream">
+Incoming SSE chunks are parsed and pushed into BehaviorSubjects — one per signal type.
+</Step>
+<Step title="streamResource() converts to Signals">
+BehaviorSubjects are converted to Angular Signals via `toSignal()`. Every update triggers Angular's change detection automatically.
+</Step>
+<Step title="Templates re-render">
+Components using `OnPush` re-render only when signal values change. No manual `detectChanges()`, no zone triggers, no subscriptions to manage.
+</Step>
+</Steps>
+
+## Python State Design
+
+On the Python side, your agent's state is a `TypedDict`. The fields you define here are exactly what `streamResource<T>()` exposes in TypeScript. Getting the Python state design right is the most important architectural decision in your agent.
+
+### The TypedDict Pattern
+
+Every LangGraph state is a `TypedDict`. Fields can be plain values or annotated with reducers that control how updates are merged.
+
+<Tabs>
+<Tab label="Basic state">
+
+```python
+from typing_extensions import TypedDict
+
+class ChatState(TypedDict):
+    messages: list        # Will be replaced on each update
+    session_id: str       # Single value, replaced on update
+    turn_count: int       # Single value, replaced on update
 ```
-LangGraph Platform (source of truth)
-  ↓ SSE stream
-FetchStreamTransport (transport layer)
-  ↓ events
-streamResource() (signal conversion)
-  ↓ Signals
-Angular templates (reactive rendering)
+
+</Tab>
+<Tab label="With reducers">
+
+```python
+from typing_extensions import TypedDict, Annotated
+from operator import add
+
+class AgentState(TypedDict):
+    # Annotated[list, add] means: append new items, don't replace
+    messages: Annotated[list, add]
+    tool_results: Annotated[list, add]
+
+    # Plain fields: each update replaces the previous value
+    status: str
+    current_plan: list[str]
 ```
 
-## The state shape
+</Tab>
+<Tab label="MessagesState (recommended)">
 
-Your state type defines what the agent manages. The `value()` signal exposes the full state object.
+```python
+from langgraph.graph import MessagesState
+
+# MessagesState is a built-in TypedDict that pre-wires
+# messages: Annotated[list[AnyMessage], add_messages]
+# add_messages handles deduplication, type coercion, and ordering
+
+class ProjectState(MessagesState):
+    # Extend with your own fields
+    files: Annotated[list[str], add]    # Accumulates file paths
+    analysis: dict                       # Latest analysis result
+    progress: int                        # 0–100 progress value
+```
+
+</Tab>
+</Tabs>
+
+### Reducers: How State Merges
+
+When a node returns `{"messages": [new_msg]}`, LangGraph doesn't replace the messages list — it **calls the reducer** to merge the update. This is what `Annotated[list, add]` means: use Python's `operator.add` to concatenate lists.
+
+```python
+from typing_extensions import TypedDict, Annotated
+from operator import add
+
+class ResearchState(TypedDict):
+    # Each node can append to these — they accumulate across the run
+    messages: Annotated[list, add]
+    sources: Annotated[list[str], add]
+    findings: Annotated[list[str], add]
+
+    # These are replaced (last write wins)
+    query: str
+    model: str
+    confidence: float
+
+def researcher_node(state: ResearchState) -> dict:
+    result = llm.invoke(state["messages"])
+    new_sources = extract_sources(result.content)
+
+    # Returns partial state — only fields being updated
+    # LangGraph merges this into the existing state
+    return {
+        "messages": [result],           # Appended via reducer
+        "sources": new_sources,          # Appended via reducer
+        "confidence": 0.87,              # Replaced
+    }
+```
+
+<Callout type="tip" title="Partial returns are the norm">
+Nodes return only the fields they change. LangGraph merges partial updates into the full state object. This is why you can have 10 nodes each updating different fields without conflicts.
+</Callout>
+
+## TypeScript Interface Mapping
+
+The TypeScript interface you pass to `streamResource<T>()` is your contract with the Python state. Every Python state field maps to a TypeScript property. The types don't need to match exactly — they just need to be compatible with the JSON that LangGraph streams back.
+
+<Tabs>
+<Tab label="Python state">
+
+```python
+from typing_extensions import TypedDict, Annotated
+from operator import add
+from langgraph.graph import MessagesState
+
+class ProjectState(MessagesState):
+    # From MessagesState: messages: Annotated[list[AnyMessage], add_messages]
+    files: Annotated[list[str], add]
+    analysis: dict[str, any] | None
+    progress: int
+    plan: Annotated[list[str], add]
+    error: str | None
+```
+
+</Tab>
+<Tab label="TypeScript interface">
 
 ```typescript
+import { BaseMessage } from '@langchain/core/messages';
+
 interface ProjectState {
+  // Maps from MessagesState.messages
   messages: BaseMessage[];
+
+  // Maps from Python fields (reducers are transparent — you see the final list)
   files: string[];
-  analysis: { score: number; issues: string[] };
+  analysis: { score: number; issues: string[]; summary: string } | null;
+  progress: number;
+  plan: string[];
+  error: string | null;
 }
 
 const agent = streamResource<ProjectState>({
   assistantId: 'project_agent',
 });
-
-// Access any state field as a reactive value
-const files = computed(() => agent.value().files);
-const score = computed(() => agent.value().analysis.score);
 ```
 
-## Thread state vs application state
+</Tab>
+<Tab label="Type reference">
 
-<Callout type="info" title="Two kinds of state">
-Thread state (managed by LangGraph) and application state (managed by Angular) are separate concerns. Don't try to sync them — read thread state from signals, manage UI state with Angular signals.
-</Callout>
+| Python type | TypeScript type |
+|-------------|-----------------|
+| `str` | `string` |
+| `int` / `float` | `number` |
+| `bool` | `boolean` |
+| `list[str]` | `string[]` |
+| `dict[str, any]` | `Record<string, unknown>` |
+| `TypedDict` | `interface` or `type` |
+| `str \| None` | `string \| null` |
+| `list[AnyMessage]` | `BaseMessage[]` |
+| `Annotated[list, add]` | Same as the list type — reducer is invisible |
+
+</Tab>
+</Tabs>
+
+Once you define the interface, every field is accessible via `agent.value()`:
 
 ```typescript
-// Thread state — from the agent
-const messages = agent.messages();     // Read-only signal
-const agentStatus = agent.status();    // Read-only signal
+// Full typed state object
+const state = agent.value();         // Signal<ProjectState>
 
-// Application state — your Angular code
-const sidebarOpen = signal(true);      // Your UI state
-const selectedTab = signal('chat');    // Your UI state
+// Computed values from nested fields
+const score = computed(() => agent.value().analysis?.score ?? 0);
+const fileCount = computed(() => agent.value().files.length);
+const isDone = computed(() => agent.value().progress === 100);
+
+// Direct messages access (shortcut for agent.value().messages)
+const messages = agent.messages();   // Signal<BaseMessage[]>
 ```
 
-## State updates are immutable
+## State Updates During Streaming
 
-Every state update from the agent creates a new signal value. Angular's change detection picks this up automatically.
+The agent doesn't wait until it's finished to send state updates. It streams partial state updates as each node completes. Your Angular signals update incrementally throughout the run.
+
+### How Partial Updates Arrive
+
+LangGraph streams in `values` mode by default — each SSE event contains the full state snapshot after a node completes. In `messages` mode, you get individual message tokens as they're generated.
 
 ```typescript
-// This works with OnPush because the Signal reference changes
+const agent = streamResource<ProjectState>({
+  assistantId: 'project_agent',
+  // Default: values mode — full state after each node
+  // streamMode: 'messages' — token-by-token for text fields
+});
+```
+
+### Signals Update Mid-Stream
+
+Because every state update is a new signal value, your templates reflect the agent's progress in real time — without polling, without timers, without manual state management.
+
+```typescript
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <!-- Updates as each file is processed -->
+    <p>Files processed: {{ agent.value().files.length }}</p>
+
+    <!-- Progress bar updates as agent emits progress updates -->
+    <progress [value]="agent.value().progress" max="100" />
+
+    <!-- Plan items appear as the agent builds the plan -->
+    @for (step of agent.value().plan; track step) {
+      <li>{{ step }}</li>
+    }
+
+    <!-- Messages stream token by token -->
+    @for (msg of agent.messages(); track $index) {
+      <app-message [message]="msg" />
+    }
+  `
+})
+export class ProjectComponent {
+  readonly agent = streamResource<ProjectState>({
+    assistantId: 'project_agent',
+  });
+}
+```
+
+### Immutability and OnPush
+
+Every signal update produces a new object reference. Angular's `OnPush` change detection compares references — when a signal emits a new value, the component re-renders. You never need to clone objects or call `markForCheck()` manually.
+
+```typescript
+// Safe: computed() re-evaluates when agent.value() changes
+const hasErrors = computed(() =>
+  (agent.value().analysis?.issues ?? []).length > 0
+);
+
+// Safe: @for tracks by identity, not index, for stable DOM
+// track $index is fine for messages since they always append
 @for (msg of agent.messages(); track $index) {
-  <p>{{ msg.content }}</p>
+  <app-message [message]="msg" />
 }
 
-// Computed values re-evaluate when dependencies change
-const hasErrors = computed(() =>
-  agent.value().analysis.issues.length > 0
-);
+// Safe: null-coalescing handles state fields not yet populated
+const score = computed(() => agent.value().analysis?.score ?? 0);
+```
+
+<Callout type="tip" title="No manual subscriptions">
+`streamResource()` uses `toSignal()` internally with `requireSync: false`. Signals always have a value — even before the first stream update. You never need to handle `undefined` explicitly for the signal itself, though individual state fields may be `null` until the agent populates them.
+</Callout>
+
+## Thread State vs Application State
+
+There are two kinds of state in a LangGraph Angular app, and keeping them separate makes your code much easier to reason about.
+
+**Thread state** is owned by LangGraph Platform. You read it through `streamResource()` signals. You never write to it directly — you only send new input via `.submit()`.
+
+**Application state** is owned by your Angular component or service. It's UI-only: sidebar visibility, active tab, selected message, form input values. It has nothing to do with the agent.
+
+```typescript
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ChatComponent {
+  // --- Thread state (from agent, read-only) ---
+  readonly agent = streamResource<ChatState>({
+    assistantId: 'chat_agent',
+  });
+
+  // Convenience computed values from thread state
+  readonly messages = this.agent.messages;           // Signal<BaseMessage[]>
+  readonly isLoading = this.agent.isLoading;         // Signal<boolean>
+  readonly interrupted = this.agent.interrupt;       // Signal<Interrupt | null>
+
+  // --- Application state (your Angular signals) ---
+  readonly sidebarOpen = signal(true);
+  readonly activeTab = signal<'chat' | 'history' | 'settings'>('chat');
+  readonly inputText = signal('');
+  readonly selectedMessageId = signal<string | null>(null);
+
+  // --- Actions ---
+  send() {
+    const text = this.inputText();
+    if (!text.trim()) return;
+    this.agent.submit({ messages: [{ role: 'user', content: text }] });
+    this.inputText.set('');                          // UI state — clear the input
+  }
+
+  approve() {
+    this.agent.submit(null, { resume: { approved: true } });
+  }
+}
+```
+
+<Callout type="warning" title="Don't mirror thread state into Angular signals">
+A common mistake is copying `agent.messages()` into a local signal to "control" it. This creates stale state bugs and defeats the purpose of the reactive signal model. Read thread state directly from `agent.*` signals and derive what you need with `computed()`.
+</Callout>
+
+## The Checkpoint Model
+
+LangGraph Platform persists state at every node boundary using a checkpoint store. Each checkpoint is an immutable snapshot of the full state at a point in time.
+
+```
+Thread: "user_123_session"
+│
+├── Checkpoint 1  ← After call_model: { messages: [HumanMessage, AIMessage] }
+├── Checkpoint 2  ← After tool_node: { messages: [..., ToolMessage] }
+├── Checkpoint 3  ← After call_model: { messages: [..., AIMessage("Here's what I found...")] }
+└── (current)
+```
+
+### What This Means for Your Angular App
+
+**Resumable threads** — If the user refreshes the page or closes the browser, the thread is still there. Pass the same `threadId` and `streamResource()` will restore the full conversation history automatically.
+
+**Time travel** — You can fork a thread at any checkpoint and replay it with different input. This powers the time-travel debugging guides.
+
+**Interrupt persistence** — When the agent raises an `Interrupt`, the checkpoint captures everything. The agent can be resumed hours or days later.
+
+```typescript
+const agent = streamResource<ChatState>({
+  assistantId: 'chat_agent',
+
+  // Same threadId = restored conversation history
+  threadId: signal(this.route.snapshot.params['threadId']),
+
+  // New threadId auto-created for new conversations
+  onThreadId: (id) => this.router.navigate(['/chat', id]),
+});
+
+// Read checkpoint history for time-travel UI
+const history = agent.history();    // Signal<ThreadState[]>
+const branch = agent.branch();      // Signal<string> — active branch ID
+```
+
+For full checkpoint and time-travel patterns, see the [Persistence guide](/docs/guides/persistence) and [Time Travel guide](/docs/guides/time-travel).
+
+## Custom State Fields
+
+`messages` is just one field. Real agents carry rich state: structured plans, tool results, progress indicators, metadata, and more. Every custom field you define in Python is available in your TypeScript interface.
+
+<Tabs>
+<Tab label="Python state">
+
+```python
+from typing_extensions import TypedDict, Annotated
+from operator import add
+from langgraph.graph import MessagesState
+from langchain_openai import ChatOpenAI
+
+llm = ChatOpenAI(model="gpt-5-mini")
+
+class ResearchState(MessagesState):
+    # Accumulating lists — each node can append
+    plan: Annotated[list[str], add]
+    sources: Annotated[list[str], add]
+    findings: Annotated[list[str], add]
+
+    # Scalar progress
+    progress: int          # 0–100
+
+    # Structured results
+    report: dict | None    # Final report when complete
+
+    # Agent metadata
+    query: str
+    model_used: str
+
+def planner_node(state: ResearchState) -> dict:
+    steps = llm.invoke([
+        {"role": "system", "content": "Break this query into research steps."},
+        *state["messages"]
+    ])
+    plan_items = steps.content.split("\n")
+    return {
+        "plan": plan_items,       # Appended via reducer
+        "progress": 10,
+        "model_used": "gpt-5-mini",
+    }
+
+def researcher_node(state: ResearchState) -> dict:
+    # Runs once per plan step in a loop
+    for step in state["plan"]:
+        result = search(step)
+        yield {
+            "findings": [result],  # Each iteration appends
+            "progress": state["progress"] + (80 // len(state["plan"])),
+        }
+```
+
+</Tab>
+<Tab label="TypeScript interface">
+
+```typescript
+import { BaseMessage } from '@langchain/core/messages';
+import { streamResource } from '@cacheplane/stream-resource';
+
+interface ResearchState {
+  messages: BaseMessage[];
+  plan: string[];
+  sources: string[];
+  findings: string[];
+  progress: number;
+  report: {
+    title: string;
+    summary: string;
+    sections: { heading: string; content: string }[];
+  } | null;
+  query: string;
+  model_used: string;
+}
+
+// In your component:
+readonly agent = streamResource<ResearchState>({
+  assistantId: 'research_agent',
+});
+```
+
+</Tab>
+<Tab label="Angular component">
+
+```typescript
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <!-- Progress indicator -->
+    <div class="progress-bar">
+      <div [style.width.%]="agent.value().progress"></div>
+    </div>
+    <p>{{ agent.value().progress }}% complete</p>
+
+    <!-- Live plan as it's built -->
+    <ol class="plan">
+      @for (step of agent.value().plan; track step) {
+        <li>{{ step }}</li>
+      }
+    </ol>
+
+    <!-- Findings stream in as each source is researched -->
+    <ul class="findings">
+      @for (finding of agent.value().findings; track finding) {
+        <li>{{ finding }}</li>
+      }
+    </ul>
+
+    <!-- Final report appears when agent completes -->
+    @if (agent.value().report; as report) {
+      <article>
+        <h1>{{ report.title }}</h1>
+        <p>{{ report.summary }}</p>
+        @for (section of report.sections; track section.heading) {
+          <section>
+            <h2>{{ section.heading }}</h2>
+            <p>{{ section.content }}</p>
+          </section>
+        }
+      </article>
+    }
+  `
+})
+export class ResearchComponent {
+  readonly agent = streamResource<ResearchState>({
+    assistantId: 'research_agent',
+  });
+
+  startResearch(query: string) {
+    this.agent.submit({
+      messages: [{ role: 'user', content: query }],
+    });
+  }
+}
+```
+
+</Tab>
+</Tabs>
+
+### Derived State with computed()
+
+You rarely need to consume `agent.value()` raw in your template. Use `computed()` to derive clean, focused values:
+
+```typescript
+readonly agent = streamResource<ResearchState>({
+  assistantId: 'research_agent',
+});
+
+// Derived signals — recalculate only when their dependencies change
+readonly progress = computed(() => this.agent.value().progress);
+readonly isPlanning = computed(() => this.agent.value().plan.length === 0 && this.agent.isLoading());
+readonly sourceCount = computed(() => this.agent.value().sources.length);
+readonly hasReport = computed(() => this.agent.value().report !== null);
+readonly reportTitle = computed(() => this.agent.value().report?.title ?? '');
 ```
 
 ## What's Next
 
 <CardGroup cols={2}>
   <Card title="Angular Signals" href="/docs/concepts/angular-signals">
-    Learn how streamResource uses Signals for reactive rendering.
+    How streamResource() uses Angular Signals for zero-subscription reactive rendering.
+  </Card>
+  <Card title="Streaming" href="/docs/guides/streaming">
+    Configure stream modes — values, messages, events — for different use cases.
   </Card>
   <Card title="Persistence" href="/docs/guides/persistence">
-    Persist thread state so users can resume conversations later.
+    Thread-based conversation persistence and checkpoint configuration.
   </Card>
-  <Card title="Memory" href="/docs/guides/memory">
-    Preserve context across sessions with LangGraph's memory store.
+  <Card title="Time Travel" href="/docs/guides/time-travel">
+    Fork threads at any checkpoint and replay with different input.
+  </Card>
+  <Card title="Interrupts" href="/docs/guides/interrupts">
+    Human-in-the-loop approval flows and how interrupt state surfaces in Angular.
+  </Card>
+  <Card title="LangGraph Basics" href="/docs/concepts/langgraph-basics">
+    Nodes, edges, and the graph execution model behind the state machine.
   </Card>
 </CardGroup>
-```

--- a/apps/website/content/docs-v2/concepts/state-management.mdx
+++ b/apps/website/content/docs-v2/concepts/state-management.mdx
@@ -66,6 +66,7 @@ Every state update from the agent creates a new signal value. Angular's change d
 const hasErrors = computed(() =>
   agent.value().analysis.issues.length > 0
 );
+```
 
 ## What's Next
 

--- a/apps/website/content/docs-v2/getting-started/installation.mdx
+++ b/apps/website/content/docs-v2/getting-started/installation.mdx
@@ -48,8 +48,8 @@ Any option passed to `streamResource()` directly overrides the global provider c
 
 ## Environment setup
 
-<Tabs items={['Development', 'Production']}>
-<Tab>
+<Tabs>
+<Tab label="Development">
 
 For local development, run a LangGraph server:
 
@@ -61,7 +61,7 @@ langgraph dev
 ```
 
 </Tab>
-<Tab>
+<Tab label="Production">
 
 For production, point to your LangGraph Cloud deployment:
 

--- a/apps/website/content/docs-v2/getting-started/quickstart.mdx
+++ b/apps/website/content/docs-v2/getting-started/quickstart.mdx
@@ -33,8 +33,8 @@ export const appConfig: ApplicationConfig = {
 
 Use `streamResource()` in a component field initializer. Every property on the returned ref is an Angular Signal.
 
-<Tabs items={['TypeScript', 'Template']}>
-<Tab>
+<Tabs>
+<Tab label="TypeScript">
 
 ```typescript
 // chat.component.ts
@@ -67,7 +67,7 @@ export class ChatComponent {
 ```
 
 </Tab>
-<Tab>
+<Tab label="Template">
 
 ```html
 <!-- chat.component.html -->

--- a/apps/website/content/docs-v2/guides/deployment.mdx
+++ b/apps/website/content/docs-v2/guides/deployment.mdx
@@ -6,7 +6,7 @@ Deploy your LangGraph agent to the cloud and ship your Angular frontend to produ
 
 Your agent code needs a `langgraph.json` manifest at the project root. This file tells LangGraph Cloud how to build and serve your agent.
 
-```json title="langgraph.json"
+```json
 {
   "dependencies": ["."],
   "graphs": {
@@ -20,7 +20,7 @@ The `graphs` key maps an assistant ID (used by `streamResource()` on the Angular
 
 ### Agent entry point
 
-```python title="agent/graph.py"
+```python
 from langchain_openai import ChatOpenAI
 from langgraph.graph import StateGraph, MessagesState
 
@@ -83,7 +83,7 @@ Angular uses file-based environment replacement at build time rather than `proce
 <Tabs>
 <Tab label="Development">
 
-```typescript title="src/environments/environment.ts"
+```typescript
 export const environment = {
   production: false,
   langgraphUrl: 'http://localhost:2024',
@@ -94,7 +94,7 @@ export const environment = {
 </Tab>
 <Tab label="Production">
 
-```typescript title="src/environments/environment.prod.ts"
+```typescript
 export const environment = {
   production: true,
   langgraphUrl: 'https://my-agent-abc123.langgraph.app',
@@ -107,7 +107,7 @@ export const environment = {
 
 Wire the environment into `provideStreamResource()`:
 
-```typescript title="app.config.ts"
+```typescript
 import { provideStreamResource } from '@cacheplane/stream-resource';
 import { environment } from '../environments/environment';
 
@@ -128,7 +128,7 @@ Angular CLI replaces `environment.ts` with `environment.prod.ts` during `ng buil
 
 LangGraph Cloud deployments require an API key on every request. The recommended approach is an Angular HTTP interceptor that attaches the key as a header.
 
-```typescript title="auth.interceptor.ts"
+```typescript
 import { HttpInterceptorFn } from '@angular/common/http';
 import { environment } from '../environments/environment';
 
@@ -147,7 +147,7 @@ export const langGraphAuthInterceptor: HttpInterceptorFn = (req, next) => {
 
 Register the interceptor in your application config:
 
-```typescript title="app.config.ts"
+```typescript
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { langGraphAuthInterceptor } from './auth.interceptor';
 
@@ -161,7 +161,7 @@ export const appConfig: ApplicationConfig = {
 };
 ```
 
-<Callout type="warn" title="Never commit API keys">
+<Callout type="warning" title="Never commit API keys">
 Add `environment.prod.ts` to `.gitignore`. In CI, generate it from environment variables or inject secrets at build time.
 </Callout>
 
@@ -175,7 +175,7 @@ When your Angular frontend and LangGraph backend are on different origins, you m
 
 In `langgraph.json`, add an `http` section:
 
-```json title="langgraph.json"
+```json
 {
   "dependencies": ["."],
   "graphs": {
@@ -200,7 +200,7 @@ During local development with `langgraph dev`, CORS is permissive by default. Yo
 
 Production apps need graceful error handling. Build a reactive error boundary using `streamResource()` signals.
 
-```typescript title="chat.component.ts"
+```typescript
 import { ChangeDetectionStrategy, Component, computed } from '@angular/core';
 import { streamResource } from '@cacheplane/stream-resource';
 
@@ -246,7 +246,7 @@ export class ChatComponent {
 
 For automated retries (network blips, transient 5xx errors), wrap `.submit()` with a backoff utility:
 
-```typescript title="retry-submit.ts"
+```typescript
 export async function retrySubmit(
   chat: ReturnType<typeof streamResource>,
   input: Record<string, unknown>,
@@ -290,7 +290,7 @@ if (savedRunId) {
 
 A typical pipeline deploys the Python agent and Angular frontend in parallel since they are independent artifacts.
 
-```yaml title=".github/workflows/deploy.yml"
+```yaml
 name: Deploy
 on:
   push:

--- a/apps/website/content/docs-v2/guides/deployment.mdx
+++ b/apps/website/content/docs-v2/guides/deployment.mdx
@@ -6,8 +6,8 @@ Configure streamResource() for production with LangGraph Cloud, environment-base
 
 Point `apiUrl` to your LangGraph Cloud deployment.
 
-<Tabs items={['Environment-based', 'Direct URL']}>
-<Tab>
+<Tabs>
+<Tab label="Environment-based">
 
 ```typescript
 // app.config.ts
@@ -24,7 +24,7 @@ export const environment = {
 ```
 
 </Tab>
-<Tab>
+<Tab label="Direct URL">
 
 ```typescript
 // app.config.ts

--- a/apps/website/content/docs-v2/guides/deployment.mdx
+++ b/apps/website/content/docs-v2/guides/deployment.mdx
@@ -1,91 +1,407 @@
 # Deployment
 
-Configure streamResource() for production with LangGraph Cloud, environment-based URLs, and error handling patterns.
+Deploy your LangGraph agent to the cloud and ship your Angular frontend to production with environment-based configuration, authentication, error handling, and observability.
 
-## Production configuration
+## Python: LangGraph Cloud deployment
 
-Point `apiUrl` to your LangGraph Cloud deployment.
+Your agent code needs a `langgraph.json` manifest at the project root. This file tells LangGraph Cloud how to build and serve your agent.
 
-<Tabs>
-<Tab label="Environment-based">
-
-```typescript
-// app.config.ts
-provideStreamResource({
-  apiUrl: environment.langgraphUrl,
-})
+```json title="langgraph.json"
+{
+  "dependencies": ["."],
+  "graphs": {
+    "chat_agent": "./agent/graph.py:graph"
+  },
+  "env": ".env"
+}
 ```
 
-```typescript
-// environment.prod.ts
+The `graphs` key maps an assistant ID (used by `streamResource()` on the Angular side) to the Python module path and graph variable. The `env` key points to a file with secrets like `OPENAI_API_KEY` that will be injected at runtime.
+
+### Agent entry point
+
+```python title="agent/graph.py"
+from langchain_openai import ChatOpenAI
+from langgraph.graph import StateGraph, MessagesState
+
+llm = ChatOpenAI(model="gpt-5-mini")
+
+def call_model(state: MessagesState):
+    return {"messages": [llm.invoke(state["messages"])]}
+
+graph = StateGraph(MessagesState)
+graph.add_node("model", call_model)
+graph.set_entry_point("model")
+graph = graph.compile()
+```
+
+### Push and deploy
+
+```bash
+# Initialize and push to GitHub
+git init && git add . && git commit -m "initial agent"
+gh repo create my-agent --public --source=. --push
+
+# Deploy via CLI (alternative to the LangSmith UI)
+pip install langgraph-cli
+langgraph deploy --project my-agent
+```
+
+The CLI watches your repository and builds a container image on LangGraph Cloud. First deployments take roughly 10-15 minutes. Subsequent pushes to the default branch trigger automatic redeployments.
+
+## LangSmith deployment walkthrough
+
+The LangSmith UI provides a visual deployment flow if you prefer not to use the CLI.
+
+<Steps>
+<Step title="Open LangSmith Deployments">
+
+Navigate to [smith.langchain.com](https://smith.langchain.com) and click **Deployments** in the left sidebar, then **+ New Deployment**.
+
+</Step>
+<Step title="Connect your GitHub repository">
+
+Authorize LangSmith to access your GitHub account. Select the repository containing your `langgraph.json`. LangSmith auto-detects the manifest and shows the graphs it found.
+
+</Step>
+<Step title="Configure environment variables">
+
+Add secrets like `OPENAI_API_KEY` in the deployment settings. These are encrypted at rest and injected into your container at runtime. You can also set `LANGCHAIN_TRACING_V2=true` here to enable automatic tracing.
+
+</Step>
+<Step title="Deploy and copy the URL">
+
+Click **Deploy**. Once the build succeeds, you will see a deployment URL like `https://my-agent-abc123.langgraph.app`. Copy this URL for your Angular environment configuration.
+
+</Step>
+</Steps>
+
+## Angular: environment configuration
+
+Angular uses file-based environment replacement at build time rather than `process.env`. Create separate environment files for development and production.
+
+<Tabs>
+<Tab label="Development">
+
+```typescript title="src/environments/environment.ts"
 export const environment = {
-  langgraphUrl: 'https://your-project.langgraph.app',
+  production: false,
+  langgraphUrl: 'http://localhost:2024',
+  langsmithApiKey: '', // not needed locally
 };
 ```
 
 </Tab>
-<Tab label="Direct URL">
+<Tab label="Production">
 
-```typescript
-// app.config.ts
-provideStreamResource({
-  apiUrl: 'https://your-project.langgraph.app',
-})
+```typescript title="src/environments/environment.prod.ts"
+export const environment = {
+  production: true,
+  langgraphUrl: 'https://my-agent-abc123.langgraph.app',
+  langsmithApiKey: 'lsv2_pt_xxxxxxxx',
+};
 ```
 
 </Tab>
 </Tabs>
 
-## Error boundaries
+Wire the environment into `provideStreamResource()`:
 
-Handle errors gracefully in production.
+```typescript title="app.config.ts"
+import { provideStreamResource } from '@cacheplane/stream-resource';
+import { environment } from '../environments/environment';
 
-```typescript
-const chat = streamResource<ChatState>({
-  assistantId: 'chat_agent',
-});
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideStreamResource({
+      apiUrl: environment.langgraphUrl,
+    }),
+  ],
+};
+```
 
-// Reactive error display
-hasError = computed(() => chat.status() === 'error');
-errorMessage = computed(() => {
-  const err = chat.error();
-  return err instanceof Error ? err.message : 'Something went wrong';
-});
+Angular CLI replaces `environment.ts` with `environment.prod.ts` during `ng build --configuration production` automatically via the `fileReplacements` array in `angular.json`.
 
-// Retry after error
-retry() {
-  chat.reload();
+## Authentication
+
+### API key for LangGraph Platform
+
+LangGraph Cloud deployments require an API key on every request. The recommended approach is an Angular HTTP interceptor that attaches the key as a header.
+
+```typescript title="auth.interceptor.ts"
+import { HttpInterceptorFn } from '@angular/common/http';
+import { environment } from '../environments/environment';
+
+export const langGraphAuthInterceptor: HttpInterceptorFn = (req, next) => {
+  if (req.url.startsWith(environment.langgraphUrl)) {
+    const cloned = req.clone({
+      setHeaders: {
+        'x-api-key': environment.langsmithApiKey,
+      },
+    });
+    return next(cloned);
+  }
+  return next(req);
+};
+```
+
+Register the interceptor in your application config:
+
+```typescript title="app.config.ts"
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
+import { langGraphAuthInterceptor } from './auth.interceptor';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideHttpClient(withInterceptors([langGraphAuthInterceptor])),
+    provideStreamResource({
+      apiUrl: environment.langgraphUrl,
+    }),
+  ],
+};
+```
+
+<Callout type="warn" title="Never commit API keys">
+Add `environment.prod.ts` to `.gitignore`. In CI, generate it from environment variables or inject secrets at build time.
+</Callout>
+
+### User-level authentication
+
+If your app has its own user authentication (JWT, session cookies), you can add a second interceptor or extend the one above to forward identity headers that your agent can use for per-user scoping.
+
+## CORS configuration
+
+When your Angular frontend and LangGraph backend are on different origins, you must configure CORS on the LangGraph side.
+
+In `langgraph.json`, add an `http` section:
+
+```json title="langgraph.json"
+{
+  "dependencies": ["."],
+  "graphs": {
+    "chat_agent": "./agent/graph.py:graph"
+  },
+  "http": {
+    "cors": {
+      "allow_origins": ["https://your-angular-app.com"],
+      "allow_methods": ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+      "allow_headers": ["Content-Type", "x-api-key", "Authorization"],
+      "allow_credentials": true
+    }
+  }
 }
 ```
 
-## Recovering interrupted streams
-
-Use `joinStream()` to reconnect to a running stream after a network interruption.
-
-```typescript
-// If you know the run ID (e.g., from a status endpoint)
-await chat.joinStream(runId, lastEventId);
-// Resumes streaming from where it left off
-```
-
-<Callout type="tip" title="Stateless client pattern">
-streamResource() is a stateless client. All state lives on the LangGraph Platform. This means your Angular app can be deployed anywhere (CDN, edge, SSR) without state management concerns.
+<Callout type="tip" title="Local development">
+During local development with `langgraph dev`, CORS is permissive by default. You only need explicit CORS configuration for production deployments.
 </Callout>
 
-## Checklist
+## Error boundaries
+
+Production apps need graceful error handling. Build a reactive error boundary using `streamResource()` signals.
+
+```typescript title="chat.component.ts"
+import { ChangeDetectionStrategy, Component, computed } from '@angular/core';
+import { streamResource } from '@cacheplane/stream-resource';
+
+@Component({
+  selector: 'app-chat',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    @if (hasError()) {
+      <div class="error-banner">
+        <p>{{ errorMessage() }}</p>
+        <button (click)="retry()">Try again</button>
+      </div>
+    }
+  `,
+})
+export class ChatComponent {
+  chat = streamResource<MessagesState>({
+    assistantId: 'chat_agent',
+  });
+
+  hasError = computed(() => this.chat.status() === 'error');
+
+  errorMessage = computed(() => {
+    const err = this.chat.error();
+    if (err instanceof HttpErrorResponse) {
+      switch (err.status) {
+        case 401: return 'Authentication failed. Please check your API key.';
+        case 429: return 'Rate limit exceeded. Please wait a moment.';
+        case 503: return 'Agent is starting up. Please try again shortly.';
+        default:  return 'Something went wrong. Please try again.';
+      }
+    }
+    return err instanceof Error ? err.message : 'An unexpected error occurred.';
+  });
+
+  retry(): void {
+    this.chat.reload();
+  }
+}
+```
+
+### Retry with exponential backoff
+
+For automated retries (network blips, transient 5xx errors), wrap `.submit()` with a backoff utility:
+
+```typescript title="retry-submit.ts"
+export async function retrySubmit(
+  chat: ReturnType<typeof streamResource>,
+  input: Record<string, unknown>,
+  maxAttempts = 3,
+): Promise<void> {
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      chat.submit(input);
+      return;
+    } catch {
+      if (attempt === maxAttempts - 1) throw new Error('Max retries exceeded');
+      await new Promise(r => setTimeout(r, 1000 * 2 ** attempt));
+    }
+  }
+}
+```
+
+## Stream recovery
+
+Use `joinStream()` to reconnect to a running agent execution after a network interruption, page refresh, or navigation event.
+
+```typescript
+// Store the run ID when starting a stream
+const runId = this.chat.runId();
+localStorage.setItem('activeRunId', runId);
+
+// After reconnecting, resume from where the stream left off
+const savedRunId = localStorage.getItem('activeRunId');
+if (savedRunId) {
+  await this.chat.joinStream(savedRunId, lastEventId);
+}
+```
+
+`joinStream()` replays any events the client missed, then switches to live streaming. This works because all state lives on the LangGraph Platform, and the SSE endpoint supports event ID-based resumption.
+
+<Callout type="tip" title="Stateless client pattern">
+`streamResource()` is a stateless client. All state lives on the LangGraph Platform. This means your Angular app can be deployed anywhere (CDN, edge, SSR) without state management concerns. Scale your frontend independently of your agent infrastructure.
+</Callout>
+
+## CI/CD pipeline
+
+A typical pipeline deploys the Python agent and Angular frontend in parallel since they are independent artifacts.
+
+```yaml title=".github/workflows/deploy.yml"
+name: Deploy
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy-agent:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install langgraph-cli
+      - run: langgraph deploy --project my-agent
+        env:
+          LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
+
+  deploy-angular:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - run: npm ci
+      - name: Generate production environment
+        run: |
+          cat > src/environments/environment.prod.ts << 'EOF'
+          export const environment = {
+            production: true,
+            langgraphUrl: '${{ secrets.LANGGRAPH_URL }}',
+            langsmithApiKey: '${{ secrets.LANGSMITH_API_KEY }}',
+          };
+          EOF
+      - run: npx ng build --configuration production
+      - name: Deploy to hosting
+        run: |
+          # Replace with your hosting provider's CLI
+          # e.g., npx vercel deploy --prod dist/my-app/browser
+          echo "Deploy dist/ to your hosting platform"
+```
+
+## Monitoring
+
+### LangSmith observability
+
+When `LANGCHAIN_TRACING_V2=true` is set in your agent environment, every run is automatically traced in LangSmith. No code changes are needed.
+
+Key metrics to track in production:
+
+| Metric | Where to find it | Why it matters |
+|--------|-------------------|----------------|
+| End-to-end latency | LangSmith Runs tab | Directly affects user-perceived responsiveness |
+| Error rate | LangSmith Runs tab, filter by error | Spike detection for broken tools or provider outages |
+| Token usage | LangSmith per-run detail | Cost control and budget alerting |
+| Time to first token | Angular performance monitoring | Stream startup latency visible to users |
+| Thread count | LangGraph Platform dashboard | Capacity planning |
+
+### Client-side monitoring
+
+Track stream health from your Angular app:
+
+```typescript
+const status = this.chat.status(); // 'idle' | 'streaming' | 'error'
+const isStreaming = this.chat.isStreaming();
+
+// Log stream lifecycle for your APM tool
+effect(() => {
+  const s = this.chat.status();
+  if (s === 'error') {
+    this.analytics.trackError('stream_error', this.chat.error());
+  }
+});
+```
+
+## Deployment checklist
 
 <Steps>
 <Step title="Set production apiUrl">
-Point to your LangGraph Cloud deployment URL.
+Point `provideStreamResource({ apiUrl })` to your LangGraph Cloud deployment URL via `environment.prod.ts`.
 </Step>
-<Step title="Handle errors">
-Show user-friendly error messages and retry buttons.
+<Step title="Configure authentication">
+Add an HTTP interceptor to attach `x-api-key` headers to all LangGraph requests.
+</Step>
+<Step title="Set up CORS">
+Add your Angular app's origin to the `allow_origins` list in `langgraph.json`.
+</Step>
+<Step title="Handle errors gracefully">
+Show user-friendly error messages for 401, 429, 503, and network failures. Provide retry buttons.
+</Step>
+<Step title="Implement stream recovery">
+Store `runId` and use `joinStream()` to reconnect after network interruptions.
 </Step>
 <Step title="Persist thread IDs">
-Store threadId in localStorage or a backend so users can resume conversations.
+Store `threadId` in `localStorage` or a backend so users can resume conversations across sessions.
 </Step>
 <Step title="Configure throttle">
-Set `throttle` option if token-by-token updates are too frequent for your UI.
+Set the `throttle` option if token-by-token updates are too frequent for your UI rendering.
+</Step>
+<Step title="Enable LangSmith tracing">
+Set `LANGCHAIN_TRACING_V2=true` in your agent environment for production observability.
+</Step>
+<Step title="Secure environment files">
+Add `environment.prod.ts` to `.gitignore`. Generate it from CI secrets at build time.
+</Step>
+<Step title="Set up CI/CD">
+Automate agent and Angular deployments on push to your main branch.
+</Step>
+<Step title="Verify monitoring">
+Confirm LangSmith traces are arriving and set up alerts for error rate spikes and latency regressions.
 </Step>
 </Steps>
 
@@ -93,15 +409,21 @@ Set `throttle` option if token-by-token updates are too frequent for your UI.
 
 <CardGroup cols={2}>
   <Card title="Testing" href="/docs/guides/testing">
-    Test agent interactions deterministically before deploying.
+    Test agent interactions deterministically before deploying to production.
   </Card>
   <Card title="Persistence" href="/docs/guides/persistence">
     Store thread IDs so users can resume conversations across sessions.
   </Card>
   <Card title="Streaming" href="/docs/guides/streaming">
-    Tune streaming options like throttle for production performance.
+    Tune streaming options like throttle and stream modes for production performance.
+  </Card>
+  <Card title="LangGraph Basics" href="/docs/concepts/langgraph-basics">
+    Understand the agent patterns your deployment will serve.
   </Card>
   <Card title="API Reference" href="/docs/api/provide-stream-resource">
     Full reference for provideStreamResource configuration options.
+  </Card>
+  <Card title="Error Handling" href="/docs/guides/error-handling">
+    Deep dive into error recovery patterns beyond basic error boundaries.
   </Card>
 </CardGroup>

--- a/apps/website/content/docs-v2/guides/interrupts.mdx
+++ b/apps/website/content/docs-v2/guides/interrupts.mdx
@@ -1,46 +1,445 @@
 # Interrupts
 
-Interrupts let your LangGraph agent pause execution and wait for human input. streamResource() surfaces interrupts as Angular Signals, making it easy to build approval flows, confirmation dialogs, and human-in-the-loop experiences.
+Interrupts let your LangGraph agent pause mid-execution and hand control to a human. The agent proposes an action, the graph freezes, your Angular UI shows an approval dialog, the user decides, and the agent resumes with the human's decision. streamResource() surfaces interrupts as Angular Signals, so building approval flows, confirmation dialogs, and multi-step review experiences requires no manual event wiring.
 
 <Callout type="info" title="When to use interrupts">
-Use interrupts for human approval, late-binding decisions, or any step where the agent needs external input before continuing.
+Use interrupts when an agent action is irreversible (sending an email, placing an order, deleting data), when the agent needs a human decision it cannot make on its own, or when compliance requires explicit approval before execution.
 </Callout>
 
-## Basic interrupt handling
+## The Interrupt Lifecycle
 
-When an agent interrupts, the `interrupt()` signal contains the interrupt data.
+Before diving into code, understand the five-stage lifecycle that every interrupt follows:
+
+<Steps>
+<Step title="Agent Plans">
+The agent reasons about the user's request and determines an action that requires human approval. It builds a structured payload describing what it wants to do.
+</Step>
+<Step title="Interrupt Fires">
+The agent node calls `raise Interrupt(value={...})`, which freezes the graph. The interrupt payload is persisted in the checkpoint and streamed to the client.
+</Step>
+<Step title="UI Shows Dialog">
+streamResource() updates the `interrupt()` signal. Your Angular template detects the change through OnPush change detection and renders an approval dialog with the interrupt payload.
+</Step>
+<Step title="User Decides">
+The user reviews the proposed action and clicks Approve or Reject. Your component calls `agent.submit()` with a resume payload containing the decision.
+</Step>
+<Step title="Agent Resumes">
+LangGraph resumes the graph from the interrupted checkpoint. The next node receives the human's decision and either executes or aborts the action.
+</Step>
+</Steps>
+
+## Python: Raising an Interrupt
+
+An interrupt is raised inside any graph node by calling `raise Interrupt(value={...})`. The value can be any JSON-serializable object — it becomes the payload your Angular component displays.
 
 <Tabs>
-<Tab label="TypeScript">
+<Tab label="agent.py">
 
-```typescript
-// approval.component.ts
-interface ApprovalPayload {
-  action: string;
-  description: string;
-  risk: 'low' | 'medium' | 'high';
-}
+```python
+from langgraph.graph import END, START, StateGraph
+from langgraph.types import Interrupt, Command
+from langchain_openai import ChatOpenAI
+from typing_extensions import TypedDict, Annotated
+from operator import add
 
-const agent = streamResource<AgentState>({
-  assistantId: 'approval_agent',
-});
+llm = ChatOpenAI(model="gpt-5-mini")
 
-// Check for pending interrupts
-pendingApproval = computed(() => agent.interrupt());
+class State(TypedDict):
+    messages: Annotated[list, add]
+    proposed_action: dict
+    approval_result: dict
+
+def plan_action(state: State) -> dict:
+    """Agent analyzes the request and proposes an action."""
+    response = llm.invoke([
+        {"role": "system", "content": (
+            "Analyze the user's request. If it requires sending "
+            "an email, modifying data, or any irreversible action, "
+            "return a JSON action plan with keys: action, target, "
+            "description, risk_level."
+        )},
+        *state["messages"]
+    ])
+    action = parse_json(response.content)
+    return {
+        "proposed_action": action,
+        "messages": [response],
+    }
+
+def request_approval(state: State) -> dict:
+    """Pause the graph and ask the human for approval."""
+    action = state["proposed_action"]
+    raise Interrupt(value={
+        "action": action["action"],
+        "target": action["target"],
+        "description": action["description"],
+        "risk_level": action.get("risk_level", "medium"),
+    })
+
+def execute_action(state: State) -> dict:
+    """Run the approved action or explain the rejection."""
+    result = state.get("approval_result", {})
+    if result.get("approved"):
+        # Execute the real action
+        outcome = perform_action(state["proposed_action"])
+        return {
+            "messages": [{"role": "assistant", "content": (
+                f"Done. {outcome}"
+            )}]
+        }
+    else:
+        reason = result.get("reason", "No reason given")
+        return {
+            "messages": [{"role": "assistant", "content": (
+                f"Action cancelled. Reason: {reason}"
+            )}]
+        }
+
+# Build the graph: plan → approve → execute
+builder = StateGraph(State)
+builder.add_node("plan", plan_action)
+builder.add_node("approve", request_approval)
+builder.add_node("execute", execute_action)
+builder.add_edge(START, "plan")
+builder.add_edge("plan", "approve")
+builder.add_edge("approve", "execute")
+builder.add_edge("execute", END)
+
+graph = builder.compile()
 ```
 
 </Tab>
-<Tab label="Template">
+<Tab label="langgraph.json">
+
+```json
+{
+  "dependencies": ["."],
+  "graphs": {
+    "approval_agent": "./src/approval_agent/agent.py:graph"
+  },
+  "env": ".env",
+  "python_version": "3.12"
+}
+```
+
+</Tab>
+</Tabs>
+
+<Callout type="tip" title="Interrupt placement matters">
+Place the `raise Interrupt()` call in its own dedicated node. This gives you a clean three-node pattern (plan, approve, execute) where the interrupt sits between reasoning and action. If you raise an interrupt inside a node that also does work, the work before the interrupt runs twice on resume.
+</Callout>
+
+## Angular: Building an Approval Component
+
+When the agent raises an interrupt, streamResource() populates the `interrupt()` signal with the interrupt payload. Your component reads this signal to render a dialog and calls `submit()` to resume.
+
+<Tabs>
+<Tab label="approval.component.ts">
+
+```typescript
+import {
+  Component,
+  computed,
+  signal,
+  ChangeDetectionStrategy,
+} from '@angular/core';
+import { streamResource, BaseMessage } from '@cacheplane/stream-resource';
+
+interface ApprovalPayload {
+  action: string;
+  target: string;
+  description: string;
+  risk_level: 'low' | 'medium' | 'high';
+}
+
+interface AgentState {
+  messages: BaseMessage[];
+  proposed_action: ApprovalPayload;
+  approval_result: { approved: boolean; reason?: string };
+}
+
+@Component({
+  selector: 'app-approval',
+  templateUrl: './approval.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ApprovalComponent {
+  agent = streamResource<AgentState>({
+    assistantId: 'approval_agent',
+  });
+
+  messages = computed(() => this.agent.messages());
+  pendingApproval = computed(() => this.agent.interrupt());
+  isLoading = computed(() => this.agent.isLoading());
+
+  rejectionReason = signal('');
+
+  riskClass = computed(() => {
+    const interrupt = this.pendingApproval();
+    if (!interrupt) return '';
+    const level = interrupt.value?.risk_level ?? 'medium';
+    return `risk-${level}`;
+  });
+
+  send(input: string) {
+    this.agent.submit({
+      messages: [{ role: 'user', content: input }],
+    });
+  }
+
+  approve() {
+    this.agent.submit(null, {
+      resume: { approved: true },
+    });
+  }
+
+  reject() {
+    this.agent.submit(null, {
+      resume: {
+        approved: false,
+        reason: this.rejectionReason() || 'User rejected',
+      },
+    });
+    this.rejectionReason.set('');
+  }
+}
+```
+
+</Tab>
+<Tab label="template">
 
 ```html
-<!-- Show approval dialog when agent interrupts -->
+<!-- Chat messages -->
+<section class="chat">
+  @for (msg of messages(); track msg) {
+    <div [class]="msg.role">{{ msg.content }}</div>
+  }
+
+  @if (isLoading()) {
+    <div class="typing-indicator">Agent is working...</div>
+  }
+</section>
+
+<!-- Approval dialog — appears when agent interrupts -->
 @if (pendingApproval(); as approval) {
-  <div class="approval-dialog">
-    <h3>Agent needs approval</h3>
-    <p>{{ approval.value.description }}</p>
-    <p>Risk level: {{ approval.value.risk }}</p>
-    <button (click)="approve()">Approve</button>
-    <button (click)="reject()">Reject</button>
+  <div class="approval-dialog" [class]="riskClass()">
+    <h3>Agent Needs Approval</h3>
+
+    <dl class="action-details">
+      <dt>Action</dt>
+      <dd>{{ approval.value.action }}</dd>
+
+      <dt>Target</dt>
+      <dd>{{ approval.value.target }}</dd>
+
+      <dt>Description</dt>
+      <dd>{{ approval.value.description }}</dd>
+
+      <dt>Risk Level</dt>
+      <dd>
+        <span class="risk-badge" [class]="'risk-' + approval.value.risk_level">
+          {{ approval.value.risk_level | titlecase }}
+        </span>
+      </dd>
+    </dl>
+
+    <div class="rejection-input">
+      <label for="reason">Rejection reason (optional)</label>
+      <input
+        id="reason"
+        [value]="rejectionReason()"
+        (input)="rejectionReason.set($event.target.value)"
+        placeholder="Why are you rejecting this action?"
+      />
+    </div>
+
+    <div class="actions">
+      <button class="btn-approve" (click)="approve()">
+        Approve
+      </button>
+      <button class="btn-reject" (click)="reject()">
+        Reject
+      </button>
+    </div>
+  </div>
+}
+
+<!-- Input form -->
+@if (!pendingApproval()) {
+  <form (ngSubmit)="send(input.value); input.value = ''">
+    <input #input placeholder="Ask the agent to do something..." />
+    <button type="submit" [disabled]="isLoading()">Send</button>
+  </form>
+}
+```
+
+</Tab>
+</Tabs>
+
+## Multi-Step Approval Pattern
+
+Some workflows require multiple approvals in sequence. For example, an agent that plans a multi-step deployment might need approval at each stage. Each node in the graph can raise its own interrupt.
+
+<Tabs>
+<Tab label="agent.py">
+
+```python
+from langgraph.graph import END, START, StateGraph
+from langgraph.types import Interrupt
+from typing_extensions import TypedDict, Annotated
+from operator import add
+
+class DeployState(TypedDict):
+    messages: Annotated[list, add]
+    plan: list[dict]
+    current_step: int
+    completed_steps: list[str]
+
+def create_plan(state: DeployState) -> dict:
+    """Generate a multi-step deployment plan."""
+    plan = [
+        {"step": "backup", "description": "Back up current database"},
+        {"step": "migrate", "description": "Run schema migrations"},
+        {"step": "deploy", "description": "Deploy new application version"},
+    ]
+    return {"plan": plan, "current_step": 0}
+
+def approve_step(state: DeployState) -> dict:
+    """Interrupt for each step that needs approval."""
+    step_index = state["current_step"]
+    step = state["plan"][step_index]
+    raise Interrupt(value={
+        "step_number": step_index + 1,
+        "total_steps": len(state["plan"]),
+        "step": step["step"],
+        "description": step["description"],
+        "completed": state.get("completed_steps", []),
+    })
+
+def execute_step(state: DeployState) -> dict:
+    """Execute the approved step and advance."""
+    step = state["plan"][state["current_step"]]
+    # ... perform the actual deployment step ...
+    return {
+        "completed_steps": [step["step"]],
+        "current_step": state["current_step"] + 1,
+        "messages": [{"role": "assistant", "content": (
+            f"Completed: {step['description']}"
+        )}],
+    }
+
+def should_continue(state: DeployState) -> str:
+    if state["current_step"] < len(state["plan"]):
+        return "approve_step"
+    return END
+
+builder = StateGraph(DeployState)
+builder.add_node("create_plan", create_plan)
+builder.add_node("approve_step", approve_step)
+builder.add_node("execute_step", execute_step)
+builder.add_edge(START, "create_plan")
+builder.add_edge("create_plan", "approve_step")
+builder.add_edge("approve_step", "execute_step")
+builder.add_conditional_edges("execute_step", should_continue)
+
+graph = builder.compile()
+```
+
+</Tab>
+<Tab label="approval.component.ts">
+
+```typescript
+import {
+  Component,
+  computed,
+  ChangeDetectionStrategy,
+} from '@angular/core';
+import { streamResource, BaseMessage } from '@cacheplane/stream-resource';
+
+interface StepApproval {
+  step_number: number;
+  total_steps: number;
+  step: string;
+  description: string;
+  completed: string[];
+}
+
+@Component({
+  selector: 'app-deploy-approval',
+  templateUrl: './approval.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DeployApprovalComponent {
+  agent = streamResource<{
+    messages: BaseMessage[];
+    plan: { step: string; description: string }[];
+    current_step: number;
+    completed_steps: string[];
+  }>({
+    assistantId: 'deploy_agent',
+  });
+
+  currentStep = computed(() => {
+    const interrupt = this.agent.interrupt();
+    return interrupt?.value as StepApproval | null;
+  });
+
+  progress = computed(() => {
+    const step = this.currentStep();
+    if (!step) return 0;
+    return (step.completed.length / step.total_steps) * 100;
+  });
+
+  allInterrupts = computed(() => this.agent.interrupts());
+
+  approveStep() {
+    this.agent.submit(null, { resume: { approved: true } });
+  }
+
+  abortDeploy() {
+    this.agent.submit(null, {
+      resume: { approved: false, reason: 'Deployment aborted by user' },
+    });
+  }
+}
+```
+
+</Tab>
+<Tab label="template">
+
+```html
+@if (currentStep(); as step) {
+  <div class="deploy-approval">
+    <h3>Step {{ step.step_number }} of {{ step.total_steps }}</h3>
+
+    <!-- Progress bar -->
+    <div class="progress-bar">
+      <div class="fill" [style.width.%]="progress()"></div>
+    </div>
+
+    <!-- Completed steps -->
+    @if (step.completed.length) {
+      <ul class="completed">
+        @for (done of step.completed; track done) {
+          <li class="done">{{ done }}</li>
+        }
+      </ul>
+    }
+
+    <!-- Current step details -->
+    <div class="current-step">
+      <strong>{{ step.step }}</strong>
+      <p>{{ step.description }}</p>
+    </div>
+
+    <div class="actions">
+      <button class="btn-approve" (click)="approveStep()">
+        Approve Step {{ step.step_number }}
+      </button>
+      <button class="btn-abort" (click)="abortDeploy()">
+        Abort Deployment
+      </button>
+    </div>
   </div>
 }
 ```
@@ -48,48 +447,115 @@ pendingApproval = computed(() => agent.interrupt());
 </Tab>
 </Tabs>
 
-## Resuming from an interrupt
+## Typed Interrupt Payloads with BagTemplate
 
-Call `submit()` with the resume payload to continue execution.
+By default, `interrupt()` returns an untyped object. The BagTemplate generic parameter on streamResource() lets you define the exact shape of your interrupt payloads, giving you full TypeScript safety throughout your component.
 
-```typescript
-approve() {
-  this.agent.submit(null, { resume: { approved: true } });
-}
-
-reject() {
-  this.agent.submit(null, { resume: { approved: false, reason: 'User rejected' } });
-}
-```
-
-## Multiple interrupts
-
-The `interrupts()` signal tracks all interrupts received during a run, not just the current one.
+BagTemplate is a type parameter on the streamResource configuration that maps signal names to their types. When you specify an interrupt type through BagTemplate, the `interrupt()` signal returns a properly typed object instead of `unknown`. This means your template expressions, computed signals, and event handlers all benefit from compile-time checking.
 
 ```typescript
-// Track interrupt history
-allInterrupts = computed(() => agent.interrupts());
-latestInterrupt = computed(() => agent.interrupt());
-interruptCount = computed(() => agent.interrupts().length);
+import { streamResource, BagTemplate } from '@cacheplane/stream-resource';
+
+// Define the exact shape of your interrupt payload
+interface DeployApproval {
+  step_number: number;
+  total_steps: number;
+  step: string;
+  description: string;
+  completed: string[];
+}
+
+// Pass the interrupt type via BagTemplate
+const agent = streamResource<
+  DeployState,
+  BagTemplate<{ interrupt: DeployApproval }>
+>({
+  assistantId: 'deploy_agent',
+});
+
+// Now interrupt() is typed — no casting needed
+const step = agent.interrupt();
+//    ^? Signal<{ value: DeployApproval } | null>
+
+// TypeScript catches errors at compile time
+const num = step?.value.step_number;    // number — correct
+const bad = step?.value.nonexistent;    // Error — property doesn't exist
 ```
 
-<Callout type="warning" title="Typed interrupts">
-Use the BagTemplate generic parameter to type your interrupt payloads for full TypeScript safety.
+<Callout type="tip" title="Type your interrupts early">
+Define your interrupt payload interfaces alongside your Python state schema. This creates a contract between your agent and your UI. When the Python payload shape changes, the TypeScript interface should change too. Consider generating types from a shared schema to keep them in sync.
+</Callout>
+
+## Timeout Handling
+
+Interrupts pause graph execution indefinitely by default — the agent waits until a human responds. In production, you often need to handle cases where no one responds within a reasonable time. There are two strategies for managing interrupt timeouts.
+
+**Server-side timeout with a background task:** Schedule a background job that checks for stale interrupts and resumes them with a default decision.
+
+```python
+async def check_stale_interrupts():
+    """Periodic task to auto-reject stale interrupts."""
+    threads = await client.threads.search(
+        status="interrupted",
+        metadata={"interrupt_type": "approval"},
+    )
+    for thread in threads:
+        created = thread.updated_at
+        if (now() - created).total_seconds() > 3600:  # 1 hour timeout
+            await client.runs.create(
+                thread["thread_id"],
+                assistant_id="approval_agent",
+                input=None,
+                command={"resume": {
+                    "approved": False,
+                    "reason": "Auto-rejected: approval timeout",
+                }},
+            )
+```
+
+**Client-side timeout in Angular:** Use a timer in your component to auto-reject if the user does not act.
+
+```typescript
+import { effect } from '@angular/core';
+import { timer } from 'rxjs';
+
+// Watch for interrupts and start a timeout
+effect(() => {
+  const interrupt = this.agent.interrupt();
+  if (interrupt) {
+    const sub = timer(5 * 60 * 1000).subscribe(() => {
+      // Auto-reject after 5 minutes of inaction
+      this.agent.submit(null, {
+        resume: { approved: false, reason: 'Approval timeout' },
+      });
+    });
+    // Clean up if user responds before timeout
+    return () => sub.unsubscribe();
+  }
+});
+```
+
+<Callout type="warning" title="Pick one timeout strategy">
+Avoid running both server-side and client-side timeouts simultaneously. If both fire, the second resume call will fail because the graph already moved past the interrupt. Choose server-side timeouts for reliability (works even if the browser closes) or client-side timeouts for immediacy.
+</Callout>
+
+<Callout type="info" title="Checkpoint persistence saves you">
+Because interrupts are checkpointed, the user can close their browser, come back hours later, and still approve or reject the pending action. The graph state is frozen in the checkpoint store, not in browser memory.
 </Callout>
 
 ## What's Next
 
 <CardGroup cols={2}>
+  <Card title="Memory" href="/docs/guides/memory">
+    Give your agent short-term and long-term memory with the Store API.
+  </Card>
   <Card title="Persistence" href="/docs/guides/persistence">
-    Resume conversations across page refreshes with thread persistence.
+    Configure checkpointers that keep interrupt state across deployments.
   </Card>
   <Card title="Streaming" href="/docs/guides/streaming">
-    Stream token-by-token responses and tool progress in real time.
+    Stream token-by-token responses alongside interrupt events.
   </Card>
   <Card title="Testing" href="/docs/guides/testing">
     Script interrupt events deterministically with MockStreamTransport.
-  </Card>
-  <Card title="API Reference" href="/docs/api/stream-resource">
-    Full reference for streamResource options and returned signals.
   </Card>
 </CardGroup>

--- a/apps/website/content/docs-v2/guides/interrupts.mdx
+++ b/apps/website/content/docs-v2/guides/interrupts.mdx
@@ -10,8 +10,8 @@ Use interrupts for human approval, late-binding decisions, or any step where the
 
 When an agent interrupts, the `interrupt()` signal contains the interrupt data.
 
-<Tabs items={['TypeScript', 'Template']}>
-<Tab>
+<Tabs>
+<Tab label="TypeScript">
 
 ```typescript
 // approval.component.ts
@@ -30,7 +30,7 @@ pendingApproval = computed(() => agent.interrupt());
 ```
 
 </Tab>
-<Tab>
+<Tab label="Template">
 
 ```html
 <!-- Show approval dialog when agent interrupts -->

--- a/apps/website/content/docs-v2/guides/memory.mdx
+++ b/apps/website/content/docs-v2/guides/memory.mdx
@@ -1,82 +1,414 @@
 # Memory
 
-Memory in LangGraph preserves useful context that later steps can read back. streamResource() exposes memory through the messages and state signals, with thread persistence providing cross-session continuity.
+Memory gives your LangGraph agent the ability to recall past interactions, user preferences, and learned facts. There are two distinct kinds: short-term memory scoped to a single thread (conversation), and long-term memory that persists across threads using the LangGraph Store API. streamResource() surfaces both through Angular Signals so your components stay reactive without manual state wiring.
 
 <Callout type="info" title="Short-term vs long-term">
-Short-term memory lives within a thread (conversation history). Long-term memory persists across threads via LangGraph's memory store.
+Short-term memory lives within a thread — it is the conversation history plus any custom state fields your agent accumulates during a run. Long-term memory lives in the LangGraph Store and survives across threads, users, and sessions. Think of short-term as "what happened in this conversation" and long-term as "what the agent knows about this user."
 </Callout>
 
-## Short-term memory (thread-scoped)
+## Agent State with Custom Memory Fields
 
-Every message in a thread is automatically preserved. When you reconnect with the same `threadId`, the full conversation history is restored.
+Every LangGraph agent has a state schema. You control what the agent remembers by adding fields to that schema. Messages accumulate automatically, but you can define any additional fields the agent should track.
 
-```typescript
-const chat = streamResource<{ messages: BaseMessage[] }>({
-  assistantId: 'memory_agent',
-  threadId: signal(userId()),  // User-specific thread
-});
+<Tabs>
+<Tab label="agent.py">
 
-// Messages accumulate across the conversation
-const messageCount = computed(() => chat.messages().length);
+```python
+from typing_extensions import TypedDict, Annotated
+from operator import add
+from langgraph.graph import END, START, StateGraph
+from langchain_openai import ChatOpenAI
 
-// Resume where you left off on next visit
-// threadId persists, so history is restored
+llm = ChatOpenAI(model="gpt-5-mini")
+
+class State(TypedDict):
+    messages: Annotated[list, add]
+    user_preferences: dict          # Accumulated user preferences
+    conversation_summary: str       # Rolling summary of past context
+    mentioned_topics: list[str]     # Topics the user has brought up
+
+def call_model(state: State) -> dict:
+    system = "You are a helpful assistant."
+    if state.get("conversation_summary"):
+        system += f"\n\nPrevious context: {state['conversation_summary']}"
+    if state.get("user_preferences"):
+        system += f"\n\nUser preferences: {state['user_preferences']}"
+
+    response = llm.invoke([
+        {"role": "system", "content": system},
+        *state["messages"]
+    ])
+    return {"messages": [response]}
+
+def update_memory(state: State) -> dict:
+    """Extract preferences and topics from the latest exchange."""
+    extraction = llm.invoke([
+        {"role": "system", "content": (
+            "Extract any user preferences and topics from "
+            "this conversation. Return JSON with keys: "
+            "preferences (dict), topics (list[str]), summary (str)."
+        )},
+        *state["messages"][-4:]  # Last two exchanges
+    ])
+    parsed = parse_json(extraction.content)
+    return {
+        "user_preferences": {
+            **state.get("user_preferences", {}),
+            **parsed.get("preferences", {}),
+        },
+        "mentioned_topics": parsed.get("topics", []),
+        "conversation_summary": parsed.get("summary", ""),
+    }
+
+builder = StateGraph(State)
+builder.add_node("model", call_model)
+builder.add_node("update_memory", update_memory)
+builder.add_edge(START, "model")
+builder.add_edge("model", "update_memory")
+builder.add_edge("update_memory", END)
+
+graph = builder.compile()
 ```
 
-## Accessing agent state as memory
-
-The `value()` signal contains the full agent state, which can include custom memory fields.
+</Tab>
+<Tab label="memory.component.ts">
 
 ```typescript
+import { Component, computed, ChangeDetectionStrategy } from '@angular/core';
+import { streamResource, BaseMessage } from '@cacheplane/stream-resource';
+
 interface AgentState {
   messages: BaseMessage[];
-  userPreferences: { theme: string; language: string };
-  projectContext: { name: string; files: string[] };
+  user_preferences: Record<string, string>;
+  conversation_summary: string;
+  mentioned_topics: string[];
 }
 
-const agent = streamResource<AgentState>({
-  assistantId: 'context_agent',
-  threadId: signal(projectId()),
-});
+@Component({
+  selector: 'app-memory-chat',
+  templateUrl: './memory.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class MemoryChatComponent {
+  agent = streamResource<AgentState>({
+    assistantId: 'memory_agent',
+    threadId: signal(localStorage.getItem('memory-thread')),
+    onThreadId: (id) => localStorage.setItem('memory-thread', id),
+  });
 
-// Read memory fields from agent state
-const prefs = computed(() => agent.value().userPreferences);
-const context = computed(() => agent.value().projectContext);
+  // Reactive memory signals derived from agent state
+  preferences = computed(() => this.agent.value()?.user_preferences ?? {});
+  summary = computed(() => this.agent.value()?.conversation_summary ?? '');
+  topics = computed(() => this.agent.value()?.mentioned_topics ?? []);
+  messages = computed(() => this.agent.messages());
+
+  send(input: string) {
+    this.agent.submit({
+      messages: [{ role: 'user', content: input }],
+    });
+  }
+}
 ```
 
-## Cross-session memory
+</Tab>
+<Tab label="template">
 
-Thread persistence enables memory that spans sessions. The agent decides what to store in its state.
+```html
+<section class="chat">
+  @for (msg of messages(); track msg) {
+    <div [class]="msg.role">{{ msg.content }}</div>
+  }
+
+  @if (agent.isLoading()) {
+    <div class="typing-indicator">Agent is thinking...</div>
+  }
+</section>
+
+<!-- Memory sidebar -->
+<aside class="memory-panel">
+  @if (summary()) {
+    <h4>Context Summary</h4>
+    <p>{{ summary() }}</p>
+  }
+
+  @if (topics().length) {
+    <h4>Topics Discussed</h4>
+    <ul>
+      @for (topic of topics(); track topic) {
+        <li>{{ topic }}</li>
+      }
+    </ul>
+  }
+
+  @if (preferences() | keyvalue; as prefs) {
+    <h4>Learned Preferences</h4>
+    <dl>
+      @for (pref of prefs; track pref.key) {
+        <dt>{{ pref.key }}</dt>
+        <dd>{{ pref.value }}</dd>
+      }
+    </dl>
+  }
+</aside>
+```
+
+</Tab>
+</Tabs>
+
+<Callout type="tip" title="Node return values merge, not replace">
+When `update_memory` returns `user_preferences`, the dict is merged into the existing state. For list fields using the `Annotated[list, add]` reducer, new items are appended. Design your state schema with these merge semantics in mind.
+</Callout>
+
+## Short-Term Memory (Thread-Scoped)
+
+Short-term memory is the simplest form: the conversation history and any accumulated state fields within a single thread. Every message, tool call, and state update is automatically checkpointed. When a user reconnects with the same `threadId`, the full history is restored.
+
+```python
+from langgraph.checkpoint.postgres import PostgresSaver
+
+checkpointer = PostgresSaver.from_connection_string(DATABASE_URL)
+graph = builder.compile(checkpointer=checkpointer)
+
+# Every invocation within the same thread accumulates state
+result = graph.invoke(
+    {"messages": [{"role": "user", "content": "I prefer dark mode"}]},
+    config={"configurable": {"thread_id": "user_42_session"}}
+)
+
+# Later invocation — same thread, memory intact
+result = graph.invoke(
+    {"messages": [{"role": "user", "content": "What theme do I like?"}]},
+    config={"configurable": {"thread_id": "user_42_session"}}
+)
+# Agent responds: "You mentioned you prefer dark mode."
+```
+
+On the Angular side, thread-scoped memory requires no extra code. The `threadId` signal handles it:
 
 ```typescript
-// User returns days later — same threadId resumes context
-const agent = streamResource<AgentState>({
+const chat = streamResource<AgentState>({
   assistantId: 'memory_agent',
-  threadId: signal(localStorage.getItem('agent-thread')),
-  onThreadId: (id) => localStorage.setItem('agent-thread', id),
+  threadId: signal(userId()),  // Same user = same thread = same memory
 });
 
-// Agent recalls past decisions, preferences, and context
-// No explicit memory management needed on the Angular side
+// chat.messages() restores full history on reconnect
+// chat.value() restores all custom state fields
 ```
 
-<Callout type="tip" title="Memory is server-side">
-The agent controls what gets stored in memory. streamResource() just surfaces the current state. Design your agent's state schema to include the fields you want to persist.
+## Long-Term Memory (Cross-Thread) with the Store API
+
+Short-term memory disappears when you start a new thread. For knowledge that should persist across conversations — user preferences, learned facts, project context — use the LangGraph Store API. The Store is a key-value layer that any node can read from and write to, independent of the current thread.
+
+<Tabs>
+<Tab label="agent.py">
+
+```python
+from langgraph.graph import END, START, StateGraph, MessagesState
+from langgraph.store.base import BaseStore
+from langchain_openai import ChatOpenAI
+
+llm = ChatOpenAI(model="gpt-5-mini")
+
+def recall_memories(state: MessagesState, *, store: BaseStore, config) -> dict:
+    """Load long-term memories for this user before responding."""
+    user_id = config["configurable"]["user_id"]
+
+    # Fetch all memories in this user's namespace
+    memories = store.search(("memories", user_id))
+    memory_text = "\n".join(
+        f"- {m.value['content']}" for m in memories
+    )
+
+    system = (
+        "You are a helpful assistant with long-term memory.\n\n"
+        f"What you remember about this user:\n{memory_text}"
+    )
+    response = llm.invoke([
+        {"role": "system", "content": system},
+        *state["messages"]
+    ])
+    return {"messages": [response]}
+
+def save_memories(state: MessagesState, *, store: BaseStore, config) -> dict:
+    """Extract and persist new facts to the Store."""
+    user_id = config["configurable"]["user_id"]
+
+    extraction = llm.invoke([
+        {"role": "system", "content": (
+            "Extract new facts about the user from the latest "
+            "exchange. Return a JSON list of strings. "
+            "Return [] if nothing new."
+        )},
+        *state["messages"][-4:]
+    ])
+    facts = parse_json(extraction.content)
+
+    for fact in facts:
+        store.put(
+            ("memories", user_id),
+            key=str(uuid4()),
+            value={"content": fact},
+        )
+
+    return {}
+
+builder = StateGraph(MessagesState)
+builder.add_node("recall", recall_memories)
+builder.add_node("save", save_memories)
+builder.add_edge(START, "recall")
+builder.add_edge("recall", "save")
+builder.add_edge("save", END)
+
+graph = builder.compile()
+```
+
+</Tab>
+<Tab label="memory.component.ts">
+
+```typescript
+import { Component, computed, signal, ChangeDetectionStrategy } from '@angular/core';
+import { streamResource, BaseMessage } from '@cacheplane/stream-resource';
+
+@Component({
+  selector: 'app-longterm-chat',
+  templateUrl: './memory.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class LongTermChatComponent {
+  // Each conversation gets a new thread, but the agent
+  // remembers the user across all of them via the Store.
+  agent = streamResource<{ messages: BaseMessage[] }>({
+    assistantId: 'memory_agent',
+    config: { configurable: { user_id: 'user_42' } },
+  });
+
+  messages = computed(() => this.agent.messages());
+
+  send(input: string) {
+    this.agent.submit({
+      messages: [{ role: 'user', content: input }],
+    });
+  }
+}
+```
+
+</Tab>
+<Tab label="template">
+
+```html
+<section class="chat">
+  @for (msg of messages(); track msg) {
+    <div [class]="msg.role">{{ msg.content }}</div>
+  }
+
+  @if (agent.isLoading()) {
+    <div class="typing-indicator">Thinking...</div>
+  }
+
+  <form (ngSubmit)="send(input.value); input.value = ''">
+    <input #input placeholder="Ask me anything..." />
+    <button type="submit">Send</button>
+  </form>
+</section>
+```
+
+</Tab>
+</Tabs>
+
+<Callout type="warning" title="Store vs checkpointer">
+The checkpointer saves thread state (short-term memory). The Store saves cross-thread knowledge (long-term memory). They serve different purposes and you will typically use both. The checkpointer is configured at compile time; the Store is injected into nodes that declare a `store` parameter.
+</Callout>
+
+## Semantic Memory with Vector Search
+
+For agents that accumulate hundreds or thousands of memories, keyword matching is not enough. The Store API supports semantic search with embeddings, so your agent can retrieve the most relevant memories for any given context.
+
+```python
+from langchain_openai import OpenAIEmbeddings
+from langgraph.store.base import BaseStore
+
+def recall_relevant(state: MessagesState, *, store: BaseStore, config) -> dict:
+    """Retrieve memories semantically related to the current question."""
+    user_id = config["configurable"]["user_id"]
+    query = state["messages"][-1].content
+
+    # Vector search — returns memories ranked by cosine similarity
+    results = store.search(
+        ("memories", user_id),
+        query=query,
+        limit=5,
+    )
+
+    memory_text = "\n".join(
+        f"- [{r.score:.2f}] {r.value['content']}" for r in results
+    )
+
+    response = llm.invoke([
+        {"role": "system", "content": (
+            "Relevant memories (similarity score in brackets):\n"
+            f"{memory_text}\n\n"
+            "Use these memories to personalize your response."
+        )},
+        *state["messages"]
+    ])
+    return {"messages": [response]}
+```
+
+The `store.search()` call accepts a `query` string and returns results ranked by vector similarity. You control how many results to retrieve with the `limit` parameter. Each result includes a `score` field (0 to 1) indicating how relevant the memory is to the query.
+
+<Callout type="tip" title="Embedding configuration">
+Semantic search requires an embedding model configured on the Store. LangGraph Platform handles this configuration in `langgraph.json`. When running locally, pass the embeddings provider when constructing your Store instance.
+</Callout>
+
+## Surfacing Memory in Angular with value()
+
+The `value()` signal is the primary way memory surfaces in your Angular components. It contains the full agent state object, including all custom memory fields. Because it is a Signal, your template re-renders automatically through OnPush change detection whenever the agent state changes.
+
+```typescript
+// The value() signal contains everything the agent knows
+const state = agent.value();
+
+// Access specific memory fields
+const prefs = state?.user_preferences;
+const summary = state?.conversation_summary;
+const topics = state?.mentioned_topics;
+
+// Compose derived signals for template binding
+const hasMemory = computed(() => {
+  const val = agent.value();
+  return val?.conversation_summary || val?.mentioned_topics?.length;
+});
+```
+
+For long-term memory stored in the Store, the agent must explicitly include retrieved memories in its response or state output. The Store lives server-side; your Angular app only sees what the agent puts into the thread state.
+
+## Memory Best Practices
+
+<Callout type="tip" title="Design your state schema intentionally">
+Every field in your state schema is persisted by the checkpointer. Only include fields the agent actively uses. Avoid dumping raw LLM outputs into state — extract structured data instead.
+</Callout>
+
+<Callout type="warning" title="Memory is not unlimited">
+Thread state grows with every message and state update. For long-running conversations, consider summarizing older messages into a `conversation_summary` field and trimming the message list. This keeps checkpoints small and LLM context windows manageable.
+</Callout>
+
+<Callout type="info" title="Namespace your Store keys">
+Use hierarchical namespaces like `("memories", user_id)` or `("project", project_id, "notes")` to keep long-term memories organized. This also makes cleanup straightforward — delete an entire namespace when a user requests data removal.
 </Callout>
 
 ## What's Next
 
 <CardGroup cols={2}>
   <Card title="Persistence" href="/docs/guides/persistence">
-    Save thread IDs and resume conversations across sessions.
+    Configure checkpointers and thread storage for production deployments.
   </Card>
   <Card title="Time Travel" href="/docs/guides/time-travel">
     Replay and branch agent runs from any past checkpoint.
   </Card>
-  <Card title="State Management" href="/docs/concepts/state-management">
-    Understand how agent state flows into Angular Signals.
+  <Card title="Interrupts" href="/docs/guides/interrupts">
+    Pause for human input before the agent acts on its memory.
   </Card>
-  <Card title="Testing" href="/docs/guides/testing">
-    Test memory and state behavior with MockStreamTransport.
+  <Card title="State Management" href="/docs/concepts/state-management">
+    How agent state flows from LangGraph into Angular Signals.
   </Card>
 </CardGroup>

--- a/apps/website/content/docs-v2/guides/persistence.mdx
+++ b/apps/website/content/docs-v2/guides/persistence.mdx
@@ -10,8 +10,8 @@ LangGraph checkpoints state at every super-step. streamResource() connects to th
 
 Save the thread ID to localStorage so conversations survive page refreshes.
 
-<Tabs items={['TypeScript', 'Template']}>
-<Tab>
+<Tabs>
+<Tab label="TypeScript">
 
 ```typescript
 // chat.component.ts
@@ -23,7 +23,7 @@ const chat = streamResource<{ messages: BaseMessage[] }>({
 ```
 
 </Tab>
-<Tab>
+<Tab label="Template">
 
 ```html
 <!-- Thread ID is managed automatically -->

--- a/apps/website/content/docs-v2/guides/persistence.mdx
+++ b/apps/website/content/docs-v2/guides/persistence.mdx
@@ -1,47 +1,260 @@
 # Persistence
 
-Thread persistence keeps conversations alive across page refreshes, browser restarts, and session changes. streamResource() manages thread state through the `threadId` signal and `onThreadId` callback.
+Thread persistence keeps conversations alive across page refreshes, browser restarts, and server deployments. This guide covers configuring checkpointers on the Python side and wiring up thread management in your Angular components with streamResource().
 
 <Callout type="info" title="How it works">
-LangGraph checkpoints state at every super-step. streamResource() connects to these checkpoints via thread IDs, letting you resume exactly where you left off.
+LangGraph checkpoints agent state at every super-step. Each checkpoint is keyed by a thread ID. streamResource() connects to these checkpoints automatically, so your users resume exactly where they left off — even if your server restarted between sessions.
 </Callout>
 
-## Basic thread persistence
+## Python: Checkpointer Setup
 
-Save the thread ID to localStorage so conversations survive page refreshes.
+Every LangGraph agent needs a checkpointer to persist state between invocations. The checkpointer you choose depends on your environment.
 
 <Tabs>
-<Tab label="TypeScript">
+<Tab label="MemorySaver (dev)">
 
-```typescript
-// chat.component.ts
-const chat = streamResource<{ messages: BaseMessage[] }>({
-  assistantId: 'chat_agent',
-  threadId: signal(localStorage.getItem('threadId')),
-  onThreadId: (id) => localStorage.setItem('threadId', id),
-});
+```python
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.graph import START, END, MessagesState, StateGraph
+from langchain_openai import ChatOpenAI
+
+llm = ChatOpenAI(model="gpt-5-mini")
+
+def call_model(state: MessagesState) -> dict:
+    return {"messages": [llm.invoke(state["messages"])]}
+
+builder = StateGraph(MessagesState)
+builder.add_node("model", call_model)
+builder.add_edge(START, "model")
+builder.add_edge("model", END)
+
+# MemorySaver stores checkpoints in-process memory
+# Fast for development — lost when the process restarts
+graph = builder.compile(checkpointer=MemorySaver())
 ```
 
 </Tab>
-<Tab label="Template">
+<Tab label="SqliteSaver (prototype)">
+
+```python
+from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
+from langgraph.graph import START, END, MessagesState, StateGraph
+
+# Persists to a local file — survives restarts, zero infrastructure
+async with AsyncSqliteSaver.from_conn_string("checkpoints.db") as checkpointer:
+    builder = StateGraph(MessagesState)
+    builder.add_node("model", call_model)
+    builder.add_edge(START, "model")
+    builder.add_edge("model", END)
+
+    graph = builder.compile(checkpointer=checkpointer)
+```
+
+</Tab>
+<Tab label="PostgresSaver (production)">
+
+```python
+from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
+from langgraph.graph import START, END, MessagesState, StateGraph
+
+DATABASE_URL = "postgresql://user:pass@localhost:5432/myapp"
+
+async with AsyncPostgresSaver.from_conn_string(DATABASE_URL) as checkpointer:
+    # Run migrations once on startup
+    await checkpointer.setup()
+
+    builder = StateGraph(MessagesState)
+    builder.add_node("model", call_model)
+    builder.add_edge(START, "model")
+    builder.add_edge("model", END)
+
+    graph = builder.compile(checkpointer=checkpointer)
+```
+
+</Tab>
+</Tabs>
+
+<Callout type="warning" title="Production checkpointers">
+MemorySaver is for development only — all state vanishes when the process exits. For anything users depend on, use PostgresSaver. SqliteSaver is a middle ground for prototypes and single-server deployments where you need persistence without a database.
+</Callout>
+
+## Python: Thread IDs in Graph Invocation
+
+The thread ID is how LangGraph associates a conversation with its checkpoint history. Pass it in the `configurable` dict every time you invoke the graph:
+
+```python
+# First message creates the thread
+result = graph.invoke(
+    {"messages": [{"role": "user", "content": "What is LangGraph?"}]},
+    config={"configurable": {"thread_id": "user_123"}}
+)
+
+# Second message continues the same conversation
+result = graph.invoke(
+    {"messages": [{"role": "user", "content": "How does it handle state?"}]},
+    config={"configurable": {"thread_id": "user_123"}}
+)
+# The agent sees both messages — the full history is restored from the checkpoint
+```
+
+<Callout type="tip" title="Thread ID strategy">
+Use stable, user-scoped identifiers for thread IDs. A common pattern is `f"{user_id}_{session_id}"` — this prevents cross-user data leaks and lets one user have multiple conversations.
+</Callout>
+
+## Angular: Basic Thread Persistence
+
+Save the thread ID to localStorage so conversations survive page refreshes. streamResource() handles thread creation and restoration automatically.
+
+<Tabs>
+<Tab label="chat.component.ts">
+
+```typescript
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { signal } from '@angular/core';
+import { streamResource } from '@cacheplane/stream-resource';
+
+@Component({
+  selector: 'app-chat',
+  templateUrl: './chat.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ChatComponent {
+  chat = streamResource<{ messages: BaseMessage[] }>({
+    assistantId: 'chat_agent',
+    // Restore thread from localStorage on mount
+    threadId: signal(localStorage.getItem('threadId')),
+    // Persist thread ID whenever a new thread is created
+    onThreadId: (id) => localStorage.setItem('threadId', id),
+  });
+
+  send(text: string) {
+    this.chat.submit({ messages: [{ role: 'user', content: text }] });
+  }
+}
+```
+
+</Tab>
+<Tab label="chat.component.html">
 
 ```html
-<!-- Thread ID is managed automatically -->
-<!-- Messages restore when the component remounts -->
+<!-- Messages restore automatically when the component remounts -->
 @for (msg of chat.messages(); track $index) {
-  <p>{{ msg.content }}</p>
+  <div [class]="msg.role">
+    <p>{{ msg.content }}</p>
+  </div>
+}
+
+@if (chat.isLoading()) {
+  <div class="loading-indicator">Agent is thinking...</div>
 }
 ```
 
 </Tab>
 </Tabs>
 
-## Reactive thread switching
+## Angular: Thread-List Component
 
-Pass a Signal as `threadId` to reactively switch between conversations.
+A real chat application needs a sidebar showing all conversations. Here is a full thread-list component that manages multiple threads alongside your chat resource.
+
+<Tabs>
+<Tab label="thread-list.component.ts">
 
 ```typescript
-// conversation-list.component.ts
+import { ChangeDetectionStrategy, Component, signal, computed } from '@angular/core';
+import { streamResource } from '@cacheplane/stream-resource';
+
+interface Thread {
+  id: string;
+  title: string;
+  updatedAt: Date;
+}
+
+@Component({
+  selector: 'app-thread-list',
+  templateUrl: './thread-list.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ThreadListComponent {
+  threads = signal<Thread[]>(this.loadThreads());
+  activeThreadId = signal<string | null>(null);
+
+  chat = streamResource<{ messages: BaseMessage[] }>({
+    assistantId: 'chat_agent',
+    threadId: this.activeThreadId,
+    onThreadId: (id) => {
+      this.activeThreadId.set(id);
+      this.addThread(id, 'New conversation');
+    },
+  });
+
+  activeThread = computed(() =>
+    this.threads().find((t) => t.id === this.activeThreadId())
+  );
+
+  selectThread(id: string) {
+    this.activeThreadId.set(id);
+  }
+
+  newConversation() {
+    this.chat.switchThread(null);
+    // A new thread ID is assigned on the next submit
+  }
+
+  private addThread(id: string, title: string) {
+    this.threads.update((list) => [
+      { id, title, updatedAt: new Date() },
+      ...list.filter((t) => t.id !== id),
+    ]);
+    this.saveThreads();
+  }
+
+  private loadThreads(): Thread[] {
+    return JSON.parse(localStorage.getItem('threads') ?? '[]');
+  }
+
+  private saveThreads() {
+    localStorage.setItem('threads', JSON.stringify(this.threads()));
+  }
+}
+```
+
+</Tab>
+<Tab label="thread-list.component.html">
+
+```html
+<aside class="thread-sidebar">
+  <button (click)="newConversation()">+ New Chat</button>
+
+  @for (thread of threads(); track thread.id) {
+    <button
+      [class.active]="thread.id === activeThreadId()"
+      (click)="selectThread(thread.id)"
+    >
+      <span class="title">{{ thread.title }}</span>
+      <span class="date">{{ thread.updatedAt | date: 'short' }}</span>
+    </button>
+  }
+</aside>
+
+<main class="chat-area">
+  @if (chat.isThreadLoading()) {
+    <div class="skeleton">Loading conversation...</div>
+  } @else {
+    @for (msg of chat.messages(); track $index) {
+      <div [class]="msg.role">{{ msg.content }}</div>
+    }
+  }
+</main>
+```
+
+</Tab>
+</Tabs>
+
+## Reactive Thread Switching
+
+When you pass a Signal as `threadId`, streamResource() reacts to every change. Set the signal and the conversation switches automatically — no imperative calls needed.
+
+```typescript
 activeThreadId = signal<string | null>(null);
 
 chat = streamResource<{ messages: BaseMessage[] }>({
@@ -50,57 +263,89 @@ chat = streamResource<{ messages: BaseMessage[] }>({
   onThreadId: (id) => this.activeThreadId.set(id),
 });
 
-// Switch to a different conversation
+// Clicking a thread in the sidebar triggers a reactive switch
 selectThread(id: string) {
   this.activeThreadId.set(id);
-  // streamResource automatically loads the new thread's state
+  // streamResource detects the signal change, fetches the thread's
+  // checkpoint from the server, and updates all derived signals
 }
 ```
 
 <Callout type="tip" title="Thread loading state">
-Use the `isThreadLoading()` signal to show a loading indicator while thread state is being fetched from the server.
+Use the `isThreadLoading()` signal to show a skeleton UI while streamResource() fetches checkpoint state from the server. This avoids a flash of empty content when switching threads.
 </Callout>
 
-## Manual thread switching
+## Manual Thread Switching
 
-Use `switchThread()` for imperative thread changes that also reset derived state.
+Use `switchThread()` for imperative thread changes. This is useful when you want to explicitly control when the switch happens — for example, after an animation completes or a modal closes.
 
 ```typescript
-// Reset and start a new conversation
+// Start a fresh conversation (null = new thread on next submit)
 newConversation() {
   this.chat.switchThread(null);
-  // Creates a new thread on next submit
 }
 
-// Switch to a specific thread
+// Jump to a specific thread
 loadConversation(threadId: string) {
   this.chat.switchThread(threadId);
 }
+
+// Fork a conversation — create a new thread from current state
+forkConversation() {
+  this.chat.switchThread(null);
+  this.chat.submit({
+    messages: this.chat.messages(),
+  });
+}
 ```
 
-## Checkpoint recovery
+## Checkpoint Recovery
 
-When a connection drops, streamResource() can rejoin an in-progress run.
+When a connection drops mid-stream, `joinStream()` reconnects to an in-progress run without restarting the agent. This prevents duplicate work and lost tokens.
 
 ```typescript
-// Rejoin a running stream
+// Rejoin a running stream after a network interruption
 await chat.joinStream(runId, lastEventId);
-// Picks up from where the connection was lost
+// Picks up from the last event — no duplicate agent execution
 ```
+
+<Callout type="info" title="Automatic recovery">
+In most cases streamResource() handles reconnection internally. Use `joinStream()` directly only when you need explicit control — for example, when restoring a run ID from a URL parameter after a full page reload.
+</Callout>
+
+## Thread Lifecycle
+
+<Steps>
+<Step title="Component mounts">
+streamResource() reads the `threadId` signal. If it contains a value, the existing thread's checkpoint is fetched from the server.
+</Step>
+<Step title="User sends first message">
+If `threadId` is null, streamResource() creates a new thread via the LangGraph API and fires `onThreadId` with the new ID.
+</Step>
+<Step title="Agent streams response">
+Each super-step is checkpointed server-side. The `messages()` signal updates in real time as events arrive.
+</Step>
+<Step title="User switches threads">
+Setting the `threadId` signal (or calling `switchThread()`) loads the target thread's latest checkpoint. All signals update to reflect the restored state.
+</Step>
+<Step title="Connection drops">
+`joinStream()` reconnects to the in-progress run. The agent does not restart — streaming resumes from the last received event.
+</Step>
+</Steps>
 
 ## What's Next
 
 <CardGroup cols={2}>
   <Card title="Interrupts" href="/docs/guides/interrupts">
-    Pause agent execution and wait for human input with interrupt signals.
+    Pause agent execution and wait for human approval before continuing.
   </Card>
   <Card title="Memory" href="/docs/guides/memory">
-    Preserve context across sessions using LangGraph's memory store.
+    Preserve long-term context across sessions with LangGraph's memory store.
   </Card>
   <Card title="Streaming" href="/docs/guides/streaming">
     Stream token-by-token responses and tool progress in real time.
   </Card>
   <Card title="Testing" href="/docs/guides/testing">
-    Test agent interactions deterministically with MockStreamTransport.
+    Test thread persistence and switching deterministically with MockStreamTransport.
   </Card>
 </CardGroup>

--- a/apps/website/content/docs-v2/guides/streaming.mdx
+++ b/apps/website/content/docs-v2/guides/streaming.mdx
@@ -15,7 +15,7 @@ Create a `streamResource` in your component, pass it a message, and bind to the 
 
 ```typescript
 import { Component, computed } from '@angular/core';
-import { streamResource } from '@stream-resource/angular';
+import { streamResource } from '@cacheplane/stream-resource';
 import { BaseMessage } from '@langchain/core/messages';
 
 @Component({ selector: 'app-chat', templateUrl: './chat.component.html' })
@@ -24,10 +24,10 @@ export class ChatComponent {
     assistantId: 'chat_agent',
   });
 
-  readonly isStreaming = computed(() => this.chat.status() === 'streaming');
+  readonly isStreaming = computed(() => this.chat.status() === 'loading');
 
   send(text: string) {
-    this.chat.stream({ messages: [{ role: 'user', content: text }] });
+    this.chat.submit({ messages: [{ role: 'user', content: text }] });
   }
 }
 ```
@@ -126,7 +126,7 @@ If the SSE connection drops or the agent throws, `status()` transitions to `'err
 
 ```typescript
 import { Component, computed, effect } from '@angular/core';
-import { streamResource } from '@stream-resource/angular';
+import { streamResource } from '@cacheplane/stream-resource';
 import { BaseMessage } from '@langchain/core/messages';
 
 @Component({ selector: 'app-chat', templateUrl: './chat.component.html' })
@@ -139,7 +139,7 @@ export class ChatComponent {
 
   retry() {
     // Re-stream using the same thread so context is preserved
-    this.chat.stream();
+    this.chat.submit();
   }
 }
 ```
@@ -184,22 +184,22 @@ The value is in milliseconds. A `throttle` of `0` (default) disables batching an
 | Background summarisation | 150 ms |
 
 <Callout type="tip" title="SSE connection behavior">
-Each call to `chat.stream()` opens a new SSE connection. Connections are automatically closed when the agent run completes or when the Angular component is destroyed — you do not need to manage the lifecycle manually.
+Each call to `chat.submit()` opens a new SSE connection. Connections are automatically closed when the agent run completes or when the Angular component is destroyed — you do not need to manage the lifecycle manually.
 </Callout>
 
 ## What's Next
 
 <CardGroup cols={2}>
-  <Card title="Persistence" href="/docs-v2/guides/persistence">
+  <Card title="Persistence" href="/docs/guides/persistence">
     Resume conversations across page reloads using thread IDs and checkpointers.
   </Card>
-  <Card title="Interrupts" href="/docs-v2/guides/interrupts">
+  <Card title="Interrupts" href="/docs/guides/interrupts">
     Pause agent execution mid-stream to collect human input before continuing.
   </Card>
-  <Card title="Testing" href="/docs-v2/guides/testing">
+  <Card title="Testing" href="/docs/guides/testing">
     Unit-test components that use streamResource with the built-in test harness.
   </Card>
-  <Card title="API Reference" href="/docs-v2/api/stream-resource">
+  <Card title="API Reference" href="/docs/api/stream-resource">
     Full option reference for streamResource(), including all configuration keys.
   </Card>
 </CardGroup>

--- a/apps/website/content/docs-v2/guides/subgraphs.mdx
+++ b/apps/website/content/docs-v2/guides/subgraphs.mdx
@@ -76,7 +76,7 @@ const pipelineStatus = computed(() => {
 Render live progress for each subagent using the signals above.
 
 <Tabs>
-<Tab label="progress-panel.tsx">
+<Tab label="progress-panel.component.ts">
 ```typescript
 import { computed } from '@angular/core';
 
@@ -183,16 +183,13 @@ Use **subagents** when tasks are independent and can run in parallel, when each 
 ## What's Next
 
 <CardGroup cols={2}>
-  <Card title="Streaming" href="/docs-v2/guides/streaming">
+  <Card title="Streaming" href="/docs/guides/streaming">
     Understand how streamResource() surfaces tokens, status, and errors in real time.
   </Card>
-  <Card title="Testing" href="/docs-v2/guides/testing">
+  <Card title="Testing" href="/docs/guides/testing">
     Write unit and integration tests for orchestrator graphs and subagent interactions.
   </Card>
-  <Card title="API Reference" href="/docs-v2/api/stream-resource">
+  <Card title="API Reference" href="/docs/api/stream-resource">
     Full reference for streamResource() options, signals, and subagent configuration.
-  </Card>
-  <Card title="Error Handling" href="/docs-v2/guides/error-handling">
-    Patterns for retries, fallbacks, and surfacing errors from deeply nested agents.
   </Card>
 </CardGroup>

--- a/apps/website/content/docs-v2/guides/testing.mdx
+++ b/apps/website/content/docs-v2/guides/testing.mdx
@@ -1,19 +1,55 @@
 # Testing
 
-MockStreamTransport lets you test agent interactions deterministically without a running LangGraph server. Script exact event sequences and step through them in your Angular test specs.
+MockStreamTransport lets you test agent interactions deterministically without a running LangGraph server. Script exact event sequences, step through streaming lifecycles, and verify every signal transition in your Angular test specs.
 
 <Callout type="tip" title="No flaky tests">
-MockStreamTransport eliminates network dependencies, timing issues, and server state. Every test run produces identical results.
+MockStreamTransport eliminates network dependencies, timing issues, and server state. Every test run produces identical results. Your CI pipeline stays green.
 </Callout>
 
-## Basic test setup
+## Python: Testing the Agent
 
-Create a MockStreamTransport with scripted events and pass it to streamResource.
+Before testing the Angular side, make sure your agent logic is correct. LangGraph agents are plain Python functions — test them directly with pytest.
+
+```python
+import pytest
+from langchain_core.messages import HumanMessage
+from my_agent.agent import graph
+
+@pytest.mark.asyncio
+async def test_agent_responds():
+    result = await graph.ainvoke(
+        {"messages": [HumanMessage(content="Hello")]},
+        config={"configurable": {"thread_id": "test_1"}},
+    )
+    assert len(result["messages"]) >= 2
+    assert result["messages"][-1].type == "ai"
+
+@pytest.mark.asyncio
+async def test_agent_uses_tools():
+    result = await graph.ainvoke(
+        {"messages": [HumanMessage(content="Search for LangGraph docs")]},
+        config={"configurable": {"thread_id": "test_2"}},
+    )
+    # Verify the agent called the search tool
+    tool_messages = [m for m in result["messages"] if m.type == "tool"]
+    assert len(tool_messages) > 0
+```
+
+<Callout type="info" title="Agent tests are fast">
+With MemorySaver and a mocked LLM, agent tests run in milliseconds. Use `langchain_core.language_models.FakeListChatModel` to remove the LLM dependency entirely.
+</Callout>
+
+## MockStreamTransport: Basic Setup
+
+On the Angular side, MockStreamTransport replaces the real HTTP transport. Create it inside `TestBed.runInInjectionContext` so streamResource() has access to Angular's dependency injection.
+
+<Tabs>
+<Tab label="chat.spec.ts">
 
 ```typescript
 import { TestBed } from '@angular/core/testing';
-import { MockStreamTransport } from '@cacheplane/stream-resource';
-import type { StreamEvent } from '@cacheplane/stream-resource';
+import { MockStreamTransport, streamResource } from '@cacheplane/stream-resource';
+import type { BaseMessage } from '@cacheplane/stream-resource';
 
 describe('ChatComponent', () => {
   it('should display agent messages', () => {
@@ -25,9 +61,12 @@ describe('ChatComponent', () => {
         transport,
       });
 
-      // Emit a values event
+      // Emit a values event — simulates the agent responding
       transport.emit([
-        { type: 'values', messages: [{ role: 'assistant', content: 'Hello!' }] },
+        {
+          type: 'values',
+          messages: [{ role: 'assistant', content: 'Hello!' }],
+        },
       ]);
 
       expect(chat.messages().length).toBe(1);
@@ -37,72 +76,441 @@ describe('ChatComponent', () => {
 });
 ```
 
-## Scripting event sequences
+</Tab>
+<Tab label="chat.component.ts">
 
-Pass event batches to the constructor for sequential playback.
+```typescript
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { streamResource } from '@cacheplane/stream-resource';
+
+@Component({
+  selector: 'app-chat',
+  templateUrl: './chat.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ChatComponent {
+  chat = streamResource<{ messages: BaseMessage[] }>({
+    assistantId: 'chat_agent',
+  });
+
+  send(text: string) {
+    this.chat.submit({ messages: [{ role: 'user', content: text }] });
+  }
+}
+```
+
+</Tab>
+</Tabs>
+
+## Scripted Event Sequences
+
+Pass event batches to the constructor for sequential playback. Each call to `nextBatch()` advances one step — giving you frame-by-frame control over what the component sees.
 
 ```typescript
 const transport = new MockStreamTransport([
-  // Batch 1: Initial response
+  // Batch 1: Agent starts thinking
   [{ type: 'values', messages: [{ role: 'assistant', content: 'Analyzing...' }] }],
-  // Batch 2: Final response
-  [{ type: 'values', messages: [{ role: 'assistant', content: 'Done!' }] }],
+  // Batch 2: Agent finishes
+  [{ type: 'values', messages: [{ role: 'assistant', content: 'Here is your answer.' }] }],
 ]);
 
-// Advance through batches
-const batch1 = transport.nextBatch();  // First batch
-const batch2 = transport.nextBatch();  // Second batch
+TestBed.runInInjectionContext(() => {
+  const chat = streamResource<{ messages: BaseMessage[] }>({
+    assistantId: 'test_agent',
+    transport,
+  });
+
+  chat.submit({ messages: [{ role: 'user', content: 'Explain signals' }] });
+
+  // Step through each batch
+  transport.nextBatch();
+  expect(chat.messages()[0].content).toBe('Analyzing...');
+
+  transport.nextBatch();
+  expect(chat.messages()[0].content).toBe('Here is your answer.');
+});
 ```
 
-## Testing interrupts
+## Testing the Streaming Lifecycle
 
-Script an interrupt event to test human-in-the-loop flows.
+The most common test pattern verifies the full submit-to-resolved lifecycle: submit triggers loading, values arrive, and the status settles to resolved.
+
+<Tabs>
+<Tab label="lifecycle.spec.ts">
 
 ```typescript
-it('should handle interrupts', () => {
-  const transport = new MockStreamTransport();
+import { TestBed } from '@angular/core/testing';
+import { MockStreamTransport, streamResource } from '@cacheplane/stream-resource';
 
-  TestBed.runInInjectionContext(() => {
-    const agent = streamResource<AgentState>({
-      assistantId: 'approval_agent',
-      transport,
-    });
-
-    // Emit an interrupt
-    transport.emit([
-      { type: 'interrupt', value: { action: 'delete', risk: 'high' } },
+describe('streaming lifecycle', () => {
+  it('should transition through loading → values → resolved', () => {
+    const transport = new MockStreamTransport([
+      [{ type: 'values', messages: [{ role: 'assistant', content: 'Thinking...' }] }],
+      [{ type: 'values', messages: [{ role: 'assistant', content: 'Done!' }] }],
     ]);
 
-    expect(agent.interrupt()).toBeDefined();
-    expect(agent.interrupt()?.value.risk).toBe('high');
+    TestBed.runInInjectionContext(() => {
+      const chat = streamResource<{ messages: BaseMessage[] }>({
+        assistantId: 'test_agent',
+        transport,
+      });
+
+      // Initial state
+      expect(chat.status()).toBe('idle');
+      expect(chat.messages()).toEqual([]);
+
+      // Submit triggers loading
+      chat.submit({ messages: [{ role: 'user', content: 'Hello' }] });
+      expect(chat.status()).toBe('loading');
+      expect(chat.isLoading()).toBe(true);
+
+      // First batch — partial response
+      transport.nextBatch();
+      expect(chat.messages()[0].content).toBe('Thinking...');
+      expect(chat.status()).toBe('loading');
+
+      // Second batch — final response
+      transport.nextBatch();
+      expect(chat.messages()[0].content).toBe('Done!');
+
+      // Stream completes
+      transport.complete();
+      expect(chat.status()).toBe('resolved');
+      expect(chat.isLoading()).toBe(false);
+    });
   });
 });
 ```
 
-## Testing errors
-
-Inject errors to test error handling.
+</Tab>
+<Tab label="chat.component.ts">
 
 ```typescript
-it('should surface errors', () => {
-  const transport = new MockStreamTransport();
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { streamResource } from '@cacheplane/stream-resource';
 
-  TestBed.runInInjectionContext(() => {
-    const chat = streamResource<ChatState>({
-      assistantId: 'test_agent',
-      transport,
+@Component({
+  selector: 'app-chat',
+  template: `
+    @if (chat.isLoading()) {
+      <div class="spinner">Thinking...</div>
+    }
+    @for (msg of chat.messages(); track $index) {
+      <div [class]="msg.role">{{ msg.content }}</div>
+    }
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ChatComponent {
+  chat = streamResource<{ messages: BaseMessage[] }>({
+    assistantId: 'chat_agent',
+  });
+
+  send(text: string) {
+    this.chat.submit({ messages: [{ role: 'user', content: text }] });
+  }
+}
+```
+
+</Tab>
+</Tabs>
+
+## Testing Interrupts
+
+Script an interrupt event to test human-in-the-loop flows. Verify the interrupt signal surfaces the payload, then resume and confirm the agent continues.
+
+<Tabs>
+<Tab label="interrupt.spec.ts">
+
+```typescript
+import { TestBed } from '@angular/core/testing';
+import { MockStreamTransport, streamResource } from '@cacheplane/stream-resource';
+
+describe('interrupt handling', () => {
+  it('should surface interrupt and resume on approval', () => {
+    const transport = new MockStreamTransport();
+
+    TestBed.runInInjectionContext(() => {
+      const agent = streamResource<{ messages: BaseMessage[] }>({
+        assistantId: 'approval_agent',
+        transport,
+      });
+
+      // Agent hits an interrupt
+      transport.emit([
+        {
+          type: 'interrupt',
+          value: { action: 'delete_account', risk: 'high' },
+        },
+      ]);
+
+      // Verify interrupt signal
+      expect(agent.interrupt()).toBeDefined();
+      expect(agent.interrupt()?.value.action).toBe('delete_account');
+      expect(agent.interrupt()?.value.risk).toBe('high');
+
+      // User approves — resume the agent
+      agent.submit(null, { resume: { approved: true } });
+
+      // Agent continues after approval
+      transport.emit([
+        {
+          type: 'values',
+          messages: [{ role: 'assistant', content: 'Account deleted.' }],
+        },
+      ]);
+
+      expect(agent.interrupt()).toBeNull();
+      expect(agent.messages()[0].content).toBe('Account deleted.');
     });
-
-    transport.emitError(new Error('Connection lost'));
-
-    expect(chat.error()).toBeDefined();
-    expect(chat.status()).toBe('error');
   });
 });
 ```
 
-<Callout type="warning" title="Injection context required">
-streamResource() must be called within an Angular injection context. In tests, wrap calls in `TestBed.runInInjectionContext()`.
+</Tab>
+<Tab label="approval.component.ts">
+
+```typescript
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { streamResource } from '@cacheplane/stream-resource';
+
+@Component({
+  selector: 'app-approval',
+  template: `
+    @if (agent.interrupt(); as interrupt) {
+      <div class="interrupt-dialog">
+        <p>Action: {{ interrupt.value.action }}</p>
+        <p>Risk: {{ interrupt.value.risk }}</p>
+        <button (click)="approve()">Approve</button>
+        <button (click)="reject()">Reject</button>
+      </div>
+    }
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ApprovalComponent {
+  agent = streamResource<{ messages: BaseMessage[] }>({
+    assistantId: 'approval_agent',
+  });
+
+  approve() {
+    this.agent.submit(null, { resume: { approved: true } });
+  }
+
+  reject() {
+    this.agent.submit(null, { resume: { approved: false } });
+  }
+}
+```
+
+</Tab>
+</Tabs>
+
+## Testing Errors
+
+Inject errors with `emitError()` to verify your component handles failures gracefully.
+
+<Tabs>
+<Tab label="error.spec.ts">
+
+```typescript
+import { TestBed } from '@angular/core/testing';
+import { MockStreamTransport, streamResource } from '@cacheplane/stream-resource';
+
+describe('error handling', () => {
+  it('should surface errors and set error status', () => {
+    const transport = new MockStreamTransport();
+
+    TestBed.runInInjectionContext(() => {
+      const chat = streamResource<{ messages: BaseMessage[] }>({
+        assistantId: 'test_agent',
+        transport,
+      });
+
+      chat.submit({ messages: [{ role: 'user', content: 'Hello' }] });
+
+      // Simulate a connection failure
+      transport.emitError(new Error('Connection lost'));
+
+      expect(chat.error()).toBeDefined();
+      expect(chat.error()?.message).toBe('Connection lost');
+      expect(chat.status()).toBe('error');
+      expect(chat.isLoading()).toBe(false);
+    });
+  });
+
+  it('should recover from errors on retry', () => {
+    const transport = new MockStreamTransport();
+
+    TestBed.runInInjectionContext(() => {
+      const chat = streamResource<{ messages: BaseMessage[] }>({
+        assistantId: 'test_agent',
+        transport,
+      });
+
+      // First attempt fails
+      chat.submit({ messages: [{ role: 'user', content: 'Hello' }] });
+      transport.emitError(new Error('Timeout'));
+      expect(chat.status()).toBe('error');
+
+      // Retry succeeds
+      chat.submit({ messages: [{ role: 'user', content: 'Hello' }] });
+      transport.emit([
+        {
+          type: 'values',
+          messages: [{ role: 'assistant', content: 'Sorry for the delay!' }],
+        },
+      ]);
+
+      expect(chat.status()).not.toBe('error');
+      expect(chat.messages()[0].content).toBe('Sorry for the delay!');
+    });
+  });
+});
+```
+
+</Tab>
+<Tab label="chat.component.ts">
+
+```typescript
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { streamResource } from '@cacheplane/stream-resource';
+
+@Component({
+  selector: 'app-chat',
+  template: `
+    @if (chat.error(); as err) {
+      <div class="error-banner">
+        <p>{{ err.message }}</p>
+        <button (click)="retry()">Retry</button>
+      </div>
+    }
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ChatComponent {
+  chat = streamResource<{ messages: BaseMessage[] }>({
+    assistantId: 'chat_agent',
+  });
+  private lastMessage = '';
+
+  send(text: string) {
+    this.lastMessage = text;
+    this.chat.submit({ messages: [{ role: 'user', content: text }] });
+  }
+
+  retry() {
+    this.send(this.lastMessage);
+  }
+}
+```
+
+</Tab>
+</Tabs>
+
+## Testing Thread Switching
+
+Verify that switching threads loads the correct conversation state and clears the previous thread's messages.
+
+```typescript
+describe('thread switching', () => {
+  it('should load new thread state on switch', () => {
+    const transport = new MockStreamTransport();
+
+    TestBed.runInInjectionContext(() => {
+      const threadId = signal<string | null>('thread_A');
+
+      const chat = streamResource<{ messages: BaseMessage[] }>({
+        assistantId: 'test_agent',
+        threadId,
+        transport,
+      });
+
+      // Thread A has messages
+      transport.emit([
+        {
+          type: 'values',
+          messages: [{ role: 'assistant', content: 'Thread A response' }],
+        },
+      ]);
+      expect(chat.messages()[0].content).toBe('Thread A response');
+
+      // Switch to thread B
+      chat.switchThread('thread_B');
+
+      // Thread B loads its own state
+      transport.emit([
+        {
+          type: 'values',
+          messages: [{ role: 'assistant', content: 'Thread B response' }],
+        },
+      ]);
+      expect(chat.messages()[0].content).toBe('Thread B response');
+    });
+  });
+
+  it('should create a new thread when switching to null', () => {
+    const transport = new MockStreamTransport();
+
+    TestBed.runInInjectionContext(() => {
+      const chat = streamResource<{ messages: BaseMessage[] }>({
+        assistantId: 'test_agent',
+        transport,
+      });
+
+      // Start a conversation
+      transport.emit([
+        {
+          type: 'values',
+          messages: [{ role: 'assistant', content: 'Hello' }],
+        },
+      ]);
+
+      // Switch to new thread
+      chat.switchThread(null);
+      expect(chat.messages()).toEqual([]);
+    });
+  });
+});
+```
+
+## Test Setup Workflow
+
+<Steps>
+<Step title="Install dependencies">
+Make sure `@cacheplane/stream-resource` is available in your test environment. MockStreamTransport ships with the main package — no extra install needed.
+</Step>
+<Step title="Create the transport">
+Instantiate `MockStreamTransport` with optional pre-scripted batches for sequential playback, or leave it empty for imperative `emit()` calls.
+</Step>
+<Step title="Wrap in injection context">
+Call `TestBed.runInInjectionContext(() => { ... })` so streamResource() can access Angular's injector for signal creation and cleanup.
+</Step>
+<Step title="Create the resource">
+Pass the transport to streamResource() via the `transport` option. All other options (assistantId, threadId, onThreadId) work identically to production code.
+</Step>
+<Step title="Script events">
+Use `transport.emit()` for ad-hoc events, `transport.nextBatch()` for pre-scripted sequences, or `transport.emitError()` for failure scenarios.
+</Step>
+<Step title="Assert signal values">
+Read signals like `chat.messages()`, `chat.status()`, `chat.interrupt()`, and `chat.error()` to verify your component reacts correctly.
+</Step>
+</Steps>
+
+## Integration Testing
+
+For end-to-end confidence, run tests against a real LangGraph dev server. The LangGraph CLI starts a local server that your tests can hit directly.
+
+```bash
+# Start the dev server
+langgraph dev --config langgraph.json
+
+# Run Angular tests against it (no MockStreamTransport needed)
+ng test --watch=false
+```
+
+<Callout type="warning" title="Integration tests are slow">
+Integration tests hit a real server and (potentially) a real LLM. Reserve them for CI pipelines or pre-release smoke tests. Use MockStreamTransport for the vast majority of your test suite — it runs in milliseconds with zero external dependencies.
 </Callout>
 
 ## What's Next
@@ -112,10 +520,10 @@ streamResource() must be called within an Angular injection context. In tests, w
     Understand the SSE event model your tests simulate.
   </Card>
   <Card title="Interrupts" href="/docs/guides/interrupts">
-    Test human-in-the-loop approval flows with scripted interrupt events.
+    Build human-in-the-loop approval flows tested with scripted interrupt events.
   </Card>
-  <Card title="Deployment" href="/docs/guides/deployment">
-    Configure streamResource() for production LangGraph Cloud.
+  <Card title="Persistence" href="/docs/guides/persistence">
+    Thread persistence patterns that pair with thread-switching tests.
   </Card>
   <Card title="API Reference" href="/docs/api/mock-stream-transport">
     Full reference for MockStreamTransport options and methods.

--- a/apps/website/content/docs-v2/guides/time-travel.mdx
+++ b/apps/website/content/docs-v2/guides/time-travel.mdx
@@ -80,7 +80,7 @@ Expose checkpoint history directly in your component to let users scrub through 
 <Tab label="history-viewer.component.ts">
 ```typescript
 import { Component, inject, computed } from '@angular/core';
-import { streamResource } from '@stream-resource/angular';
+import { streamResource } from '@cacheplane/stream-resource';
 import { AgentService } from './agent.service';
 
 @Component({
@@ -159,16 +159,13 @@ Time travel is most useful during development. Inspect why an agent chose a part
 ## What's Next
 
 <CardGroup cols={2}>
-  <Card title="Persistence" href="/docs-v2/guides/persistence">
+  <Card title="Persistence" href="/docs/guides/persistence">
     Configure thread storage so checkpoints survive page reloads and are available across sessions.
   </Card>
-  <Card title="Streaming" href="/docs-v2/guides/streaming">
+  <Card title="Streaming" href="/docs/guides/streaming">
     Understand how streamResource() surfaces incremental updates and how history integrates with live streaming state.
   </Card>
-  <Card title="API Reference" href="/docs-v2/reference/stream-resource">
+  <Card title="API Reference" href="/docs/api/stream-resource">
     Full reference for streamResource() options, signals, and the submit() API including checkpoint parameters.
-  </Card>
-  <Card title="Forking & Branching" href="/docs-v2/guides/branching">
-    Deep dive into branch management, merging strategies, and presenting multi-branch UIs to end users.
   </Card>
 </CardGroup>

--- a/apps/website/next-env.d.ts
+++ b/apps/website/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./../../dist/apps/website/.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/docs/superpowers/plans/2026-04-04-docs-comprehensive-overhaul.md
+++ b/docs/superpowers/plans/2026-04-04-docs-comprehensive-overhaul.md
@@ -1,0 +1,234 @@
+# Comprehensive Docs Overhaul — Master Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring all 18 docs pages to gold standard quality — every page shows both Python agent code AND Angular streamResource code, uses correct MDX syntax, has 200+ lines of rich content, and tells the product story.
+
+**Architecture:** Each task rewrites one MDX file. The gold standard is `introduction.mdx` (337 lines) and `langgraph-basics.mdx` (384 lines). Every page should pair Python LangGraph patterns with Angular streamResource consumption, use correct Tab label syntax, include Callouts, Steps, and CardGroup navigation.
+
+**Tech Stack:** MDX with custom components (Callout, Steps, Tabs/Tab with label prop, CardGroup/Card, FeatureChips, ArchFlowDiagram)
+
+---
+
+## Phase 0: Critical Fixes (do first, affects all pages)
+
+### Task 0: Fix Cross-Cutting Issues
+
+**Files:** Multiple
+
+- [ ] **Step 1: Fix import path inconsistency**
+
+Search all MDX and TSX files for `@ngxp/stream-resource` and `@stream-resource/angular`. Replace ALL with `@cacheplane/stream-resource`.
+
+Run: `grep -rn "@ngxp/stream-resource\|@stream-resource/angular" apps/website/content/docs-v2/ apps/website/src/`
+
+Replace all occurrences with `@cacheplane/stream-resource`.
+
+- [ ] **Step 2: Fix API method inconsistency**
+
+Search for `.stream(` in docs (should be `.submit(`). Search for `status() === 'streaming'` (should be `status() === 'loading'`).
+
+- [ ] **Step 3: Fix broken links**
+
+Search for `/docs-v2/` (should be `/docs/`). Search for `/docs/guides/branching` and `/docs/guides/error-handling` (don't exist — remove or replace).
+
+- [ ] **Step 4: Fix unclosed code fence in state-management.mdx**
+
+Line ~60 has an unclosed TypeScript code fence that swallows the rest of the page.
+
+- [ ] **Step 5: Fix .tsx file extensions**
+
+Search for `.tsx` in Tab labels (should be `.ts` — this is Angular, not React).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "fix(website): resolve import paths, API naming, broken links, code fence"
+```
+
+---
+
+## Phase 1: Rewrite THIN Pages (highest impact)
+
+Each page below needs to be expanded to 200+ lines with Python + Angular code pairs.
+
+### Task 1: Rewrite `concepts/angular-signals.mdx` (76 → 250+ lines)
+
+Current: Surface-level primer. No Python code. No streaming lifecycle explanation.
+
+New content needed:
+- How `toSignal()` converts BehaviorSubjects internally
+- Streaming lifecycle: idle → loading → streaming tokens → resolved
+- `computed()` for derived AI state (message count, last message, tool progress)
+- `effect()` for side effects (analytics, logging, error reporting)
+- A complete component example showing all signal patterns
+- Performance: why Signals + OnPush is efficient for high-frequency streaming
+- Python agent code showing what produces the streaming events that Signals consume
+
+### Task 2: Rewrite `concepts/agent-architecture.mdx` (70 → 250+ lines)
+
+Current: 5-bullet overview, single code snippet, 3-line pattern list.
+
+New content needed:
+- Full ReAct agent pattern with Python code + Angular streamResource code
+- Tool calling: Python `@tool` decorator → Angular `toolCalls()` signal
+- Multi-agent: Python supervisor graph → Angular `subagents()` signal
+- Error handling and recovery patterns
+- Planning phase: how LLMs decide actions
+- Checkpointing: how `history()` and `branch()` expose decisions
+
+### Task 3: Rewrite `concepts/state-management.mdx` (83 → 200+ lines)
+
+Current: Has syntax error (unclosed code fence). No Python code. ASCII diagram.
+
+New content needed:
+- Fix unclosed code fence
+- Python TypedDict with reducers → TypeScript interface mapping
+- How `Annotated[list, add]` works and why messages accumulate
+- State updates during streaming (partial values)
+- Checkpoint model: persistence, restore, branching
+- Tabs showing Python state definition + Angular consumption
+- Replace ASCII diagram with Steps component
+
+### Task 4: Rewrite `guides/memory.mdx` (83 → 200+ lines)
+
+Current: Thinnest guide. No Tabs, no Python, no template code.
+
+New content needed:
+- Python: agent state with memory fields, LangGraph Store API
+- Short-term (thread-scoped) vs long-term (cross-thread) memory
+- Semantic memory with vector search
+- Tabs: TypeScript component + Angular template for memory-aware UI
+- How memory updates surface through `value()` signal
+
+### Task 5: Rewrite `guides/interrupts.mdx` (96 → 200+ lines)
+
+Current: No Python code. Dangling reference to BagTemplate. Tab syntax wrong.
+
+New content needed:
+- Python: `raise Interrupt(value={...})` in agent node
+- Python: graph structure with approval node
+- Full approval component: TypeScript + Template in Tabs
+- Multi-step approval pattern
+- Typed interrupt payloads with BagTemplate (explain the reference)
+- Steps component for interrupt lifecycle
+- Fix Tab syntax to use `label` prop
+
+### Task 6: Rewrite `guides/persistence.mdx` (107 → 200+ lines)
+
+Current: No Python code. Tab syntax wrong.
+
+New content needed:
+- Python: checkpointer setup (MemorySaver, PostgresSaver)
+- Python: thread_id in graph invocation
+- Full thread-list component: TypeScript + Template
+- Thread switching UI pattern
+- Fix Tab syntax to use `label` prop
+
+### Task 7: Rewrite `guides/testing.mdx` (124 → 200+ lines)
+
+Current: No Tabs, no Python, no template code.
+
+New content needed:
+- Python: how to test the agent side
+- Tabs: spec file + component file pairs
+- Testing subagent interactions
+- Testing interrupts and thread switching
+- Integration testing with real LangGraph dev server
+- Steps for test setup workflow
+
+### Task 8: Rewrite `guides/deployment.mdx` (108 → 200+ lines)
+
+Current: Tab syntax wrong. Introduction page has better deployment content.
+
+New content needed:
+- Python: LangGraph Cloud deployment (langgraph.json, CLI)
+- LangSmith deployment walkthrough
+- Authentication / API key configuration
+- CORS configuration for SSE
+- CI/CD pipeline example
+- Monitoring and health checks
+- Fix Tab syntax to use `label` prop
+
+---
+
+## Phase 2: Polish CLOSE Pages
+
+### Task 9: Polish `guides/streaming.mdx` (206 lines — fix issues)
+
+Fix:
+- Import path: `@stream-resource/angular` → `@cacheplane/stream-resource`
+- `.stream()` → `.submit()`
+- `'streaming'` status → `'loading'`
+- Add Python agent showing `stream_mode` configuration
+- Add `ChangeDetectionStrategy.OnPush` to component
+
+### Task 10: Polish `guides/time-travel.mdx` (175 lines — fix issues)
+
+Fix:
+- `.tsx` extension in Tab label → `.ts`
+- Remove broken link to `/docs-v2/guides/branching`
+- Add Python checkpointer setup code
+- Expand to 200+ lines
+
+### Task 11: Polish `guides/subgraphs.mdx` (199 lines — fix issues)
+
+Fix:
+- `.tsx` extension in Tab label → `.ts`
+- Remove broken link to `/docs-v2/guides/error-handling`
+- Add Python subgraph composition code
+
+### Task 12: Polish `getting-started/quickstart.mdx` (131 lines)
+
+Fix:
+- Tab syntax: `items={[...]}` → `<Tab label="...">`
+- Replace plain `##` numbered headings with `<Steps>/<Step>`
+- Add `ChangeDetectionStrategy.OnPush`
+- Add error display (`chat.error()`) to template
+- Add agent setup context or link
+
+### Task 13: Polish `getting-started/installation.mdx` (103 lines)
+
+Fix:
+- Tab syntax: `items={[...]}` → `<Tab label="...">`
+- Fix `process.env` error → use Angular `environment.ts`
+- Fix verify example (needs injection context)
+- Add troubleshooting section
+- Expand "Next steps" to 4+ cards
+
+---
+
+## Phase 3: Expand API Pages
+
+### Task 14: Expand 4 API Reference Pages
+
+Fix import path `@ngxp/stream-resource` → `@cacheplane/stream-resource` in all 4.
+Add "What's Next" CardGroup to all 4.
+Expand intros with more context about when/why to use each.
+
+---
+
+## Execution Strategy
+
+**Phase 0** (Task 0): Do first — fixes affect all pages. Single commit.
+**Phase 1** (Tasks 1-8): Highest impact. 8 full rewrites. Dispatch as parallel subagents.
+**Phase 2** (Tasks 9-13): Polish passes. 5 targeted fixes. Dispatch as parallel subagents.
+**Phase 3** (Task 14): API pages. Single task.
+
+Total: 15 tasks, ~14 files rewritten.
+
+## Quality Checklist (apply to every page)
+
+- [ ] 200+ lines of content
+- [ ] Python LangGraph code showing the agent/server pattern
+- [ ] Angular streamResource code showing the frontend consumption
+- [ ] Both paired together to tell the product story
+- [ ] All imports use `@cacheplane/stream-resource`
+- [ ] All Tab components use `<Tab label="...">` syntax
+- [ ] `ChangeDetectionStrategy.OnPush` in component examples
+- [ ] At least 2 Callouts (tip, info, or warning)
+- [ ] "What's Next" CardGroup with 4+ cards
+- [ ] No broken links
+- [ ] Correct API method names (`.submit()`, not `.stream()`)
+- [ ] Correct status values (`'loading'`, not `'streaming'`)


### PR DESCRIPTION
## Summary

Phase 0 + Phase 1 of the comprehensive docs overhaul. 

**Phase 0: Critical fixes**
- Fixed import paths: `@ngxp/stream-resource`, `@stream-resource/angular` → `@cacheplane/stream-resource`
- Fixed API naming: `.stream()` → `.submit()`, `'streaming'` → `'loading'`
- Fixed broken links (`/docs-v2/` → `/docs/`, removed nonexistent pages)
- Fixed unclosed code fence in state-management.mdx
- Fixed `.tsx` extensions → `.ts` in Tab labels
- Fixed `type="warn"` → `type="warning"` in Callouts
- Converted all Tabs from `items={[]}` to `<Tab label="...">` syntax

**Phase 1: 8 pages rewritten with Python + Angular code pairs**

| Page | Before | After |
|------|--------|-------|
| Angular Signals | 76 | 559 |
| Agent Architecture | 70 | 701 |
| State Management | 84 | 541 |
| Memory | 83 | 414 |
| Interrupts | 96 | 561 |
| Persistence | 107 | 351 |
| Testing | 124 | 531 |
| Deployment | 108 | 429 |

Every page now pairs Python LangGraph agent code with Angular streamResource consumption code.

## Test plan
- [ ] Build passes: `npx nx build website`
- [ ] All 19 doc pages render
- [ ] No import path inconsistencies
- [ ] No broken links

🤖 Generated with [Claude Code](https://claude.com/claude-code)