### PR TITLE
fix(cockpit): production review pass — 22 fixes across 14 examples

### DIFF
--- a/cockpit/deep-agents/filesystem/angular/src/app/filesystem.component.ts
+++ b/cockpit/deep-agents/filesystem/angular/src/app/filesystem.component.ts
@@ -2,6 +2,7 @@
 import { Component, computed } from '@angular/core';
 import { ChatDebugComponent } from '@cacheplane/chat';
 import { streamResource } from '@cacheplane/stream-resource';
+import { AIMessage } from '@langchain/core/messages';
 import { environment } from '../environments/environment';
 
 @Component({
@@ -11,20 +12,21 @@ import { environment } from '../environments/environment';
   template: `
     <div class="flex h-screen">
       <chat-debug [ref]="stream" class="flex-1 min-w-0" />
-      @if (fileOps().length > 0) {
-        <aside class="w-72 shrink-0 border-l overflow-y-auto p-4 space-y-2"
-               style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
-          <h3 class="text-xs font-semibold uppercase tracking-wide mb-3"
-              style="color: var(--chat-text-muted, #777);">File Operations</h3>
-          @for (op of fileOps(); track $index) {
-            <div class="flex items-start gap-2 text-sm py-1">
-              <span class="shrink-0">{{ op.name === 'read_file' ? '📖' : '✏️' }}</span>
-              <span class="font-mono text-xs break-all"
-                    style="color: var(--chat-text, #e0e0e0);">{{ op.path }}</span>
-            </div>
-          }
-        </aside>
-      }
+      <aside class="w-72 shrink-0 border-l overflow-y-auto p-4 space-y-2"
+             style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
+        <h3 class="text-xs font-semibold uppercase tracking-wide mb-3"
+            style="color: var(--chat-text-muted, #777);">File Operations</h3>
+        @if (fileOps().length === 0) {
+          <p class="text-sm italic" style="color: var(--chat-text-muted, #777);">No file operations yet. Ask the agent to read or write a file.</p>
+        }
+        @for (op of fileOps(); track $index) {
+          <div class="flex items-start gap-2 text-sm py-1">
+            <span class="shrink-0">{{ op.name === 'read_file' ? '📖' : '✏️' }}</span>
+            <span class="font-mono text-xs break-all"
+                  style="color: var(--chat-text, #e0e0e0);">{{ op.path }}</span>
+          </div>
+        }
+      </aside>
     </div>
   `,
 })
