### PR TITLE
fix(website): remove invalid eslint-disable blocking all deploys

### DIFF
--- a/apps/website/src/components/landing/SocialProof.tsx
+++ b/apps/website/src/components/landing/SocialProof.tsx
@@ -93,7 +93,6 @@ export function SocialProof() {
                   padding: '0 8px',
                 }}
               >
-                {/* eslint-disable-next-line @next/next/no-img-element */}
                 <img
                   src={logo.src}
                   alt={logo.name}

--- a/vercel.cockpit.json
+++ b/vercel.cockpit.json
@@ -2,5 +2,6 @@
   "framework": "nextjs",
   "buildCommand": "npx nx build cockpit --skip-nx-cache",
   "outputDirectory": "dist/apps/cockpit/.next",
-  "installCommand": "npm ci"
+  "installCommand": "npm ci",
+  "$comment": "NEXT_PUBLIC_COCKPIT_RUNTIME_BASE_URL set in Vercel env vars to https://examples.cacheplane.ai"
 }


### PR DESCRIPTION
The eslint-disable comment for @next/next/no-img-element references a rule that doesn't exist in the current ESLint config, causing lint to error. This blocks the Deploy step on every CI run. Fix: remove the comment.