### PR TITLE
feat(cockpit): complete sidebar implementations for all 14 capability examples

### DIFF
--- a/cockpit/deep-agents/filesystem/angular/src/app/filesystem.component.ts
+++ b/cockpit/deep-agents/filesystem/angular/src/app/filesystem.component.ts
@@ -1,22 +1,100 @@
-import { Component } from '@angular/core';
+import { Component, computed } from '@angular/core';
 import { ChatComponent } from '@cacheplane/chat';
 import { streamResource } from '@cacheplane/stream-resource';
 import { environment } from '../environments/environment';
 
 /**
+ * Represents a file operation extracted from agent tool calls.
+ */
+interface FileOperation {
+  type: 'read' | 'write';
+  path: string;
+  preview: string;
+}
+
+/**
  * FilesystemComponent demonstrates agent file operations.
  *
- * The agent can read and write files using tool calls.
+ * The agent can read and write files using tool calls. The sidebar displays
+ * a live log of file operations derived from `stream.messages()`, filtering
+ * for `read_file` and `write_file` tool calls.
+ *
+ * Key integration points:
+ * - `stream.messages()` exposes the full message history including tool calls
+ * - `fileOps` filters messages for file-related tool calls and extracts metadata
+ * - Operations appear in the sidebar in real time as the agent works
  */
 @Component({
   selector: 'app-filesystem',
   standalone: true,
   imports: [ChatComponent],
-  template: `<chat [ref]="stream" class="block h-screen" />`,
+  template: `
+    <div class="flex h-screen">
+      <chat [ref]="stream" class="flex-1 min-w-0" />
+      <aside class="w-72 shrink-0 border-l overflow-y-auto p-4 space-y-2"
+             style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
+        <h3 class="text-xs font-semibold uppercase tracking-wide"
+            style="color: var(--chat-text-muted, #777);">File Operations</h3>
+        @if (fileOps().length === 0) {
+          <p class="text-sm italic" style="color: var(--chat-text-muted, #777);">No file operations yet</p>
+        }
+        @for (op of fileOps(); track $index) {
+          <div class="rounded-md px-2 py-1.5 text-sm space-y-1"
+               style="background: var(--chat-bg-hover, #222);">
+            <div class="flex items-center gap-2">
+              <span class="inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium"
+                    [style.background]="op.type === 'read' ? 'rgba(59,130,246,0.15)' : 'rgba(234,179,8,0.15)'"
+                    [style.color]="op.type === 'read' ? '#60a5fa' : '#facc15'">
+                {{ op.type === 'read' ? 'READ' : 'WRITE' }}
+              </span>
+              <span class="truncate text-xs" style="color: var(--chat-text, #e0e0e0);">{{ op.path }}</span>
+            </div>
+            @if (op.preview) {
+              <p class="truncate text-xs" style="color: var(--chat-text-muted, #777);">{{ op.preview }}</p>
+            }
+          </div>
+        }
+      </aside>
+    </div>
+  `,
 })
 export class FilesystemComponent {
+  /**
+   * The streaming resource connected to the filesystem graph.
+   *
+   * The graph uses `read_file` and `write_file` tool calls that appear
+   * in `stream.messages()`. We filter and display them in the sidebar.
+   */
   protected readonly stream = streamResource({
     apiUrl: environment.langGraphApiUrl,
     assistantId: environment.streamingAssistantId,
+  });
+
+  /**
+   * Reactive list of file operations derived from the message history.
+   *
+   * Scans all messages for tool calls named `read_file` or `write_file`,
+   * extracts the file path and a short result preview for sidebar display.
+   */
+  protected readonly fileOps = computed<FileOperation[]>(() => {
+    const msgs = this.stream.messages();
+    const ops: FileOperation[] = [];
+    for (const msg of msgs) {
+      const m = msg as unknown as Record<string, unknown>;
+      if (!('tool_calls' in m) || !Array.isArray(m['tool_calls'])) continue;
+      for (const tc of m['tool_calls'] as Array<Record<string, unknown>>) {
+        const name = tc['name'] as string | undefined;
+        if (name !== 'read_file' && name !== 'write_file') continue;
+        const args = (tc['args'] ?? {}) as Record<string, unknown>;
+        const path = String(args['path'] ?? args['file_path'] ?? '');
+        const content = String(args['content'] ?? args['result'] ?? '');
+        ops.push({
+          type: name === 'read_file' ? 'read' : 'write',
+          path,
+          preview: content.slice(0, 80),
+        });
+      }
+    }
+    return ops;
   });
 }

--- a/cockpit/deep-agents/memory/angular/src/app/memory.component.ts
+++ b/cockpit/deep-agents/memory/angular/src/app/memory.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, computed } from '@angular/core';
 import { ChatComponent } from '@cacheplane/chat';
 import { streamResource } from '@cacheplane/stream-resource';
 import { environment } from '../environments/environment';
@@ -7,17 +7,65 @@ import { environment } from '../environments/environment';
  * MemoryComponent demonstrates persistent agent memory across sessions.
  *
  * The agent extracts facts about the user from each conversation turn
- * and stores them in `agent_memory` state.
+ * and stores them in `agent_memory` (or `memory`) state. The sidebar
+ * displays all learned facts as key-value pairs with a live count.
+ *
+ * Key integration points:
+ * - `stream.value()` exposes the full graph state including the memory dict
+ * - `memoryEntries` is derived reactively for sidebar rendering
+ * - Facts appear as the agent learns them during conversation
  */
 @Component({
   selector: 'app-da-memory',
   standalone: true,
   imports: [ChatComponent],
-  template: `<chat [ref]="stream" class="block h-screen" />`,
+  template: `
+    <div class="flex h-screen">
+      <chat [ref]="stream" class="flex-1 min-w-0" />
+      <aside class="w-72 shrink-0 border-l overflow-y-auto p-4 space-y-2"
+             style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
+        <h3 class="text-xs font-semibold uppercase tracking-wide"
+            style="color: var(--chat-text-muted, #777);">
+          Learned Facts
+          @if (memoryEntries().length > 0) {
+            <span class="ml-1 tabular-nums">({{ memoryEntries().length }})</span>
+          }
+        </h3>
+        @if (memoryEntries().length === 0) {
+          <p class="text-sm italic" style="color: var(--chat-text-muted, #777);">No facts learned yet</p>
+        }
+        @for (entry of memoryEntries(); track entry[0]) {
+          <div class="text-sm py-1">
+            <span class="font-medium" style="color: var(--chat-text, #e0e0e0);">{{ entry[0] }}:</span>
+            <span style="color: var(--chat-text-muted, #777);"> {{ entry[1] }}</span>
+          </div>
+        }
+      </aside>
+    </div>
+  `,
 })
 export class MemoryComponent {
+  /**
+   * The streaming resource connected to the memory graph.
+   *
+   * The graph returns an `agent_memory` (or `memory`) dict alongside messages
+   * in its state. We derive a reactive signal from `stream.value()` for display.
+   */
   protected readonly stream = streamResource({
     apiUrl: environment.langGraphApiUrl,
     assistantId: environment.streamingAssistantId,
+  });
+
+  /**
+   * Reactive list of [key, value] memory entries derived from the graph state.
+   *
+   * Checks for `agent_memory` first, then falls back to `memory`.
+   * This signal re-computes whenever the stream state changes.
+   */
+  protected readonly memoryEntries = computed(() => {
+    const val = this.stream.value() as Record<string, unknown>;
+    const mem = val?.['agent_memory'] ?? val?.['memory'];
+    if (!mem || typeof mem !== 'object') return [];
+    return Object.entries(mem as Record<string, string>);
   });
 }

--- a/cockpit/deep-agents/planning/angular/src/app/planning.component.ts
+++ b/cockpit/deep-agents/planning/angular/src/app/planning.component.ts
@@ -1,23 +1,89 @@
-import { Component } from '@angular/core';
+import { Component, computed } from '@angular/core';
 import { ChatComponent } from '@cacheplane/chat';
 import { streamResource } from '@cacheplane/stream-resource';
 import { environment } from '../environments/environment';
 
 /**
+ * Represents a single step in an agent-generated plan.
+ */
+interface PlanStep {
+  title: string;
+  status: 'pending' | 'in_progress' | 'complete';
+}
+
+/**
  * PlanningComponent demonstrates agent task decomposition.
  *
  * The agent receives a complex task, breaks it into ordered steps,
- * and executes them sequentially.
+ * and executes them sequentially. The sidebar displays a live checklist
+ * of plan steps derived from the `plan` array in the graph state.
+ *
+ * Key integration points:
+ * - `stream.value()` exposes the full graph state, including the `plan` array
+ * - `planSteps` is derived from `stream.value()` for reactive sidebar rendering
+ * - Step status icons update in real time as the agent progresses
  */
 @Component({
   selector: 'app-planning',
   standalone: true,
   imports: [ChatComponent],
-  template: `<chat [ref]="stream" class="block h-screen" />`,
+  template: `
+    <div class="flex h-screen">
+      <chat [ref]="stream" class="flex-1 min-w-0" />
+      <aside class="w-72 shrink-0 border-l overflow-y-auto p-4 space-y-2"
+             style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
+        <h3 class="text-xs font-semibold uppercase tracking-wide"
+            style="color: var(--chat-text-muted, #777);">Plan</h3>
+        @if (planSteps().length === 0) {
+          <p class="text-sm italic" style="color: var(--chat-text-muted, #777);">No plan yet</p>
+        }
+        @for (step of planSteps(); track step.title) {
+          <div class="flex items-start gap-2 rounded-md px-2 py-1.5 text-sm"
+               style="background: var(--chat-bg-hover, #222);">
+            <span class="mt-0.5 shrink-0 text-base leading-none">
+              @if (step.status === 'complete') {
+                <span style="color: #22c55e;">&#10003;</span>
+              } @else if (step.status === 'in_progress') {
+                <span class="inline-block animate-spin" style="color: var(--chat-text-muted, #777);">&#9696;</span>
+              } @else {
+                <span style="color: var(--chat-border-light, #444);">&#9675;</span>
+              }
+            </span>
+            <span style="color: var(--chat-text, #e0e0e0);">{{ step.title }}</span>
+          </div>
+        }
+      </aside>
+    </div>
+  `,
 })
 export class PlanningComponent {
+  /**
+   * The streaming resource connected to the planning graph.
+   *
+   * The graph returns a `plan` array alongside messages in its state.
+   * Each plan entry has a `title` and `status` that drive the sidebar checklist.
+   */
   protected readonly stream = streamResource({
     apiUrl: environment.langGraphApiUrl,
     assistantId: environment.streamingAssistantId,
+  });
+
+  /**
+   * Reactive list of plan steps derived from the graph state.
+   *
+   * The Python graph stores the plan as `state.plan` — an array of objects
+   * with `title` and `status` fields. This signal re-computes whenever
+   * the stream state changes.
+   */
+  protected readonly planSteps = computed<PlanStep[]>(() => {
+    const val = this.stream.value() as Record<string, unknown>;
+    const plan = val?.['plan'];
+    if (!Array.isArray(plan)) return [];
+    return plan.map((step: Record<string, unknown>) => ({
+      title: String(step['title'] ?? ''),
+      status: (['pending', 'in_progress', 'complete'].includes(step['status'] as string)
+        ? step['status']
+        : 'pending') as PlanStep['status'],
+    }));
   });
 }

