### PR TITLE
chore: trigger examples redeploy with base-href fix

### DIFF
--- a/scripts/assemble-examples.ts
+++ b/scripts/assemble-examples.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env npx tsx
 /**
- * Build all 14 Angular example apps and assemble them into a deploy directory.
+ * Build all Angular example apps and assemble them into a deploy directory.
  *
  * Output: deploy/examples/{product}/{topic}/ with index.html, main.js, styles.css
  *


### PR DESCRIPTION
Touches assemble-examples.ts to trigger the examples deploy step. The base-href fix from PR #37 was merged but never deployed because the change detection didn't fire on subsequent PRs.