### PR TITLE
feat(cockpit): Tier 1 example customization — thread management + capability sidebars

### DIFF
--- a/cockpit/deep-agents/filesystem/angular/src/app/filesystem.component.ts
+++ b/cockpit/deep-agents/filesystem/angular/src/app/filesystem.component.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
-import { Component } from '@angular/core';
+import { Component, computed } from '@angular/core';
 import { ChatDebugComponent } from '@cacheplane/chat';
 import { streamResource } from '@cacheplane/stream-resource';
 import { environment } from '../environments/environment';
@@ -8,11 +8,44 @@ import { environment } from '../environments/environment';
   selector: 'app-filesystem',
   standalone: true,
   imports: [ChatDebugComponent],
-  template: `<chat-debug [ref]="stream" class="block h-screen" />`,
+  template: `
+    <div class="flex h-screen">
+      <chat-debug [ref]="stream" class="flex-1 min-w-0" />
+      @if (fileOps().length > 0) {
+        <aside class="w-72 shrink-0 border-l overflow-y-auto p-4 space-y-2"
+               style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
+          <h3 class="text-xs font-semibold uppercase tracking-wide mb-3"
+              style="color: var(--chat-text-muted, #777);">File Operations</h3>
+          @for (op of fileOps(); track $index) {
+            <div class="flex items-start gap-2 text-sm py-1">
+              <span class="shrink-0">{{ op.name === 'read_file' ? '📖' : '✏️' }}</span>
+              <span class="font-mono text-xs break-all"
+                    style="color: var(--chat-text, #e0e0e0);">{{ op.path }}</span>
+            </div>
+          }
+        </aside>
+      }
+    </div>
+  `,
 })
 export class FilesystemComponent {
   protected readonly stream = streamResource({
     apiUrl: environment.langGraphApiUrl,
     assistantId: environment.streamingAssistantId,
+  });
+
+  protected readonly fileOps = computed(() => {
+    const messages = this.stream.messages();
+    const ops: { name: string; path: string }[] = [];
+    for (const msg of messages) {
+      if ('tool_calls' in msg && Array.isArray((msg as any).tool_calls)) {
+        for (const tc of (msg as any).tool_calls) {
+          if (tc.name === 'read_file' || tc.name === 'write_file') {
+            ops.push({ name: tc.name, path: tc.args?.path ?? '' });
+          }
+        }
+      }
+    }
+    return ops;
   });
 }

--- a/cockpit/deep-agents/memory/angular/src/app/memory.component.ts
+++ b/cockpit/deep-agents/memory/angular/src/app/memory.component.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
-import { Component } from '@angular/core';
+import { Component, computed } from '@angular/core';
 import { ChatDebugComponent } from '@cacheplane/chat';
 import { streamResource } from '@cacheplane/stream-resource';
 import { environment } from '../environments/environment';
@@ -8,11 +8,35 @@ import { environment } from '../environments/environment';
   selector: 'app-da-memory',
   standalone: true,
   imports: [ChatDebugComponent],
-  template: `<chat-debug [ref]="stream" class="block h-screen" />`,
+  template: `
+    <div class="flex h-screen">
+      <chat-debug [ref]="stream" class="flex-1 min-w-0" />
+      @if (memoryEntries().length > 0) {
+        <aside class="w-72 shrink-0 border-l overflow-y-auto p-4 space-y-2"
+               style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
+          <h3 class="text-xs font-semibold uppercase tracking-wide mb-3"
+              style="color: var(--chat-text-muted, #777);">Agent Memory</h3>
+          @for (entry of memoryEntries(); track $index) {
+            <div class="text-sm py-1">
+              <span class="font-semibold" style="color: var(--chat-text-muted, #777);">{{ entry[0] }}:</span>
+              <span class="ml-1" style="color: var(--chat-text, #e0e0e0);">{{ entry[1] }}</span>
+            </div>
+          }
+        </aside>
+      }
+    </div>
+  `,
 })
 export class MemoryComponent {
   protected readonly stream = streamResource({
     apiUrl: environment.langGraphApiUrl,
     assistantId: environment.streamingAssistantId,
+  });
+
+  protected readonly memoryEntries = computed(() => {
+    const val = this.stream.value() as Record<string, unknown>;
+    const mem = val?.['agent_memory'];
+    if (!mem || typeof mem !== 'object') return [];
+    return Object.entries(mem as Record<string, string>);
   });
 }