--- a/cockpit/deep-agents/sandboxes/angular/src/app/sandboxes.component.ts
+++ b/cockpit/deep-agents/sandboxes/angular/src/app/sandboxes.component.ts
@@ -1,23 +1,129 @@
-import { Component } from '@angular/core';
+import { Component, computed } from '@angular/core';
 import { ChatComponent } from '@cacheplane/chat';
 import { streamResource } from '@cacheplane/stream-resource';
 import { environment } from '../environments/environment';
 
 /**
+ * Represents a parsed code execution: the code that was run and its output.
+ */
+interface CodeExecution {
+  id: string;
+  code: string;
+  stdout: string;
+  stderr: string;
+  exitStatus: number;
+}
+
+/**
  * SandboxesComponent demonstrates a coding agent that executes Python code.
  *
  * The agent writes and runs code snippets to solve problems using a
- * `run_code` tool.
+ * `run_code` tool. The sidebar displays a real-time log of code executions
+ * derived from `stream.messages()`, showing the code, stdout, and stderr
+ * for each invocation.
  */
 @Component({
   selector: 'app-sandboxes',
   standalone: true,
   imports: [ChatComponent],
-  template: `<chat [ref]="stream" class="block h-screen" />`,
+  template: `
+    <div class="flex h-screen">
+      <chat [ref]="stream" class="flex-1 min-w-0" />
+      <aside class="w-80 shrink-0 border-l overflow-y-auto p-4 space-y-3"
+             style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
+        <h3 class="text-xs font-semibold uppercase tracking-wide"
+            style="color: var(--chat-text-muted, #777);">Execution Output</h3>
+        @if (executions().length === 0) {
+          <p class="text-sm italic" style="color: var(--chat-text-muted, #777);">No code executed yet</p>
+        }
+        @for (exec of executions(); track exec.id) {
+          <div class="rounded-lg p-3 space-y-2"
+               style="background: var(--chat-input-bg, #262626); border: 1px solid var(--chat-border, #333);">
+            <div class="text-xs font-semibold" style="color: var(--chat-text-muted, #777);">Code</div>
+            <pre class="whitespace-pre-wrap break-words font-mono text-xs leading-relaxed p-2 rounded overflow-x-auto"
+                 style="background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">{{ exec.code }}</pre>
+            @if (exec.stdout) {
+              <div class="text-xs font-semibold" style="color: var(--chat-success, #4ade80);">stdout</div>
+              <pre class="whitespace-pre-wrap break-words font-mono text-xs leading-relaxed p-2 rounded"
+                   style="background: var(--chat-bg, #171717); color: var(--chat-success, #4ade80);">{{ exec.stdout }}</pre>
+            }
+            @if (exec.stderr) {
+              <div class="text-xs font-semibold" style="color: var(--chat-error-text, #f87171);">stderr</div>
+              <pre class="whitespace-pre-wrap break-words font-mono text-xs leading-relaxed p-2 rounded"
+                   style="background: var(--chat-bg, #171717); color: var(--chat-error-text, #f87171);">{{ exec.stderr }}</pre>
+            }
+          </div>
+        }
+      </aside>
+    </div>
+  `,
 })
 export class SandboxesComponent {
   protected readonly stream = streamResource({
     apiUrl: environment.langGraphApiUrl,
     assistantId: environment.streamingAssistantId,
+  });
+
+  /**
+   * Derived signal: extracts code executions from the message stream.
+   *
+   * Scans AI messages for tool_calls with name `run_code`, then pairs each
+   * with its corresponding tool result message. Tool results are parsed as
+   * JSON with {stdout, stderr, exit_status} fields.
+   */
+  protected readonly executions = computed<CodeExecution[]>(() => {
+    const msgs = this.stream.messages();
+    const resultMap = new Map<string, { stdout: string; stderr: string; exitStatus: number }>();
+
+    // Build a lookup of tool_call_id -> parsed result from tool messages
+    for (const msg of msgs) {
+      const type = typeof msg._getType === 'function'
+        ? msg._getType()
+        : (msg as unknown as Record<string, string>)['type'] ?? '';
+      if (type === 'tool') {
+        const toolCallId = (msg as unknown as Record<string, string>)['tool_call_id'];
+        if (toolCallId) {
+          const raw = typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content);
+          try {
+            const parsed = JSON.parse(raw);
+            resultMap.set(toolCallId, {
+              stdout: parsed.stdout ?? '',
+              stderr: parsed.stderr ?? '',
+              exitStatus: parsed.exit_status ?? 0,
+            });
+          } catch {
+            resultMap.set(toolCallId, { stdout: raw, stderr: '', exitStatus: 0 });
+          }
+        }
+      }
+    }
+
+    // Extract run_code tool_calls from AI messages
+    const executions: CodeExecution[] = [];
+    for (const msg of msgs) {
+      const type = typeof msg._getType === 'function'
+        ? msg._getType()
+        : (msg as unknown as Record<string, string>)['type'] ?? '';
+      if (type === 'ai') {
+        const toolCalls = (msg as unknown as Record<string, unknown[]>)['tool_calls'];
+        if (Array.isArray(toolCalls)) {
+          for (const tc of toolCalls) {
+            const call = tc as { id: string; name: string; args: Record<string, unknown> };
+            if (call.name === 'run_code') {
+              const result = resultMap.get(call.id);
+              executions.push({
+                id: call.id,
+                code: (call.args['code'] as string) ?? '',
+                stdout: result?.stdout ?? '',
+                stderr: result?.stderr ?? '',
+                exitStatus: result?.exitStatus ?? 0,
+              });
+            }
+          }
+        }
+      }
+    }
+
+    return executions;
   });
 }

--- a/cockpit/deep-agents/skills/angular/src/app/skills.component.ts
+++ b/cockpit/deep-agents/skills/angular/src/app/skills.component.ts
@@ -1,23 +1,131 @@
-import { Component } from '@angular/core';
+import { Component, computed } from '@angular/core';
 import { ChatComponent } from '@cacheplane/chat';
 import { streamResource } from '@cacheplane/stream-resource';
 import { environment } from '../environments/environment';
+
+/**
+ * Represents a matched skill invocation: tool call paired with its result.
+ */
+interface SkillInvocation {
+  id: string;
+  name: string;
+  args: Record<string, unknown>;
+  result: string | undefined;
+}
 
 /**
  * SkillsComponent demonstrates a multi-skill agent with specialized tools.
  *
  * The agent can calculate math expressions, count words, and summarize text
  * by selecting the appropriate skill tool for each user request.
+ *
+ * The sidebar displays a real-time log of skill invocations derived from
+ * `stream.messages()`, matching AI tool_calls with their corresponding
+ * tool result messages.
  */
 @Component({
   selector: 'app-skills',
   standalone: true,
   imports: [ChatComponent],
-  template: `<chat [ref]="stream" class="block h-screen" />`,
+  template: `
+    <div class="flex h-screen">
+      <chat [ref]="stream" class="flex-1 min-w-0" />
+      <aside class="w-72 shrink-0 border-l overflow-y-auto p-4 space-y-3"
+             style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
+        <h3 class="text-xs font-semibold uppercase tracking-wide"
+            style="color: var(--chat-text-muted, #777);">Skill Invocations</h3>
+        @if (invocations().length === 0) {
+          <p class="text-sm italic" style="color: var(--chat-text-muted, #777);">No skills invoked yet</p>
+        }
+        @for (inv of invocations(); track inv.id) {
+          <div class="rounded-lg p-3 space-y-2"
+               style="background: var(--chat-input-bg, #262626); border: 1px solid var(--chat-border, #333);">
+            <div class="flex items-center gap-2">
+              <span class="inline-block rounded-full px-2 py-0.5 text-xs font-semibold"
+                    style="background: var(--chat-accent, #6d28d9); color: #fff;">
+                {{ inv.name }}
+              </span>
+            </div>
+            <div class="text-xs space-y-1" style="color: var(--chat-text-muted, #777);">
+              <p class="font-semibold" style="color: var(--chat-text, #e0e0e0);">Input</p>
+              <pre class="whitespace-pre-wrap break-words font-mono text-xs leading-relaxed p-1.5 rounded"
+                   style="background: var(--chat-bg, #171717);">{{ formatArgs(inv.args) }}</pre>
+            </div>
+            @if (inv.result !== undefined) {
+              <div class="text-xs space-y-1" style="color: var(--chat-text-muted, #777);">
+                <p class="font-semibold" style="color: var(--chat-success, #4ade80);">Output</p>
+                <pre class="whitespace-pre-wrap break-words font-mono text-xs leading-relaxed p-1.5 rounded"
+                     style="background: var(--chat-bg, #171717);">{{ inv.result }}</pre>
+              </div>
+            }
+          </div>
+        }
+      </aside>
+    </div>
+  `,
 })
 export class SkillsComponent {
   protected readonly stream = streamResource({
     apiUrl: environment.langGraphApiUrl,
     assistantId: environment.streamingAssistantId,
   });
+
+  private readonly SKILL_NAMES = new Set(['calculator', 'word_count', 'summarize']);
+
+  /**
+   * Derived signal: extracts skill invocations from the message stream.
+   *
+   * Scans AI messages for tool_calls matching known skill names, then pairs
+   * each with its corresponding tool result message via tool_call_id.
+   */
+  protected readonly invocations = computed<SkillInvocation[]>(() => {
+    const msgs = this.stream.messages();
+    const resultMap = new Map<string, string>();
+
+    // Build a lookup of tool_call_id -> result content from tool messages
+    for (const msg of msgs) {
+      const type = typeof msg._getType === 'function'
+        ? msg._getType()
+        : (msg as unknown as Record<string, string>)['type'] ?? '';
+      if (type === 'tool') {
+        const toolCallId = (msg as unknown as Record<string, string>)['tool_call_id'];
+        const content = typeof msg.content === 'string'
+          ? msg.content
+          : JSON.stringify(msg.content);
+        if (toolCallId) {
+          resultMap.set(toolCallId, content);
+        }
+      }
+    }
+
+    // Extract tool_calls from AI messages that match known skill names
+    const invocations: SkillInvocation[] = [];
+    for (const msg of msgs) {
+      const type = typeof msg._getType === 'function'
+        ? msg._getType()
+        : (msg as unknown as Record<string, string>)['type'] ?? '';
+      if (type === 'ai') {
+        const toolCalls = (msg as unknown as Record<string, unknown[]>)['tool_calls'];
+        if (Array.isArray(toolCalls)) {
+          for (const tc of toolCalls) {
+            const call = tc as { id: string; name: string; args: Record<string, unknown> };
+            if (this.SKILL_NAMES.has(call.name)) {
+              invocations.push({
+                id: call.id,
+                name: call.name,
+                args: call.args,
+                result: resultMap.get(call.id),
+              });
+            }
+          }
+        }
+      }
+    }
+
+    return invocations;
+  });
+
+  protected formatArgs(args: Record<string, unknown>): string {
+    return JSON.stringify(args, null, 2);
+  }
 }

