### PR TITLE
feat(cockpit): Tier 2 — memory sidebar, subagent tracking, interrupt panel

### DIFF
--- a/apps/website/src/components/landing/ProblemSection.tsx
+++ b/apps/website/src/components/landing/ProblemSection.tsx
@@ -1,0 +1,322 @@
+'use client';
+import { useRef, useEffect, useState, useCallback } from 'react';
+import { motion, useInView } from 'framer-motion';
+import { tokens } from '@cacheplane/design-tokens';
+
+const STATS = [
+  { num: '66%', label: 'of AI solutions are almost right — not quite production-ready' },
+  { num: '31%', label: 'of prioritized AI use cases actually reach production' },
+  { num: '75%', label: 'of developers still want a human in the loop when trust breaks down' },
+];
+
+function useCounter(target: number, duration: number, running: boolean) {
+  const [value, setValue] = useState(0);
+  useEffect(() => {
+    if (!running) return;
+    const start = performance.now();
+    let raf: number;
+    function tick(now: number) {
+      const t = Math.min((now - start) / duration, 1);
+      const eased = t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t;
+      setValue(Math.round(eased * target));
+      if (t < 1) raf = requestAnimationFrame(tick);
+    }
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [running, target, duration]);
+  return value;
+}
+
+type Phase = 'idle' | 'filling' | 'stall' | 'closing' | 'done';
+
+export function ProblemSection() {
+  const triggerRef = useRef<HTMLDivElement>(null);
+  const inView = useInView(triggerRef, { once: true, amount: 0.3 });
+  const [phase, setPhase] = useState<Phase>('idle');
+  const [fillWidth, setFillWidth] = useState('0%');
+  const [fillGradient, setFillGradient] = useState(
+    `linear-gradient(90deg, rgba(221,0,49,.6), rgba(221,0,49,.4))`
+  );
+  const [fillTransition, setFillTransition] = useState('none');
+  const counterRunning77 = phase === 'filling';
+  const counterRunning100 = phase === 'closing' || phase === 'done';
+  const count77 = useCounter(77, 1700, counterRunning77);
+  const count100 = useCounter(23, 1000, counterRunning100);
+  const displayCount = phase === 'done' ? 100 : phase === 'closing' ? 77 + count100 : count77;
+
+  const runAnimation = useCallback(() => {
+    if (phase !== 'idle') return;
+    // Phase 1: fill to 77%
+    setTimeout(() => {
+      setFillTransition('width 1.7s cubic-bezier(.4,0,.2,1)');
+      setFillWidth('77%');
+      setPhase('filling');
+    }, 150);
+    // Phase 2: stall
+    setTimeout(() => setPhase('stall'), 2100);
+    // Phase 3: close gap
+    setTimeout(() => {
+      setFillTransition('width 1s cubic-bezier(.4,0,.2,1)');
+      setFillGradient(
+        'linear-gradient(90deg, rgba(221,0,49,.5) 0%, rgba(221,0,49,.38) 70%, rgba(0,64,144,.8) 82%, #004090 100%)'
+      );
+      setFillWidth('100%');
+      setPhase('closing');
+    }, 3200);
+    // Phase 4: done
+    setTimeout(() => setPhase('done'), 4400);
+  }, [phase]);
+
+  useEffect(() => {
+    if (inView) runAnimation();
+  }, [inView, runAnimation]);
+
+  const showStall = phase === 'stall';
+  const showBadge = phase === 'closing' || phase === 'done';
+  const showEnd = phase === 'done';
+
+  return (
+    <section style={{ padding: '80px 32px' }}>
+      {/* Eyebrow + headline */}
+      <motion.div
+        initial={{ opacity: 0, y: 16 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.5 }}
+        style={{ textAlign: 'center', marginBottom: 48 }}
+      >
+        <p style={{
+          fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+          fontSize: '0.7rem',
+          textTransform: 'uppercase',
+          letterSpacing: '0.12em',
+          fontWeight: 700,
+          color: tokens.colors.angularRed,
+          marginBottom: 14,
+        }}>
+          The Last Mile Problem
+        </p>
+        <h2 style={{
+          fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+          fontSize: 'clamp(26px, 3.5vw, 46px)',
+          fontWeight: 800,
+          lineHeight: 1.1,
+          color: tokens.colors.textPrimary,
+          marginBottom: 10,
+        }}>
+          Most AI projects get close.<br />
+          <span style={{ color: tokens.colors.angularRed }}>Almost none ship.</span>
+        </h2>
+        <p style={{
+          fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+          fontStyle: 'italic',
+          fontSize: '1.05rem',
+          color: tokens.colors.textSecondary,
+          maxWidth: 560,
+          margin: '0 auto',
+        }}>
+          The issue is not generating a demo. It is shipping a trustworthy product.
+        </p>
+      </motion.div>
+
+      {/* Stat cards */}
+      <div style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(3, 1fr)',
+        gap: 16,
+        maxWidth: 840,
+        margin: '0 auto 36px',
+      }}>
+        {STATS.map((s, i) => (
+          <motion.div
+            key={s.num}
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ delay: i * 0.1, duration: 0.5 }}
+            style={{
+              padding: '28px 20px',
+              textAlign: 'center',
+              borderRadius: 18,
+              background: tokens.glass.bg,
+              backdropFilter: `blur(${tokens.glass.blur})`,
+              WebkitBackdropFilter: `blur(${tokens.glass.blur})`,
+              border: `1px solid ${tokens.glass.border}`,
+              boxShadow: tokens.glass.shadow,
+            }}
+          >
+            <div style={{
+              fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+              fontSize: '3.4rem',
+              fontWeight: 800,
+              lineHeight: 1,
+              marginBottom: 10,
+              background: `linear-gradient(135deg, #c00, ${tokens.colors.angularRed})`,
+              WebkitBackgroundClip: 'text',
+              WebkitTextFillColor: 'transparent',
+              backgroundClip: 'text',
+            }}>{s.num}</div>
+            <p style={{ fontSize: '0.82rem', color: tokens.colors.textSecondary, lineHeight: 1.5 }}>
+              {s.label}
+            </p>
+          </motion.div>
+        ))}
+      </div>
+
+      {/* Gap animation */}
+      <motion.div
+        ref={triggerRef}
+        initial={{ opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ delay: 0.4, duration: 0.5 }}
+        style={{
+          maxWidth: 840,
+          margin: '0 auto',
+          padding: '36px 44px',
+          borderRadius: 20,
+          background: tokens.glass.bg,
+          backdropFilter: `blur(${tokens.glass.blur})`,
+          WebkitBackdropFilter: `blur(${tokens.glass.blur})`,
+          border: `1px solid ${tokens.glass.border}`,
+          boxShadow: tokens.glass.shadow,
+        }}
+      >
+        {/* Labels row */}
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end', marginBottom: 10 }}>
+          <span style={{ fontFamily: 'var(--font-mono,"JetBrains Mono",monospace)', fontSize: '0.68rem', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.07em', color: '#aaa' }}>
+            Project kickoff
+          </span>
+          <span style={{
+            fontFamily: 'var(--font-mono,"JetBrains Mono",monospace)', fontSize: '0.68rem', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.07em',
+            color: tokens.colors.angularRed,
+            opacity: showStall ? 1 : 0,
+            transition: 'opacity 0.4s',
+          }}>
+            ⚠ Teams stall here
+          </span>
+          <span style={{
+            fontFamily: 'var(--font-mono,"JetBrains Mono",monospace)', fontSize: '0.68rem', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.07em',
+            color: tokens.colors.accent,
+            opacity: showEnd ? 1 : 0,
+            transition: 'opacity 0.4s',
+          }}>
+            ✓ Production
+          </span>
+        </div>
+
+        {/* Track — overflow:hidden clips fill at container boundary, no border-radius artifact */}
+        <div style={{ position: 'relative', marginBottom: 10 }}>
+          <div style={{
+            height: 16,
+            borderRadius: 8,
+            background: 'rgba(0,0,0,0.07)',
+            overflow: 'hidden',
+            position: 'relative',
+          }}>
+            <div style={{
+              position: 'absolute',
+              left: 0, top: 0,
+              height: '100%',
+              width: fillWidth,
+              background: fillGradient,
+              transition: fillTransition,
+            }} />
+            {/* Hatch overlay (gap zone) */}
+            <div style={{
+              position: 'absolute',
+              left: '77%', top: 0,
+              width: '23%', height: '100%',
+              overflow: 'hidden',
+              opacity: showStall ? 1 : 0,
+              transition: 'opacity 0.4s',
+              pointerEvents: 'none',
+            }}>
+              <svg width="100%" height="100%" viewBox="0 0 100 16" preserveAspectRatio="none">
+                <defs>
+                  <pattern id="gap-hatch" patternUnits="userSpaceOnUse" width="10" height="10" patternTransform="rotate(45)">
+                    <line x1="0" y1="0" x2="0" y2="10" stroke="rgba(221,0,49,.18)" strokeWidth="4" />
+                  </pattern>
+                </defs>
+                <rect width="100" height="16" fill="url(#gap-hatch)" />
+              </svg>
+            </div>
+          </div>
+          {/* Stall pin — outside the overflow:hidden track */}
+          <div style={{
+            position: 'absolute',
+            left: '77%',
+            top: -8,
+            transform: 'translateX(-50%)',
+            opacity: showStall ? 1 : 0,
+            transition: 'opacity 0.4s',
+            pointerEvents: 'none',
+            textAlign: 'center',
+          }}>
+            <div style={{ width: 2, height: 34, background: tokens.colors.angularRed, margin: '0 auto', borderRadius: 1 }} />
+            <div style={{ fontFamily: 'var(--font-mono,"JetBrains Mono",monospace)', fontSize: '0.6rem', color: tokens.colors.angularRed, whiteSpace: 'nowrap', marginTop: 3, fontWeight: 700 }}>
+              77%
+            </div>
+          </div>
+        </div>
+
+        {/* Counter row */}
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: 8 }}>
+          <span style={{
+            fontFamily: 'var(--font-mono,"JetBrains Mono",monospace)', fontSize: '0.78rem', fontWeight: 700,
+            color: showEnd ? tokens.colors.accent : tokens.colors.angularRed,
+            transition: 'color 0.4s',
+            minWidth: 40,
+          }}>
+            {displayCount}%
+          </span>
+          <div style={{
+            display: 'inline-flex', alignItems: 'center', gap: 6,
+            background: `rgba(0,64,144,0.08)`,
+            border: `1px solid rgba(0,64,144,0.2)`,
+            borderRadius: 20,
+            padding: '4px 14px',
+            fontFamily: 'var(--font-mono,"JetBrains Mono",monospace)',
+            fontSize: '0.68rem',
+            color: tokens.colors.accent,
+            fontWeight: 700,
+            opacity: showBadge ? 1 : 0,
+            transform: showBadge ? 'scale(1)' : 'scale(0.9)',
+            transition: 'opacity 0.4s, transform 0.4s',
+          }}>
+            <span style={{ width: 6, height: 6, borderRadius: '50%', background: tokens.colors.accent, display: 'inline-block', animation: 'sr-pulse 1.2s ease-in-out infinite' }} />
+            StreamResource closes the gap
+          </div>
+          <span style={{
+            fontFamily: 'var(--font-mono,"JetBrains Mono",monospace)', fontSize: '0.78rem', fontWeight: 700,
+            color: tokens.colors.accent,
+            opacity: showEnd ? 1 : 0,
+            transition: 'opacity 0.4s',
+            minWidth: 40,
+            textAlign: 'right',
+          }}>
+            100%
+          </span>
+        </div>
+
+        {/* Tagline */}
+        <p style={{
+          textAlign: 'center',
+          marginTop: 20,
+          fontFamily: 'var(--font-garamond,"EB Garamond",Georgia,serif)',
+          fontStyle: 'italic',
+          fontSize: '1rem',
+          color: tokens.colors.textSecondary,
+          opacity: showEnd ? 1 : 0,
+          transition: 'opacity 0.6s',
+        }}>
+          Your backend agent may already work. The frontend and production path is what slips the schedule.
+        </p>
+      </motion.div>
+
+      <style>{`
+        @keyframes sr-pulse { 0%,100%{opacity:1;transform:scale(1)} 50%{opacity:.4;transform:scale(.6)} }
+      `}</style>
+    </section>
+  );
+}