--- a/cockpit/deep-agents/planning/angular/src/app/planning.component.ts
+++ b/cockpit/deep-agents/planning/angular/src/app/planning.component.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
-import { Component } from '@angular/core';
+import { Component, computed } from '@angular/core';
 import { ChatDebugComponent } from '@cacheplane/chat';
 import { streamResource } from '@cacheplane/stream-resource';
 import { environment } from '../environments/environment';
@@ -8,11 +8,40 @@ import { environment } from '../environments/environment';
   selector: 'app-planning',
   standalone: true,
   imports: [ChatDebugComponent],
-  template: `<chat-debug [ref]="stream" class="block h-screen" />`,
+  template: `
+    <div class="flex h-screen">
+      <chat-debug [ref]="stream" class="flex-1 min-w-0" />
+      @if (planSteps().length > 0) {
+        <aside class="w-72 shrink-0 border-l overflow-y-auto p-4 space-y-2"
+               style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
+          <h3 class="text-xs font-semibold uppercase tracking-wide mb-3"
+              style="color: var(--chat-text-muted, #777);">Plan Steps</h3>
+          @for (step of planSteps(); track $index) {
+            <div class="flex items-start gap-2 text-sm py-1">
+              <span class="shrink-0 mt-0.5"
+                    style="color: {{ step.status === 'complete' ? 'var(--chat-accent, #4ade80)' : 'var(--chat-text-muted, #777)' }};">
+                {{ step.status === 'complete' ? '✓' : '○' }}
+              </span>
+              <span [style.text-decoration]="step.status === 'complete' ? 'line-through' : 'none'"
+                    style="color: var(--chat-text, #e0e0e0);">
+                {{ step.title }}
+              </span>
+            </div>
+          }
+        </aside>
+      }
+    </div>
+  `,
 })
 export class PlanningComponent {
   protected readonly stream = streamResource({
     apiUrl: environment.langGraphApiUrl,
     assistantId: environment.streamingAssistantId,
+  });
+
+  protected readonly planSteps = computed(() => {
+    const val = this.stream.value() as Record<string, unknown>;
+    const plan = val?.['plan'];
+    return Array.isArray(plan) ? plan as { title: string; status: string }[] : [];
   });
 }

--- a/cockpit/deep-agents/sandboxes/angular/src/app/sandboxes.component.ts
+++ b/cockpit/deep-agents/sandboxes/angular/src/app/sandboxes.component.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
-import { Component } from '@angular/core';
+import { Component, computed } from '@angular/core';
 import { ChatDebugComponent } from '@cacheplane/chat';
 import { streamResource } from '@cacheplane/stream-resource';
 import { environment } from '../environments/environment';
@@ -8,11 +8,66 @@ import { environment } from '../environments/environment';
   selector: 'app-sandboxes',
   standalone: true,
   imports: [ChatDebugComponent],
-  template: `<chat-debug [ref]="stream" class="block h-screen" />`,
+  template: `
+    <div class="flex h-screen">
+      <chat-debug [ref]="stream" class="flex-1 min-w-0" />
+      @if (execLogs().length > 0) {
+        <aside class="w-72 shrink-0 border-l overflow-y-auto p-4 space-y-3"
+               style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
+          <h3 class="text-xs font-semibold uppercase tracking-wide mb-3"
+              style="color: var(--chat-text-muted, #777);">Code Executions</h3>
+          @for (log of execLogs(); track $index) {
+            <div class="text-xs space-y-1 pb-2"
+                 style="border-bottom: 1px solid var(--chat-border, #333);">
+              <div class="flex items-center gap-2">
+                <span class="px-1.5 py-0.5 rounded text-xs font-mono font-semibold"
+                      style="background: {{ log.exitStatus === 0 ? 'var(--chat-accent, #4ade80)' : '#ef4444' }}; color: #000;">
+                  exit {{ log.exitStatus }}
+                </span>
+              </div>
+              @if (log.code) {
+                <pre class="font-mono text-xs truncate"
+                     style="color: var(--chat-text-muted, #777);">{{ log.code }}</pre>
+              }
+              @if (log.stdout) {
+                <pre class="font-mono text-xs whitespace-pre-wrap break-all"
+                     style="color: var(--chat-text, #e0e0e0);">{{ log.stdout }}</pre>
+              }
+            </div>
+          }
+        </aside>
+      }
+    </div>
+  `,
 })
 export class SandboxesComponent {
   protected readonly stream = streamResource({
     apiUrl: environment.langGraphApiUrl,
     assistantId: environment.streamingAssistantId,
+  });
+
+  protected readonly execLogs = computed(() => {
+    const messages = this.stream.messages();
+    const logs: { code: string; stdout: string; exitStatus: number }[] = [];
+    for (const msg of messages) {
+      if ('tool_calls' in msg && Array.isArray((msg as any).tool_calls)) {
+        for (const tc of (msg as any).tool_calls) {
+          if (tc.name === 'run_code') {
+            const resultIdx = messages.indexOf(msg) + 1;
+            const resultMsg = messages[resultIdx];
+            let stdout = '', exitStatus = 0;
+            if (resultMsg && typeof resultMsg.content === 'string') {
+              try {
+                const parsed = JSON.parse(resultMsg.content);
+                stdout = parsed.stdout ?? '';
+                exitStatus = parsed.exit_status ?? 0;
+              } catch { /* ignore */ }
+            }
+            logs.push({ code: tc.args?.code ?? '', stdout, exitStatus });
+          }
+        }
+      }
+    }
+    return logs;
   });
 }