--- a/cockpit/deep-agents/subagents/angular/src/app/subagents.component.ts
+++ b/cockpit/deep-agents/subagents/angular/src/app/subagents.component.ts
@@ -1,23 +1,112 @@
-import { Component } from '@angular/core';
+import { Component, computed } from '@angular/core';
 import { ChatComponent } from '@cacheplane/chat';
 import { streamResource } from '@cacheplane/stream-resource';
 import { environment } from '../environments/environment';
 
 /**
+ * Delegation status derived from matching tool calls with tool result messages.
+ */
+interface Delegation {
+  /** Tool call ID used to track request/response pairing. */
+  id: string;
+  /** Name of the delegated agent (tool name). */
+  agent: string;
+  /** Execution status: running until a matching tool result arrives. */
+  status: 'running' | 'complete' | 'error';
+  /** Human-readable status text. */
+  statusText: string;
+}
+
+/**
  * SubagentsComponent demonstrates the Deep Agents subagent delegation pattern.
  *
  * The orchestrator agent receives a task and delegates subtasks to specialist
- * subagents via tool calls.
+ * subagents via tool calls. The sidebar tracks each delegation by scanning
+ * `stream.messages()` for AI tool_calls and matching ToolMessage results.
  */
 @Component({
   selector: 'app-subagents',
   standalone: true,
   imports: [ChatComponent],
-  template: `<chat [ref]="stream" class="block h-screen" />`,
+  template: `
+    <div class="flex h-screen">
+      <chat [ref]="stream" class="flex-1 min-w-0" />
+      <aside class="w-72 shrink-0 border-l overflow-y-auto p-4 space-y-2"
+             style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
+        <h3 class="text-xs font-semibold uppercase tracking-wide"
+            style="color: var(--chat-text-muted, #777);">Delegations</h3>
+        @if (delegations().length === 0) {
+          <p class="text-sm italic" style="color: var(--chat-text-muted, #777);">No delegations yet</p>
+        }
+        @for (d of delegations(); track d.id) {
+          <div class="flex items-center gap-2 text-sm py-1">
+            <span class="w-2 h-2 rounded-full shrink-0"
+                  [style.background]="d.status === 'complete' ? 'var(--chat-success, #4ade80)' : d.status === 'error' ? 'var(--chat-error-text, #f87171)' : 'var(--chat-warning-text, #fbbf24)'">
+            </span>
+            <span class="font-medium truncate" style="color: var(--chat-text, #e0e0e0);">{{ d.agent }}</span>
+            <span class="text-xs ml-auto" style="color: var(--chat-text-muted, #777);">{{ d.statusText }}</span>
+          </div>
+        }
+      </aside>
+    </div>
+  `,
 })
 export class SubagentsComponent {
+  /**
+   * The streaming resource connected to the subagents orchestrator graph.
+   */
   protected readonly stream = streamResource({
     apiUrl: environment.langGraphApiUrl,
     assistantId: environment.streamingAssistantId,
+  });
+
+  /**
+   * Reactive delegation list derived from messages.
+   *
+   * Scans all messages for AI tool_calls, then checks for matching
+   * ToolMessage results (by tool_call_id) to determine completion status.
+   */
+  protected readonly delegations = computed<Delegation[]>(() => {
+    const msgs = this.stream.messages();
+    const toolResultIds = new Set<string>();
+    const errorResultIds = new Set<string>();
+
+    // Collect all tool result message IDs and detect errors
+    for (const msg of msgs) {
+      const type = typeof msg._getType === 'function' ? msg._getType() : (msg as any).type;
+      if (type === 'tool') {
+        const toolCallId = (msg as any).tool_call_id;
+        if (toolCallId) {
+          toolResultIds.add(toolCallId);
+          const status = (msg as any).status;
+          if (status === 'error') {
+            errorResultIds.add(toolCallId);
+          }
+        }
+      }
+    }
+
+    // Extract tool calls from AI messages and match with results
+    const delegations: Delegation[] = [];
+    for (const msg of msgs) {
+      const type = typeof msg._getType === 'function' ? msg._getType() : (msg as any).type;
+      if (type === 'ai') {
+        const toolCalls = (msg as any).tool_calls as Array<{ id: string; name: string }> | undefined;
+        if (toolCalls?.length) {
+          for (const tc of toolCalls) {
+            const isError = errorResultIds.has(tc.id);
+            const isComplete = toolResultIds.has(tc.id);
+            delegations.push({
+              id: tc.id,
+              agent: tc.name,
+              status: isError ? 'error' : isComplete ? 'complete' : 'running',
+              statusText: isError ? 'error' : isComplete ? 'done' : 'running',
+            });
+          }
+        }
+      }
+    }
+
+    return delegations;
   });
 }

--- a/cockpit/langgraph/durable-execution/angular/src/app/durable-execution.component.ts
+++ b/cockpit/langgraph/durable-execution/angular/src/app/durable-execution.component.ts
@@ -1,7 +1,26 @@
-import { Component } from '@angular/core';
+import { Component, computed } from '@angular/core';
 import { ChatComponent } from '@cacheplane/chat';
 import { streamResource } from '@cacheplane/stream-resource';
 import { environment } from '../environments/environment';
+
+/**
+ * Pipeline step definition for the vertical progress indicator.
+ */
+interface PipelineStep {
+  id: string;
+  label: string;
+  status: 'pending' | 'active' | 'complete';
+}
+
+/** Ordered node names emitted by the Python graph's `state.step` field. */
+const STEP_ORDER = ['analyze', 'plan', 'generate'] as const;
+
+/** Human-readable labels for each pipeline step. */
+const STEP_LABELS: Record<string, string> = {
+  analyze: 'Analyze',
+  plan: 'Plan',
+  generate: 'Generate',
+};
 
 /**
  * DurableExecutionComponent demonstrates fault-tolerant multi-step execution
@@ -10,17 +29,89 @@ import { environment } from '../environments/environment';
  * This example shows how a graph checkpoints at each node, enabling it to
  * resume after failures. The backend processes each request through three
  * nodes: analyze, plan, generate. Each node updates `state.step` so the
- * UI can track progress.
+ * UI can track progress via a vertical step indicator in the sidebar.
  */
 @Component({
   selector: 'app-durable-execution',
   standalone: true,
   imports: [ChatComponent],
-  template: `<chat [ref]="stream" class="block h-screen" />`,
+  template: `
+    <div class="flex h-screen">
+      <chat [ref]="stream" class="flex-1 min-w-0" />
+      <aside class="w-64 shrink-0 border-l overflow-y-auto p-4"
+             style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
+        <h3 class="text-xs font-semibold uppercase tracking-wide mb-6"
+            style="color: var(--chat-text-muted, #777);">Pipeline</h3>
+
+        <div class="space-y-0">
+          @for (step of steps(); track step.id; let last = $last) {
+            <div class="flex items-start gap-3">
+              <!-- Step indicator column -->
+              <div class="flex flex-col items-center">
+                <!-- Circle / icon -->
+                @switch (step.status) {
+                  @case ('complete') {
+                    <div class="w-7 h-7 rounded-full bg-green-600 flex items-center justify-center">
+                      <svg class="w-4 h-4 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+                      </svg>
+                    </div>
+                  }
+                  @case ('active') {
+                    <div class="w-7 h-7 rounded-full border-2 border-amber-500 flex items-center justify-center animate-spin"
+                         style="animation-duration: 1.2s;">
+                      <div class="w-2 h-2 rounded-full bg-amber-500"></div>
+                    </div>
+                  }
+                  @default {
+                    <div class="w-7 h-7 rounded-full border-2 flex items-center justify-center"
+                         style="border-color: var(--chat-text-muted, #555);">
+                      <div class="w-2 h-2 rounded-full" style="background: var(--chat-text-muted, #555);"></div>
+                    </div>
+                  }
+                }
+                <!-- Connecting line -->
+                @if (!last) {
+                  <div class="w-0.5 h-8"
+                       [style.background]="step.status === 'complete' ? '#16a34a' : 'var(--chat-text-muted, #555)'">
+                  </div>
+                }
+              </div>
+
+              <!-- Label -->
+              <span class="text-sm pt-1"
+                    [class]="step.status === 'active' ? 'font-semibold text-amber-400' : step.status === 'complete' ? 'text-green-400' : ''"
+                    [style.color]="step.status === 'pending' ? 'var(--chat-text-muted, #777)' : ''">
+                {{ step.label }}
+              </span>
+            </div>
+          }
+        </div>
+      </aside>
+    </div>
+  `,
 })
 export class DurableExecutionComponent {
   protected readonly stream = streamResource({
     apiUrl: environment.langGraphApiUrl,
     assistantId: environment.streamingAssistantId,
+  });
+
+  /**
+   * Derives the 3-step pipeline status from the graph's `state.step` field.
+   *
+   * Steps before the current one are marked complete, the current step is
+   * active, and subsequent steps remain pending.
+   */
+  protected readonly steps = computed<PipelineStep[]>(() => {
+    const val = this.stream.value() as Record<string, unknown> | undefined;
+    const currentStep = (val?.['step'] as string) ?? '';
+    const activeIndex = STEP_ORDER.indexOf(currentStep as (typeof STEP_ORDER)[number]);
+
+    return STEP_ORDER.map((id, i) => ({
+      id,
+      label: STEP_LABELS[id],
+      status: activeIndex < 0 ? 'pending' : i < activeIndex ? 'complete' : i === activeIndex ? 'active' : 'pending',
+    }));
   });
 }

--- a/cockpit/langgraph/persistence/angular/src/app/persistence.component.ts
+++ b/cockpit/langgraph/persistence/angular/src/app/persistence.component.ts
@@ -1,28 +1,90 @@
-import { Component } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { ChatComponent } from '@cacheplane/chat';
 import { streamResource } from '@cacheplane/stream-resource';
 import { environment } from '../environments/environment';
 