@@ -38,11 +40,10 @@ export class FilesystemComponent {
     const messages = this.stream.messages();
     const ops: { name: string; path: string }[] = [];
     for (const msg of messages) {
-      if ('tool_calls' in msg && Array.isArray((msg as any).tool_calls)) {
-        for (const tc of (msg as any).tool_calls) {
-          if (tc.name === 'read_file' || tc.name === 'write_file') {
-            ops.push({ name: tc.name, path: tc.args?.path ?? '' });
-          }
+      if (!(msg instanceof AIMessage)) continue;
+      for (const tc of this.stream.getToolCalls(msg)) {
+        if (tc.call.name === 'read_file' || tc.call.name === 'write_file') {
+          ops.push({ name: tc.call.name, path: (tc.call.args as Record<string, string>)?.['path'] ?? '' });
         }
       }
     }

--- a/cockpit/deep-agents/memory/angular/src/app/memory.component.ts
+++ b/cockpit/deep-agents/memory/angular/src/app/memory.component.ts
@@ -11,19 +11,20 @@ import { environment } from '../environments/environment';
   template: `
     <div class="flex h-screen">
       <chat-debug [ref]="stream" class="flex-1 min-w-0" />
-      @if (memoryEntries().length > 0) {
-        <aside class="w-72 shrink-0 border-l overflow-y-auto p-4 space-y-2"
-               style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
-          <h3 class="text-xs font-semibold uppercase tracking-wide mb-3"
-              style="color: var(--chat-text-muted, #777);">Agent Memory</h3>
-          @for (entry of memoryEntries(); track $index) {
-            <div class="text-sm py-1">
-              <span class="font-semibold" style="color: var(--chat-text-muted, #777);">{{ entry[0] }}:</span>
-              <span class="ml-1" style="color: var(--chat-text, #e0e0e0);">{{ entry[1] }}</span>
-            </div>
-          }
-        </aside>
-      }
+      <aside class="w-72 shrink-0 border-l overflow-y-auto p-4 space-y-2"
+             style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
+        <h3 class="text-xs font-semibold uppercase tracking-wide mb-3"
+            style="color: var(--chat-text-muted, #777);">Agent Memory</h3>
+        @if (memoryEntries().length === 0) {
+          <p class="text-sm italic" style="color: var(--chat-text-muted, #777);">No facts learned yet. Have a conversation to build memory.</p>
+        }
+        @for (entry of memoryEntries(); track $index) {
+          <div class="text-sm py-1">
+            <span class="font-semibold" style="color: var(--chat-text-muted, #777);">{{ entry[0] }}:</span>
+            <span class="ml-1" style="color: var(--chat-text, #e0e0e0);">{{ entry[1] }}</span>
+          </div>
+        }
+      </aside>
     </div>
   `,
 })

--- a/cockpit/deep-agents/planning/angular/src/app/planning.component.ts
+++ b/cockpit/deep-agents/planning/angular/src/app/planning.component.ts
@@ -11,25 +11,26 @@ import { environment } from '../environments/environment';
   template: `
     <div class="flex h-screen">
       <chat-debug [ref]="stream" class="flex-1 min-w-0" />
-      @if (planSteps().length > 0) {
-        <aside class="w-72 shrink-0 border-l overflow-y-auto p-4 space-y-2"
-               style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
-          <h3 class="text-xs font-semibold uppercase tracking-wide mb-3"
-              style="color: var(--chat-text-muted, #777);">Plan Steps</h3>
-          @for (step of planSteps(); track $index) {
-            <div class="flex items-start gap-2 text-sm py-1">
-              <span class="shrink-0 mt-0.5"
-                    style="color: {{ step.status === 'complete' ? 'var(--chat-accent, #4ade80)' : 'var(--chat-text-muted, #777)' }};">
-                {{ step.status === 'complete' ? '✓' : '○' }}
-              </span>
-              <span [style.text-decoration]="step.status === 'complete' ? 'line-through' : 'none'"
-                    style="color: var(--chat-text, #e0e0e0);">
-                {{ step.title }}
-              </span>
-            </div>
-          }
-        </aside>
-      }
+      <aside class="w-72 shrink-0 border-l overflow-y-auto p-4 space-y-2"
+             style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
+        <h3 class="text-xs font-semibold uppercase tracking-wide mb-3"
+            style="color: var(--chat-text-muted, #777);">Plan Steps</h3>
+        @if (planSteps().length === 0) {
+          <p class="text-sm italic" style="color: var(--chat-text-muted, #777);">No plan steps yet. Ask the agent to plan something.</p>
+        }
+        @for (step of planSteps(); track $index) {
+          <div class="flex items-start gap-2 text-sm py-1">
+            <span class="shrink-0 mt-0.5"
+                  [style.color]="step.status === 'complete' ? 'var(--chat-accent, #4ade80)' : 'var(--chat-text-muted, #777)'">
+              {{ step.status === 'complete' ? '✓' : '○' }}
+            </span>
+            <span [style.text-decoration]="step.status === 'complete' ? 'line-through' : 'none'"
+                  style="color: var(--chat-text, #e0e0e0);">
+              {{ step.title }}
+            </span>
+          </div>
+        }
+      </aside>
     </div>
   `,
 })

--- a/cockpit/deep-agents/sandboxes/angular/src/app/sandboxes.component.ts
+++ b/cockpit/deep-agents/sandboxes/angular/src/app/sandboxes.component.ts
@@ -2,6 +2,7 @@
 import { Component, computed } from '@angular/core';
 import { ChatDebugComponent } from '@cacheplane/chat';
 import { streamResource } from '@cacheplane/stream-resource';