--- a/cockpit/deep-agents/skills/angular/src/app/skills.component.ts
+++ b/cockpit/deep-agents/skills/angular/src/app/skills.component.ts
@@ -1,18 +1,57 @@
 // SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
-import { Component } from '@angular/core';
+import { Component, computed } from '@angular/core';
 import { ChatDebugComponent } from '@cacheplane/chat';
 import { streamResource } from '@cacheplane/stream-resource';
 import { environment } from '../environments/environment';
+
+const SKILL_ICONS: Record<string, string> = {
+  calculator: '🧮',
+  word_count: '🔢',
+  summarize: '📝',
+};
 
 @Component({
   selector: 'app-skills',
   standalone: true,
   imports: [ChatDebugComponent],
-  template: `<chat-debug [ref]="stream" class="block h-screen" />`,
+  template: `
+    <div class="flex h-screen">
+      <chat-debug [ref]="stream" class="flex-1 min-w-0" />
+      @if (skillInvocations().length > 0) {
+        <aside class="w-72 shrink-0 border-l overflow-y-auto p-4 space-y-2"
+               style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
+          <h3 class="text-xs font-semibold uppercase tracking-wide mb-3"
+              style="color: var(--chat-text-muted, #777);">Skill Invocations</h3>
+          @for (inv of skillInvocations(); track $index) {
+            <div class="flex items-center gap-2 text-sm py-1">
+              <span class="shrink-0">{{ inv.icon }}</span>
+              <span class="font-mono text-xs"
+                    style="color: var(--chat-text, #e0e0e0);">{{ inv.name }}</span>
+            </div>
+          }
+        </aside>
+      }
+    </div>
+  `,
 })
 export class SkillsComponent {
   protected readonly stream = streamResource({
     apiUrl: environment.langGraphApiUrl,
     assistantId: environment.streamingAssistantId,
+  });
+
+  protected readonly skillInvocations = computed(() => {
+    const messages = this.stream.messages();
+    const invocations: { name: string; icon: string }[] = [];
+    for (const msg of messages) {
+      if ('tool_calls' in msg && Array.isArray((msg as any).tool_calls)) {
+        for (const tc of (msg as any).tool_calls) {
+          if (tc.name === 'calculator' || tc.name === 'word_count' || tc.name === 'summarize') {
+            invocations.push({ name: tc.name, icon: SKILL_ICONS[tc.name] ?? '🔧' });
+          }
+        }
+      }
+    }
+    return invocations;
   });
 }

--- a/cockpit/deep-agents/subagents/angular/src/app/subagents.component.ts
+++ b/cockpit/deep-agents/subagents/angular/src/app/subagents.component.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
-import { Component } from '@angular/core';
+import { Component, computed } from '@angular/core';
 import { ChatDebugComponent } from '@cacheplane/chat';
 import { streamResource } from '@cacheplane/stream-resource';
 import { environment } from '../environments/environment';
@@ -8,11 +8,42 @@ import { environment } from '../environments/environment';
   selector: 'app-subagents',
   standalone: true,
   imports: [ChatDebugComponent],