+interface Thread {
+  id: string;
+  label: string;
+}
+
 /**
  * PersistenceComponent demonstrates thread persistence with `streamResource()`.
  *
- * This example shows how conversations persist across browser refreshes.
- * Each thread has a unique ID that can be stored and resumed later.
- * Use `stream.switchThread(id)` to load a previous conversation,
- * or `stream.switchThread(null)` to start fresh.
+ * Layout: a full-height flex row with the `<chat>` area (flex-1) on the left
+ * and a fixed-width thread-picker sidebar on the right.
  *
  * Key integration points:
- * - `onThreadId` callback captures new thread IDs for storage
- * - `stream.switchThread(id)` resumes a previous conversation
- * - `stream.messages()` loads the full history when switching threads
+ * - `onThreadId` callback captures new thread IDs for the sidebar list
+ * - `switchThread(id)` resumes a previous conversation
+ * - `newThread()` starts a fresh conversation
  */
 @Component({
   selector: 'app-persistence',
   standalone: true,
   imports: [ChatComponent],
-  template: `<chat [ref]="stream" class="block h-screen" />`,
+  styles: `
+    :host {
+      display: flex;
+      height: 100vh;
+    }
+  `,
+  template: `
+    <chat [ref]="stream" class="block flex-1 min-w-0" />
+
+    <aside
+      class="w-56 flex flex-col border-l"
+      style="
+        border-color: var(--chat-border);
+        background: var(--chat-bg-alt);
+        color: var(--chat-text);
+      "
+    >
+      <div
+        class="px-3 py-2 text-xs font-semibold uppercase tracking-wide border-b"
+        style="border-color: var(--chat-border); color: var(--chat-text-muted)"
+      >
+        Threads
+      </div>
+
+      <div class="flex-1 overflow-y-auto">
+        @for (thread of threads(); track thread.id) {
+          <button
+            class="w-full text-left px-3 py-2 text-sm truncate transition-colors"
+            [class.font-semibold]="thread.id === activeThreadId()"
+            [style.background]="thread.id === activeThreadId() ? 'var(--chat-bg-hover)' : 'transparent'"
+            (mouseenter)="$event.currentTarget.style.background = 'var(--chat-bg-hover)'"
+            (mouseleave)="$event.currentTarget.style.background = thread.id === activeThreadId() ? 'var(--chat-bg-hover)' : 'transparent'"
+            (click)="switchThread(thread.id)"
+          >
+            {{ thread.label }}
+          </button>
+        }
+      </div>
+
+      <div class="p-2 border-t" style="border-color: var(--chat-border)">
+        <button
+          class="w-full rounded px-3 py-1.5 text-sm font-medium transition-colors"
+          style="
+            background: var(--chat-bg-hover);
+            color: var(--chat-text);
+          "
+          (mouseenter)="$event.currentTarget.style.opacity = '0.8'"
+          (mouseleave)="$event.currentTarget.style.opacity = '1'"
+          (click)="newThread()"
+        >
+          + New Thread
+        </button>
+      </div>
+    </aside>
+  `,
 })
 export class PersistenceComponent {
+  protected readonly threads = signal<Thread[]>([]);
+  protected readonly activeThreadId = signal<string | null>(null);
+
+  private threadCounter = 0;
+
   /**
    * The streaming resource with thread persistence.
    *
@@ -32,5 +94,30 @@ export class PersistenceComponent {
   protected readonly stream = streamResource({
     apiUrl: environment.langGraphApiUrl,
     assistantId: environment.streamingAssistantId,
+    onThreadId: (id: string) => {
+      this.activeThreadId.set(id);
+
+      // Only add if not already tracked
+      const existing = this.threads();
+      if (!existing.some((t) => t.id === id)) {
+        this.threadCounter++;
+        this.threads.set([
+          ...existing,
+          { id, label: `Thread ${this.threadCounter}` },
+        ]);
+      }
+    },
   });
+
+  /** Switch to an existing thread by ID. */
+  switchThread(id: string): void {
+    this.activeThreadId.set(id);
+    this.stream.switchThread(id);
+  }
+
+  /** Start a brand-new thread. */
+  newThread(): void {
+    this.activeThreadId.set(null);
+    this.stream.switchThread(null);
+  }
 }

--- a/cockpit/langgraph/time-travel/angular/src/app/time-travel.component.ts
+++ b/cockpit/langgraph/time-travel/angular/src/app/time-travel.component.ts
@@ -1,10 +1,13 @@
-import { Component } from '@angular/core';
+import { Component, computed, signal } from '@angular/core';
 import { ChatComponent } from '@cacheplane/chat';
 import { streamResource } from '@cacheplane/stream-resource';
+import type { ThreadState } from '@cacheplane/stream-resource';
 import { environment } from '../environments/environment';
 
 /**
  * TimeTravelComponent demonstrates replaying and branching conversation history.
+ *
+ * Layout: chat panel (flex-1) + checkpoint timeline sidebar (w-72).
  *
  * Key integration points:
  * - `stream.history()` -- array of ThreadState snapshots
@@ -15,11 +18,126 @@ import { environment } from '../environments/environment';
   selector: 'app-time-travel',
   standalone: true,
   imports: [ChatComponent],
-  template: `<chat [ref]="stream" class="block h-screen" />`,
+  template: `
+    <div class="flex h-screen">
+      <!-- Chat panel -->
+      <chat [ref]="stream" class="block flex-1" />
+
+      <!-- Checkpoint timeline sidebar -->
+      <aside
+        class="w-72 border-l border-[var(--chat-border)] bg-[var(--chat-bg)] flex flex-col overflow-hidden"
+      >
+        <div class="px-4 py-3 border-b border-[var(--chat-border)]">
+          <h2 class="text-sm font-semibold text-[var(--chat-text)] uppercase tracking-wide">
+            Timeline
+          </h2>
+          <p class="text-xs text-[var(--chat-text-muted)] mt-0.5">
+            {{ checkpoints().length }} checkpoint(s)
+          </p>
+        </div>
+
+        <div class="flex-1 overflow-y-auto px-3 py-2 space-y-1.5">
+          @if (checkpoints().length === 0) {
+            <p class="text-xs text-[var(--chat-text-muted)] text-center py-6">
+              No checkpoints yet. Send a message to begin.
+            </p>
+          }
+
+          @for (state of checkpoints(); track $index; let i = $index) {
+            <div
+              class="flex items-center gap-2 rounded-lg border px-3 py-2 transition-colors"
+              [class]="
+                i === selectedIndex()
+                  ? 'border-[var(--chat-input-focus-border)] bg-[var(--chat-bg-hover)]'
+                  : 'border-[var(--chat-border)] bg-[var(--chat-bg)] hover:bg-[var(--chat-bg-hover)]'
+              "
+            >
+              <!-- Numbered badge -->
+              <span
+                class="w-6 h-6 flex items-center justify-center rounded-full text-xs font-bold shrink-0"
+                [class]="
+                  i === selectedIndex()
+                    ? 'bg-[var(--chat-send-bg)] text-[var(--chat-send-text)]'
+                    : 'bg-[var(--chat-bg-alt)] text-[var(--chat-text-muted)]'
+                "
+              >
+                {{ i + 1 }}
+              </span>
+
+              <!-- Checkpoint info -->
+              <div class="flex-1 min-w-0">
+                <p class="text-xs font-medium text-[var(--chat-text)] truncate">
+                  {{ checkpointLabel(state, i) }}
+                </p>
+                @if (state.checkpoint?.checkpoint_id) {
+                  <p class="text-xs text-[var(--chat-text-muted)] font-mono truncate">
+                    {{ state.checkpoint.checkpoint_id }}
+                  </p>
+                }
+              </div>
+
+              <!-- Action buttons -->
+              <div class="flex gap-1 shrink-0">
+                <button
+                  class="px-2 py-1 text-xs rounded bg-[var(--chat-bg-alt)] text-[var(--chat-text)] hover:bg-[var(--chat-bg-hover)] transition-colors"
+                  title="Replay from this checkpoint"
+                  (click)="replay(state, i)"
+                >
+                  Replay
+                </button>
+                <button
+                  class="px-2 py-1 text-xs rounded bg-[var(--chat-bg-alt)] text-[var(--chat-text)] hover:bg-[var(--chat-bg-hover)] transition-colors"
+                  title="Fork from this checkpoint"
+                  (click)="fork(state, i)"
+                >
+                  Fork
+                </button>
+              </div>
+            </div>
+          }
+        </div>
+      </aside>
+    </div>
+  `,
 })
 export class TimeTravelComponent {
   protected readonly stream = streamResource({
     apiUrl: environment.langGraphApiUrl,
     assistantId: environment.streamingAssistantId,
   });
+
+  /** Index of the currently selected checkpoint in the sidebar. */
+  protected readonly selectedIndex = signal<number>(-1);
+
+  /** Checkpoint history derived from the stream resource. */
+  protected readonly checkpoints = computed(
+    (): ThreadState<any>[] => this.stream.history(),
+  );
+
+  /** Display label for a checkpoint entry. */
+  protected checkpointLabel(
+    state: ThreadState<any>,
+    index: number,
+  ): string {
+    if (state.checkpoint?.checkpoint_id) {
+      return `Checkpoint ${index + 1}`;
+    }
+    return `State ${index + 1}`;
+  }
+
+  /** Replay the conversation from the given checkpoint. */
+  protected replay(state: ThreadState<any>, index: number): void {
+    if (state.checkpoint?.checkpoint_id) {
+      this.selectedIndex.set(index);
+      this.stream.setBranch(state.checkpoint.checkpoint_id);
+    }
+  }
+
+  /** Fork the conversation from the given checkpoint. */
+  protected fork(state: ThreadState<any>, index: number): void {
+    if (state.checkpoint?.checkpoint_id) {
+      this.selectedIndex.set(index);
+      this.stream.setBranch(state.checkpoint.checkpoint_id);
+    }
+  }
 }

