### PR TITLE
fix(cockpit): strip Render/Chat prefix from sidebar titles

### DIFF
--- a/apps/cockpit/src/components/sidebar/navigation-groups.tsx
+++ b/apps/cockpit/src/components/sidebar/navigation-groups.tsx
@@ -8,11 +8,13 @@ import { toCockpitPath } from '../../lib/route-resolution';
 const PRODUCT_LABELS: Record<string, string> = {
   'deep-agents': 'Deep Agents',
   'langgraph': 'LangGraph',
+  'render': 'Render',
+  'chat': 'Chat',
 };
 
 
 function stripProductPrefix(title: string): string {
-  const prefixes = ['Deep Agents ', 'LangGraph '];
+  const prefixes = ['Deep Agents ', 'LangGraph ', 'Render ', 'Chat '];
   for (const p of prefixes) {
     if (title.startsWith(p)) return title.slice(p.length);
   }


### PR DESCRIPTION
## Summary
Add `Render` and `Chat` to sidebar product labels and prefix stripping.

Before: "Render Spec Rendering", "Render Element Rendering", "Chat Messages", etc.
After: "Spec Rendering", "Element Rendering", "Messages", etc.

Matches the existing pattern for Deep Agents and LangGraph.