### PR TITLE
fix(stream-resource): persist thread ID across messages + smooth scroll

### DIFF
--- a/libs/chat/src/lib/compositions/chat-debug/chat-debug.component.ts
+++ b/libs/chat/src/lib/compositions/chat-debug/chat-debug.component.ts
@@ -226,7 +226,12 @@ export class ChatDebugComponent {
       this.ref().isLoading(); // track
       const el = this.scrollContainer()?.nativeElement;
       if (el) {
-        setTimeout(() => el.scrollTop = el.scrollHeight, 0);
+        const isNearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 150;
+        if (isNearBottom) {
+          requestAnimationFrame(() => {
+            el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
+          });
+        }
       }
     });
   }

--- a/libs/chat/src/lib/compositions/chat/chat.component.ts
+++ b/libs/chat/src/lib/compositions/chat/chat.component.ts
@@ -189,13 +189,20 @@ export class ChatComponent {
   private readonly messageCount = computed(() => this.ref().messages().length);
 
   constructor() {
-    // Auto-scroll to bottom when new messages arrive or loading state changes
+    // Auto-scroll to bottom when new messages arrive.
+    // Only scrolls if user is already near the bottom (within 150px),
+    // so reading earlier messages isn't interrupted.
     effect(() => {
       this.messageCount(); // track
       this.ref().isLoading(); // track
       const el = this.scrollContainer()?.nativeElement;
       if (el) {
-        setTimeout(() => el.scrollTop = el.scrollHeight, 0);
+        const isNearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 150;
+        if (isNearBottom) {
+          requestAnimationFrame(() => {
+            el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
+          });
+        }
       }
     });
   }

--- a/libs/stream-resource/src/lib/internals/stream-manager.bridge.ts
+++ b/libs/stream-resource/src/lib/internals/stream-manager.bridge.ts
@@ -30,8 +30,16 @@ export interface StreamManagerBridge {
 export function createStreamManagerBridge<T, ResolvedBag extends BagTemplate = BagTemplate>(
   { options, subjects, threadId$, destroy$ }: StreamManagerBridgeOptions<T, ResolvedBag>
 ): StreamManagerBridge {
+  // Intercept onThreadId to update currentThreadId when the transport
+  // auto-creates a thread. Without this, each submit() creates a new thread
+  // because currentThreadId stays null.
+  const userOnThreadId = options.onThreadId;
+  const wrappedOnThreadId = (id: string) => {
+    currentThreadId = id;
+    userOnThreadId?.(id);
+  };
   const transport: StreamResourceTransport =
-    options.transport ?? new FetchStreamTransport(options.apiUrl, options.onThreadId);
+    options.transport ?? new FetchStreamTransport(options.apiUrl, wrappedOnThreadId);
 
   let currentThreadId: string | null = null;
   let lastPayload: unknown = null;


### PR DESCRIPTION
## Summary

- **Thread persistence**: Each `submit()` was creating a brand new thread because `currentThreadId` was never updated after the transport auto-created a thread. The `onThreadId` callback from `FetchStreamTransport` was passed through to the consumer but never connected to the bridge's internal thread tracking. Fix: wrap the callback to update `currentThreadId` first.
- **Smooth scroll**: Replace `setTimeout` + `scrollTop` assignment with `requestAnimationFrame` + `scrollTo({behavior:'smooth'})`. Only auto-scrolls when user is near bottom (<150px) so reading earlier messages isn't interrupted.

## Verified in Chrome
- 3-turn conversation: all 6 messages (3 human + 3 AI) visible and properly threaded
- Zero console errors
- Smooth scrolling behavior

## Test plan
- [x] stream-resource tests pass (32/32)
- [x] chat library tests pass
- [x] Multi-turn conversation verified in browser via Chrome extension