--- a/docs/superpowers/plans/2026-04-06-cockpit-examples-validation.md
+++ b/docs/superpowers/plans/2026-04-06-cockpit-examples-validation.md
@@ -1,0 +1,1053 @@
+# Cockpit Examples Validation & Sidebar Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement capability-specific sidebars for all 9 incomplete cockpit examples, validating that the chat and stream-resource libraries fully support every LangGraph and Deep Agent capability. Each example is a minimal, isolated Angular app that uses the libs — changes discovered here feed back into the libs.
+
+**Architecture:** Each example follows the pattern: `streamResource()` → `<chat [ref]="stream">` + custom sidebar derived from `stream.value()` or `stream.messages()`. Sidebars are built directly in each example's component using Tailwind classes and the chat theme CSS vars. No new library components needed — the sidebars are example-specific UI, not reusable primitives.
+
+**Tech Stack:** Angular 20+, `@cacheplane/chat`, `@cacheplane/stream-resource`, Tailwind CSS v4
+
+**Parallelism:** Tasks 1-4 (LangGraph examples) are independent. Tasks 5-8 (Deep Agent examples) are independent. All can run in parallel within their group.
+
+**Verification:** Each task ends with `npx nx build <project>` to verify the example compiles. Full E2E testing requires running the Python backend, which is out of scope — the focus is on Angular compilation and correct library usage.
+
+---
+
+## File Structure
+
+Each task modifies ONE file — the example's main component. All sidebar UI is co-located in the component (small, focused, example-specific).
+
+### Modified files (9 examples needing sidebars)
+
+| Task | File | Sidebar Feature |
+|------|------|----------------|
+| 1 | `cockpit/langgraph/persistence/angular/src/app/persistence.component.ts` | Thread picker list |
+| 2 | `cockpit/langgraph/time-travel/angular/src/app/time-travel.component.ts` | Checkpoint timeline |
+| 3 | `cockpit/langgraph/durable-execution/angular/src/app/durable-execution.component.ts` | Step progress pipeline |
+| 4 | `cockpit/deep-agents/planning/angular/src/app/planning.component.ts` | Plan step checklist |
+| 5 | `cockpit/deep-agents/filesystem/angular/src/app/filesystem.component.ts` | File operations log |
+| 6 | `cockpit/deep-agents/subagents/angular/src/app/subagents.component.ts` | Delegation tracker |
+| 7 | `cockpit/deep-agents/memory/angular/src/app/memory.component.ts` | Learned facts sidebar |
+| 8 | `cockpit/deep-agents/skills/angular/src/app/skills.component.ts` | Skill invocations log |
+| 9 | `cockpit/deep-agents/sandboxes/angular/src/app/sandboxes.component.ts` | Execution output log |
+
+### Already complete (5 examples — verify only)
+- `cockpit/langgraph/streaming/angular/` — basic streaming ✓
+- `cockpit/langgraph/interrupts/angular/` — interrupt panel ✓
+- `cockpit/langgraph/memory/angular/` — facts sidebar ✓
+- `cockpit/langgraph/subgraphs/angular/` — subagent sidebar ✓
+- `cockpit/langgraph/deployment-runtime/angular/` — production config ✓
+
+---
+
+## Shared Sidebar Pattern
+
+Every sidebar follows this template. Subagents should reference this when implementing:
+
+```typescript
+// Layout: chat (flex-1) + aside sidebar
+template: `
+  <div class="flex h-screen">
+    <chat [ref]="stream" class="flex-1 min-w-0" />
+    <aside
+      class="w-72 border-l overflow-y-auto p-4 flex flex-col gap-3 shrink-0"
+      style="border-color: var(--chat-border); background: var(--chat-bg-alt);"
+    >
+      <h2
+        class="text-[11px] font-semibold uppercase tracking-wider m-0"
+        style="color: var(--chat-text-muted);"
+      >Sidebar Title</h2>
+      <!-- Sidebar content using computed() signals from stream.value() -->
+    </aside>
+  </div>
+`
+```
+
+Key rules:
+- Import `ChatComponent` from `@cacheplane/chat`
+- Use `streamResource()` from `@cacheplane/stream-resource`
+- Derive sidebar state with `computed()` from `stream.value()` or `stream.messages()`
+- Use Tailwind + chat theme CSS vars for styling
+- The `<chat>` component handles all message rendering, input, typing, errors internally
+
+---
+
+## Task 1: Persistence — Thread Picker Sidebar
+
+**Files:**
+- Modify: `cockpit/langgraph/persistence/angular/src/app/persistence.component.ts`
+
+**Capability:** Thread-based conversation persistence. Users can create new threads and switch between them.
+
+- [ ] **Step 1: Read the current component**
+
+Read `cockpit/langgraph/persistence/angular/src/app/persistence.component.ts` to understand current state.
+
+- [ ] **Step 2: Implement thread picker sidebar**
+
+Replace the component with a layout that has chat + thread sidebar:
+
+```typescript
+import { Component, signal, computed } from '@angular/core';
+import { ChatComponent } from '@cacheplane/chat';
+import { streamResource } from '@cacheplane/stream-resource';
+import { environment } from '../environments/environment';
+
+interface ThreadEntry {
+  id: string;
+  createdAt: string;
+}
+
+@Component({
+  selector: 'app-persistence',
+  standalone: true,
+  imports: [ChatComponent],
+  template: `
+    <div class="flex h-screen">
+      <chat
+        [ref]="stream"
+        [threads]="threads()"
+        [activeThreadId]="activeThreadId()"
+        (threadSelected)="switchThread($event)"
+        class="flex-1 min-w-0"
+      />
+      <aside
+        class="w-56 border-l overflow-y-auto flex flex-col shrink-0"
+        style="border-color: var(--chat-border); background: var(--chat-bg-alt);"
+      >
+        <div class="p-3 border-b flex items-center justify-between" style="border-color: var(--chat-border);">
+          <h2 class="text-[11px] font-semibold uppercase tracking-wider m-0" style="color: var(--chat-text-muted);">Threads</h2>
+          <button
+            class="text-xs px-2 py-1 rounded border-0 cursor-pointer"
+            style="background: var(--chat-bg-hover); color: var(--chat-text);"
+            (click)="newThread()"
+          >+ New</button>
+        </div>
+        @for (thread of threadList(); track thread.id) {
+          <button
+            class="w-full text-left px-3 py-2 text-sm border-0 cursor-pointer transition-colors duration-150"
+            [style.background]="thread.id === activeThreadId() ? 'var(--chat-bg-hover)' : 'transparent'"
+            [style.color]="'var(--chat-text)'"
+            [style.fontWeight]="thread.id === activeThreadId() ? '500' : '400'"
+            (click)="switchThread(thread.id)"
+          >
+            <div class="truncate">{{ thread.id.substring(0, 8) }}...</div>
+            <div class="text-[11px] mt-0.5" style="color: var(--chat-text-muted);">{{ thread.createdAt }}</div>
+          </button>
+        } @empty {
+          <p class="text-xs p-3 m-0" style="color: var(--chat-text-muted);">No threads yet.</p>
+        }
+      </aside>
+    </div>
+  `,
+})
+export class PersistenceComponent {
+  readonly activeThreadId = signal<string>('');
+  readonly threadList = signal<ThreadEntry[]>([]);
+
+  protected readonly stream = streamResource({
+    apiUrl: environment.langGraphApiUrl,
+    assistantId: environment.persistenceAssistantId,
+    onThreadId: (id: string) => {
+      this.activeThreadId.set(id);
+      if (!this.threadList().find(t => t.id === id)) {
+        this.threadList.update(list => [
+          { id, createdAt: new Date().toLocaleTimeString() },
+          ...list,
+        ]);
+      }
+    },
+  });
+
+  readonly threads = computed(() =>
+    this.threadList().map(t => ({ id: t.id }))
+  );
+
+  switchThread(threadId: string): void {
+    this.activeThreadId.set(threadId);
+    this.stream.switchThread(threadId);
+  }
+
+  newThread(): void {
+    this.activeThreadId.set('');
+    this.stream.switchThread(null);
+  }
+}
+```
+
+- [ ] **Step 3: Build to verify compilation**
+
+```bash
+npx nx build cockpit-langgraph-persistence-angular
+```
+
+Expected: Build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cockpit/langgraph/persistence/angular/src/app/persistence.component.ts
+git commit -m "feat(cockpit): add thread picker sidebar to persistence example"
+```
+
+---
+
+## Task 2: Time-Travel — Checkpoint Timeline Sidebar
+
+**Files:**
+- Modify: `cockpit/langgraph/time-travel/angular/src/app/time-travel.component.ts`
+
+**Capability:** Navigate conversation history checkpoints, replay or fork from any point.
+
+- [ ] **Step 1: Read the current component**
+
+Read `cockpit/langgraph/time-travel/angular/src/app/time-travel.component.ts`.
+
+- [ ] **Step 2: Implement checkpoint timeline sidebar**
+
+```typescript
+import { Component, computed } from '@angular/core';
+import { ChatComponent } from '@cacheplane/chat';
+import { streamResource } from '@cacheplane/stream-resource';
+import { environment } from '../environments/environment';
+
+@Component({
+  selector: 'app-time-travel',
+  standalone: true,
+  imports: [ChatComponent],
+  template: `
+    <div class="flex h-screen">
+      <chat [ref]="stream" class="flex-1 min-w-0" />
+      <aside
+        class="w-72 border-l overflow-y-auto flex flex-col shrink-0"
+        style="border-color: var(--chat-border); background: var(--chat-bg-alt);"
+      >
+        <div class="p-3 border-b" style="border-color: var(--chat-border);">
+          <h2 class="text-[11px] font-semibold uppercase tracking-wider m-0" style="color: var(--chat-text-muted);">
+            Timeline ({{ checkpoints().length }})
+          </h2>
+        </div>
+        @for (cp of checkpoints(); track $index; let i = $index) {
+          <div
+            class="px-3 py-2 border-b flex items-start gap-2"
+            style="border-color: var(--chat-border-light);"
+          >
+            <div
+              class="w-5 h-5 flex items-center justify-center rounded-full text-[11px] font-bold shrink-0 mt-0.5"
+              style="background: var(--chat-bg-hover); color: var(--chat-text-muted);"
+            >{{ i + 1 }}</div>
+            <div class="flex-1 min-w-0">
+              <p class="text-xs font-medium m-0 truncate" style="color: var(--chat-text);">
+                Checkpoint {{ i + 1 }}
+              </p>
+              @if (cp.checkpoint?.checkpoint_id) {
+                <p class="text-[11px] font-mono m-0 truncate" style="color: var(--chat-text-muted);">
+                  {{ cp.checkpoint.checkpoint_id.substring(0, 12) }}...
+                </p>
+              }
+              <div class="flex gap-1 mt-1">
+                <button
+                  class="text-[11px] px-1.5 py-0.5 rounded border-0 cursor-pointer"
+                  style="background: var(--chat-bg-hover); color: var(--chat-text);"
+                  (click)="replay(cp)"
+                >Replay</button>
+                <button
+                  class="text-[11px] px-1.5 py-0.5 rounded border-0 cursor-pointer"
+                  style="background: var(--chat-bg-hover); color: var(--chat-text);"
+                  (click)="fork(cp)"
+                >Fork</button>
+              </div>
+            </div>
+          </div>
+        } @empty {
+          <p class="text-xs p-3 m-0" style="color: var(--chat-text-muted);">Send a message to create checkpoints.</p>
+        }
+      </aside>
+    </div>
+  `,
+})
+export class TimeTravelComponent {
+  protected readonly stream = streamResource({
+    apiUrl: environment.langGraphApiUrl,
+    assistantId: environment.timeTravelAssistantId,
+  });
+
+  readonly checkpoints = computed(() => this.stream.history());
+
+  replay(state: any): void {
+    if (state.checkpoint?.checkpoint_id) {
+      this.stream.setBranch(state.checkpoint.checkpoint_id);
+    }
+  }
+
+  fork(state: any): void {
+    if (state.checkpoint?.checkpoint_id) {
+      this.stream.setBranch(state.checkpoint.checkpoint_id);
+    }
+  }
+}
+```
+
+- [ ] **Step 3: Build to verify**
+
+```bash
+npx nx build cockpit-langgraph-time-travel-angular
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cockpit/langgraph/time-travel/angular/src/app/time-travel.component.ts
+git commit -m "feat(cockpit): add checkpoint timeline sidebar to time-travel example"
+```
+
+---
+
+## Task 3: Durable Execution — Step Progress Sidebar
+
+**Files:**
+- Modify: `cockpit/langgraph/durable-execution/angular/src/app/durable-execution.component.ts`
+
+**Capability:** Multi-step pipeline (analyze → plan → generate) with checkpoint recovery.
+
+- [ ] **Step 1: Read the current component**
+
+Read `cockpit/langgraph/durable-execution/angular/src/app/durable-execution.component.ts`.
+
+- [ ] **Step 2: Implement step progress sidebar**
+
+```typescript
+import { Component, computed } from '@angular/core';
+import { ChatComponent } from '@cacheplane/chat';
+import { streamResource } from '@cacheplane/stream-resource';
+import { environment } from '../environments/environment';
+
+const PIPELINE_STEPS = ['analyze', 'plan', 'generate'] as const;
+
+@Component({
+  selector: 'app-durable-execution',
+  standalone: true,
+  imports: [ChatComponent],
+  template: `
+    <div class="flex h-screen">
+      <chat [ref]="stream" class="flex-1 min-w-0" />
+      <aside
+        class="w-64 border-l overflow-y-auto flex flex-col shrink-0"
+        style="border-color: var(--chat-border); background: var(--chat-bg-alt);"
+      >
+        <div class="p-3 border-b" style="border-color: var(--chat-border);">
+          <h2 class="text-[11px] font-semibold uppercase tracking-wider m-0" style="color: var(--chat-text-muted);">Pipeline</h2>
+        </div>
+        <div class="p-3 flex flex-col gap-2">
+          @for (step of steps; track step) {
+            <div class="flex items-center gap-2">
+              <div
+                class="w-5 h-5 flex items-center justify-center rounded-full text-[11px] font-bold"
+                [style.background]="stepStatus(step) === 'complete' ? 'var(--chat-success)' : stepStatus(step) === 'active' ? 'var(--chat-warning-text)' : 'var(--chat-bg-hover)'"
+                [style.color]="stepStatus(step) === 'complete' || stepStatus(step) === 'active' ? '#fff' : 'var(--chat-text-muted)'"
+              >
+                @if (stepStatus(step) === 'complete') {
+                  <svg width="10" height="10" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M2.5 6L5 8.5L9.5 3.5"/></svg>
+                } @else {
+                  {{ steps.indexOf(step) + 1 }}
+                }
+              </div>
+              <span
+                class="text-sm capitalize"
+                [style.color]="stepStatus(step) === 'pending' ? 'var(--chat-text-muted)' : 'var(--chat-text)'"
+                [style.fontWeight]="stepStatus(step) === 'active' ? '500' : '400'"
+              >{{ step }}</span>
+            </div>
+            @if (steps.indexOf(step) < steps.length - 1) {
+              <div class="w-0.5 h-3 ml-[9px]" style="background: var(--chat-border);"></div>
+            }
+          }
+        </div>
+        @if (stream.isLoading()) {
+          <div class="px-3 pb-3">
+            <p class="text-xs m-0" style="color: var(--chat-text-muted);">Processing...</p>
+          </div>
+        }
+      </aside>
+    </div>
+  `,
+})
+export class DurableExecutionComponent {
+  protected readonly stream = streamResource({
+    apiUrl: environment.langGraphApiUrl,
+    assistantId: environment.durableExecutionAssistantId,
+  });
+
+  readonly steps = [...PIPELINE_STEPS];
+
+  private readonly currentStep = computed(() => {
+    const val = this.stream.value() as Record<string, unknown>;
+    return (val?.['step'] as string) ?? '';
+  });
+
+  stepStatus(step: string): 'pending' | 'active' | 'complete' {
+    const current = this.currentStep();
+    if (!current) return 'pending';
+    const currentIdx = this.steps.indexOf(current);
+    const stepIdx = this.steps.indexOf(step);
+    if (stepIdx < currentIdx) return 'complete';
+    if (stepIdx === currentIdx) return this.stream.isLoading() ? 'active' : 'complete';
+    return 'pending';
+  }
+}
+```
+
+- [ ] **Step 3: Build to verify**
+
+```bash
+npx nx build cockpit-langgraph-durable-execution-angular
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cockpit/langgraph/durable-execution/angular/src/app/durable-execution.component.ts
+git commit -m "feat(cockpit): add step progress sidebar to durable-execution example"
+```
+
+---
+
+## Task 4: Planning — Plan Step Checklist Sidebar
+
+**Files:**
+- Modify: `cockpit/deep-agents/planning/angular/src/app/planning.component.ts`
+
+**Capability:** Agent decomposes tasks into ordered steps, executes them sequentially.
+
+- [ ] **Step 1: Read the current component**
+
+Read `cockpit/deep-agents/planning/angular/src/app/planning.component.ts`.
+
+- [ ] **Step 2: Implement plan checklist sidebar**
+
+```typescript
+import { Component, computed } from '@angular/core';
+import { ChatComponent } from '@cacheplane/chat';
+import { streamResource } from '@cacheplane/stream-resource';
+import { environment } from '../environments/environment';
+
+interface PlanStep {
+  title: string;
+  status: 'pending' | 'in_progress' | 'complete';
+}
+
+@Component({
+  selector: 'app-planning',
+  standalone: true,
+  imports: [ChatComponent],
+  template: `
+    <div class="flex h-screen">
+      <chat [ref]="stream" class="flex-1 min-w-0" />
+      <aside
+        class="w-72 border-l overflow-y-auto flex flex-col shrink-0"
+        style="border-color: var(--chat-border); background: var(--chat-bg-alt);"
+      >
+        <div class="p-3 border-b" style="border-color: var(--chat-border);">
+          <h2 class="text-[11px] font-semibold uppercase tracking-wider m-0" style="color: var(--chat-text-muted);">
+            Plan ({{ planSteps().length }} steps)
+          </h2>
+        </div>
+        <div class="p-3 flex flex-col gap-1.5">
+          @for (step of planSteps(); track $index; let i = $index) {
+            <div class="flex items-start gap-2 py-1">
+              @if (step.status === 'complete') {
+                <svg class="w-4 h-4 shrink-0 mt-0.5" style="color: var(--chat-success);" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 8L6.5 11.5L13 4.5"/></svg>
+              } @else if (step.status === 'in_progress') {
+                <div class="w-4 h-4 shrink-0 mt-0.5 rounded-full border-2 border-t-transparent animate-spin" style="border-color: var(--chat-warning-text); border-top-color: transparent;"></div>
+              } @else {
+                <div class="w-4 h-4 shrink-0 mt-0.5 rounded-full border" style="border-color: var(--chat-border);"></div>
+              }
+              <span
+                class="text-sm"
+                [style.color]="step.status === 'pending' ? 'var(--chat-text-muted)' : 'var(--chat-text)'"
+              >{{ step.title }}</span>
+            </div>
+          } @empty {
+            <p class="text-xs m-0" style="color: var(--chat-text-muted);">Send a task to generate a plan.</p>
+          }
+        </div>
+      </aside>
+    </div>
+  `,
+})
+export class PlanningComponent {
+  protected readonly stream = streamResource({
+    apiUrl: environment.langGraphApiUrl,
+    assistantId: environment.planningAssistantId,
+  });
+
+  readonly planSteps = computed((): PlanStep[] => {
+    const val = this.stream.value() as Record<string, unknown>;
+    const plan = val?.['plan'];
+    if (!Array.isArray(plan)) return [];
+    return plan.map((s: any) => ({
+      title: s.title ?? s.description ?? String(s),
+      status: s.status ?? 'pending',
+    }));
+  });
+}
+```
+
+- [ ] **Step 3: Build to verify**
+
+```bash
+npx nx build cockpit-deep-agents-planning-angular
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cockpit/deep-agents/planning/angular/src/app/planning.component.ts
+git commit -m "feat(cockpit): add plan checklist sidebar to planning example"
+```
+
+---
+
+## Task 5: Filesystem — File Operations Log Sidebar
+
+**Files:**
+- Modify: `cockpit/deep-agents/filesystem/angular/src/app/filesystem.component.ts`
+
+**Capability:** Agent reads/writes files via tool calls.
+
+- [ ] **Step 1: Read the current component**
+
+Read `cockpit/deep-agents/filesystem/angular/src/app/filesystem.component.ts`.
+
+- [ ] **Step 2: Implement file operations sidebar**
+
+Derive file operations from `stream.messages()` by filtering for tool call messages with `read_file` or `write_file` names.
+
+```typescript
+import { Component, computed } from '@angular/core';
+import { ChatComponent } from '@cacheplane/chat';
+import { streamResource } from '@cacheplane/stream-resource';
+import { environment } from '../environments/environment';
+
+interface FileOp {
+  operation: string;
+  path: string;
+  result: string;
+}
+
+@Component({
+  selector: 'app-filesystem',
+  standalone: true,
+  imports: [ChatComponent],
+  template: `
+    <div class="flex h-screen">
+      <chat [ref]="stream" class="flex-1 min-w-0" />
+      <aside
+        class="w-72 border-l overflow-y-auto flex flex-col shrink-0"
+        style="border-color: var(--chat-border); background: var(--chat-bg-alt);"
+      >
+        <div class="p-3 border-b" style="border-color: var(--chat-border);">
+          <h2 class="text-[11px] font-semibold uppercase tracking-wider m-0" style="color: var(--chat-text-muted);">File Operations</h2>
+        </div>
+        @for (op of fileOps(); track $index) {
+          <div class="px-3 py-2 border-b" style="border-color: var(--chat-border-light);">
+            <div class="flex items-center gap-1.5">
+              <span class="text-[11px] font-mono px-1 rounded" style="background: var(--chat-bg-hover); color: var(--chat-text-muted);">{{ op.operation }}</span>
+              <span class="text-xs font-mono truncate" style="color: var(--chat-text);">{{ op.path }}</span>
+            </div>
+            @if (op.result) {
+              <p class="text-[11px] font-mono mt-1 m-0 truncate" style="color: var(--chat-text-muted);">{{ op.result }}</p>
+            }
+          </div>
+        } @empty {
+          <p class="text-xs p-3 m-0" style="color: var(--chat-text-muted);">No file operations yet.</p>
+        }
+      </aside>
+    </div>
+  `,
+})
+export class FilesystemComponent {
+  protected readonly stream = streamResource({
+    apiUrl: environment.langGraphApiUrl,
+    assistantId: environment.filesystemAssistantId,
+  });
+
+  readonly fileOps = computed((): FileOp[] => {
+    const messages = this.stream.messages();
+    const ops: FileOp[] = [];
+    for (const msg of messages) {
+      const tc = (msg as any).tool_calls;
+      if (Array.isArray(tc)) {
+        for (const call of tc) {
+          if (call.name === 'read_file' || call.name === 'write_file') {
+            ops.push({
+              operation: call.name.replace('_', ' '),
+              path: call.args?.path ?? call.args?.file_path ?? '(unknown)',
+              result: '',
+            });
+          }
+        }
+      }
+      // Tool result messages have name + content
+      if ((msg as any).type === 'tool' && (msg as any).name) {
+        const lastOp = ops[ops.length - 1];
+        if (lastOp) {
+          lastOp.result = typeof (msg as any).content === 'string'
+            ? (msg as any).content.substring(0, 100)
+            : '';
+        }
+      }
+    }
+    return ops;
+  });
+}
+```
+
+- [ ] **Step 3: Build to verify**
+
+```bash
+npx nx build cockpit-deep-agents-filesystem-angular
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cockpit/deep-agents/filesystem/angular/src/app/filesystem.component.ts
+git commit -m "feat(cockpit): add file operations sidebar to filesystem example"
+```
+
+---
+
+## Task 6: Subagents (DA) — Delegation Tracker Sidebar
+
+**Files:**
+- Modify: `cockpit/deep-agents/subagents/angular/src/app/subagents.component.ts`
+
+**Capability:** Orchestrator delegates to specialist subagents.
+
+- [ ] **Step 1: Read the current component**
+
+Read `cockpit/deep-agents/subagents/angular/src/app/subagents.component.ts`.
+
+- [ ] **Step 2: Implement delegation tracker sidebar**
+
+```typescript
+import { Component, computed } from '@angular/core';
+import { ChatComponent } from '@cacheplane/chat';
+import { streamResource } from '@cacheplane/stream-resource';
+import { environment } from '../environments/environment';
+
+interface Delegation {
+  agent: string;
+  status: string;
+}
+
+@Component({
+  selector: 'app-subagents',
+  standalone: true,
+  imports: [ChatComponent],
+  template: `
+    <div class="flex h-screen">
+      <chat [ref]="stream" class="flex-1 min-w-0" />
+      <aside
+        class="w-72 border-l overflow-y-auto flex flex-col shrink-0"
+        style="border-color: var(--chat-border); background: var(--chat-bg-alt);"
+      >
+        <div class="p-3 border-b" style="border-color: var(--chat-border);">
+          <h2 class="text-[11px] font-semibold uppercase tracking-wider m-0" style="color: var(--chat-text-muted);">Delegations</h2>
+        </div>
+        @for (d of delegations(); track $index) {
+          <div class="px-3 py-2 border-b flex items-center gap-2" style="border-color: var(--chat-border-light);">
+            <div
+              class="w-2 h-2 rounded-full shrink-0"
+              [style.background]="d.status === 'complete' ? 'var(--chat-success)' : d.status === 'error' ? 'var(--chat-error-text)' : 'var(--chat-warning-text)'"
+            ></div>
+            <div class="flex-1 min-w-0">
+              <p class="text-sm m-0 font-medium truncate" style="color: var(--chat-text);">{{ d.agent }}</p>
+              <p class="text-[11px] m-0 capitalize" style="color: var(--chat-text-muted);">{{ d.status }}</p>
+            </div>
+          </div>
+        } @empty {
+          <p class="text-xs p-3 m-0" style="color: var(--chat-text-muted);">No delegations yet.</p>
+        }
+      </aside>
+    </div>
+  `,
+})
+export class SubagentsComponent {
+  protected readonly stream = streamResource({
+    apiUrl: environment.langGraphApiUrl,
+    assistantId: environment.subagentsAssistantId,
+  });
+
+  readonly delegations = computed((): Delegation[] => {
+    const messages = this.stream.messages();
+    const delegations: Delegation[] = [];
+    for (const msg of messages) {
+      const tc = (msg as any).tool_calls;
+      if (Array.isArray(tc)) {
+        for (const call of tc) {
+          delegations.push({
+            agent: call.name?.replace(/_/g, ' ') ?? 'unknown',
+            status: 'running',
+          });
+        }
+      }
+      if ((msg as any).type === 'tool') {
+        const last = delegations[delegations.length - 1];
+        if (last) last.status = 'complete';
+      }
+    }
+    return delegations;
+  });
+}
+```
+
+- [ ] **Step 3: Build to verify**
+
+```bash
+npx nx build cockpit-deep-agents-subagents-angular
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cockpit/deep-agents/subagents/angular/src/app/subagents.component.ts
+git commit -m "feat(cockpit): add delegation tracker sidebar to subagents example"
+```
+
+---
+
+## Task 7: Memory (DA) — Learned Facts Sidebar
+
+**Files:**
+- Modify: `cockpit/deep-agents/memory/angular/src/app/memory.component.ts`
+
+**Capability:** Agent extracts and remembers facts from conversations.
+
+- [ ] **Step 1: Read the current component**
+
+Read `cockpit/deep-agents/memory/angular/src/app/memory.component.ts`.
+
+- [ ] **Step 2: Implement learned facts sidebar**
+
+Same pattern as the LangGraph memory example but using `agent_memory` state field:
+
+```typescript
+import { Component, computed } from '@angular/core';
+import { ChatComponent } from '@cacheplane/chat';
+import { streamResource } from '@cacheplane/stream-resource';
+import { environment } from '../environments/environment';
+
+@Component({
+  selector: 'app-memory',
+  standalone: true,
+  imports: [ChatComponent],
+  template: `
+    <div class="flex h-screen">
+      <chat [ref]="stream" class="flex-1 min-w-0" />
+      <aside
+        class="w-72 border-l overflow-y-auto flex flex-col shrink-0"
+        style="border-color: var(--chat-border); background: var(--chat-bg-alt);"
+      >
+        <div class="p-3 border-b" style="border-color: var(--chat-border);">
+          <h2 class="text-[11px] font-semibold uppercase tracking-wider m-0" style="color: var(--chat-text-muted);">
+            Learned Facts ({{ memoryEntries().length }})
+          </h2>
+        </div>
+        @for (entry of memoryEntries(); track entry[0]) {
+          <div class="px-3 py-2 border-b" style="border-color: var(--chat-border-light);">
+            <p class="text-xs font-semibold m-0" style="color: var(--chat-text);">{{ entry[0] }}</p>
+            <p class="text-xs mt-0.5 m-0" style="color: var(--chat-text-muted);">{{ entry[1] }}</p>
+          </div>
+        } @empty {
+          <p class="text-xs p-3 m-0" style="color: var(--chat-text-muted);">No facts learned yet.</p>
+        }
+      </aside>
+    </div>
+  `,
+})
+export class MemoryComponent {
+  protected readonly stream = streamResource({
+    apiUrl: environment.langGraphApiUrl,
+    assistantId: environment.memoryAssistantId,
+  });
+
+  readonly memoryEntries = computed((): [string, string][] => {
+    const val = this.stream.value() as Record<string, unknown>;
+    const memory = val?.['agent_memory'] ?? val?.['memory'];
+    if (!memory || typeof memory !== 'object') return [];
+    return Object.entries(memory as Record<string, string>);
+  });
+}
+```
+
+- [ ] **Step 3: Build to verify**
+
+```bash
+npx nx build cockpit-deep-agents-memory-angular
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cockpit/deep-agents/memory/angular/src/app/memory.component.ts
+git commit -m "feat(cockpit): add learned facts sidebar to memory example"
+```
+
+---
+
+## Task 8: Skills — Skill Invocations Log Sidebar
+
+**Files:**
+- Modify: `cockpit/deep-agents/skills/angular/src/app/skills.component.ts`
+
+**Capability:** Agent uses multiple skills (calculator, word_count, summarize).
+
+- [ ] **Step 1: Read the current component**
+
+Read `cockpit/deep-agents/skills/angular/src/app/skills.component.ts`.
+
+- [ ] **Step 2: Implement skill invocations sidebar**
+
+```typescript
+import { Component, computed } from '@angular/core';
+import { ChatComponent } from '@cacheplane/chat';
+import { streamResource } from '@cacheplane/stream-resource';
+import { environment } from '../environments/environment';
+
+interface SkillInvocation {
+  name: string;
+  input: string;
+  output: string;
+}
+
+@Component({
+  selector: 'app-skills',
+  standalone: true,
+  imports: [ChatComponent],
+  template: `
+    <div class="flex h-screen">
+      <chat [ref]="stream" class="flex-1 min-w-0" />
+      <aside
+        class="w-72 border-l overflow-y-auto flex flex-col shrink-0"
+        style="border-color: var(--chat-border); background: var(--chat-bg-alt);"
+      >
+        <div class="p-3 border-b" style="border-color: var(--chat-border);">
+          <h2 class="text-[11px] font-semibold uppercase tracking-wider m-0" style="color: var(--chat-text-muted);">Skills Used</h2>
+        </div>
+        @for (skill of skillInvocations(); track $index) {
+          <div class="px-3 py-2 border-b" style="border-color: var(--chat-border-light);">
+            <div class="flex items-center gap-1.5">
+              <span class="text-[11px] font-mono px-1 rounded" style="background: var(--chat-bg-hover); color: var(--chat-text);">{{ skill.name }}</span>
+            </div>
+            <p class="text-[11px] font-mono mt-1 m-0" style="color: var(--chat-text-muted);">in: {{ skill.input }}</p>
+            @if (skill.output) {
+              <p class="text-[11px] font-mono m-0" style="color: var(--chat-text-muted);">out: {{ skill.output }}</p>
+            }
+          </div>
+        } @empty {
+          <p class="text-xs p-3 m-0" style="color: var(--chat-text-muted);">No skills invoked yet.</p>
+        }
+      </aside>
+    </div>
+  `,
+})
+export class SkillsComponent {
+  protected readonly stream = streamResource({
+    apiUrl: environment.langGraphApiUrl,
+    assistantId: environment.skillsAssistantId,
+  });
+
+  readonly skillInvocations = computed((): SkillInvocation[] => {
+    const messages = this.stream.messages();
+    const invocations: SkillInvocation[] = [];
+    for (const msg of messages) {
+      const tc = (msg as any).tool_calls;
+      if (Array.isArray(tc)) {
+        for (const call of tc) {
+          invocations.push({
+            name: call.name ?? 'unknown',
+            input: JSON.stringify(call.args ?? {}).substring(0, 60),
+            output: '',
+          });
+        }
+      }
+      if ((msg as any).type === 'tool') {
+        const last = invocations[invocations.length - 1];
+        if (last) {
+          last.output = typeof (msg as any).content === 'string'
+            ? (msg as any).content.substring(0, 60)
+            : '';
+        }
+      }
+    }
+    return invocations;
+  });
+}
+```
+
+- [ ] **Step 3: Build to verify**
+
+```bash
+npx nx build cockpit-deep-agents-skills-angular
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cockpit/deep-agents/skills/angular/src/app/skills.component.ts
+git commit -m "feat(cockpit): add skill invocations sidebar to skills example"
+```
+
+---
+
+## Task 9: Sandboxes — Execution Output Log Sidebar
+
+**Files:**
+- Modify: `cockpit/deep-agents/sandboxes/angular/src/app/sandboxes.component.ts`
+
+**Capability:** Agent generates and executes Python code.
+
+- [ ] **Step 1: Read the current component**
+
+Read `cockpit/deep-agents/sandboxes/angular/src/app/sandboxes.component.ts`.
+
+- [ ] **Step 2: Implement execution output sidebar**
+
+```typescript
+import { Component, computed } from '@angular/core';
+import { ChatComponent } from '@cacheplane/chat';
+import { streamResource } from '@cacheplane/stream-resource';
+import { environment } from '../environments/environment';
+
+interface CodeExecution {
+  code: string;
+  stdout: string;
+  stderr: string;
+  exitStatus: number;
+}
+
+@Component({
+  selector: 'app-sandboxes',
+  standalone: true,
+  imports: [ChatComponent],
+  template: `
+    <div class="flex h-screen">
+      <chat [ref]="stream" class="flex-1 min-w-0" />
+      <aside
+        class="w-80 border-l overflow-y-auto flex flex-col shrink-0"
+        style="border-color: var(--chat-border); background: var(--chat-bg-alt);"
+      >
+        <div class="p-3 border-b" style="border-color: var(--chat-border);">
+          <h2 class="text-[11px] font-semibold uppercase tracking-wider m-0" style="color: var(--chat-text-muted);">Executions</h2>
+        </div>
+        @for (exec of executions(); track $index) {
+          <div class="px-3 py-2 border-b" style="border-color: var(--chat-border-light);">
+            <pre class="text-[11px] font-mono m-0 p-2 rounded overflow-x-auto whitespace-pre-wrap" style="background: var(--chat-bg); color: var(--chat-text);">{{ exec.code }}</pre>
+            @if (exec.stdout) {
+              <div class="mt-1">
+                <span class="text-[10px] font-semibold uppercase" style="color: var(--chat-text-muted);">stdout</span>
+                <pre class="text-[11px] font-mono m-0 mt-0.5 p-1.5 rounded" style="background: var(--chat-bg); color: var(--chat-success);">{{ exec.stdout }}</pre>
+              </div>
+            }
+            @if (exec.stderr) {
+              <div class="mt-1">
+                <span class="text-[10px] font-semibold uppercase" style="color: var(--chat-text-muted);">stderr</span>
+                <pre class="text-[11px] font-mono m-0 mt-0.5 p-1.5 rounded" style="background: var(--chat-error-bg); color: var(--chat-error-text);">{{ exec.stderr }}</pre>
+              </div>
+            }
+          </div>
+        } @empty {
+          <p class="text-xs p-3 m-0" style="color: var(--chat-text-muted);">No code executed yet.</p>
+        }
+      </aside>
+    </div>
+  `,
+})
+export class SandboxesComponent {
+  protected readonly stream = streamResource({
+    apiUrl: environment.langGraphApiUrl,
+    assistantId: environment.sandboxesAssistantId,
+  });
+
+  readonly executions = computed((): CodeExecution[] => {
+    const messages = this.stream.messages();
+    const execs: CodeExecution[] = [];
+    for (const msg of messages) {
+      const tc = (msg as any).tool_calls;
+      if (Array.isArray(tc)) {
+        for (const call of tc) {
+          if (call.name === 'run_code') {
+            execs.push({
+              code: call.args?.code ?? '',
+              stdout: '',
+              stderr: '',
+              exitStatus: 0,
+            });
+          }
+        }
+      }
+      if ((msg as any).type === 'tool' && (msg as any).name === 'run_code') {
+        const last = execs[execs.length - 1];
+        if (last) {
+          try {
+            const result = JSON.parse((msg as any).content);
+            last.stdout = result.stdout ?? '';
+            last.stderr = result.stderr ?? '';
+            last.exitStatus = result.exit_status ?? 0;
+          } catch {
+            last.stdout = typeof (msg as any).content === 'string' ? (msg as any).content : '';
+          }
+        }
+      }
+    }
+    return execs;
+  });
+}
+```
+
+- [ ] **Step 3: Build to verify**
+
+```bash
+npx nx build cockpit-deep-agents-sandboxes-angular
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cockpit/deep-agents/sandboxes/angular/src/app/sandboxes.component.ts
+git commit -m "feat(cockpit): add execution output sidebar to sandboxes example"
+```
+
+---
+
+## Task 10: Build All & Final Verification
+
+- [ ] **Step 1: Build all 14 cockpit examples**
+
+```bash
+npx nx run-many -t build --projects='cockpit-*-angular'
+```
+
+Expected: All 14 examples build successfully.
+
+- [ ] **Step 2: Run library tests**
+
+```bash
+npx nx test chat && npx nx test render && npx nx test stream-resource
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 3: Commit any final fixes**
+
+If any builds fail, fix the compilation errors and commit.
+
+- [ ] **Step 4: Final commit**
+
+```bash
+git add -A
+git commit -m "feat(cockpit): complete sidebar implementations for all 14 capability examples"
+```