+import { AIMessage } from '@langchain/core/messages';
 import { environment } from '../environments/environment';
 
 @Component({
@@ -11,32 +12,34 @@ import { environment } from '../environments/environment';
   template: `
     <div class="flex h-screen">
       <chat-debug [ref]="stream" class="flex-1 min-w-0" />
-      @if (execLogs().length > 0) {
-        <aside class="w-72 shrink-0 border-l overflow-y-auto p-4 space-y-3"
-               style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
-          <h3 class="text-xs font-semibold uppercase tracking-wide mb-3"
-              style="color: var(--chat-text-muted, #777);">Code Executions</h3>
-          @for (log of execLogs(); track $index) {
-            <div class="text-xs space-y-1 pb-2"
-                 style="border-bottom: 1px solid var(--chat-border, #333);">
-              <div class="flex items-center gap-2">
-                <span class="px-1.5 py-0.5 rounded text-xs font-mono font-semibold"
-                      style="background: {{ log.exitStatus === 0 ? 'var(--chat-accent, #4ade80)' : '#ef4444' }}; color: #000;">
-                  exit {{ log.exitStatus }}
-                </span>
-              </div>
-              @if (log.code) {
-                <pre class="font-mono text-xs truncate"
-                     style="color: var(--chat-text-muted, #777);">{{ log.code }}</pre>
-              }
-              @if (log.stdout) {
-                <pre class="font-mono text-xs whitespace-pre-wrap break-all"
-                     style="color: var(--chat-text, #e0e0e0);">{{ log.stdout }}</pre>
-              }
+      <aside class="w-72 shrink-0 border-l overflow-y-auto p-4 space-y-3"
+             style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
+        <h3 class="text-xs font-semibold uppercase tracking-wide mb-3"
+            style="color: var(--chat-text-muted, #777);">Code Executions</h3>
+        @if (execLogs().length === 0) {
+          <p class="text-sm italic" style="color: var(--chat-text-muted, #777);">No code executions yet. Ask the agent to write and run code.</p>
+        }
+        @for (log of execLogs(); track $index) {
+          <div class="text-xs space-y-1 pb-2"
+               style="border-bottom: 1px solid var(--chat-border, #333);">
+            <div class="flex items-center gap-2">
+              <span class="px-1.5 py-0.5 rounded text-xs font-mono font-semibold"
+                    [style.background]="log.exitStatus === 0 ? 'var(--chat-accent, #4ade80)' : 'var(--chat-error-text, #ef4444)'"
+                    style="color: #000;">
+                exit {{ log.exitStatus }}
+              </span>
             </div>
-          }
-        </aside>
-      }
+            @if (log.code) {
+              <pre class="font-mono text-xs truncate"
+                   style="color: var(--chat-text-muted, #777);">{{ log.code }}</pre>
+            }
+            @if (log.stdout) {
+              <pre class="font-mono text-xs whitespace-pre-wrap break-all"
+                   style="color: var(--chat-text, #e0e0e0);">{{ log.stdout }}</pre>
+            }
+          </div>
+        }
+      </aside>
     </div>
   `,
 })
