### PR TITLE
chore: trigger cockpit redeploy for updated examples domain

### DIFF
--- a/vercel.cockpit.json
+++ b/vercel.cockpit.json
@@ -2,6 +2,5 @@
   "framework": "nextjs",
   "buildCommand": "npx nx build cockpit --skip-nx-cache",
   "outputDirectory": "dist/apps/cockpit/.next",
-  "installCommand": "npm ci",
-  "$comment": "NEXT_PUBLIC_COCKPIT_RUNTIME_BASE_URL set in Vercel env vars to https://examples.cacheplane.ai"
+  "installCommand": "npm ci"
 }


### PR DESCRIPTION
Touches vercel.cockpit.json to trigger the cockpit deploy step. The Vercel env var NEXT_PUBLIC_COCKPIT_RUNTIME_BASE_URL was updated to examples.cacheplane.ai but the cockpit hasn't been rebuilt yet.