--- a/libs/stream-resource/src/lib/internals/stream-manager.bridge.ts
+++ b/libs/stream-resource/src/lib/internals/stream-manager.bridge.ts
@@ -219,23 +219,16 @@ export function createStreamManagerBridge<T, ResolvedBag extends BagTemplate = B
 
 /**
  * Extracts the payload data from a normalized SDK event.
- *
- * Handles two formats:
- * 1. SDK events (via normalizeSdkEvent): data at event['data'] (record) + spread into event
- * 2. Mock/test events: data at event[event.type] (e.g., event['values'], event['updates'])
+ * normalizeSdkEvent spreads record data into the event object and also
+ * stores the original under event['data']. Prefer event['data'] when
+ * it's a record; fall back to stripping event metadata keys.
  */
 function extractEventData(event: StreamEvent): unknown {
-  // Try event['data'] first (SDK format from normalizeSdkEvent)
   const d = event['data'];
   if (d != null && typeof d === 'object' && !Array.isArray(d)) {
     return d;
   }
-  // Try event[event.type] (mock/test format: { type: 'values', values: {...} })
-  const named = event[event.type];
-  if (named != null && typeof named === 'object' && !Array.isArray(named)) {
-    return named;
-  }
-  // Fallback: reconstruct from remaining keys
+  // Fallback: the data was spread into the event — reconstruct
   const { type: _t, data: _d, ...rest } = event;
   return Object.keys(rest).length > 0 ? rest : d;
 }

