### PR TITLE
fix(angular): normalize relative apiUrl to absolute for LangGraph SDK

### DIFF
--- a/libs/angular/src/lib/transport/fetch-stream.transport.ts
+++ b/libs/angular/src/lib/transport/fetch-stream.transport.ts
@@ -25,7 +25,15 @@ export class FetchStreamTransport implements AgentTransport {
    * @param onThreadId - Optional callback invoked when a new thread is created
    */
   constructor(apiUrl: string, onThreadId?: (id: string) => void) {
-    this.client = new Client({ apiUrl });
+    // Normalize relative paths (e.g. '/api') to absolute URLs.
+    // The LangGraph SDK Client requires an absolute URL, but production
+    // environments use relative paths that are proxied by Vercel middleware.
+    const absoluteUrl = apiUrl.startsWith('http://') || apiUrl.startsWith('https://')
+      ? apiUrl
+      : typeof window !== 'undefined'
+        ? `${window.location.origin}${apiUrl}`
+        : apiUrl;
+    this.client = new Client({ apiUrl: absoluteUrl });
     this.onThreadId = onThreadId;
   }
 


### PR DESCRIPTION
## Summary

Production cockpit examples show `Failed to construct 'URL': Invalid URL` because the LangGraph SDK `Client` requires an absolute URL, but production environments use relative paths (`/api`) that are proxied by Vercel middleware.

**Fix:** `FetchStreamTransport` now prepends `window.location.origin` for relative paths before passing to the SDK Client.

## Evidence
- Reproduced in Chrome at `examples.stream-resource.dev/langgraph/streaming`
- Error banner: "Failed to construct 'URL': Invalid URL"
- All 14 examples affected (all use `apiUrl: '/api'` in production)

## Test plan
- [x] Angular library tests pass
- [x] Chat library tests pass
- [x] Angular library builds
- [ ] Verify in production after deploy