### PR TITLE
fix(cockpit): fix chat/input and chat/threads production builds

### DIFF
--- a/cockpit/chat/input/angular/src/app/input.component.ts
+++ b/cockpit/chat/input/angular/src/app/input.component.ts
@@ -58,7 +58,7 @@ export class InputComponent {
   });
 
   protected readonly streamStatus = computed(() => this.stream.status());
-  protected readonly isLoading = computed(() => this.stream.status() === 'streaming');
+  protected readonly isLoading = computed(() => this.stream.isLoading());
 
   submitMessage(content: string) {
     this.stream.submit([{ role: 'human', content }]);

--- a/cockpit/chat/threads/angular/src/app/threads.component.ts
+++ b/cockpit/chat/threads/angular/src/app/threads.component.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
-import { Component } from '@angular/core';
-import { ChatComponent, ChatThreadListComponent } from '@cacheplane/chat';
+import { Component, signal } from '@angular/core';
+import { ChatComponent, ChatThreadListComponent, type Thread } from '@cacheplane/chat';
 import { agent } from '@cacheplane/angular';
 import { environment } from '../environments/environment';
 
@@ -18,9 +18,12 @@ import { environment } from '../environments/environment';
              style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
         <h3 class="text-xs font-semibold uppercase tracking-wide"
             style="color: var(--chat-text-muted, #777);">Threads</h3>
-        <chat-thread-list [ref]="stream" />
+        <chat-thread-list
+          [threads]="threads()"
+          [activeThreadId]="activeThreadId()"
+          (threadSelected)="onThreadSelected($event)" />
       </aside>
-      <chat [ref]="stream" class="flex-1 min-w-0" />
+      <chat [ref]="stream" [threads]="threads()" [activeThreadId]="activeThreadId()" (threadSelected)="onThreadSelected($event)" class="flex-1 min-w-0" />
     </div>
   `,
 })
@@ -29,4 +32,16 @@ export class ThreadsComponent {
     apiUrl: environment.langGraphApiUrl,
     assistantId: environment.streamingAssistantId,
   });
+
+  protected readonly threads = signal<Thread[]>([
+    { id: 'thread-1', title: 'First Conversation' },
+    { id: 'thread-2', title: 'Second Conversation' },
+    { id: 'thread-3', title: 'Third Conversation' },
+  ]);
+
+  protected readonly activeThreadId = signal('thread-1');
+
+  protected onThreadSelected(threadId: string): void {
+    this.activeThreadId.set(threadId);
+  }
 }


### PR DESCRIPTION
## Summary
- **chat/input**: Replace `status() === 'streaming'` with `isLoading()` — `ResourceStatus` is no longer a string enum
- **chat/threads**: Pass required `threads` input to `ChatThreadListComponent` with demo thread data

Fixes the `Cockpit — build all examples` CI check that's been failing on main.

## Test plan
- [x] `npx nx run-many -t build --projects='cockpit-*-angular'` — all 30 pass locally
- [ ] `Cockpit — build all examples` CI check passes