--- a/libs/stream-resource/src/lib/internals/stream-manager.bridge.ts
+++ b/libs/stream-resource/src/lib/internals/stream-manager.bridge.ts
@@ -219,16 +219,23 @@ export function createStreamManagerBridge<T, ResolvedBag extends BagTemplate = B
 
 /**
  * Extracts the payload data from a normalized SDK event.
- * normalizeSdkEvent spreads record data into the event object and also
- * stores the original under event['data']. Prefer event['data'] when
- * it's a record; fall back to stripping event metadata keys.
+ *
+ * Handles two formats:
+ * 1. SDK events (via normalizeSdkEvent): data at event['data'] (record) + spread into event
+ * 2. Mock/test events: data at event[event.type] (e.g., event['values'], event['updates'])
  */
 function extractEventData(event: StreamEvent): unknown {
+  // Try event['data'] first (SDK format from normalizeSdkEvent)
   const d = event['data'];
   if (d != null && typeof d === 'object' && !Array.isArray(d)) {
     return d;
   }
-  // Fallback: the data was spread into the event — reconstruct
+  // Try event[event.type] (mock/test format: { type: 'values', values: {...} })
+  const named = event[event.type];
+  if (named != null && typeof named === 'object' && !Array.isArray(named)) {
+    return named;
+  }
+  // Fallback: reconstruct from remaining keys
   const { type: _t, data: _d, ...rest } = event;
   return Object.keys(rest).length > 0 ? rest : d;
 }