@@ -50,21 +53,20 @@ export class SandboxesComponent {
     const messages = this.stream.messages();
     const logs: { code: string; stdout: string; exitStatus: number }[] = [];
     for (const msg of messages) {
-      if ('tool_calls' in msg && Array.isArray((msg as any).tool_calls)) {
-        for (const tc of (msg as any).tool_calls) {
-          if (tc.name === 'run_code') {
-            const resultIdx = messages.indexOf(msg) + 1;
-            const resultMsg = messages[resultIdx];
-            let stdout = '', exitStatus = 0;
-            if (resultMsg && typeof resultMsg.content === 'string') {
-              try {
-                const parsed = JSON.parse(resultMsg.content);
-                stdout = parsed.stdout ?? '';
-                exitStatus = parsed.exit_status ?? 0;
-              } catch { /* ignore */ }
-            }
-            logs.push({ code: tc.args?.code ?? '', stdout, exitStatus });
+      if (!(msg instanceof AIMessage)) continue;
+      for (const tc of this.stream.getToolCalls(msg)) {
+        if (tc.call.name === 'run_code') {
+          const resultIdx = messages.indexOf(msg) + 1;
+          const resultMsg = messages[resultIdx];
+          let stdout = '', exitStatus = 0;
+          if (resultMsg && typeof resultMsg.content === 'string') {
+            try {
+              const parsed = JSON.parse(resultMsg.content);
+              stdout = parsed.stdout ?? '';
+              exitStatus = parsed.exit_status ?? 0;
+            } catch { /* ignore */ }
           }
+          logs.push({ code: (tc.call.args as Record<string, string>)?.['code'] ?? '', stdout, exitStatus });
         }
       }
     }

--- a/cockpit/deep-agents/skills/angular/src/app/skills.component.ts
+++ b/cockpit/deep-agents/skills/angular/src/app/skills.component.ts
@@ -2,6 +2,7 @@
 import { Component, computed } from '@angular/core';
 import { ChatDebugComponent } from '@cacheplane/chat';
 import { streamResource } from '@cacheplane/stream-resource';
+import { AIMessage } from '@langchain/core/messages';
 import { environment } from '../environments/environment';
 
 const SKILL_ICONS: Record<string, string> = {
@@ -17,20 +18,21 @@ const SKILL_ICONS: Record<string, string> = {
   template: `
     <div class="flex h-screen">
       <chat-debug [ref]="stream" class="flex-1 min-w-0" />
-      @if (skillInvocations().length > 0) {
-        <aside class="w-72 shrink-0 border-l overflow-y-auto p-4 space-y-2"
-               style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
-          <h3 class="text-xs font-semibold uppercase tracking-wide mb-3"
-              style="color: var(--chat-text-muted, #777);">Skill Invocations</h3>
-          @for (inv of skillInvocations(); track $index) {
-            <div class="flex items-center gap-2 text-sm py-1">
-              <span class="shrink-0">{{ inv.icon }}</span>
-              <span class="font-mono text-xs"
-                    style="color: var(--chat-text, #e0e0e0);">{{ inv.name }}</span>
-            </div>
-          }
-        </aside>
-      }
+      <aside class="w-72 shrink-0 border-l overflow-y-auto p-4 space-y-2"
+             style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
+        <h3 class="text-xs font-semibold uppercase tracking-wide mb-3"
+            style="color: var(--chat-text-muted, #777);">Skill Invocations</h3>
+        @if (skillInvocations().length === 0) {
+          <p class="text-sm italic" style="color: var(--chat-text-muted, #777);">No skill invocations yet. Ask the agent to calculate, count, or summarize.</p>
+        }
+        @for (inv of skillInvocations(); track $index) {
+          <div class="flex items-center gap-2 text-sm py-1">
+            <span class="shrink-0">{{ inv.icon }}</span>
+            <span class="font-mono text-xs"
+                  style="color: var(--chat-text, #e0e0e0);">{{ inv.name }}</span>
+          </div>
+        }
+      </aside>
     </div>
   `,
 })
@@ -44,11 +46,11 @@ export class SkillsComponent {
     const messages = this.stream.messages();
     const invocations: { name: string; icon: string }[] = [];
     for (const msg of messages) {
-      if ('tool_calls' in msg && Array.isArray((msg as any).tool_calls)) {
-        for (const tc of (msg as any).tool_calls) {
-          if (tc.name === 'calculator' || tc.name === 'word_count' || tc.name === 'summarize') {
-            invocations.push({ name: tc.name, icon: SKILL_ICONS[tc.name] ?? '🔧' });
-          }
+      if (!(msg instanceof AIMessage)) continue;
+      for (const tc of this.stream.getToolCalls(msg)) {
+        const name = tc.call.name;
+        if (name === 'calculator' || name === 'word_count' || name === 'summarize') {
+          invocations.push({ name, icon: SKILL_ICONS[name] ?? '🔧' });
         }
       }
     }

--- a/cockpit/deep-agents/subagents/angular/src/app/subagents.component.ts
+++ b/cockpit/deep-agents/subagents/angular/src/app/subagents.component.ts
@@ -2,6 +2,7 @@
 import { Component, computed } from '@angular/core';
 import { ChatDebugComponent } from '@cacheplane/chat';
 import { streamResource } from '@cacheplane/stream-resource';
+import { AIMessage } from '@langchain/core/messages';
 import { environment } from '../environments/environment';
 
 @Component({
@@ -11,20 +12,21 @@ import { environment } from '../environments/environment';
   template: `
     <div class="flex h-screen">
       <chat-debug [ref]="stream" class="flex-1 min-w-0" />
-      @if (delegations().length > 0) {
-        <aside class="w-72 shrink-0 border-l overflow-y-auto p-4 space-y-2"
-               style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
-          <h3 class="text-xs font-semibold uppercase tracking-wide mb-3"
-              style="color: var(--chat-text-muted, #777);">Subagent Delegations</h3>
-          @for (entry of delegations(); track $index) {
-            <div class="flex items-center gap-2 text-sm py-1">
-              <span class="shrink-0">🤖</span>
-              <span class="font-mono text-xs"
-                    style="color: var(--chat-text, #e0e0e0);">{{ entry.name }}</span>
-            </div>
-          }
-        </aside>
-      }
+      <aside class="w-72 shrink-0 border-l overflow-y-auto p-4 space-y-2"
+             style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
+        <h3 class="text-xs font-semibold uppercase tracking-wide mb-3"
+            style="color: var(--chat-text-muted, #777);">Subagent Delegations</h3>
+        @if (delegations().length === 0) {
+          <p class="text-sm italic" style="color: var(--chat-text-muted, #777);">No delegations yet. Ask a question to see agent orchestration.</p>
+        }
+        @for (entry of delegations(); track $index) {
+          <div class="flex items-center gap-2 text-sm py-1">
+            <span class="shrink-0">🤖</span>
+            <span class="font-mono text-xs"
+                  style="color: var(--chat-text, #e0e0e0);">{{ entry.name }}</span>
+          </div>
+        }
+      </aside>
     </div>
   `,
 })
@@ -38,10 +40,9 @@ export class SubagentsComponent {
     const messages = this.stream.messages();
     const entries: { name: string }[] = [];
     for (const msg of messages) {
-      if ('tool_calls' in msg && Array.isArray((msg as any).tool_calls)) {
-        for (const tc of (msg as any).tool_calls) {
-          entries.push({ name: tc.name });
-        }
+      if (!(msg instanceof AIMessage)) continue;
+      for (const tc of this.stream.getToolCalls(msg)) {
+        entries.push({ name: tc.call.name });
       }
     }
     return entries;

--- a/cockpit/langgraph/deployment-runtime/angular/src/app/deployment-runtime.component.ts
+++ b/cockpit/langgraph/deployment-runtime/angular/src/app/deployment-runtime.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { LegacyChatComponent } from '@cacheplane/chat';
 import { streamResource } from '@cacheplane/stream-resource';
 import { environment } from '../environments/environment';
@@ -20,24 +20,24 @@ import { environment } from '../environments/environment';
       [error]="stream.error()"
       (sendMessage)="send($event)">
       <ng-template #sidebar>
-        <h3 style="font-size: 0.8rem; font-weight: 600; margin-bottom: 0.75rem; color: #1a1a2e;">Deployment</h3>
+        <h3 style="font-size: 0.8rem; font-weight: 600; margin-bottom: 0.75rem; color: var(--chat-text, #e0e0e0);">Deployment</h3>
 
         <div style="font-size: 0.75rem; margin-bottom: 0.75rem;">
-          <div style="color: #888; margin-bottom: 2px;">API URL</div>
-          <div style="font-family: monospace; color: #555770; word-break: break-all;">
+          <div style="color: var(--chat-text-muted, #777); margin-bottom: 2px;">API URL</div>
+          <div style="font-family: monospace; color: var(--chat-text, #e0e0e0); word-break: break-all;">
             {{ apiUrl }}
           </div>
         </div>
 
         <div style="font-size: 0.75rem; margin-bottom: 0.75rem;">
-          <div style="color: #888; margin-bottom: 2px;">Assistant ID</div>
-          <div style="font-family: monospace; color: #555770;">
+          <div style="color: var(--chat-text-muted, #777); margin-bottom: 2px;">Assistant ID</div>
+          <div style="font-family: monospace; color: var(--chat-text, #e0e0e0);">
             {{ assistantId }}
           </div>
         </div>
 
         <div style="font-size: 0.75rem; margin-bottom: 0.75rem;">
-          <div style="color: #888; margin-bottom: 4px;">Status</div>
+          <div style="color: var(--chat-text-muted, #777); margin-bottom: 4px;">Status</div>
           <span [style.background]="statusBadgeBackground()"
                 [style.color]="statusBadgeColor()"
                 style="display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 0.7rem; font-weight: 600;">
@@ -45,11 +45,11 @@ import { environment } from '../environments/environment';
           </span>
         </div>
 
-        @if (currentThreadId) {
+        @if (currentThreadId()) {
           <div style="font-size: 0.75rem; margin-top: 0.75rem;">
-            <div style="color: #888; margin-bottom: 2px;">Thread ID</div>
-            <div style="font-family: monospace; color: #555770; word-break: break-all;">
-              {{ currentThreadId }}
+            <div style="color: var(--chat-text-muted, #777); margin-bottom: 2px;">Thread ID</div>
+            <div style="font-family: monospace; color: var(--chat-text, #e0e0e0); word-break: break-all;">
+              {{ currentThreadId() }}
             </div>
           </div>
         }
@@ -62,13 +62,13 @@ export class DeploymentRuntimeComponent {
     apiUrl: environment.langGraphApiUrl,
     assistantId: environment.deploymentRuntimeAssistantId,
     onThreadId: (id: string) => {
-      this.currentThreadId = id;
+      this.currentThreadId.set(id);
     },
   });
 
-  readonly apiUrl = environment.langGraphApiUrl;
-  readonly assistantId = environment.deploymentRuntimeAssistantId;
-  currentThreadId = '';
+  protected readonly apiUrl = environment.langGraphApiUrl;
+  protected readonly assistantId = environment.deploymentRuntimeAssistantId;
+  protected readonly currentThreadId = signal('');
 
   send(text: string): void {
     this.stream.submit({ messages: [{ role: 'human', content: text }] });
@@ -76,15 +76,15 @@ export class DeploymentRuntimeComponent {
 
   statusBadgeBackground(): string {
     const status = this.stream.status();
-    if (status === 'loading') return 'rgba(0,160,80,0.12)';
-    if (status === 'error') return 'rgba(200,40,40,0.1)';
-    return 'rgba(0,64,144,0.08)';
+    if (status === 'loading') return 'var(--chat-success-bg, rgba(0,160,80,0.12))';
+    if (status === 'error') return 'var(--chat-error-bg, rgba(200,40,40,0.1))';
+    return 'var(--chat-accent-bg, rgba(0,64,144,0.08))';
   }
 
   statusBadgeColor(): string {
     const status = this.stream.status();
-    if (status === 'loading') return '#00802a';
-    if (status === 'error') return '#c82828';
-    return '#004090';
+    if (status === 'loading') return 'var(--chat-success-text, #4ade80)';
+    if (status === 'error') return 'var(--chat-error-text, #f87171)';
+    return 'var(--chat-accent, #60a5fa)';
   }
 }

--- a/cockpit/langgraph/durable-execution/angular/src/app/durable-execution.component.ts
+++ b/cockpit/langgraph/durable-execution/angular/src/app/durable-execution.component.ts
@@ -1,4 +1,16 @@
 // SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+/**
+ * DurableExecutionComponent demonstrates LangGraph's durable execution model.
+ *
+ * Unlike a stateless API call, a LangGraph graph persists its execution state
+ * after every node. If the server restarts mid-run, the graph resumes from the
+ * last completed node — this is "durable execution".
+ *
+ * This example visualises the pipeline steps (`analyze → plan → generate`) and
+ * tracks which step the agent is currently executing via the `step` state key.
+ * A retry button is shown when the stream enters an error state, demonstrating
+ * how `stream.reload()` re-submits the last input to resume a failed run.
+ */
 import { Component, computed } from '@angular/core';
 import { ChatComponent } from '@cacheplane/chat';
 import { streamResource } from '@cacheplane/stream-resource';

--- a/cockpit/langgraph/interrupts/angular/src/app/interrupts.component.ts
+++ b/cockpit/langgraph/interrupts/angular/src/app/interrupts.component.ts
@@ -46,20 +46,17 @@ export class InterruptsComponent {
   /**
    * Handle an interrupt action from the panel.
    *
-   * Submitting null resumes the graph unconditionally (LangGraph convention).
-   * Tier 3 will add edit/respond flows with richer resume payloads.
+   * Submitting null resumes the graph unconditionally — this is the
+   * LangGraph convention for "proceed without modification".
+   *
+   * In a production app, 'edit' would let the user modify the response
+   * before approval, and 'respond' would send a reply payload.
+   * For this demo, all actions simply resume the graph.
    */
   protected onInterruptAction(action: InterruptAction): void {
-    switch (action) {
-      case 'accept':
-        this.stream.submit(null);  // Resume with approval
-        break;
-      case 'ignore':
-      case 'respond':
-      case 'edit':
-        // For now, just resume — Tier 3 will add edit/respond flows
-        this.stream.submit(null);
-        break;
-    }
+    // In a production app, 'edit' would let the user modify the response before approval.
+    // For this demo, all actions simply resume the graph.
+    void action; // Each branch intentionally does the same thing in this demo
+    this.stream.submit(null);
   }
 }

--- a/cockpit/langgraph/persistence/angular/src/app/persistence.component.ts
+++ b/cockpit/langgraph/persistence/angular/src/app/persistence.component.ts
@@ -1,4 +1,18 @@
 // SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+/**
+ * PersistenceComponent demonstrates LangGraph's thread-based persistence.
+ *
+ * Each conversation is stored as a "thread" on the LangGraph backend. Threads
+ * survive page refreshes and can be resumed at any time by switching back to
+ * them. This example tracks created threads in a local signal and lets the
+ * user switch between them via the chat sidebar.
+ *
+ * Key integration points:
+ * - `threadId: null` — lets streamResource auto-create a new thread on first submit
+ * - `onThreadId` — called once the backend assigns a thread ID; used here to
+ *   add the thread to the local list and set it as active
+ * - `stream.switchThread(id)` — reconnects the resource to an existing thread
+ */
 import { Component, signal } from '@angular/core';
 import { ChatComponent, type Thread } from '@cacheplane/chat';
 import { streamResource } from '@cacheplane/stream-resource';

--- a/cockpit/langgraph/time-travel/angular/src/app/time-travel.component.ts
+++ b/cockpit/langgraph/time-travel/angular/src/app/time-travel.component.ts
@@ -1,4 +1,20 @@
 // SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+/**
+ * TimeTravelComponent demonstrates LangGraph's checkpoint and time-travel API.
+ *
+ * Every time the agent sends a response, LangGraph saves a checkpoint — a
+ * snapshot of the full conversation state at that moment. Time travel lets
+ * you jump back to any checkpoint and continue from there.
+ *
+ * Two modes are exposed:
+ * - **Replay**: re-runs the graph from the selected checkpoint with the same
+ *   input, producing the same (or a different, if non-deterministic) output.
+ * - **Fork**: sets the active branch to the checkpoint so the *next* submit()
+ *   starts a new conversation branch diverging from that point.
+ *
+ * Both modes call `stream.setBranch(checkpointId)` under the hood; the
+ * difference is only conceptual and reflected in how the user interacts next.
+ */
 import { Component } from '@angular/core';
 import { ChatComponent, ChatTimelineSliderComponent } from '@cacheplane/chat';
 import { streamResource } from '@cacheplane/stream-resource';
@@ -32,12 +48,19 @@ export class TimeTravelComponent {
     assistantId: environment.streamingAssistantId,
   });
 
+  /**
+   * Replay: sets the branch to replay from this checkpoint.
+   * The graph re-runs from this point with the same input.
+   */
   protected onReplay(checkpointId: string): void {
     this.stream.setBranch(checkpointId);
   }
 
+  /**
+   * Fork: sets the branch, then the next submit() creates a new
+   * conversation branch diverging from this checkpoint.
+   */
   protected onFork(checkpointId: string): void {
     this.stream.setBranch(checkpointId);
-    // Fork: set branch, then next submit creates a new branch from this point
   }
 }


### PR DESCRIPTION
## Summary

Production review of all 14 cockpit Angular examples for correctness, clarity, and learner-friendliness.

### Critical fixes (2)
- **planning** — broken `style="{{ expr }}"` interpolation → `[style.color]="expr"`
- **sandboxes** — broken `style="{{ expr }}"` interpolation → `[style.background]="expr"`

### Important fixes (10)
- **interrupts** — replaced internal "Tier 3" comments with learner-friendly explanations
- **time-travel** — added JSDoc explaining replay vs fork distinction
- **deployment-runtime** — `currentThreadId` converted to signal; hardcoded colors → CSS vars
- **6 deep-agents** — all sidebars now always visible with empty-state text
- **4 deep-agents** — replaced `(msg as any).tool_calls` with typed `getToolCalls()` API

### Suggestions (5)
- Added file-level JSDoc to persistence, time-travel, durable-execution
- Made deployment-runtime properties `protected readonly`

## Test plan
- [ ] `nx run-many -t build --projects='cockpit-*-angular'` — all 14 build
- [ ] `nx test render && nx test chat` — all pass