### PR TITLE
fix(deploy): rewrite base href per example so assets resolve to correct subpath

### DIFF
--- a/scripts/assemble-examples.ts
+++ b/scripts/assemble-examples.ts
@@ -9,7 +9,7 @@
  *   npx tsx scripts/assemble-examples.ts --skip-build
  */
 import { execSync } from 'child_process';
-import { cpSync, mkdirSync, rmSync, existsSync, writeFileSync } from 'fs';
+import { cpSync, mkdirSync, rmSync, existsSync, writeFileSync, readFileSync } from 'fs';
 import { resolve } from 'path';
 
 const root = resolve(__dirname, '..');
@@ -54,6 +54,20 @@ for (const cap of capabilities) {
 
   mkdirSync(dest, { recursive: true });
   cpSync(src, dest, { recursive: true });
+
+  // Fix <base href="/"> to point to the correct subpath so assets resolve correctly.
+  // Without this, main.js/styles.css/chunks load from the root (/) instead of
+  // /{product}/{topic}/ and return 404 in production.
+  const indexPath = resolve(dest, 'index.html');
+  if (existsSync(indexPath)) {
+    const html = readFileSync(indexPath, 'utf-8');
+    const fixed = html.replace(
+      '<base href="/">',
+      `<base href="/${cap.product}/${cap.topic}/">`,
+    );
+    writeFileSync(indexPath, fixed);
+  }
+
   console.log(`✅ ${cap.product}/${cap.topic}`);
 }
 


### PR DESCRIPTION
## Summary

**Production Angular examples at examples.stream-resource.dev are completely broken** — all 14 show dark/blank screens because asset files (main.js, styles.css, chunks) return 404.

**Root cause:** All `index.html` files have `<base href="/">` which resolves asset URLs to the domain root (`/main.js`) instead of the correct subpath (`/langgraph/streaming/main.js`).

**Fix:** `assemble-examples.ts` now rewrites `<base href="/">` to `<base href="/{product}/{topic}/">` for each example after copying build output.

## Evidence
- Navigated to `https://examples.stream-resource.dev/langgraph/streaming` in Chrome
- `main.js` → HTTP 404
- `styles.css` → HTTP 404  
- `chunk-C6Q5SG76.js` → HTTP 404
- Angular bootstrap fails silently — dark screen, no errors

## Test plan
- [x] Chat library tests pass
- [ ] Verify fix deploys correctly (CI deploy step)
- [ ] Verify all 14 examples load in production after deploy