### PR DESCRIPTION
## Summary

Implements capability-specific sidebars for all 9 incomplete cockpit examples, validating that the chat and stream-resource libraries fully support every LangGraph and Deep Agent capability.

### LangGraph Examples
- **Persistence**: Thread picker sidebar with new/switch thread controls
- **Time-travel**: Checkpoint timeline with replay/fork buttons per checkpoint
- **Durable-execution**: 3-step pipeline progress indicator (analyze → plan → generate)

### Deep Agent Examples
- **Planning**: Plan step checklist with status indicators (pending/in_progress/complete)
- **Filesystem**: File operations log showing read/write tool calls with paths and results
- **Subagents**: Delegation tracker with status dots (running/complete/error)
- **Memory**: Learned facts sidebar from agent_memory state
- **Skills**: Skill invocations log (calculator/word_count/summarize) with inputs/outputs
- **Sandboxes**: Code execution output with stdout (green) / stderr (red) display

### Already Complete (5 examples verified)
- Streaming, Interrupts, Memory (LG), Subgraphs, Deployment-runtime

### Stream-Resource Fixes (included)
- Fix `Object.keys` crash on null values in stream subscriber
- Fix `_getType` error with plain JSON messages from SSE
- Fix event data extraction (`event['values']` was always undefined)
- Handle both SDK and mock event formats in `extractEventData`

## Test plan
- [x] All 14 cockpit Angular examples build (`nx run-many -t build --projects='cockpit-*-angular'`)
- [x] Chat library tests pass
- [x] Render library tests pass
- [x] Each sidebar derives state from `stream.value()` or `stream.messages()` signals