### PR TITLE
fix(website): add remark-gfm dependency for table rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "react-dom": "^19.0.0",
         "rehype-pretty-code": "^0.14.3",
         "rehype-slug": "^6.0.0",
+        "remark-gfm": "^4.0.1",
         "rxjs": "~7.8.0",
         "shiki": "^4.0.2"
       },

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "react-dom": "^19.0.0",
     "rehype-pretty-code": "^0.14.3",
     "rehype-slug": "^6.0.0",
+    "remark-gfm": "^4.0.1",
     "rxjs": "~7.8.0",
     "shiki": "^4.0.2"
   },


### PR DESCRIPTION
## Summary
- Add `remark-gfm` to `package.json` — the import was added in #48 but the dependency was missing

## Test plan
- [x] Tables render correctly on dev server (verified on 4 pages across all 3 libraries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)