### PR TITLE
fix(cockpit): strip duplicate Render/Chat prefix from sidebar titles

### DIFF
--- a/apps/cockpit/src/components/sidebar/navigation-groups.tsx
+++ b/apps/cockpit/src/components/sidebar/navigation-groups.tsx
@@ -8,11 +8,13 @@ import { toCockpitPath } from '../../lib/route-resolution';
 const PRODUCT_LABELS: Record<string, string> = {
   'deep-agents': 'Deep Agents',
   'langgraph': 'LangGraph',
+  'render': 'Render',
+  'chat': 'Chat',
 };
 
 
 function stripProductPrefix(title: string): string {
-  const prefixes = ['Deep Agents ', 'LangGraph '];
+  const prefixes = ['Deep Agents ', 'LangGraph ', 'Render ', 'Chat '];
   for (const p of prefixes) {
     if (title.startsWith(p)) return title.slice(p.length);
   }


### PR DESCRIPTION
Add render and chat to PRODUCT_LABELS and stripProductPrefix. Before: 'Render Spec Rendering'. After: 'Spec Rendering'.