--- a/cockpit/langgraph/interrupts/angular/src/app/interrupts.component.ts
+++ b/cockpit/langgraph/interrupts/angular/src/app/interrupts.component.ts
@@ -1,5 +1,6 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 import { Component } from '@angular/core';
-import { LegacyChatComponent } from '@cacheplane/chat';
+import { ChatComponent, ChatInterruptPanelComponent, type InterruptAction } from '@cacheplane/chat';
 import { streamResource } from '@cacheplane/stream-resource';
 import { environment } from '../environments/environment';
 
@@ -8,42 +9,26 @@ import { environment } from '../environments/environment';
  *
  * The LangGraph backend pauses execution when it needs human approval.
  * The `stream.interrupt()` signal provides the interrupt data, and
- * `stream.submit()` resumes execution with the human's decision.
+ * `stream.submit(null)` resumes execution with the human's decision.
  *
  * Key integration points:
- * - `stream.interrupt()` — current pause data
- * - `stream.submit({ resume: true })` — resume after approval
- * - The graph uses LangGraph's `interrupt()` function to pause
+ * - `stream.interrupt()` — current pause data (undefined when not interrupted)
+ * - `ChatInterruptPanelComponent` — renders the approval UI with action buttons
+ * - `stream.submit(null)` — resumes the graph (LangGraph convention)
  */
 @Component({
   selector: 'app-interrupts',
   standalone: true,
-  imports: [LegacyChatComponent],
+  imports: [ChatComponent, ChatInterruptPanelComponent],
   template: `
-    <cp-chat
-      [messages]="stream.messages()"
-      [isLoading]="stream.isLoading()"
-      [error]="stream.error()"
-      (sendMessage)="send($event)">
-      <ng-template #sidebar>
-        <h3 style="font-size: 0.8rem; font-weight: 600; margin-bottom: 0.75rem; color: #1a1a2e;">Approvals</h3>
-        @if (stream.interrupt()) {
-          <div style="padding: 8px; border: 1px solid rgba(0,64,144,0.15); border-radius: 6px; margin-bottom: 0.75rem; font-size: 0.8rem; color: #1a1a2e;">
-            <p style="margin: 0 0 8px 0;">{{ stream.interrupt() }}</p>
-            <button (click)="approve()"
-                    style="padding: 6px 10px; border: none; border-radius: 6px; background: #004090; color: white; cursor: pointer; font-size: 0.75rem; margin-right: 4px;">
-              Approve
-            </button>
-            <button (click)="reject()"
-                    style="padding: 6px 10px; border: 1px solid rgba(0,64,144,0.15); border-radius: 6px; background: none; cursor: pointer; font-size: 0.75rem; color: #004090;">
-              Reject
-            </button>
-          </div>
-        } @else {
-          <p style="font-size: 0.8rem; color: #555770;">No pending approvals</p>
-        }
-      </ng-template>
-    </cp-chat>
+    <div class="flex flex-col h-screen">
+      <chat [ref]="stream" class="flex-1 min-w-0" />
+      @if (stream.interrupt()) {
+        <div class="p-4" style="border-top: 1px solid var(--chat-border, #333);">
+          <chat-interrupt-panel [ref]="stream" (action)="onInterruptAction($event)" />
+        </div>
+      }
+    </div>
   `,
 })
 export class InterruptsComponent {
@@ -51,7 +36,7 @@ export class InterruptsComponent {
    * The streaming resource with interrupt support.
    *
    * When the LangGraph backend calls `interrupt()`, the `stream.interrupt()`
-   * signal emits the interrupt payload for display in the sidebar.
+   * signal emits the interrupt payload for display via ChatInterruptPanelComponent.
    */
   protected readonly stream = streamResource({
     apiUrl: environment.langGraphApiUrl,
@@ -59,25 +44,22 @@ export class InterruptsComponent {
   });
 
   /**
-   * Submit a message to the assistant.
+   * Handle an interrupt action from the panel.
+   *
+   * Submitting null resumes the graph unconditionally (LangGraph convention).
+   * Tier 3 will add edit/respond flows with richer resume payloads.
    */
-  send(text: string): void {
-    this.stream.submit({ messages: [{ role: 'human', content: text }] });
-  }
-
-  /**
-   * Approve the pending action and resume execution.
-   * Submitting null continues the graph (LangGraph convention).
-   */
-  approve(): void {
-    this.stream.submit(null);
-  }
-
-  /**
-   * Reject the pending action. Sends a resume value of false
-   * so the graph can handle rejection logic.
-   */
-  reject(): void {
-    this.stream.submit({ resume: false });
+  protected onInterruptAction(action: InterruptAction): void {
+    switch (action) {
+      case 'accept':
+        this.stream.submit(null);  // Resume with approval
+        break;
+      case 'ignore':
+      case 'respond':
+      case 'edit':
+        // For now, just resume — Tier 3 will add edit/respond flows
+        this.stream.submit(null);
+        break;
+    }
   }
 }

--- a/cockpit/langgraph/memory/angular/src/app/memory.component.ts
+++ b/cockpit/langgraph/memory/angular/src/app/memory.component.ts
@@ -1,5 +1,6 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 import { Component, computed } from '@angular/core';
-import { LegacyChatComponent } from '@cacheplane/chat';
+import { ChatComponent } from '@cacheplane/chat';
 import { streamResource } from '@cacheplane/stream-resource';
 import { environment } from '../environments/environment';
 
@@ -12,38 +13,31 @@ import { environment } from '../environments/environment';
  *
  * Key integration points:
  * - `stream.value()` exposes the full graph state, including the `memory` field
- * - `memory()` signal is derived from `stream.value()` for reactive sidebar rendering
+ * - `memoryEntries` is derived from `stream.value()` for reactive sidebar rendering
  * - Facts appear in the sidebar as the agent learns them during conversation
  */
 @Component({
   selector: 'app-memory',
   standalone: true,
-  imports: [LegacyChatComponent],
+  imports: [ChatComponent],
   template: `
-    <cp-chat
-      [messages]="stream.messages()"
-      [isLoading]="stream.isLoading()"
-      [error]="stream.error()"
-      (sendMessage)="send($event)">
-      <ng-template #sidebar>
-        <h3 style="font-size: 0.8rem; font-weight: 600; margin-bottom: 0.75rem; color: #1a1a2e;">Agent Memory</h3>
+    <div class="flex h-screen">
+      <chat [ref]="stream" class="flex-1 min-w-0" />
+      <aside class="w-72 shrink-0 border-l overflow-y-auto p-4 space-y-2"
+             style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
+        <h3 class="text-xs font-semibold uppercase tracking-wide"
+            style="color: var(--chat-text-muted, #777);">Learned Facts</h3>
         @if (memoryEntries().length === 0) {
-          <p style="font-size: 0.75rem; color: #888; font-style: italic;">
-            No facts learned yet. Start chatting!
-          </p>
+          <p class="text-sm italic" style="color: var(--chat-text-muted, #777);">No facts learned yet</p>
         }
-        @for (entry of memoryEntries(); track entry.key) {
-          <div style="margin-bottom: 0.5rem; padding: 6px 8px; background: rgba(0,64,144,0.04); border-radius: 6px; border-left: 3px solid rgba(0,64,144,0.2);">
-            <div style="font-size: 0.7rem; font-weight: 600; color: #004090; text-transform: uppercase; letter-spacing: 0.03em; margin-bottom: 2px;">
-              {{ entry.key }}
-            </div>
-            <div style="font-size: 0.8rem; color: #333; word-break: break-word;">
-              {{ entry.value }}
-            </div>
+        @for (entry of memoryEntries(); track entry[0]) {
+          <div class="text-sm py-1">
+            <span class="font-medium" style="color: var(--chat-text, #e0e0e0);">{{ entry[0] }}:</span>
+            <span style="color: var(--chat-text-muted, #777);"> {{ entry[1] }}</span>
           </div>
         }
-      </ng-template>
-    </cp-chat>
+      </aside>
+    </div>
   `,
 })
 export class MemoryComponent {
@@ -59,24 +53,15 @@ export class MemoryComponent {
   });
 
   /**
-   * Reactive list of key-value memory entries derived from the graph state.
+   * Reactive list of [key, value] memory entries derived from the graph state.
    *
-   * The graph updates `memory` as it learns facts from the conversation.
+   * The Python graph stores learned facts in `state.memory` as a plain dict.
    * This signal re-computes whenever the stream state changes.
    */
   protected readonly memoryEntries = computed(() => {
-    const state = this.stream.value() as { memory?: Record<string, unknown> } | null;
-    const memory = state?.memory ?? {};
-    return Object.entries(memory).map(([key, value]) => ({
-      key,
-      value: typeof value === 'string' ? value : JSON.stringify(value),
-    }));
+    const val = this.stream.value() as Record<string, unknown>;
+    const mem = val?.['memory'];
+    if (!mem || typeof mem !== 'object') return [];
+    return Object.entries(mem as Record<string, string>);
   });
-
-  /**
-   * Submit a message to the agent.
-   */
-  send(text: string): void {
-    this.stream.submit({ messages: [{ role: 'human', content: text }] });
-  }
 }

--- a/cockpit/langgraph/subgraphs/angular/src/app/subgraphs.component.ts
+++ b/cockpit/langgraph/subgraphs/angular/src/app/subgraphs.component.ts
@@ -1,5 +1,6 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 import { Component, computed } from '@angular/core';
-import { LegacyChatComponent } from '@cacheplane/chat';
+import { ChatComponent } from '@cacheplane/chat';
 import { streamResource } from '@cacheplane/stream-resource';
 import { environment } from '../environments/environment';
 
@@ -8,35 +9,38 @@ import { environment } from '../environments/environment';
  *
  * This example shows how a parent orchestrator delegates tasks to child subgraphs.
  * The sidebar tracks active subagents in real time using `stream.subagents()`,
- * a Map of running child graph executions and their current status.
+ * a Signal<Map<string, SubagentStreamRef>> of running child graph executions.
  *
  * Key integration points:
  * - `stream.subagents()` returns a Map<string, SubagentStreamRef> of active subagents
- * - Each entry has a unique run ID (key) and a `status()` signal ('running' | 'done' | 'error')
- * - `subagentEntries` is a `computed()` signal derived from the map for iteration in the template
+ * - Each entry has a unique tool call ID (key) and a `status()` signal
+ * - `subagentEntries` is a `computed()` signal derived from the map for template iteration
  */
 @Component({
   selector: 'app-subgraphs',
   standalone: true,
-  imports: [LegacyChatComponent],
+  imports: [ChatComponent],
   template: `
-    <cp-chat
-      [messages]="stream.messages()"
-      [isLoading]="stream.isLoading()"
-      [error]="stream.error()"
-      (sendMessage)="send($event)">
-      <ng-template #sidebar>
-        <h3 style="font-size: 0.8rem; font-weight: 600; margin-bottom: 0.75rem; color: #1a1a2e;">Subagents</h3>
-        @for (entry of subagentEntries(); track entry[0]) {
-          <div style="font-size: 0.75rem; font-family: monospace; padding: 4px 0; color: #555770;">
-            {{ entry[0].substring(0, 8) }}: {{ entry[1].status() }}
+    <div class="flex h-screen">
+      <chat [ref]="stream" class="flex-1 min-w-0" />
+      <aside class="w-72 shrink-0 border-l overflow-y-auto p-4 space-y-2"
+             style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
+        <h3 class="text-xs font-semibold uppercase tracking-wide"
+            style="color: var(--chat-text-muted, #777);">Subagents</h3>
+        @if (subagentEntries().length === 0) {
+          <p class="text-sm italic" style="color: var(--chat-text-muted, #777);">No subagents active</p>
+        }
+        @for (entry of subagentEntries(); track entry.id) {
+          <div class="flex items-center gap-2 text-sm py-1">
+            <span class="w-2 h-2 rounded-full shrink-0"
+                  [style.background]="entry.status === 'complete' ? 'var(--chat-success, #4ade80)' : entry.status === 'error' ? 'var(--chat-error-text, #f87171)' : 'var(--chat-warning-text, #fbbf24)'">
+            </span>
+            <span class="font-mono text-xs truncate" style="color: var(--chat-text, #e0e0e0);">{{ entry.id }}</span>
+            <span class="text-xs ml-auto" style="color: var(--chat-text-muted, #777);">{{ entry.msgCount }} msgs</span>
           </div>
         }
-        @empty {
-          <p style="font-size: 0.75rem; color: #9ba0b4; margin: 0;">No active subagents</p>
-        }
-      </ng-template>
-    </cp-chat>
+      </aside>
+    </div>
   `,
 })
 export class SubgraphsComponent {
@@ -52,15 +56,15 @@ export class SubgraphsComponent {
   });
 
   /**
-   * Derived signal: converts the subagents Map to an array of entries for template iteration.
+   * Derived signal: converts the subagents Map to an array for template iteration.
    * Using `computed()` ensures the template re-renders whenever the Map changes.
    */
-  subagentEntries = computed(() => Array.from(this.stream.subagents().entries()));
-
-  /**
-   * Submit a message to the orchestrator graph.
-   */
-  send(text: string): void {
-    this.stream.submit({ messages: [{ role: 'human', content: text }] });
-  }
+  protected readonly subagentEntries = computed(() => {
+    const map = this.stream.subagents();
+    return Array.from(map.entries()).map(([id, ref]) => ({
+      id,
+      status: ref.status(),
+      msgCount: ref.messages().length,
+    }));
+  });
 }


### PR DESCRIPTION
## Summary

Customizes 3 LangGraph cockpit examples (Tier 2) with capability-specific UI:

- **memory** — right sidebar showing learned facts as key-value pairs, derived from `stream.value().memory`
- **subgraphs** — right sidebar with live subagent status dots + message counts, derived from `stream.subagents()` Map
- **interrupts** — `ChatInterruptPanelComponent` below chat, shown when `stream.interrupt()` is active, all actions resume via `stream.submit(null)`

All sidebars themed with `var(--chat-*)` CSS custom properties.

## Test plan

- [ ] `nx run-many -t build --projects='cockpit-*-angular'` — all 14 build
- [ ] `nx test render && nx test chat` — all pass