### PR TITLE
fix(ci): trigger examples redeploy when libs change + redeploy apiUrl fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,6 +278,9 @@ jobs:
           if printf '%s\n' "$changed_files" | grep -E '^(vercel\.examples\.json|scripts/assemble-examples\.ts)$' >/dev/null; then
             examples_changed=true
           fi
+          if printf '%s\n' "$changed_files" | grep -E '^libs/(angular|chat|render)/' >/dev/null; then
+            examples_changed=true
+          fi
           echo "changed=$examples_changed" >> "$GITHUB_OUTPUT"
       - name: Build and assemble Angular examples
         if: steps.examples_changed.outputs.changed == 'true'

--- a/scripts/assemble-examples.ts
+++ b/scripts/assemble-examples.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env npx tsx
 /**
- * Build all Angular example apps and assemble them into a deploy directory.
+ * Build all Angular example apps and assemble them into a Vercel deploy directory.
  *
  * Output: deploy/examples/{product}/{topic}/ with index.html, main.js, styles.css
  *


### PR DESCRIPTION
## Summary

Two fixes:

1. **CI change detection**: Examples deploy was only triggered by `cockpit/**/angular/` and `scripts/assemble-examples.ts` changes. Library changes (`libs/angular/`, `libs/chat/`, `libs/render/`) were ignored — so the apiUrl fix from PR #43 was built but never deployed.

2. **Trigger redeploy**: Touches `assemble-examples.ts` to force the examples deploy step to run, picking up the apiUrl normalization fix.

## Root cause
PR #43 fixed `FetchStreamTransport` to normalize relative URLs, but the CI change detection didn't detect `libs/angular/` changes as requiring an examples redeploy. The old code (without the fix) remained in production.

## Test plan
- [x] CI file syntax valid
- [ ] Deploy triggers on merge
- [ ] `window.location.origin` prepended in production main.js
- [ ] No more "Failed to construct URL" error