### PR TITLE
fix: cockpit iframe URL + stale stream-resource references

### DIFF
--- a/apps/cockpit/src/lib/content-bundle.ts
+++ b/apps/cockpit/src/lib/content-bundle.ts
@@ -45,7 +45,8 @@ export function resolveRuntimeUrl(options: {
     return null;
   }
 
-  const baseUrl = process.env['NEXT_PUBLIC_COCKPIT_RUNTIME_BASE_URL'];
+  const baseUrl = process.env['NEXT_PUBLIC_COCKPIT_RUNTIME_BASE_URL']
+    || 'https://examples.cacheplane.ai';
 
   if (baseUrl && runtimeUrl) {
     return `${baseUrl}/${runtimeUrl}`;

--- a/apps/website/content/AGENTS.md.template
+++ b/apps/website/content/AGENTS.md.template
@@ -41,4 +41,4 @@ Add to ~/.claude/settings.json:
 {"mcpServers":{"angular-agent":{"command":"npx","args":["@cacheplane/angular-mcp"]}}}
 
 ## Version check
-If this file is stale, fetch the latest: https://stream-resource.dev/llms-full.txt
+If this file is stale, fetch the latest: https://cacheplane.ai/llms-full.txt

--- a/apps/website/content/CLAUDE.md.template
+++ b/apps/website/content/CLAUDE.md.template
@@ -41,4 +41,4 @@ Add to ~/.claude/settings.json:
 {"mcpServers":{"angular-agent":{"command":"npx","args":["@cacheplane/angular-mcp"]}}}
 
 ## Version check
-If this file is stale, fetch the latest: https://stream-resource.dev/llms-full.txt
+If this file is stale, fetch the latest: https://cacheplane.ai/llms-full.txt

--- a/apps/website/src/components/shared/Footer.tsx
+++ b/apps/website/src/components/shared/Footer.tsx
@@ -110,7 +110,7 @@ export function Footer() {
             <NewsletterForm />
             {/* Social links */}
             <div className="flex items-center gap-4">
-              <a href="https://github.com/cacheplane/stream-resource"
+              <a href="https://github.com/cacheplane/angular"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="transition-colors"
@@ -156,7 +156,7 @@ export function Footer() {
               onMouseLeave={(e) => (e.currentTarget.style.color = tokens.colors.textSecondary)}>
               Pricing
             </Link>
-            <a href="https://github.com/cacheplane/stream-resource"
+            <a href="https://github.com/cacheplane/angular"
               target="_blank" rel="noopener noreferrer"
               className="transition-colors" style={{ color: tokens.colors.textSecondary }}
               onMouseEnter={(e) => (e.currentTarget.style.color = tokens.colors.accent)}

--- a/apps/website/src/components/shared/Nav.tsx
+++ b/apps/website/src/components/shared/Nav.tsx
@@ -74,7 +74,7 @@ export function Nav() {
               {l.label}
             </Link>
           ))}
-          <a href="https://github.com/cacheplane/stream-resource"
+          <a href="https://github.com/cacheplane/angular"
             target="_blank"
             rel="noopener noreferrer"
             className="transition-colors"
@@ -125,7 +125,7 @@ export function Nav() {
             </Link>
           ))}
           <div className="flex items-center gap-4 pt-2">
-            <a href="https://github.com/cacheplane/stream-resource"
+            <a href="https://github.com/cacheplane/angular"
               target="_blank"
               rel="noopener noreferrer"
               style={{ color: tokens.colors.textSecondary }}

--- a/examples/chat-agent/.env.example
+++ b/examples/chat-agent/.env.example
@@ -2,4 +2,4 @@ OPENAI_API_KEY=your-openai-api-key-here
 OPENAI_MODEL=gpt-5-mini
 LANGSMITH_API_KEY=your-langsmith-api-key-here
 LANGSMITH_TRACING=false
-LANGSMITH_PROJECT=stream-resource-example
+LANGSMITH_PROJECT=cacheplane-example


### PR DESCRIPTION
## Summary

The cockpit at cockpit.cacheplane.ai shows `DEPLOYMENT_NOT_FOUND` because the iframe loads from `examples.stream-resource.dev` (old domain). 

**Fixes:**
- Add hardcoded fallback `https://examples.cacheplane.ai` in `content-bundle.ts` so the cockpit works even without the Vercel env var
- Update 4 stale `stream-resource` GitHub URLs in Nav.tsx and Footer.tsx → `cacheplane/angular`
- Update example `.env.example` project name

**Note:** The Vercel env var `NEXT_PUBLIC_COCKPIT_RUNTIME_BASE_URL` should also be updated in the Vercel dashboard from `examples.stream-resource.dev` to `examples.cacheplane.ai`.

## Test plan
- [ ] Cockpit loads examples from cacheplane.ai after deploy
- [x] No `stream-resource` references remain in source code