### PR TITLE
fix: clean up stale stream-resource references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,10 +36,10 @@ This file is for agents working in this repository. It is contributor-facing, no
 
 ## Repo Layout
 
-- `libs/stream-resource`: main Angular library.
+- `libs/agent`: main Angular library (`@cacheplane/angular`).
 - `apps/website`: docs and marketing site.
-- `packages/mcp`: MCP server package.
-- `e2e/stream-resource-e2e`: end-to-end coverage for the workspace.
+- `packages/mcp`: MCP server package (`@cacheplane/angular-mcp`).
+- `e2e/agent-e2e`: end-to-end coverage for the workspace.
 - `apps/demo` and `apps/demo-e2e`: demo application and related end-to-end coverage.
 
 ## Working in This Repo

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <img
     src="https://cacheplane.ai/assets/hero.svg"
-    alt="Angular Stream Resource — The Enterprise Streaming Resource for LangChain and Angular"
+    alt="Angular Agent Framework — The Enterprise Streaming Resource for LangChain and Angular"
     width="100%"
   />
 </p>
@@ -11,8 +11,8 @@
 </p>
 
 <p align="center">
-  <a href="https://www.npmjs.com/package/@cacheplane/stream-resource">
-    <img alt="npm version" src="https://img.shields.io/npm/v/@cacheplane%2Fstream-resource?color=6C8EFF&labelColor=080B14&style=flat-square" />
+  <a href="https://www.npmjs.com/package/@cacheplane/angular">
+    <img alt="npm version" src="https://img.shields.io/npm/v/@cacheplane%2Fangular?color=6C8EFF&labelColor=080B14&style=flat-square" />
   </a>
   <a href="./LICENSE">
     <img alt="License: PolyForm Noncommercial + Commercial" src="https://img.shields.io/badge/license-PolyForm%20Noncommercial%20%2B%20Commercial-6C8EFF?labelColor=080B14&style=flat-square" />
@@ -34,7 +34,7 @@
 ## Install
 
 ```bash
-npm install @cacheplane/stream-resource
+npm install @cacheplane/angular
 ```
 
 **Peer dependencies:** `@angular/core ^20.0.0 || ^21.0.0`, `@langchain/core ^1.1.0`, `@langchain/langgraph-sdk ^1.7.0`, `rxjs ~7.8.0`
@@ -45,7 +45,7 @@ npm install @cacheplane/stream-resource
 
 ```typescript
 import { Component } from '@angular/core';
-import { streamResource } from '@cacheplane/stream-resource';
+import { streamResource } from '@cacheplane/angular';
 import type { BaseMessage } from '@langchain/core/messages';
 
 @Component({
@@ -111,7 +111,7 @@ That's it. `chat.messages()` is an Angular Signal. Bind it directly in your temp
 <p align="center">
   <img
     src="https://cacheplane.ai/assets/arch-diagram.svg"
-    alt="Angular Stream Resource architecture: Angular Component → streamResource() → StreamManager Bridge → LangGraph Platform, with signals returned reactively"
+    alt="Angular Agent Framework architecture: Angular Component → streamResource() → StreamManager Bridge → LangGraph Platform, with signals returned reactively"
     width="100%"
   />
 </p>
@@ -145,9 +145,9 @@ That's it. `chat.messages()` is an Angular Signal. Bind it directly in your temp
 
 ## License
 
-`@cacheplane/stream-resource` is source-available software dual-licensed:
+`@cacheplane/angular` is source-available software dual-licensed:
 
 - **PolyForm Noncommercial 1.0.0** — free for noncommercial use (personal projects, academic, research, non-profit internal tooling). See [`LICENSE`](./LICENSE).
-- **Angular Stream Resource Commercial License** — required for any for-profit or revenue-generating use. See [`LICENSE-COMMERCIAL`](./LICENSE-COMMERCIAL) and [`COMMERCIAL.md`](./COMMERCIAL.md).
+- **Angular Agent Framework Commercial License** — required for any for-profit or revenue-generating use. See [`LICENSE-COMMERCIAL`](./LICENSE-COMMERCIAL) and [`COMMERCIAL.md`](./COMMERCIAL.md).
 
 This is **not** an open-source license. Commercial use — including use in a for-profit product, service, or organization — requires a paid commercial license. See [pricing](https://cacheplane.ai/pricing).

--- a/apps/website/src/app/docs/page.tsx
+++ b/apps/website/src/app/docs/page.tsx
@@ -10,7 +10,7 @@ export default function DocsLandingPage() {
           Documentation
         </h1>
         <p className="text-lg mb-12" style={{ color: tokens.colors.textSecondary }}>
-          Angular Stream Resource is a suite of libraries for building AI agent interfaces.
+          Angular Agent Framework is a suite of libraries for building AI agent interfaces.
           Choose a library to get started.
         </p>
 

--- a/apps/website/src/components/shared/Nav.tsx
+++ b/apps/website/src/components/shared/Nav.tsx
@@ -6,7 +6,7 @@ import { tokens } from '@cacheplane/design-tokens';
 const links = [
   { label: 'Pilot to Prod', href: '/pilot-to-prod', external: false },
   { label: 'Docs', href: '/docs', external: false },
-  { label: 'API', href: '/docs/api/stream-resource', external: false },
+  { label: 'API', href: '/docs/api/angular', external: false },
   { label: 'Examples', href: 'https://cockpit.cacheplane.ai', external: true },
   { label: 'Pricing', href: '/pricing', external: false },
 ];
@@ -50,7 +50,7 @@ export function Nav() {
       {/* Top bar */}
       <div className="flex items-center justify-between px-6 py-4 md:px-8 md:py-5">
         <Link href="/" className="font-garamond text-xl font-bold" style={{ color: tokens.colors.textPrimary }}>
-          Angular Stream Resource
+          Angular Agent Framework
         </Link>
 
         {/* Desktop links */}
@@ -74,7 +74,7 @@ export function Nav() {
               {l.label}
             </Link>
           ))}
-          <a href="https://github.com/cacheplane/stream-resource"
+          <a href="https://github.com/cacheplane/angular"
             target="_blank"
             rel="noopener noreferrer"
             className="transition-colors"
@@ -125,7 +125,7 @@ export function Nav() {
             </Link>
           ))}
           <div className="flex items-center gap-4 pt-2">
-            <a href="https://github.com/cacheplane/stream-resource"
+            <a href="https://github.com/cacheplane/angular"
               target="_blank"
               rel="noopener noreferrer"
               style={{ color: tokens.colors.textSecondary }}

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cacheplane/angular-mcp",
   "version": "0.1.0",
-  "description": "MCP server for the angular Angular library",
+  "description": "MCP server for the @cacheplane/angular library",
   "license": "PolyForm-Noncommercial-1.0.0",
   "main": "src/index.js",
   "bin": { "@cacheplane/angular-mcp": "src/index.js" },


### PR DESCRIPTION
## Summary

Fixes remaining stale `stream-resource` references missed by the prior rename to `@cacheplane/angular`.

- **README.md**: npm badge, install command, import example, alt text, license text all pointed to old `@cacheplane/stream-resource` package and "Angular Stream Resource" brand
- **AGENTS.md**: repo layout still referenced `libs/stream-resource` and `e2e/stream-resource-e2e`
- **Nav.tsx**: API link href, brand wordmark, and GitHub URLs (desktop + mobile) all stale
- **docs/page.tsx**: subtitle used old "Angular Stream Resource" brand
- **packages/mcp/package.json**: description was garbled ("angular Angular library") from prior rename

## Test plan

- [ ] Website builds
- [ ] Nav links resolve correctly
- [ ] README badges render with correct npm package