### PR TITLE
chore: trigger cockpit rebuild with updated examples domain

### DIFF
--- a/vercel.cockpit.json
+++ b/vercel.cockpit.json
@@ -2,5 +2,6 @@
   "framework": "nextjs",
   "buildCommand": "npx nx build cockpit --skip-nx-cache",
   "outputDirectory": "dist/apps/cockpit/.next",
-  "installCommand": "npm ci"
+  "installCommand": "npm ci",
+  "$comment": "NEXT_PUBLIC_COCKPIT_RUNTIME_BASE_URL set in Vercel env vars to https://examples.cacheplane.ai"
 }


### PR DESCRIPTION
Triggers a cockpit rebuild so it picks up the updated NEXT_PUBLIC_COCKPIT_RUNTIME_BASE_URL env var (changed from examples.stream-resource.dev to examples.cacheplane.ai via Vercel API).