### PR TITLE
fix(website): fix flaky e2e test blocking production deploys

### DIFF
--- a/apps/website/e2e/website.spec.ts
+++ b/apps/website/e2e/website.spec.ts
@@ -28,7 +28,7 @@ test('pricing page shows 4 plan cards', async ({ page }) => {
 test('pricing page lead form validates required fields', async ({ page }) => {
   await page.goto('/pricing');
   await page.click('button[type="submit"]');
-  await expect(page.locator('form')).toBeVisible();
+  await expect(page.locator('form').first()).toBeVisible();
 });
 
 test('docs page renders sidebar and content', async ({ page }) => {

--- a/scripts/assemble-examples.ts
+++ b/scripts/assemble-examples.ts
@@ -9,7 +9,7 @@
  *   npx tsx scripts/assemble-examples.ts --skip-build
  */
 import { execSync } from 'child_process';
-import { cpSync, mkdirSync, rmSync, existsSync, writeFileSync } from 'fs';
+import { cpSync, mkdirSync, rmSync, existsSync, writeFileSync, readFileSync } from 'fs';
 import { resolve } from 'path';
 
 const root = resolve(__dirname, '..');
@@ -54,6 +54,20 @@ for (const cap of capabilities) {
 
   mkdirSync(dest, { recursive: true });
   cpSync(src, dest, { recursive: true });
+
+  // Fix <base href="/"> to point to the correct subpath so assets resolve correctly.
+  // Without this, main.js/styles.css/chunks load from the root (/) instead of
+  // /{product}/{topic}/ and return 404 in production.
+  const indexPath = resolve(dest, 'index.html');
+  if (existsSync(indexPath)) {
+    const html = readFileSync(indexPath, 'utf-8');
+    const fixed = html.replace(
+      '<base href="/">',
+      `<base href="/${cap.product}/${cap.topic}/">`,
+    );
+    writeFileSync(indexPath, fixed);
+  }
+
   console.log(`✅ ${cap.product}/${cap.topic}`);
 }
 


### PR DESCRIPTION
## Summary

The pricing page e2e test fails in strict mode because `page.locator('form')` resolves to 2 elements (lead form + newsletter form). This blocks the Vercel deploy step, preventing all production updates.

Fix: use `.first()` to target the primary lead form.

This also unblocks the base-href deploy fix from PR #37 which merged but couldn't deploy.

## Test plan
- [x] Fix matches the error: `locator('form') resolved to 2 elements`
- [ ] CI passes with fix
- [ ] Deploy proceeds after merge