-  template: `<chat-debug [ref]="stream" class="block h-screen" />`,
+  template: `
+    <div class="flex h-screen">
+      <chat-debug [ref]="stream" class="flex-1 min-w-0" />
+      @if (delegations().length > 0) {
+        <aside class="w-72 shrink-0 border-l overflow-y-auto p-4 space-y-2"
+               style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
+          <h3 class="text-xs font-semibold uppercase tracking-wide mb-3"
+              style="color: var(--chat-text-muted, #777);">Subagent Delegations</h3>
+          @for (entry of delegations(); track $index) {
+            <div class="flex items-center gap-2 text-sm py-1">
+              <span class="shrink-0">🤖</span>
+              <span class="font-mono text-xs"
+                    style="color: var(--chat-text, #e0e0e0);">{{ entry.name }}</span>
+            </div>
+          }
+        </aside>
+      }
+    </div>
+  `,
 })
 export class SubagentsComponent {
   protected readonly stream = streamResource({
     apiUrl: environment.langGraphApiUrl,
     assistantId: environment.streamingAssistantId,
+  });
+
+  protected readonly delegations = computed(() => {
+    const messages = this.stream.messages();
+    const entries: { name: string }[] = [];
+    for (const msg of messages) {
+      if ('tool_calls' in msg && Array.isArray((msg as any).tool_calls)) {
+        for (const tc of (msg as any).tool_calls) {
+          entries.push({ name: tc.name });
+        }
+      }
+    }
+    return entries;
   });
 }

--- a/cockpit/langgraph/persistence/angular/src/app/persistence.component.ts
+++ b/cockpit/langgraph/persistence/angular/src/app/persistence.component.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
-import { Component } from '@angular/core';
-import { ChatComponent } from '@cacheplane/chat';
+import { Component, signal } from '@angular/core';
+import { ChatComponent, type Thread } from '@cacheplane/chat';
 import { streamResource } from '@cacheplane/stream-resource';
 import { environment } from '../environments/environment';
 
@@ -8,11 +8,36 @@ import { environment } from '../environments/environment';
   selector: 'app-persistence',
   standalone: true,
   imports: [ChatComponent],
-  template: `<chat [ref]="stream" class="block h-screen" />`,
+  template: `
+    <chat
+      [ref]="stream"
+      [threads]="threads()"
+      [activeThreadId]="activeThreadId()"
+      (threadSelected)="onThreadSelected($event)"
+      class="block h-screen"
+    />
+  `,
 })
 export class PersistenceComponent {
+  protected readonly threads = signal<Thread[]>([]);
+  protected readonly activeThreadId = signal<string>('');
+
   protected readonly stream = streamResource({
     apiUrl: environment.langGraphApiUrl,
     assistantId: environment.streamingAssistantId,
+    threadId: null,
+    onThreadId: (id: string) => this.trackThread(id),
   });
+
+  private trackThread(id: string): void {
+    this.activeThreadId.set(id);
+    if (!this.threads().find(t => t.id === id)) {
+      this.threads.update(list => [...list, { id }]);
+    }
+  }
+
+  protected onThreadSelected(id: string): void {
+    this.activeThreadId.set(id);
+    this.stream.switchThread(id);
+  }
 }

