### PR TITLE
chore: trigger examples redeploy with views system

### DIFF
--- a/scripts/assemble-examples.ts
+++ b/scripts/assemble-examples.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env npx tsx
 /**
- * Build all Angular example apps and assemble them into a Vercel deploy directory.
+ * Build all Angular example apps and assemble them into the Vercel deploy directory.
  *
  * Output: deploy/examples/{product}/{topic}/ with index.html, main.js, styles.css
  *


### PR DESCRIPTION
PR #57 added the views system and view components to 6 examples but the examples deploy was skipped. This triggers a rebuild so the views-based code goes live.