### PR TITLE
fix(website): fix API nav link, comment out logo strip, add missing deps

### DIFF
--- a/apps/website/src/app/page.tsx
+++ b/apps/website/src/app/page.tsx
@@ -4,7 +4,7 @@ import { ValueProps } from '../components/landing/ValueProps';
 import { LangGraphShowcase } from '../components/landing/LangGraphShowcase';
 import { DeepAgentsShowcase } from '../components/landing/DeepAgentsShowcase';
 import { StatsStrip } from '../components/landing/StatsStrip';
-import { SocialProof } from '../components/landing/SocialProof';
+// import { SocialProof } from '../components/landing/SocialProof';
 import { ProblemSection } from '../components/landing/ProblemSection';
 import { FullStackSection } from '../components/landing/FullStackSection';
 import { ChatFeaturesSection } from '../components/landing/ChatFeaturesSection';

--- a/apps/website/src/app/page.tsx
+++ b/apps/website/src/app/page.tsx
@@ -29,7 +29,7 @@ export default async function HomePage() {
       <HeroTwoCol />
       {/* 2. Trust — quick credibility stats */}
       <StatsStrip />
-      <SocialProof />
+      {/* <SocialProof /> */}
       {/* 3. Problem — last-mile gap narrative */}
       <ProblemSection />
       {/* 4. Architecture — three-layer stack diagram */}

--- a/apps/website/src/components/shared/Footer.tsx
+++ b/apps/website/src/components/shared/Footer.tsx
@@ -141,7 +141,7 @@ export function Footer() {
               onMouseLeave={(e) => (e.currentTarget.style.color = tokens.colors.textSecondary)}>
               Documentation
             </Link>
-            <Link href="/docs/api/angular" className="transition-colors" style={{ color: tokens.colors.textSecondary }}
+            <Link href="/docs/agent/api/agent" className="transition-colors" style={{ color: tokens.colors.textSecondary }}
               onMouseEnter={(e) => (e.currentTarget.style.color = tokens.colors.accent)}
               onMouseLeave={(e) => (e.currentTarget.style.color = tokens.colors.textSecondary)}>
               API Reference

--- a/apps/website/src/components/shared/Nav.tsx
+++ b/apps/website/src/components/shared/Nav.tsx
@@ -6,7 +6,7 @@ import { tokens } from '@cacheplane/design-tokens';
 const links = [
   { label: 'Pilot to Prod', href: '/pilot-to-prod', external: false },
   { label: 'Docs', href: '/docs', external: false },
-  { label: 'API', href: '/docs/api/angular', external: false },
+  { label: 'API', href: '/docs/agent/api/agent', external: false },
   { label: 'Examples', href: 'https://cockpit.cacheplane.ai', external: true },
   { label: 'Pricing', href: '/pricing', external: false },
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -112,6 +112,8 @@
         "next": "~16.1.6",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "remark-gfm": "^4.0.1",
+        "resend": "^6.10.0",
         "shiki": "*",
         "tailwind-merge": "^2.5.0"
       }
@@ -6766,7 +6768,7 @@
       "dev": true,
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
-    "node_modules/@cacheplane/stream-resource-mcp": {
+    "node_modules/@cacheplane/angular-mcp": {
       "resolved": "packages/mcp",
       "link": true
     },
@@ -17572,7 +17574,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
       "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
@@ -24857,7 +24858,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
       "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
-      "dev": true,
       "license": "Unlicense"
     },
     "node_modules/fast-uri": {
@@ -29464,7 +29464,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
       "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -29496,7 +29495,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
       "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -29513,7 +29511,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
       "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -29550,7 +29547,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
       "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mdast-util-from-markdown": "^2.0.0",
@@ -29570,7 +29566,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
       "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -29588,7 +29583,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
       "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -29606,7 +29600,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
       "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -29622,7 +29615,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
       "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -29640,7 +29632,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
       "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -29946,7 +29937,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
       "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "micromark-extension-gfm-autolink-literal": "^2.0.0",
@@ -29967,7 +29957,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
       "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "micromark-util-character": "^2.0.0",
@@ -29984,7 +29973,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
       "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
@@ -30005,7 +29993,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
       "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
@@ -30024,7 +30011,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
       "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
@@ -30042,7 +30028,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
       "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "micromark-util-types": "^2.0.0"
@@ -30056,7 +30041,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
       "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
@@ -32964,7 +32948,6 @@
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
       "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
-      "dev": true,
       "license": "MIT-0"
     },
     "node_modules/postcss": {
@@ -34563,7 +34546,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
       "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -34629,7 +34611,6 @@
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
       "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -34671,7 +34652,6 @@
       "version": "6.10.0",
       "resolved": "https://registry.npmjs.org/resend/-/resend-6.10.0.tgz",
       "integrity": "sha512-i7CwZpYj4Oho1RxsTpLcCUkO08+HiL4NXrm6jLJ2WzJ89UGI8eROSieLONJA3hnUrf1OYnCyfq5F6POnHUMv1Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "postal-mime": "2.7.4",
@@ -36587,7 +36567,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
       "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@stablelib/base64": "^1.0.0",
@@ -36980,7 +36959,6 @@
       "version": "1.88.0",
       "resolved": "https://registry.npmjs.org/svix/-/svix-1.88.0.tgz",
       "integrity": "sha512-vm/JrrUd3bVyBE+3L33TIyVSs8gS5fYx7lrISvKlDJXTYX1ACH4REX8P1tHxsSKoZi/rvifM1t0XRc5Vc45THw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "standardwebhooks": "1.0.0",
@@ -36991,7 +36969,6 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -39639,14 +39616,14 @@
       }
     },
     "packages/mcp": {
-      "name": "@cacheplane/stream-resource-mcp",
+      "name": "@cacheplane/angular-mcp",
       "version": "0.1.0",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0"
       },
       "bin": {
-        "stream-resource-mcp": "src/index.js"
+        "angular-mcp": "src/index.js"
       },
       "devDependencies": {
         "typescript": "^5.4.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "agent",
+  "name": "stream-resource",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "agent",
+      "name": "stream-resource",
       "version": "0.0.0",
       "license": "PolyForm-Noncommercial-1.0.0",
       "workspaces": [
@@ -29,7 +29,6 @@
         "react-dom": "^19.0.0",
         "rehype-pretty-code": "^0.14.3",
         "rehype-slug": "^6.0.0",
-        "remark-gfm": "^4.0.1",
         "rxjs": "~7.8.0",
         "shiki": "^4.0.2"
       },
@@ -75,6 +74,7 @@
         "postcss-url": "~10.1.3",
         "prettier": "^2.6.2",
         "puppeteer": "^22.0.0",
+        "remark-gfm": "^4.0.1",
         "resend": "^6.10.0",
         "tailwindcss": "^4.2.2",
         "tslib": "^2.3.0",
@@ -112,8 +112,6 @@
         "next": "~16.1.6",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "remark-gfm": "^4.0.1",
-        "resend": "^6.10.0",
         "shiki": "*",
         "tailwind-merge": "^2.5.0"
       }
@@ -6768,7 +6766,7 @@
       "dev": true,
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
-    "node_modules/@cacheplane/angular-mcp": {
+    "node_modules/@cacheplane/stream-resource-mcp": {
       "resolved": "packages/mcp",
       "link": true
     },
@@ -17574,6 +17572,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
       "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
@@ -24858,6 +24857,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
       "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "dev": true,
       "license": "Unlicense"
     },
     "node_modules/fast-uri": {
@@ -29464,6 +29464,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
       "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -29495,6 +29496,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
       "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -29511,6 +29513,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
       "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -29547,6 +29550,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
       "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mdast-util-from-markdown": "^2.0.0",
@@ -29566,6 +29570,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
       "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -29583,6 +29588,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
       "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -29600,6 +29606,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
       "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -29615,6 +29622,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
       "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -29632,6 +29640,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
       "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -29937,6 +29946,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
       "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "micromark-extension-gfm-autolink-literal": "^2.0.0",
@@ -29957,6 +29967,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
       "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "micromark-util-character": "^2.0.0",
@@ -29973,6 +29984,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
       "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
@@ -29993,6 +30005,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
       "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
@@ -30011,6 +30024,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
       "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
@@ -30028,6 +30042,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
       "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "micromark-util-types": "^2.0.0"
@@ -30041,6 +30056,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
       "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
@@ -32948,6 +32964,7 @@
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
       "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "dev": true,
       "license": "MIT-0"
     },
     "node_modules/postcss": {
@@ -34546,6 +34563,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
       "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -34611,6 +34629,7 @@
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
       "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -34652,6 +34671,7 @@
       "version": "6.10.0",
       "resolved": "https://registry.npmjs.org/resend/-/resend-6.10.0.tgz",
       "integrity": "sha512-i7CwZpYj4Oho1RxsTpLcCUkO08+HiL4NXrm6jLJ2WzJ89UGI8eROSieLONJA3hnUrf1OYnCyfq5F6POnHUMv1Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "postal-mime": "2.7.4",
@@ -36567,6 +36587,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
       "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@stablelib/base64": "^1.0.0",
@@ -36959,6 +36980,7 @@
       "version": "1.88.0",
       "resolved": "https://registry.npmjs.org/svix/-/svix-1.88.0.tgz",
       "integrity": "sha512-vm/JrrUd3bVyBE+3L33TIyVSs8gS5fYx7lrISvKlDJXTYX1ACH4REX8P1tHxsSKoZi/rvifM1t0XRc5Vc45THw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "standardwebhooks": "1.0.0",
@@ -36969,6 +36991,7 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -39616,14 +39639,14 @@
       }
     },
     "packages/mcp": {
-      "name": "@cacheplane/angular-mcp",
+      "name": "@cacheplane/stream-resource-mcp",
       "version": "0.1.0",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0"
       },
       "bin": {
-        "angular-mcp": "src/index.js"
+        "stream-resource-mcp": "src/index.js"
       },
       "devDependencies": {
         "typescript": "^5.4.0"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "agent",
+  "name": "stream-resource",
   "version": "0.0.0",
   "license": "PolyForm-Noncommercial-1.0.0",
   "scripts": {
@@ -52,6 +52,7 @@
     "postcss-url": "~10.1.3",
     "prettier": "^2.6.2",
     "puppeteer": "^22.0.0",
+    "remark-gfm": "^4.0.1",
     "resend": "^6.10.0",
     "tailwindcss": "^4.2.2",
     "tslib": "^2.3.0",
@@ -83,7 +84,6 @@
     "react-dom": "^19.0.0",
     "rehype-pretty-code": "^0.14.3",
     "rehype-slug": "^6.0.0",
-    "remark-gfm": "^4.0.1",
     "rxjs": "~7.8.0",
     "shiki": "^4.0.2"
   },


### PR DESCRIPTION
## Summary

- Fix API link in Nav and Footer: `/docs/api/angular` (404) -> `/docs/agent/api/agent` (correct route)
- Comment out `<SocialProof />` logo strip on homepage
- Add `remark-gfm` and `resend` as devDependencies (imported in code but never installed, causing doc pages to 404)

## Verified locally

- Homepage renders without logo strip
- API nav link navigates to agent() API reference
- Doc pages render with MDX (remark-gfm resolves)
- A2UI overview page renders with sidebar, TOC, and content