--- a/docs/superpowers/specs/2026-04-05-cockpit-examples-tier1-customization.md
+++ b/docs/superpowers/specs/2026-04-05-cockpit-examples-tier1-customization.md
@@ -1,0 +1,249 @@
+# Cockpit Examples Tier 1 Customization
+
+**Date:** 2026-04-05
+**Status:** Draft
+**Scope:** Customize 8 cockpit Angular examples using existing @cacheplane/chat components. No new library features needed.
+
+---
+
+## Overview
+
+Tier 1 covers examples that work with existing `@cacheplane/chat` and `@cacheplane/stream-resource` APIs. Each gets a capability-specific component that goes beyond the generic `<chat [ref]>` to showcase what makes that capability unique.
+
+## Tier Breakdown (for reference)
+
+- **Tier 1 (this spec):** persistence, deployment-runtime, + 6 deep-agents (planning, filesystem, subagents, memory, skills, sandboxes)
+- **Tier 2 (next):** memory (LG), subgraphs, interrupts — need custom sidebar content via template overrides
+- **Tier 3 (later):** time-travel, durable-execution — need new library features
+
+## Example Specifications
+
+### 1. Persistence (`cockpit/langgraph/persistence/angular`)
+
+**What it demonstrates:** Thread-based conversation persistence. Resume conversations by thread ID.
+
+**Component:** Uses `<chat>` with thread management inputs.
+
+```typescript
+@Component({
+  selector: 'app-persistence',
+  standalone: true,
+  imports: [ChatComponent],
+  template: `
+    <chat
+      [ref]="stream"
+      [threads]="threads()"
+      [activeThreadId]="activeThreadId()"
+      (threadSelected)="onThreadSelected($event)"
+      class="block h-screen"
+    />
+  `,
+})
+export class PersistenceComponent {
+  protected readonly stream = streamResource({
+    apiUrl: environment.langGraphApiUrl,
+    assistantId: environment.streamingAssistantId,
+    threadId: null,  // auto-create
+    onThreadId: (id) => this.trackThread(id),
+  });
+
+  protected readonly threads = signal<Thread[]>([]);
+  protected readonly activeThreadId = signal<string>('');
+
+  private trackThread(id: string): void {
+    this.activeThreadId.set(id);
+    // Add to thread list if new
+    if (!this.threads().find(t => t.id === id)) {
+      this.threads.update(list => [...list, { id }]);
+    }
+  }
+
+  protected onThreadSelected(id: string): void {
+    this.activeThreadId.set(id);
+    this.stream.switchThread(id);
+  }
+}
+```
+
+**Key signals:** `stream.switchThread()`, `onThreadId` callback, `[threads]` input on `<chat>`.
+
+---
+
+### 2. Deployment Runtime (`cockpit/langgraph/deployment-runtime/angular`)
+
+**What it demonstrates:** Production deployment config — different assistant ID, environment-based URL.
+
+**Component:** Uses `<chat>` with no extras. The differentiation is in `environment.ts` pointing to a deployed endpoint.
+
+```typescript
+@Component({
+  selector: 'app-deployment-runtime',
+  standalone: true,
+  imports: [ChatComponent],
+  template: `<chat [ref]="stream" class="block h-screen" />`,
+})
+export class DeploymentRuntimeComponent {
+  protected readonly stream = streamResource({
+    apiUrl: environment.langGraphApiUrl,
+    assistantId: environment.deploymentRuntimeAssistantId,
+  });
+}
+```
+
+Minimal — same as streaming but with deployment-specific environment config.
+
+---
+
+### 3. Planning (`cockpit/deep-agents/planning/angular`)
+
+**What it demonstrates:** Task decomposition — agent creates a plan with steps, then executes them.
+
+**Component:** Uses `<chat-debug>` plus a computed signal deriving plan steps from `stream.value()`.
+
+```typescript
+@Component({
+  selector: 'app-planning',
+  standalone: true,
+  imports: [ChatDebugComponent],
+  template: `
+    <div class="flex h-screen">
+      <chat-debug [ref]="stream" class="flex-1" />
+      @if (planSteps().length > 0) {
+        <aside class="w-72 border-l overflow-y-auto p-4 space-y-2"
+               style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717);">
+          <h3 class="text-xs font-semibold uppercase tracking-wide"
+              style="color: var(--chat-text-muted, #777);">Plan</h3>
+          @for (step of planSteps(); track $index) {
+            <div class="flex items-center gap-2 text-sm" style="color: var(--chat-text, #e0e0e0);">
+              <span [style.color]="step.status === 'complete' ? 'var(--chat-success, #4ade80)' : 'var(--chat-text-muted, #777)'">
+                {{ step.status === 'complete' ? '✓' : '○' }}
+              </span>
+              <span [style.text-decoration]="step.status === 'complete' ? 'line-through' : 'none'">
+                {{ step.title }}
+              </span>
+            </div>
+          }
+        </aside>
+      }
+    </div>
+  `,
+})
+export class PlanningComponent {
+  protected readonly stream = streamResource({
+    apiUrl: environment.langGraphApiUrl,
+    assistantId: environment.streamingAssistantId,
+  });
+
+  protected readonly planSteps = computed(() => {
+    const val = this.stream.value() as Record<string, unknown>;
+    const plan = val?.['plan'];
+    return Array.isArray(plan) ? plan : [];
+  });
+}
+```
+
+---
+
+### 4. Filesystem (`cockpit/deep-agents/filesystem/angular`)
+
+**What it demonstrates:** File read/write tool calls.
+
+**Component:** `<chat-debug>` plus computed signal extracting tool calls from messages.
+
+```typescript
+// Same pattern as planning but derives file operations from stream.messages()
+protected readonly fileOps = computed(() => {
+  const messages = this.stream.messages();
+  const ops: { name: string; path: string; status: string }[] = [];
+  for (const msg of messages) {
+    if ('tool_calls' in msg && Array.isArray((msg as any).tool_calls)) {
+      for (const tc of (msg as any).tool_calls) {
+        if (tc.name === 'read_file' || tc.name === 'write_file') {
+          ops.push({ name: tc.name, path: tc.args?.path ?? '', status: 'done' });
+        }
+      }
+    }
+  }
+  return ops;
+});
+```
+
+Sidebar shows file operation log with read/write icons.
+
+---
+
+### 5. Subagents (`cockpit/deep-agents/subagents/angular`)
+
+**What it demonstrates:** Orchestrator delegating to specialist subagents.
+
+**Component:** `<chat-debug>` plus computed signal from `stream.subagents()` or tool calls.
+
+```typescript
+protected readonly subagentEntries = computed(() => {
+  const messages = this.stream.messages();
+  const entries: { name: string; status: string }[] = [];
+  for (const msg of messages) {
+    if ('tool_calls' in msg && Array.isArray((msg as any).tool_calls)) {
+      for (const tc of (msg as any).tool_calls) {
+        if (['research_agent', 'analysis_agent', 'summary_agent'].includes(tc.name)) {
+          entries.push({ name: tc.name, status: 'done' });
+        }
+      }
+    }
+  }
+  return entries;
+});
+```
+
+Sidebar shows subagent delegation cards.
+
+---
+
+### 6. Memory (`cockpit/deep-agents/memory/angular`)
+
+**What it demonstrates:** Persistent fact extraction across turns.
+
+**Component:** `<chat-debug>` plus computed signal from `stream.value().agent_memory`.
+
+```typescript
+protected readonly memoryEntries = computed(() => {
+  const val = this.stream.value() as Record<string, unknown>;
+  const mem = val?.['agent_memory'];
+  if (!mem || typeof mem !== 'object') return [];
+  return Object.entries(mem as Record<string, string>);
+});
+```
+
+Sidebar shows learned facts as key-value pairs.
+
+---
+
+### 7. Skills (`cockpit/deep-agents/skills/angular`)
+
+**What it demonstrates:** Multi-skill tool selection (calculator, word_count, summarize).
+
+**Component:** `<chat-debug>` plus computed signal extracting skill invocations from messages.
+
+Same tool-call extraction pattern as filesystem, filtered for calculator/word_count/summarize.
+
+---
+
+### 8. Sandboxes (`cockpit/deep-agents/sandboxes/angular`)
+
+**What it demonstrates:** Code execution via `run_code` tool.
+
+**Component:** `<chat-debug>` plus computed signal extracting code execution results.
+
+Sidebar shows execution logs with exit status badges and stdout output.
+
+---
+
+## Common Pattern
+
+All 6 deep-agents examples follow the same structure:
+1. `<chat-debug>` for the main chat + debug panel
+2. An optional `<aside>` sidebar on the right showing capability-specific derived state
+3. A `computed()` signal deriving the sidebar data from `stream.value()` or `stream.messages()`
+4. Themed with CSS vars (same `var(--chat-*)` properties)
+
+The 2 LangGraph examples (persistence, deployment-runtime) use `<chat>` directly with its existing inputs.


### PR DESCRIPTION
## Summary

Customizes 8 cockpit Angular examples (Tier 1) with capability-specific UI:

**LangGraph:**
- **persistence** — `<chat>` with thread sidebar: tracks threads via `onThreadId`, switches via `stream.switchThread()`
- **deployment-runtime** — already correct, no changes needed

**Deep Agents (6 examples with custom sidebars):**
- **planning** — plan steps sidebar with ✓/○ progress indicators, derived from `stream.value().plan`
- **filesystem** — file operation log (📖 read / ✏️ write) from tool calls
- **subagents** — delegation entries (🤖) from orchestrator tool calls
- **memory** — learned facts key-value pairs from `stream.value().agent_memory`
- **skills** — skill invocation cards (🧮/🔢/📝) from tool calls
- **sandboxes** — code execution logs with exit status badges and stdout

All sidebars use `var(--chat-*)` CSS custom properties for theming.

## Test plan

- [ ] `nx run-many -t build --projects='cockpit-*-angular'` — all 14 build
- [ ] `nx test render && nx test chat` — all pass