### PR TITLE
refactor: rename STREAM_RESOURCE_CONFIG to AGENT_CONFIG

### DIFF
--- a/cockpit/langgraph/interrupts/angular/prompts/interrupts.md
+++ b/cockpit/langgraph/interrupts/angular/prompts/interrupts.md
@@ -2,4 +2,4 @@
 
 This capability demonstrates human-in-the-loop interrupt handling using LangGraph's `interrupt()` primitive and the `@cacheplane/chat` Angular component library. When the graph pauses at an interrupt node, the `<chat-interrupt-panel>` surfaces the pending decision to the user; their response is submitted back to the graph via `agent`'s `resume` helper.
 
-Key components used: `<chat>`, `<chat-interrupt-panel>`. The interrupt panel renders inside the chat host and becomes visible automatically whenever the underlying stream resource detects a pending interrupt in the thread state.
+Key components used: `<chat>`, `<chat-interrupt-panel>`. The interrupt panel renders inside the chat host and becomes visible automatically whenever the underlying agent detects a pending interrupt in the thread state.

--- a/cockpit/langgraph/time-travel/angular/src/app/time-travel.component.ts
+++ b/cockpit/langgraph/time-travel/angular/src/app/time-travel.component.ts
@@ -109,7 +109,7 @@ export class TimeTravelComponent {
   /** Index of the currently selected checkpoint in the sidebar. */
   protected readonly selectedIndex = signal<number>(-1);
 
-  /** Checkpoint history derived from the stream resource. */
+  /** Checkpoint history derived from the agent. */
   protected readonly checkpoints = computed(
     (): ThreadState<any>[] => this.stream.history(),
   );

--- a/libs/agent/src/lib/agent.fn.ts
+++ b/libs/agent/src/lib/agent.fn.ts
@@ -3,7 +3,7 @@ import {
   inject, DestroyRef, computed,
   isSignal, Signal,
 } from '@angular/core';
-import { STREAM_RESOURCE_CONFIG } from './agent.provider';
+import { AGENT_CONFIG } from './agent.provider';
 import { toSignal, toObservable } from '@angular/core/rxjs-interop';
 import {
   BehaviorSubject, Subject, of,
@@ -58,7 +58,7 @@ export function agent<
 ): AgentRef<T, InferBag<T, Bag>> {
   // Injection context required
   const destroyRef   = inject(DestroyRef);
-  const globalConfig = inject(STREAM_RESOURCE_CONFIG, { optional: true });
+  const globalConfig = inject(AGENT_CONFIG, { optional: true });
   const destroy$     = new Subject<void>();
   destroyRef.onDestroy(() => { destroy$.next(); destroy$.complete(); });
 

--- a/libs/agent/src/lib/agent.provider.spec.ts
+++ b/libs/agent/src/lib/agent.provider.spec.ts
@@ -1,14 +1,14 @@
 import { describe, it, expect } from 'vitest';
 import { TestBed } from '@angular/core/testing';
-import { provideAgent, STREAM_RESOURCE_CONFIG } from './agent.provider';
+import { provideAgent, AGENT_CONFIG } from './agent.provider';
 import { MockAgentTransport } from './transport/mock-stream.transport';
 
 describe('provideAgent', () => {
-  it('provides STREAM_RESOURCE_CONFIG token', () => {
+  it('provides AGENT_CONFIG token', () => {
     TestBed.configureTestingModule({
       providers: [provideAgent({ apiUrl: 'https://api.example.com' })],
     });
-    const config = TestBed.inject(STREAM_RESOURCE_CONFIG);
+    const config = TestBed.inject(AGENT_CONFIG);
     expect(config.apiUrl).toBe('https://api.example.com');
   });
 
@@ -17,7 +17,7 @@ describe('provideAgent', () => {
     TestBed.configureTestingModule({
       providers: [provideAgent({ apiUrl: '', transport })],
     });
-    const config = TestBed.inject(STREAM_RESOURCE_CONFIG);
+    const config = TestBed.inject(AGENT_CONFIG);
     expect(config.transport).toBe(transport);
   });
 });

--- a/libs/agent/src/lib/agent.provider.ts
+++ b/libs/agent/src/lib/agent.provider.ts
@@ -13,8 +13,8 @@ export interface AgentConfig {
   transport?: AgentTransport;
 }
 
-export const STREAM_RESOURCE_CONFIG =
-  new InjectionToken<AgentConfig>('STREAM_RESOURCE_CONFIG');
+export const AGENT_CONFIG =
+  new InjectionToken<AgentConfig>('AGENT_CONFIG');
 
 /**
  * Angular provider factory that registers global defaults for all
@@ -37,7 +37,7 @@ export const STREAM_RESOURCE_CONFIG =
  */
 export function provideAgent(config: AgentConfig): Provider {
   return {
-    provide: STREAM_RESOURCE_CONFIG,
+    provide: AGENT_CONFIG,
     useValue: config,
   };
 }

--- a/libs/agent/src/public-api.ts
+++ b/libs/agent/src/public-api.ts
@@ -3,7 +3,7 @@
 export { agent } from './lib/agent.fn';
 
 // Provider
-export { provideAgent, STREAM_RESOURCE_CONFIG } from './lib/agent.provider';
+export { provideAgent, AGENT_CONFIG } from './lib/agent.provider';
 export type { AgentConfig } from './lib/agent.provider';
 
 // Public types


### PR DESCRIPTION
## Summary

- Rename `STREAM_RESOURCE_CONFIG` InjectionToken → `AGENT_CONFIG` (last remaining `stream-resource` symbol in public API)
- Fix two stale prose comments in cockpit examples ("stream resource" → "agent")

## Verified

- `nx build agent --configuration=production` passes
- `nx test agent` passes
- Zero remaining `stream-resource` / `STREAM_RESOURCE` references in source (only historical planning docs)

## Test plan

- [ ] CI passes (library build, test, lint)