### PR TITLE
feat(example-layouts): shared responsive layout library for 30 cockpit apps

### DIFF
--- a/apps/website/src/components/shared/Nav.tsx
+++ b/apps/website/src/components/shared/Nav.tsx
@@ -195,7 +195,6 @@ export function Nav() {
             {(mobileTab === 'docs' && isDocsPage && currentLib) && (
               <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
                 {currentLib.sections.map((section) => {
-                  const headerColor = section.color === 'red' ? tokens.colors.angularRed : tokens.colors.accent;
                   return (
                     <div key={section.id}>
                       <button

--- a/cockpit/chat/debug/angular/src/app/debug.component.ts
+++ b/cockpit/chat/debug/angular/src/app/debug.component.ts
@@ -2,6 +2,7 @@
 import { Component } from '@angular/core';
 import { ChatDebugComponent } from '@cacheplane/chat';
 import { agent } from '@cacheplane/angular';
+import { ExampleChatLayoutComponent } from '@cacheplane/example-layouts';
 import { environment } from '../environments/environment';
 
 /**
@@ -12,11 +13,11 @@ import { environment } from '../environments/environment';
 @Component({
   selector: 'app-debug',
   standalone: true,
-  imports: [ChatDebugComponent],
+  imports: [ChatDebugComponent, ExampleChatLayoutComponent],
   template: `
-    <div class="h-screen">
-      <chat-debug [ref]="stream" />
-    </div>
+    <example-chat-layout>
+      <chat-debug main [ref]="stream" />
+    </example-chat-layout>
   `,
 })
 export class DebugPageComponent {

--- a/cockpit/chat/generative-ui/angular/src/app/generative-ui.component.ts
+++ b/cockpit/chat/generative-ui/angular/src/app/generative-ui.component.ts
@@ -2,6 +2,7 @@
 import { Component } from '@angular/core';
 import { ChatComponent, views } from '@cacheplane/chat';
 import { agent } from '@cacheplane/angular';
+import { ExampleChatLayoutComponent } from '@cacheplane/example-layouts';
 import { environment } from '../environments/environment';
 import { WeatherCardComponent } from './views/weather-card.component';
 import { StatCardComponent } from './views/stat-card.component';
@@ -16,8 +17,12 @@ const myViews = views({
 @Component({
   selector: 'app-generative-ui',
   standalone: true,
-  imports: [ChatComponent],
-  template: `<chat [ref]="agentRef" [views]="myViews" class="block h-screen" />`,
+  imports: [ChatComponent, ExampleChatLayoutComponent],
+  template: `
+    <example-chat-layout>
+      <chat main [ref]="agentRef" [views]="myViews" class="flex-1 min-w-0" />
+    </example-chat-layout>
+  `,
 })
 export class GenerativeUiComponent {
   protected readonly agentRef = agent({

--- a/cockpit/chat/input/angular/src/app/input.component.ts
+++ b/cockpit/chat/input/angular/src/app/input.component.ts
@@ -2,6 +2,7 @@
 import { Component, computed } from '@angular/core';
 import { ChatInputComponent as ChatInputPrimitive } from '@cacheplane/chat';
 import { ChatMessagesComponent } from '@cacheplane/chat';
+import { ExampleChatLayoutComponent } from '@cacheplane/example-layouts';
 import { agent } from '@cacheplane/angular';
 import { environment } from '../environments/environment';
 
@@ -13,10 +14,10 @@ import { environment } from '../environments/environment';
 @Component({
   selector: 'app-input',
   standalone: true,
-  imports: [ChatInputPrimitive, ChatMessagesComponent],
+  imports: [ChatInputPrimitive, ChatMessagesComponent, ExampleChatLayoutComponent],
   template: `
-    <div class="flex h-screen">
-      <div class="flex-1 flex flex-col min-w-0">
+    <example-chat-layout sidebarWidth="w-72">
+      <div main class="flex-1 flex flex-col min-w-0">
         <header class="px-4 py-3 border-b" style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717);">
           <h1 class="text-sm font-semibold" style="color: var(--chat-text, #e0e0e0);">Chat Input Demo</h1>
         </header>
@@ -27,8 +28,7 @@ import { environment } from '../environments/environment';
           <chat-input [ref]="stream" placeholder="Try typing here..." (send)="submitMessage($event)" />
         </div>
       </div>
-      <aside class="w-72 shrink-0 border-l overflow-y-auto p-4 space-y-4"
-             style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
+      <div sidebar class="p-4 space-y-4" style="background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
         <h3 class="text-xs font-semibold uppercase tracking-wide"
             style="color: var(--chat-text-muted, #777);">Input State</h3>
         <dl class="text-xs space-y-2" style="color: var(--chat-text-muted, #777);">
@@ -47,8 +47,8 @@ import { environment } from '../environments/environment';
             <li>Auto-disable while streaming</li>
           </ul>
         </div>
-      </aside>
-    </div>
+      </div>
+    </example-chat-layout>
   `,
 })
 export class InputComponent {

--- a/cockpit/chat/interrupts/angular/src/app/interrupts.component.ts
+++ b/cockpit/chat/interrupts/angular/src/app/interrupts.component.ts
@@ -2,6 +2,7 @@
 import { Component, computed } from '@angular/core';
 import { JsonPipe } from '@angular/common';
 import { ChatComponent, ChatInterruptPanelComponent } from '@cacheplane/chat';
+import { ExampleChatLayoutComponent } from '@cacheplane/example-layouts';
 import { agent } from '@cacheplane/angular';
 import { environment } from '../environments/environment';
 
@@ -14,12 +15,11 @@ import { environment } from '../environments/environment';
 @Component({
   selector: 'app-interrupts',
   standalone: true,
-  imports: [ChatComponent, ChatInterruptPanelComponent, JsonPipe],
+  imports: [ChatComponent, ChatInterruptPanelComponent, JsonPipe, ExampleChatLayoutComponent],
   template: `
-    <div class="flex h-screen">
-      <chat [ref]="stream" class="flex-1 min-w-0" />
-      <aside class="w-80 shrink-0 border-l overflow-y-auto p-4 space-y-4"
-             style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
+    <example-chat-layout sidebarWidth="w-80">
+      <chat main [ref]="stream" class="flex-1 min-w-0" />
+      <div sidebar class="p-4 space-y-4" style="background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
         <h3 class="text-xs font-semibold uppercase tracking-wide"
             style="color: var(--chat-text-muted, #777);">Interrupt Panel</h3>
         <chat-interrupt-panel [ref]="stream" />
@@ -28,8 +28,8 @@ import { environment } from '../environments/environment';
               style="color: var(--chat-text-muted, #777);">Stream Status</h4>
           <p class="text-xs font-mono" style="color: var(--chat-text-muted, #777);">{{ streamStatus() }}</p>
         </div>
-      </aside>
-    </div>
+      </div>
+    </example-chat-layout>
   `,
 })
 export class InterruptsComponent {

--- a/cockpit/chat/messages/angular/src/app/messages.component.ts
+++ b/cockpit/chat/messages/angular/src/app/messages.component.ts
@@ -5,6 +5,7 @@ import {
   ChatInputComponent,
   ChatTypingIndicatorComponent,
 } from '@cacheplane/chat';
+import { ExampleChatLayoutComponent } from '@cacheplane/example-layouts';
 import { agent } from '@cacheplane/angular';
 import { environment } from '../environments/environment';
 
@@ -18,10 +19,10 @@ import { environment } from '../environments/environment';
 @Component({
   selector: 'app-messages',
   standalone: true,
-  imports: [ChatMessagesComponent, ChatInputComponent, ChatTypingIndicatorComponent],
+  imports: [ChatMessagesComponent, ChatInputComponent, ChatTypingIndicatorComponent, ExampleChatLayoutComponent],
   template: `
-    <div class="flex h-screen">
-      <div class="flex-1 flex flex-col min-w-0">
+    <example-chat-layout sidebarWidth="w-72">
+      <div main class="flex-1 flex flex-col min-w-0">
         <header class="px-4 py-3 border-b" style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717);">
           <h1 class="text-sm font-semibold" style="color: var(--chat-text, #e0e0e0);">Chat Messages Primitives</h1>
         </header>
@@ -33,8 +34,7 @@ import { environment } from '../environments/environment';
           <chat-input [ref]="stream" (send)="submitMessage($event)" />
         </div>
       </div>
-      <aside class="w-72 shrink-0 border-l overflow-y-auto p-4 space-y-4"
-             style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
+      <div sidebar class="p-4 space-y-4" style="background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
         <h3 class="text-xs font-semibold uppercase tracking-wide"
             style="color: var(--chat-text-muted, #777);">Primitives Used</h3>
         <ul class="text-xs space-y-2" style="color: var(--chat-text-muted, #777);">
@@ -42,8 +42,8 @@ import { environment } from '../environments/environment';
           <li>ChatInputComponent</li>
           <li>ChatTypingIndicatorComponent</li>
         </ul>
-      </aside>
-    </div>
+      </div>
+    </example-chat-layout>
   `,
 })
 export class MessagesComponent {

--- a/cockpit/chat/subagents/angular/src/app/subagents.component.ts
+++ b/cockpit/chat/subagents/angular/src/app/subagents.component.ts
@@ -5,6 +5,7 @@ import {
   ChatSubagentsComponent,
   ChatSubagentCardComponent,
 } from '@cacheplane/chat';
+import { ExampleChatLayoutComponent } from '@cacheplane/example-layouts';
 import { agent } from '@cacheplane/angular';
 import { environment } from '../environments/environment';
 
@@ -16,12 +17,11 @@ import { environment } from '../environments/environment';
 @Component({
   selector: 'app-subagents',
   standalone: true,
-  imports: [ChatComponent, ChatSubagentsComponent, ChatSubagentCardComponent],
+  imports: [ChatComponent, ChatSubagentsComponent, ChatSubagentCardComponent, ExampleChatLayoutComponent],
   template: `
-    <div class="flex h-screen">
-      <chat [ref]="stream" class="flex-1 min-w-0" />
-      <aside class="w-80 shrink-0 border-l overflow-y-auto p-4 space-y-4"
-             style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
+    <example-chat-layout sidebarWidth="w-80">
+      <chat main [ref]="stream" class="flex-1 min-w-0" />
+      <div sidebar class="p-4 space-y-4" style="background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
         <h3 class="text-xs font-semibold uppercase tracking-wide"
             style="color: var(--chat-text-muted, #777);">Active Subagents</h3>
         <chat-subagents [ref]="stream" />
@@ -35,8 +35,8 @@ import { environment } from '../environments/environment';
             <li>Summary Agent</li>
           </ol>
         </div>
-      </aside>
-    </div>
+      </div>
+    </example-chat-layout>
   `,
 })
 export class SubagentsComponent {

--- a/cockpit/chat/theming/angular/src/app/theming.component.ts
+++ b/cockpit/chat/theming/angular/src/app/theming.component.ts
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 import { Component, signal } from '@angular/core';
+import { TitleCasePipe } from '@angular/common';
 import { ChatComponent } from '@cacheplane/chat';
+import { ExampleChatLayoutComponent } from '@cacheplane/example-layouts';
 import { agent } from '@cacheplane/angular';
 import { environment } from '../environments/environment';
 
@@ -47,12 +49,11 @@ const THEMES: Record<string, Record<string, string>> = {
 @Component({
   selector: 'app-theming',
   standalone: true,
-  imports: [ChatComponent],
+  imports: [ChatComponent, ExampleChatLayoutComponent, TitleCasePipe],
   template: `
-    <div class="flex h-screen">
-      <chat [ref]="stream" class="flex-1 min-w-0" />
-      <aside class="w-72 shrink-0 border-l overflow-y-auto p-4 space-y-4"
-             style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
+    <example-chat-layout sidebarWidth="w-72">
+      <chat main [ref]="stream" class="flex-1 min-w-0" />
+      <div sidebar class="p-4 space-y-4" style="background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
         <h3 class="text-xs font-semibold uppercase tracking-wide"
             style="color: var(--chat-text-muted, #777);">Theme Picker</h3>
         <div class="space-y-2">
@@ -78,8 +79,8 @@ const THEMES: Record<string, Record<string, string>> = {
             <li>--chat-text-muted</li>
           </ul>
         </div>
-      </aside>
-    </div>
+      </div>
+    </example-chat-layout>
   `,
 })
 export class ThemingComponent {

--- a/cockpit/chat/threads/angular/src/app/threads.component.ts
+++ b/cockpit/chat/threads/angular/src/app/threads.component.ts
@@ -2,6 +2,7 @@
 import { Component, signal } from '@angular/core';
 import { ChatComponent, ChatThreadListComponent, type Thread } from '@cacheplane/chat';
 import { agent } from '@cacheplane/angular';
+import { ExampleChatLayoutComponent } from '@cacheplane/example-layouts';
 import { environment } from '../environments/environment';
 
 /**
@@ -11,20 +12,20 @@ import { environment } from '../environments/environment';
 @Component({
   selector: 'app-threads',
   standalone: true,
-  imports: [ChatComponent, ChatThreadListComponent],
+  imports: [ChatComponent, ChatThreadListComponent, ExampleChatLayoutComponent],
   template: `
-    <div class="flex h-screen">
-      <aside class="w-64 shrink-0 border-r overflow-y-auto p-4 space-y-4"
-             style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
+    <example-chat-layout sidebarPosition="left" sidebarWidth="w-64">
+      <chat main [ref]="stream" [threads]="threads()" [activeThreadId]="activeThreadId()" (threadSelected)="onThreadSelected($event)" class="flex-1 min-w-0" />
+      <div sidebar class="p-4 space-y-4"
+           style="background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
         <h3 class="text-xs font-semibold uppercase tracking-wide"
             style="color: var(--chat-text-muted, #777);">Threads</h3>
         <chat-thread-list
           [threads]="threads()"
           [activeThreadId]="activeThreadId()"
           (threadSelected)="onThreadSelected($event)" />
-      </aside>
-      <chat [ref]="stream" [threads]="threads()" [activeThreadId]="activeThreadId()" (threadSelected)="onThreadSelected($event)" class="flex-1 min-w-0" />
-    </div>
+      </div>
+    </example-chat-layout>
   `,
 })
 export class ThreadsComponent {

--- a/cockpit/chat/timeline/angular/src/app/timeline.component.ts
+++ b/cockpit/chat/timeline/angular/src/app/timeline.component.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 import { Component } from '@angular/core';
 import { ChatComponent, ChatTimelineSliderComponent } from '@cacheplane/chat';
+import { ExampleChatLayoutComponent } from '@cacheplane/example-layouts';
 import { agent } from '@cacheplane/angular';
 import { environment } from '../environments/environment';
 
@@ -12,12 +13,11 @@ import { environment } from '../environments/environment';
 @Component({
   selector: 'app-timeline',
   standalone: true,
-  imports: [ChatComponent, ChatTimelineSliderComponent],
+  imports: [ChatComponent, ChatTimelineSliderComponent, ExampleChatLayoutComponent],
   template: `
-    <div class="flex h-screen">
-      <chat [ref]="stream" class="flex-1 min-w-0" />
-      <aside class="w-80 shrink-0 border-l overflow-y-auto p-4 space-y-4"
-             style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
+    <example-chat-layout sidebarWidth="w-80">
+      <chat main [ref]="stream" class="flex-1 min-w-0" />
+      <div sidebar class="p-4 space-y-4" style="background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
         <h3 class="text-xs font-semibold uppercase tracking-wide"
             style="color: var(--chat-text-muted, #777);">Timeline</h3>
         <chat-timeline-slider [ref]="stream" />
@@ -29,8 +29,8 @@ import { environment } from '../environments/environment';
             through conversation history and branch from any point.
           </p>
         </div>
-      </aside>
-    </div>
+      </div>
+    </example-chat-layout>
   `,
 })
 export class TimelineComponent {

--- a/cockpit/chat/tool-calls/angular/src/app/tool-calls.component.ts
+++ b/cockpit/chat/tool-calls/angular/src/app/tool-calls.component.ts
@@ -5,6 +5,7 @@ import {
   ChatToolCallsComponent,
   ChatToolCallCardComponent,
 } from '@cacheplane/chat';
+import { ExampleChatLayoutComponent } from '@cacheplane/example-layouts';
 import { agent } from '@cacheplane/angular';
 import { environment } from '../environments/environment';
 
@@ -15,12 +16,11 @@ import { environment } from '../environments/environment';
 @Component({
   selector: 'app-tool-calls',
   standalone: true,
-  imports: [ChatComponent, ChatToolCallsComponent, ChatToolCallCardComponent],
+  imports: [ChatComponent, ChatToolCallsComponent, ChatToolCallCardComponent, ExampleChatLayoutComponent],
   template: `
-    <div class="flex h-screen">
-      <chat [ref]="stream" class="flex-1 min-w-0" />
-      <aside class="w-80 shrink-0 border-l overflow-y-auto p-4 space-y-4"
-             style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
+    <example-chat-layout sidebarWidth="w-80">
+      <chat main [ref]="stream" class="flex-1 min-w-0" />
+      <div sidebar class="p-4 space-y-4" style="background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
         <h3 class="text-xs font-semibold uppercase tracking-wide"
             style="color: var(--chat-text-muted, #777);">Tool Calls</h3>
         <chat-tool-calls [ref]="stream" />
@@ -33,8 +33,8 @@ import { environment } from '../environments/environment';
             <li>weather — City weather</li>
           </ul>
         </div>
-      </aside>
-    </div>
+      </div>
+    </example-chat-layout>
   `,
 })
 export class ToolCallsComponent {

--- a/cockpit/deep-agents/filesystem/angular/src/app/filesystem.component.ts
+++ b/cockpit/deep-agents/filesystem/angular/src/app/filesystem.component.ts
@@ -1,5 +1,6 @@
 import { Component, computed } from '@angular/core';
 import { ChatComponent, views } from '@cacheplane/chat';
+import { ExampleChatLayoutComponent } from '@cacheplane/example-layouts';
 import { agent } from '@cacheplane/angular';
 import { signalStateStore } from '@cacheplane/render';
 import { environment } from '../environments/environment';
@@ -29,12 +30,11 @@ interface FileOperation {
 @Component({
   selector: 'app-filesystem',
   standalone: true,
-  imports: [ChatComponent],
+  imports: [ChatComponent, ExampleChatLayoutComponent],
   template: `
-    <div class="flex h-screen">
-      <chat [ref]="stream" [views]="ui" [store]="uiStore" class="flex-1 min-w-0" />
-      <aside class="w-72 shrink-0 border-l overflow-y-auto p-4 space-y-2"
-             style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
+    <example-chat-layout sidebarWidth="w-72">
+      <chat main [ref]="stream" [views]="ui" [store]="uiStore" class="flex-1 min-w-0" />
+      <div sidebar class="p-4 space-y-2" style="background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
         <h3 class="text-xs font-semibold uppercase tracking-wide"
             style="color: var(--chat-text-muted, #777);">File Operations</h3>
         @if (fileOps().length === 0) {
@@ -56,8 +56,8 @@ interface FileOperation {
             }
           </div>
         }
-      </aside>
-    </div>
+      </div>
+    </example-chat-layout>
   `,
 })
 export class FilesystemComponent {

--- a/cockpit/deep-agents/memory/angular/src/app/memory.component.ts
+++ b/cockpit/deep-agents/memory/angular/src/app/memory.component.ts
@@ -1,5 +1,6 @@
 import { Component, computed } from '@angular/core';
 import { ChatComponent } from '@cacheplane/chat';
+import { ExampleChatLayoutComponent } from '@cacheplane/example-layouts';
 import { agent } from '@cacheplane/angular';
 import { environment } from '../environments/environment';
 
@@ -18,12 +19,11 @@ import { environment } from '../environments/environment';
 @Component({
   selector: 'app-da-memory',
   standalone: true,
-  imports: [ChatComponent],
+  imports: [ChatComponent, ExampleChatLayoutComponent],
   template: `
-    <div class="flex h-screen">
-      <chat [ref]="stream" class="flex-1 min-w-0" />
-      <aside class="w-72 shrink-0 border-l overflow-y-auto p-4 space-y-2"
-             style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
+    <example-chat-layout sidebarWidth="w-72">
+      <chat main [ref]="stream" class="flex-1 min-w-0" />
+      <div sidebar class="p-4 space-y-2" style="background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
         <h3 class="text-xs font-semibold uppercase tracking-wide"
             style="color: var(--chat-text-muted, #777);">
           Learned Facts
@@ -40,8 +40,8 @@ import { environment } from '../environments/environment';
             <span style="color: var(--chat-text-muted, #777);"> {{ entry[1] }}</span>
           </div>
         }
-      </aside>
-    </div>
+      </div>
+    </example-chat-layout>
   `,
 })
 export class MemoryComponent {

--- a/cockpit/deep-agents/planning/angular/src/app/planning.component.ts
+++ b/cockpit/deep-agents/planning/angular/src/app/planning.component.ts
@@ -1,5 +1,6 @@
 import { Component, computed } from '@angular/core';
 import { ChatComponent, views } from '@cacheplane/chat';
+import { ExampleChatLayoutComponent } from '@cacheplane/example-layouts';
 import { agent } from '@cacheplane/angular';
 import { signalStateStore } from '@cacheplane/render';
 import { environment } from '../environments/environment';
@@ -30,12 +31,11 @@ interface PlanStep {
 @Component({
   selector: 'app-planning',
   standalone: true,
-  imports: [ChatComponent],
+  imports: [ChatComponent, ExampleChatLayoutComponent],
   template: `
-    <div class="flex h-screen">
-      <chat [ref]="stream" [views]="ui" [store]="uiStore" class="flex-1 min-w-0" />
-      <aside class="w-72 shrink-0 border-l overflow-y-auto p-4 space-y-2"
-             style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
+    <example-chat-layout sidebarWidth="w-72">
+      <chat main [ref]="stream" [views]="ui" [store]="uiStore" class="flex-1 min-w-0" />
+      <div sidebar class="p-4 space-y-2" style="background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
         <h3 class="text-xs font-semibold uppercase tracking-wide"
             style="color: var(--chat-text-muted, #777);">Plan</h3>
         @if (planSteps().length === 0) {
@@ -56,8 +56,8 @@ interface PlanStep {
             <span style="color: var(--chat-text, #e0e0e0);">{{ step.title }}</span>
           </div>
         }
-      </aside>
-    </div>
+      </div>
+    </example-chat-layout>
   `,
 })
 export class PlanningComponent {

--- a/cockpit/deep-agents/sandboxes/angular/src/app/sandboxes.component.ts
+++ b/cockpit/deep-agents/sandboxes/angular/src/app/sandboxes.component.ts
@@ -1,5 +1,6 @@
 import { Component, computed } from '@angular/core';
 import { ChatComponent, views } from '@cacheplane/chat';
+import { ExampleChatLayoutComponent } from '@cacheplane/example-layouts';
 import { agent } from '@cacheplane/angular';
 import { signalStateStore } from '@cacheplane/render';
 import { environment } from '../environments/environment';
@@ -27,12 +28,11 @@ interface CodeExecution {
 @Component({
   selector: 'app-sandboxes',
   standalone: true,
-  imports: [ChatComponent],
+  imports: [ChatComponent, ExampleChatLayoutComponent],
   template: `
-    <div class="flex h-screen">
-      <chat [ref]="stream" [views]="ui" [store]="uiStore" class="flex-1 min-w-0" />
-      <aside class="w-80 shrink-0 border-l overflow-y-auto p-4 space-y-3"
-             style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
+    <example-chat-layout sidebarWidth="w-80">
+      <chat main [ref]="stream" [views]="ui" [store]="uiStore" class="flex-1 min-w-0" />
+      <div sidebar class="p-4 space-y-3" style="background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
         <h3 class="text-xs font-semibold uppercase tracking-wide"
             style="color: var(--chat-text-muted, #777);">Execution Output</h3>
         @if (executions().length === 0) {
@@ -56,8 +56,8 @@ interface CodeExecution {
             }
           </div>
         }
-      </aside>
-    </div>
+      </div>
+    </example-chat-layout>
   `,
 })
 export class SandboxesComponent {

--- a/cockpit/deep-agents/skills/angular/src/app/skills.component.ts
+++ b/cockpit/deep-agents/skills/angular/src/app/skills.component.ts
@@ -1,5 +1,6 @@
 import { Component, computed } from '@angular/core';
 import { ChatComponent, views } from '@cacheplane/chat';
+import { ExampleChatLayoutComponent } from '@cacheplane/example-layouts';
 import { agent } from '@cacheplane/angular';
 import { signalStateStore } from '@cacheplane/render';
 import { environment } from '../environments/environment';
@@ -29,12 +30,11 @@ interface SkillInvocation {
 @Component({
   selector: 'app-skills',
   standalone: true,
-  imports: [ChatComponent],
+  imports: [ChatComponent, ExampleChatLayoutComponent],
   template: `
-    <div class="flex h-screen">
-      <chat [ref]="stream" [views]="ui" [store]="uiStore" class="flex-1 min-w-0" />
-      <aside class="w-72 shrink-0 border-l overflow-y-auto p-4 space-y-3"
-             style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
+    <example-chat-layout sidebarWidth="w-72">
+      <chat main [ref]="stream" [views]="ui" [store]="uiStore" class="flex-1 min-w-0" />
+      <div sidebar class="p-4 space-y-3" style="background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
         <h3 class="text-xs font-semibold uppercase tracking-wide"
             style="color: var(--chat-text-muted, #777);">Skill Invocations</h3>
         @if (invocations().length === 0) {
@@ -63,8 +63,8 @@ interface SkillInvocation {
             }
           </div>
         }
-      </aside>
-    </div>
+      </div>
+    </example-chat-layout>
   `,
 })
 export class SkillsComponent {

--- a/cockpit/deep-agents/subagents/angular/src/app/subagents.component.ts
+++ b/cockpit/deep-agents/subagents/angular/src/app/subagents.component.ts
@@ -1,5 +1,6 @@
 import { Component, computed } from '@angular/core';
 import { ChatComponent } from '@cacheplane/chat';
+import { ExampleChatLayoutComponent } from '@cacheplane/example-layouts';
 import { agent } from '@cacheplane/angular';
 import { environment } from '../environments/environment';
 
@@ -27,12 +28,11 @@ interface Delegation {
 @Component({
   selector: 'app-subagents',
   standalone: true,
-  imports: [ChatComponent],
+  imports: [ChatComponent, ExampleChatLayoutComponent],
   template: `
-    <div class="flex h-screen">
-      <chat [ref]="stream" class="flex-1 min-w-0" />
-      <aside class="w-72 shrink-0 border-l overflow-y-auto p-4 space-y-2"
-             style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
+    <example-chat-layout sidebarWidth="w-72">
+      <chat main [ref]="stream" class="flex-1 min-w-0" />
+      <div sidebar class="p-4 space-y-2" style="background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
         <h3 class="text-xs font-semibold uppercase tracking-wide"
             style="color: var(--chat-text-muted, #777);">Delegations</h3>
         @if (delegations().length === 0) {
@@ -47,8 +47,8 @@ interface Delegation {
             <span class="text-xs ml-auto" style="color: var(--chat-text-muted, #777);">{{ d.statusText }}</span>
           </div>
         }
-      </aside>
-    </div>
+      </div>
+    </example-chat-layout>
   `,
 })
 export class SubagentsComponent {

--- a/cockpit/langgraph/deployment-runtime/angular/src/app/deployment-runtime.component.ts
+++ b/cockpit/langgraph/deployment-runtime/angular/src/app/deployment-runtime.component.ts
@@ -2,6 +2,7 @@
 import { Component } from '@angular/core';
 import { ChatComponent } from '@cacheplane/chat';
 import { agent } from '@cacheplane/angular';
+import { ExampleChatLayoutComponent } from '@cacheplane/example-layouts';
 import { environment } from '../environments/environment';
 
 /**
@@ -13,8 +14,12 @@ import { environment } from '../environments/environment';
 @Component({
   selector: 'app-deployment-runtime',
   standalone: true,
-  imports: [ChatComponent],
-  template: `<chat [ref]="stream" class="block h-screen" />`,
+  imports: [ChatComponent, ExampleChatLayoutComponent],
+  template: `
+    <example-chat-layout>
+      <chat main [ref]="stream" class="flex-1 min-w-0" />
+    </example-chat-layout>
+  `,
 })
 export class DeploymentRuntimeComponent {
   protected readonly stream = agent({

--- a/cockpit/langgraph/durable-execution/angular/src/app/durable-execution.component.ts
+++ b/cockpit/langgraph/durable-execution/angular/src/app/durable-execution.component.ts
@@ -2,6 +2,7 @@ import { Component, computed } from '@angular/core';
 import { ChatComponent, views } from '@cacheplane/chat';
 import { agent } from '@cacheplane/angular';
 import { signalStateStore } from '@cacheplane/render';
+import { ExampleChatLayoutComponent } from '@cacheplane/example-layouts';
 import { environment } from '../environments/environment';
 import { StepPipelineComponent } from './views/step-pipeline.component';
 
@@ -36,12 +37,12 @@ const STEP_LABELS: Record<string, string> = {
 @Component({
   selector: 'app-durable-execution',
   standalone: true,
-  imports: [ChatComponent],
+  imports: [ChatComponent, ExampleChatLayoutComponent],
   template: `
-    <div class="flex h-screen">
-      <chat [ref]="stream" [views]="ui" [store]="uiStore" class="flex-1 min-w-0" />
-      <aside class="w-64 shrink-0 border-l overflow-y-auto p-4"
-             style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
+    <example-chat-layout sidebarWidth="w-64">
+      <chat main [ref]="stream" [views]="ui" [store]="uiStore" class="flex-1 min-w-0" />
+      <div sidebar class="p-4"
+           style="background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
         <h3 class="text-xs font-semibold uppercase tracking-wide mb-6"
             style="color: var(--chat-text-muted, #777);">Pipeline</h3>
 
@@ -89,8 +90,8 @@ const STEP_LABELS: Record<string, string> = {
             </div>
           }
         </div>
-      </aside>
-    </div>
+      </div>
+    </example-chat-layout>
   `,
 })
 export class DurableExecutionComponent {

--- a/cockpit/langgraph/interrupts/angular/src/app/interrupts.component.ts
+++ b/cockpit/langgraph/interrupts/angular/src/app/interrupts.component.ts
@@ -2,6 +2,7 @@
 import { Component } from '@angular/core';
 import { ChatComponent, ChatInterruptPanelComponent, views, type InterruptAction } from '@cacheplane/chat';
 import { agent } from '@cacheplane/angular';
+import { ExampleChatLayoutComponent } from '@cacheplane/example-layouts';
 import { signalStateStore } from '@cacheplane/render';
 import { environment } from '../environments/environment';
 import { ApprovalCardComponent } from './views/approval-card.component';
@@ -21,16 +22,18 @@ import { ApprovalCardComponent } from './views/approval-card.component';
 @Component({
   selector: 'app-interrupts',
   standalone: true,
-  imports: [ChatComponent, ChatInterruptPanelComponent],
+  imports: [ChatComponent, ChatInterruptPanelComponent, ExampleChatLayoutComponent],
   template: `
-    <div class="flex flex-col h-screen">
-      <chat [ref]="stream" [views]="ui" [store]="uiStore" class="flex-1 min-w-0" />
-      @if (stream.interrupt()) {
-        <div class="p-4" style="border-top: 1px solid var(--chat-border, #333);">
-          <chat-interrupt-panel [ref]="stream" (action)="onInterruptAction($event)" />
-        </div>
-      }
-    </div>
+    <example-chat-layout>
+      <div main class="flex flex-col h-full">
+        <chat [ref]="stream" [views]="ui" [store]="uiStore" class="flex-1 min-w-0" />
+        @if (stream.interrupt()) {
+          <div class="p-4" style="border-top: 1px solid var(--chat-border, #333);">
+            <chat-interrupt-panel [ref]="stream" (action)="onInterruptAction($event)" />
+          </div>
+        }
+      </div>
+    </example-chat-layout>
   `,
 })
 export class InterruptsComponent {

--- a/cockpit/langgraph/memory/angular/src/app/memory.component.ts
+++ b/cockpit/langgraph/memory/angular/src/app/memory.component.ts
@@ -2,6 +2,7 @@
 import { Component, computed } from '@angular/core';
 import { ChatComponent } from '@cacheplane/chat';
 import { agent } from '@cacheplane/angular';
+import { ExampleChatLayoutComponent } from '@cacheplane/example-layouts';
 import { environment } from '../environments/environment';
 
 /**
@@ -19,12 +20,12 @@ import { environment } from '../environments/environment';
 @Component({
   selector: 'app-memory',
   standalone: true,
-  imports: [ChatComponent],
+  imports: [ChatComponent, ExampleChatLayoutComponent],
   template: `
-    <div class="flex h-screen">
-      <chat [ref]="stream" class="flex-1 min-w-0" />
-      <aside class="w-72 shrink-0 border-l overflow-y-auto p-4 space-y-2"
-             style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
+    <example-chat-layout>
+      <chat main [ref]="stream" class="flex-1 min-w-0" />
+      <div sidebar class="p-4 space-y-2"
+           style="background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
         <h3 class="text-xs font-semibold uppercase tracking-wide"
             style="color: var(--chat-text-muted, #777);">Learned Facts</h3>
         @if (memoryEntries().length === 0) {
@@ -36,8 +37,8 @@ import { environment } from '../environments/environment';
             <span style="color: var(--chat-text-muted, #777);"> {{ entry[1] }}</span>
           </div>
         }
-      </aside>
-    </div>
+      </div>
+    </example-chat-layout>
   `,
 })
 export class MemoryComponent {

--- a/cockpit/langgraph/persistence/angular/src/app/persistence.component.ts
+++ b/cockpit/langgraph/persistence/angular/src/app/persistence.component.ts
@@ -1,6 +1,7 @@
 import { Component, signal } from '@angular/core';
 import { ChatComponent } from '@cacheplane/chat';
 import { agent } from '@cacheplane/angular';
+import { ExampleChatLayoutComponent } from '@cacheplane/example-layouts';
 import { environment } from '../environments/environment';
 
 interface Thread {
@@ -22,61 +23,50 @@ interface Thread {
 @Component({
   selector: 'app-persistence',
   standalone: true,
-  imports: [ChatComponent],
-  styles: `
-    :host {
-      display: flex;
-      height: 100vh;
-    }
-  `,
+  imports: [ChatComponent, ExampleChatLayoutComponent],
   template: `
-    <chat [ref]="stream" class="block flex-1 min-w-0" />
+    <example-chat-layout sidebarWidth="w-56">
+      <chat main [ref]="stream" class="block flex-1 min-w-0" />
 
-    <aside
-      class="w-56 flex flex-col border-l"
-      style="
-        border-color: var(--chat-border);
-        background: var(--chat-bg-alt);
-        color: var(--chat-text);
-      "
-    >
-      <div
-        class="px-3 py-2 text-xs font-semibold uppercase tracking-wide border-b"
-        style="border-color: var(--chat-border); color: var(--chat-text-muted)"
+      <div sidebar
+        class="flex flex-col"
+        style="background: var(--chat-bg-alt); color: var(--chat-text);"
       >
-        Threads
-      </div>
-
-      <div class="flex-1 overflow-y-auto">
-        @for (thread of threads(); track thread.id) {
-          <button
-            class="w-full text-left px-3 py-2 text-sm truncate transition-colors"
-            [class.font-semibold]="thread.id === activeThreadId()"
-            [style.background]="thread.id === activeThreadId() ? 'var(--chat-bg-hover)' : 'transparent'"
-            (mouseenter)="$event.currentTarget.style.background = 'var(--chat-bg-hover)'"
-            (mouseleave)="$event.currentTarget.style.background = thread.id === activeThreadId() ? 'var(--chat-bg-hover)' : 'transparent'"
-            (click)="switchThread(thread.id)"
-          >
-            {{ thread.label }}
-          </button>
-        }
-      </div>
-
-      <div class="p-2 border-t" style="border-color: var(--chat-border)">
-        <button
-          class="w-full rounded px-3 py-1.5 text-sm font-medium transition-colors"
-          style="
-            background: var(--chat-bg-hover);
-            color: var(--chat-text);
-          "
-          (mouseenter)="$event.currentTarget.style.opacity = '0.8'"
-          (mouseleave)="$event.currentTarget.style.opacity = '1'"
-          (click)="newThread()"
+        <div
+          class="px-3 py-2 text-xs font-semibold uppercase tracking-wide border-b"
+          style="border-color: var(--chat-border); color: var(--chat-text-muted)"
         >
-          + New Thread
-        </button>
+          Threads
+        </div>
+
+        <div class="flex-1 overflow-y-auto">
+          @for (thread of threads(); track thread.id) {
+            <button
+              class="w-full text-left px-3 py-2 text-sm truncate transition-colors"
+              [class.font-semibold]="thread.id === activeThreadId()"
+              [style.background]="thread.id === activeThreadId() ? 'var(--chat-bg-hover)' : 'transparent'"
+              (mouseenter)="$event.currentTarget.style.background = 'var(--chat-bg-hover)'"
+              (mouseleave)="$event.currentTarget.style.background = thread.id === activeThreadId() ? 'var(--chat-bg-hover)' : 'transparent'"
+              (click)="switchThread(thread.id)"
+            >
+              {{ thread.label }}
+            </button>
+          }
+        </div>
+
+        <div class="p-2 border-t" style="border-color: var(--chat-border)">
+          <button
+            class="w-full rounded px-3 py-1.5 text-sm font-medium transition-colors"
+            style="background: var(--chat-bg-hover); color: var(--chat-text);"
+            (mouseenter)="$event.currentTarget.style.opacity = '0.8'"
+            (mouseleave)="$event.currentTarget.style.opacity = '1'"
+            (click)="newThread()"
+          >
+            + New Thread
+          </button>
+        </div>
       </div>
-    </aside>
+    </example-chat-layout>
   `,
 })
 export class PersistenceComponent {

--- a/cockpit/langgraph/streaming/angular/src/app/streaming.component.ts
+++ b/cockpit/langgraph/streaming/angular/src/app/streaming.component.ts
@@ -2,6 +2,7 @@
 import { Component } from '@angular/core';
 import { ChatComponent } from '@cacheplane/chat';
 import { agent } from '@cacheplane/angular';
+import { ExampleChatLayoutComponent } from '@cacheplane/example-layouts';
 import { environment } from '../environments/environment';
 
 /**
@@ -14,8 +15,12 @@ import { environment } from '../environments/environment';
 @Component({
   selector: 'app-streaming',
   standalone: true,
-  imports: [ChatComponent],
-  template: `<chat [ref]="stream" class="block h-screen" />`,
+  imports: [ChatComponent, ExampleChatLayoutComponent],
+  template: `
+    <example-chat-layout>
+      <chat main [ref]="stream" class="flex-1 min-w-0" />
+    </example-chat-layout>
+  `,
 })
 export class StreamingComponent {
   protected readonly stream = agent({

--- a/cockpit/langgraph/subgraphs/angular/src/app/subgraphs.component.ts
+++ b/cockpit/langgraph/subgraphs/angular/src/app/subgraphs.component.ts
@@ -2,6 +2,7 @@
 import { Component, computed } from '@angular/core';
 import { ChatComponent } from '@cacheplane/chat';
 import { agent } from '@cacheplane/angular';
+import { ExampleChatLayoutComponent } from '@cacheplane/example-layouts';
 import { environment } from '../environments/environment';
 
 /**
@@ -19,12 +20,12 @@ import { environment } from '../environments/environment';
 @Component({
   selector: 'app-subgraphs',
   standalone: true,
-  imports: [ChatComponent],
+  imports: [ChatComponent, ExampleChatLayoutComponent],
   template: `
-    <div class="flex h-screen">
-      <chat [ref]="stream" class="flex-1 min-w-0" />
-      <aside class="w-72 shrink-0 border-l overflow-y-auto p-4 space-y-2"
-             style="border-color: var(--chat-border, #333); background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
+    <example-chat-layout>
+      <chat main [ref]="stream" class="flex-1 min-w-0" />
+      <div sidebar class="p-4 space-y-2"
+           style="background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
         <h3 class="text-xs font-semibold uppercase tracking-wide"
             style="color: var(--chat-text-muted, #777);">Subagents</h3>
         @if (subagentEntries().length === 0) {
@@ -39,8 +40,8 @@ import { environment } from '../environments/environment';
             <span class="text-xs ml-auto" style="color: var(--chat-text-muted, #777);">{{ entry.msgCount }} msgs</span>
           </div>
         }
-      </aside>
-    </div>
+      </div>
+    </example-chat-layout>
   `,
 })
 export class SubgraphsComponent {

--- a/cockpit/langgraph/time-travel/angular/src/app/time-travel.component.ts
+++ b/cockpit/langgraph/time-travel/angular/src/app/time-travel.component.ts
@@ -2,6 +2,7 @@ import { Component, computed, signal } from '@angular/core';
 import { ChatComponent } from '@cacheplane/chat';
 import { agent } from '@cacheplane/angular';
 import type { ThreadState } from '@cacheplane/angular';
+import { ExampleChatLayoutComponent } from '@cacheplane/example-layouts';
 import { environment } from '../environments/environment';
 
 /**
@@ -17,15 +18,16 @@ import { environment } from '../environments/environment';
 @Component({
   selector: 'app-time-travel',
   standalone: true,
-  imports: [ChatComponent],
+  imports: [ChatComponent, ExampleChatLayoutComponent],
   template: `
-    <div class="flex h-screen">
+    <example-chat-layout>
       <!-- Chat panel -->
-      <chat [ref]="stream" class="block flex-1" />
+      <chat main [ref]="stream" class="block flex-1" />
 
       <!-- Checkpoint timeline sidebar -->
-      <aside
-        class="w-72 border-l border-[var(--chat-border)] bg-[var(--chat-bg)] flex flex-col overflow-hidden"
+      <div sidebar
+        class="flex flex-col overflow-hidden"
+        style="background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);"
       >
         <div class="px-4 py-3 border-b border-[var(--chat-border)]">
           <h2 class="text-sm font-semibold text-[var(--chat-text)] uppercase tracking-wide">
@@ -96,8 +98,8 @@ import { environment } from '../environments/environment';
             </div>
           }
         </div>
-      </aside>
-    </div>
+      </div>
+    </example-chat-layout>
   `,
 })
 export class TimeTravelComponent {

--- a/cockpit/render/computed-functions/angular/src/app/computed-functions.component.ts
+++ b/cockpit/render/computed-functions/angular/src/app/computed-functions.component.ts
@@ -9,6 +9,7 @@ import {
 import type { Spec } from '@json-render/core';
 import { StreamingSimulator } from '../../../../shared/streaming-simulator';
 import { StreamingTimelineComponent } from '../../../../shared/streaming-timeline.component';
+import { ExampleSplitLayoutComponent } from '@cacheplane/example-layouts';
 import { COMPUTED_FUNCTIONS_SPECS } from './specs';
 
 // --- Inline view components ---
@@ -111,11 +112,11 @@ class DemoCardComponent {
 @Component({
   selector: 'app-computed-functions',
   standalone: true,
-  imports: [RenderSpecComponent, StreamingTimelineComponent],
+  imports: [RenderSpecComponent, StreamingTimelineComponent, ExampleSplitLayoutComponent],
   template: `
-    <div class="flex flex-col h-full bg-gray-950 text-gray-100">
+    <example-split-layout>
       <!-- Spec picker -->
-      <div class="flex items-center gap-2 px-4 py-3 border-b border-gray-800">
+      <div header class="flex items-center gap-2 px-4 py-3">
         <span class="text-xs text-gray-500 uppercase tracking-wide font-semibold mr-2">Spec:</span>
         @for (spec of specs; track spec.label; let i = $index) {
           <button
@@ -127,35 +128,32 @@ class DemoCardComponent {
         }
       </div>
 
-      <!-- Split panes -->
-      <div class="flex flex-col md:flex-row flex-1 min-h-0">
-        <!-- Left: Live Render Output -->
-        <div class="flex-1 overflow-y-auto p-4 md:p-6 min-h-[200px] md:min-h-0">
-          <div class="text-[10px] text-gray-500 uppercase tracking-widest font-semibold mb-4">Live Render Output</div>
-          @if (simulator.spec(); as renderedSpec) {
-            <render-spec [spec]="renderedSpec" [registry]="registry" [store]="store" [loading]="simulator.playing()" />
-          } @else {
-            <div class="text-gray-600 text-sm italic">Press play to start streaming...</div>
-          }
-        </div>
+      <!-- Left: Live Render Output -->
+      <div primary>
+        <div class="text-[10px] text-gray-500 uppercase tracking-widest font-semibold mb-4">Live Render Output</div>
+        @if (simulator.spec(); as renderedSpec) {
+          <render-spec [spec]="renderedSpec" [registry]="registry" [store]="store" [loading]="simulator.playing()" />
+        } @else {
+          <div class="text-gray-600 text-sm italic">Press play to start streaming...</div>
+        }
+      </div>
 
-        <!-- Right: JSON + Controls -->
-        <div class="w-full md:w-80 shrink-0 flex flex-col border-t md:border-t-0 md:border-l border-gray-800 bg-gray-900/50">
-          <!-- Streaming JSON (scrollable) -->
-          <div class="flex-1 overflow-y-auto p-4" #jsonPane>
-            <div class="text-[10px] text-gray-500 uppercase tracking-widest font-semibold mb-4">Streaming JSON</div>
-            <pre class="text-[11px] font-mono text-gray-300 leading-relaxed whitespace-pre-wrap break-all">{{ simulator.rawJson() }}<span class="text-indigo-400 animate-pulse">|</span></pre>
-            <div class="mt-3 flex justify-between text-[10px]">
-              <span class="text-indigo-400">{{ simulator.playing() ? 'Streaming...' : simulator.position() >= simulator.total() ? 'Complete' : 'Paused' }}</span>
-              <span class="text-gray-500">{{ percent() }}%</span>
-            </div>
+      <!-- Right: JSON + Controls -->
+      <div secondary class="flex flex-col h-full">
+        <!-- Streaming JSON (scrollable) -->
+        <div class="flex-1 overflow-y-auto p-4" #jsonPane>
+          <div class="text-[10px] text-gray-500 uppercase tracking-widest font-semibold mb-4">Streaming JSON</div>
+          <pre class="text-[11px] font-mono text-gray-300 leading-relaxed whitespace-pre-wrap break-all">{{ simulator.rawJson() }}<span class="text-indigo-400 animate-pulse">|</span></pre>
+          <div class="mt-3 flex justify-between text-[10px]">
+            <span class="text-indigo-400">{{ simulator.playing() ? 'Streaming...' : simulator.position() >= simulator.total() ? 'Complete' : 'Paused' }}</span>
+            <span class="text-gray-500">{{ percent() }}%</span>
           </div>
         </div>
       </div>
 
       <!-- Timeline bar -->
-      <streaming-timeline [simulator]="simulator" class="border-t border-gray-800" />
-    </div>
+      <streaming-timeline footer [simulator]="simulator" class="border-t border-gray-800" />
+    </example-split-layout>
   `,
 })
 export class ComputedFunctionsComponent implements OnDestroy {

--- a/cockpit/render/element-rendering/angular/src/app/element-rendering.component.ts
+++ b/cockpit/render/element-rendering/angular/src/app/element-rendering.component.ts
@@ -9,6 +9,7 @@ import {
 import type { Spec } from '@json-render/core';
 import { StreamingSimulator } from '../../../../shared/streaming-simulator';
 import { StreamingTimelineComponent } from '../../../../shared/streaming-timeline.component';
+import { ExampleSplitLayoutComponent } from '@cacheplane/example-layouts';
 import { ELEMENT_RENDERING_SPECS } from './specs';
 
 // --- Inline view components registered in the demo registry ---
@@ -111,11 +112,11 @@ class DemoCardComponent {
 @Component({
   selector: 'app-element-rendering',
   standalone: true,
-  imports: [RenderSpecComponent, StreamingTimelineComponent],
+  imports: [RenderSpecComponent, StreamingTimelineComponent, ExampleSplitLayoutComponent],
   template: `
-    <div class="flex flex-col h-full bg-gray-950 text-gray-100">
+    <example-split-layout>
       <!-- Spec picker -->
-      <div class="flex items-center gap-2 px-4 py-3 border-b border-gray-800">
+      <div header class="flex items-center gap-2 px-4 py-3">
         <span class="text-xs text-gray-500 uppercase tracking-wide font-semibold mr-2">Spec:</span>
         @for (spec of specs; track spec.label; let i = $index) {
           <button
@@ -127,52 +128,49 @@ class DemoCardComponent {
         }
       </div>
 
-      <!-- Split panes -->
-      <div class="flex flex-col md:flex-row flex-1 min-h-0">
-        <!-- Left: Live Render Output -->
-        <div class="flex-1 overflow-y-auto p-4 md:p-6 min-h-[200px] md:min-h-0">
-          <div class="text-[10px] text-gray-500 uppercase tracking-widest font-semibold mb-4">Live Render Output</div>
-          @if (simulator.spec(); as renderedSpec) {
-            <render-spec [spec]="renderedSpec" [registry]="registry" [store]="store" [loading]="simulator.playing()" />
-          } @else {
-            <div class="text-gray-600 text-sm italic">Press play to start streaming...</div>
-          }
+      <!-- Left: Live Render Output -->
+      <div primary>
+        <div class="text-[10px] text-gray-500 uppercase tracking-widest font-semibold mb-4">Live Render Output</div>
+        @if (simulator.spec(); as renderedSpec) {
+          <render-spec [spec]="renderedSpec" [registry]="registry" [store]="store" [loading]="simulator.playing()" />
+        } @else {
+          <div class="text-gray-600 text-sm italic">Press play to start streaming...</div>
+        }
+      </div>
+
+      <!-- Right: JSON + Controls -->
+      <div secondary class="flex flex-col h-full">
+        <!-- Streaming JSON (scrollable) -->
+        <div class="flex-1 overflow-y-auto p-4" #jsonPane>
+          <div class="text-[10px] text-gray-500 uppercase tracking-widest font-semibold mb-4">Streaming JSON</div>
+          <pre class="text-[11px] font-mono text-gray-300 leading-relaxed whitespace-pre-wrap break-all">{{ simulator.rawJson() }}<span class="text-indigo-400 animate-pulse">|</span></pre>
+          <div class="mt-3 flex justify-between text-[10px]">
+            <span class="text-indigo-400">{{ simulator.playing() ? 'Streaming...' : simulator.position() >= simulator.total() ? 'Complete' : 'Paused' }}</span>
+            <span class="text-gray-500">{{ percent() }}%</span>
+          </div>
         </div>
 
-        <!-- Right: JSON + Controls -->
-        <div class="w-full md:w-80 shrink-0 flex flex-col border-t md:border-t-0 md:border-l border-gray-800 bg-gray-900/50">
-          <!-- Streaming JSON (scrollable) -->
-          <div class="flex-1 overflow-y-auto p-4" #jsonPane>
-            <div class="text-[10px] text-gray-500 uppercase tracking-widest font-semibold mb-4">Streaming JSON</div>
-            <pre class="text-[11px] font-mono text-gray-300 leading-relaxed whitespace-pre-wrap break-all">{{ simulator.rawJson() }}<span class="text-indigo-400 animate-pulse">|</span></pre>
-            <div class="mt-3 flex justify-between text-[10px]">
-              <span class="text-indigo-400">{{ simulator.playing() ? 'Streaming...' : simulator.position() >= simulator.total() ? 'Complete' : 'Paused' }}</span>
-              <span class="text-gray-500">{{ percent() }}%</span>
-            </div>
-          </div>
-
-          <!-- Controls (pinned at bottom) -->
-          <div class="shrink-0 border-t border-gray-800 p-4">
-            <div class="text-[10px] text-gray-500 uppercase tracking-widest font-semibold mb-3">Controls</div>
-            <div class="space-y-3">
-              <label class="flex items-center gap-2 cursor-pointer group">
-                <input type="checkbox"
-                       class="w-4 h-4 rounded border-gray-600 bg-gray-800 text-indigo-500 focus:ring-indigo-500 focus:ring-offset-0 cursor-pointer"
-                       [checked]="showDetail()"
-                       (change)="toggleShowDetail()" />
-                <span class="text-xs text-gray-300 group-hover:text-gray-100 transition-colors">Show Detail</span>
-              </label>
-              <p class="text-[10px] text-gray-600 leading-relaxed">
-                Toggles <code class="text-indigo-400/70 font-mono">/showDetail</code> in the state store. Elements with <code class="text-indigo-400/70 font-mono">visible: bind</code> react instantly.
-              </p>
-            </div>
+        <!-- Controls (pinned at bottom) -->
+        <div class="shrink-0 border-t border-gray-800 p-4">
+          <div class="text-[10px] text-gray-500 uppercase tracking-widest font-semibold mb-3">Controls</div>
+          <div class="space-y-3">
+            <label class="flex items-center gap-2 cursor-pointer group">
+              <input type="checkbox"
+                     class="w-4 h-4 rounded border-gray-600 bg-gray-800 text-indigo-500 focus:ring-indigo-500 focus:ring-offset-0 cursor-pointer"
+                     [checked]="showDetail()"
+                     (change)="toggleShowDetail()" />
+              <span class="text-xs text-gray-300 group-hover:text-gray-100 transition-colors">Show Detail</span>
+            </label>
+            <p class="text-[10px] text-gray-600 leading-relaxed">
+              Toggles <code class="text-indigo-400/70 font-mono">/showDetail</code> in the state store. Elements with <code class="text-indigo-400/70 font-mono">visible: bind</code> react instantly.
+            </p>
           </div>
         </div>
       </div>
 
       <!-- Timeline bar -->
-      <streaming-timeline [simulator]="simulator" class="border-t border-gray-800" />
-    </div>
+      <streaming-timeline footer [simulator]="simulator" class="border-t border-gray-800" />
+    </example-split-layout>
   `,
 })
 export class ElementRenderingComponent implements OnDestroy {

--- a/cockpit/render/registry/angular/src/app/registry.component.ts
+++ b/cockpit/render/registry/angular/src/app/registry.component.ts
@@ -9,6 +9,7 @@ import {
 import type { Spec } from '@json-render/core';
 import { StreamingSimulator } from '../../../../shared/streaming-simulator';
 import { StreamingTimelineComponent } from '../../../../shared/streaming-timeline.component';
+import { ExampleSplitLayoutComponent } from '@cacheplane/example-layouts';
 import { REGISTRY_SPECS } from './specs';
 
 // --- Inline view components registered in the demo registry ---
@@ -131,11 +132,11 @@ class DemoCardComponent {
 @Component({
   selector: 'app-registry',
   standalone: true,
-  imports: [RenderSpecComponent, StreamingTimelineComponent],
+  imports: [RenderSpecComponent, StreamingTimelineComponent, ExampleSplitLayoutComponent],
   template: `
-    <div class="flex flex-col h-full bg-gray-950 text-gray-100">
+    <example-split-layout>
       <!-- Spec picker -->
-      <div class="flex items-center gap-2 px-4 py-3 border-b border-gray-800">
+      <div header class="flex items-center gap-2 px-4 py-3">
         <span class="text-xs text-gray-500 uppercase tracking-wide font-semibold mr-2">Spec:</span>
         @for (spec of specs; track spec.label; let i = $index) {
           <button
@@ -147,35 +148,32 @@ class DemoCardComponent {
         }
       </div>
 
-      <!-- Split panes -->
-      <div class="flex flex-col md:flex-row flex-1 min-h-0">
-        <!-- Left: Live Render Output -->
-        <div class="flex-1 overflow-y-auto p-4 md:p-6 min-h-[200px] md:min-h-0">
-          <div class="text-[10px] text-gray-500 uppercase tracking-widest font-semibold mb-4">Live Render Output</div>
-          @if (simulator.spec(); as renderedSpec) {
-            <render-spec [spec]="renderedSpec" [registry]="registry" [store]="store" [loading]="simulator.playing()" />
-          } @else {
-            <div class="text-gray-600 text-sm italic">Press play to start streaming...</div>
-          }
-        </div>
+      <!-- Left: Live Render Output -->
+      <div primary>
+        <div class="text-[10px] text-gray-500 uppercase tracking-widest font-semibold mb-4">Live Render Output</div>
+        @if (simulator.spec(); as renderedSpec) {
+          <render-spec [spec]="renderedSpec" [registry]="registry" [store]="store" [loading]="simulator.playing()" />
+        } @else {
+          <div class="text-gray-600 text-sm italic">Press play to start streaming...</div>
+        }
+      </div>
 
-        <!-- Right: JSON + Controls -->
-        <div class="w-full md:w-80 shrink-0 flex flex-col border-t md:border-t-0 md:border-l border-gray-800 bg-gray-900/50">
-          <!-- Streaming JSON (scrollable) -->
-          <div class="flex-1 overflow-y-auto p-4" #jsonPane>
-            <div class="text-[10px] text-gray-500 uppercase tracking-widest font-semibold mb-4">Streaming JSON</div>
-            <pre class="text-[11px] font-mono text-gray-300 leading-relaxed whitespace-pre-wrap break-all">{{ simulator.rawJson() }}<span class="text-indigo-400 animate-pulse">|</span></pre>
-            <div class="mt-3 flex justify-between text-[10px]">
-              <span class="text-indigo-400">{{ simulator.playing() ? 'Streaming...' : simulator.position() >= simulator.total() ? 'Complete' : 'Paused' }}</span>
-              <span class="text-gray-500">{{ percent() }}%</span>
-            </div>
+      <!-- Right: JSON + Controls -->
+      <div secondary class="flex flex-col h-full">
+        <!-- Streaming JSON (scrollable) -->
+        <div class="flex-1 overflow-y-auto p-4" #jsonPane>
+          <div class="text-[10px] text-gray-500 uppercase tracking-widest font-semibold mb-4">Streaming JSON</div>
+          <pre class="text-[11px] font-mono text-gray-300 leading-relaxed whitespace-pre-wrap break-all">{{ simulator.rawJson() }}<span class="text-indigo-400 animate-pulse">|</span></pre>
+          <div class="mt-3 flex justify-between text-[10px]">
+            <span class="text-indigo-400">{{ simulator.playing() ? 'Streaming...' : simulator.position() >= simulator.total() ? 'Complete' : 'Paused' }}</span>
+            <span class="text-gray-500">{{ percent() }}%</span>
           </div>
         </div>
       </div>
 
       <!-- Timeline bar -->
-      <streaming-timeline [simulator]="simulator" class="border-t border-gray-800" />
-    </div>
+      <streaming-timeline footer [simulator]="simulator" class="border-t border-gray-800" />
+    </example-split-layout>
   `,
 })
 export class RegistryComponent implements OnDestroy {

--- a/cockpit/render/repeat-loops/angular/src/app/repeat-loops.component.ts
+++ b/cockpit/render/repeat-loops/angular/src/app/repeat-loops.component.ts
@@ -9,6 +9,7 @@ import {
 import type { Spec } from '@json-render/core';
 import { StreamingSimulator } from '../../../../shared/streaming-simulator';
 import { StreamingTimelineComponent } from '../../../../shared/streaming-timeline.component';
+import { ExampleSplitLayoutComponent } from '@cacheplane/example-layouts';
 import { REPEAT_LOOPS_SPECS } from './specs';
 
 // --- Inline view components registered in the demo registry ---
@@ -111,11 +112,11 @@ class DemoCardComponent {
 @Component({
   selector: 'app-repeat-loops',
   standalone: true,
-  imports: [RenderSpecComponent, StreamingTimelineComponent],
+  imports: [RenderSpecComponent, StreamingTimelineComponent, ExampleSplitLayoutComponent],
   template: `
-    <div class="flex flex-col h-full bg-gray-950 text-gray-100">
+    <example-split-layout>
       <!-- Spec picker -->
-      <div class="flex items-center gap-2 px-4 py-3 border-b border-gray-800">
+      <div header class="flex items-center gap-2 px-4 py-3">
         <span class="text-xs text-gray-500 uppercase tracking-wide font-semibold mr-2">Spec:</span>
         @for (spec of specs; track spec.label; let i = $index) {
           <button
@@ -127,61 +128,58 @@ class DemoCardComponent {
         }
       </div>
 
-      <!-- Split panes -->
-      <div class="flex flex-col md:flex-row flex-1 min-h-0">
-        <!-- Left: Live Render Output -->
-        <div class="flex-1 overflow-y-auto p-4 md:p-6 min-h-[200px] md:min-h-0">
-          <div class="text-[10px] text-gray-500 uppercase tracking-widest font-semibold mb-4">Live Render Output</div>
-          @if (simulator.spec(); as renderedSpec) {
-            <render-spec [spec]="renderedSpec" [registry]="registry" [store]="store" [loading]="simulator.playing()" />
-          } @else {
-            <div class="text-gray-600 text-sm italic">Press play to start streaming...</div>
-          }
+      <!-- Left: Live Render Output -->
+      <div primary>
+        <div class="text-[10px] text-gray-500 uppercase tracking-widest font-semibold mb-4">Live Render Output</div>
+        @if (simulator.spec(); as renderedSpec) {
+          <render-spec [spec]="renderedSpec" [registry]="registry" [store]="store" [loading]="simulator.playing()" />
+        } @else {
+          <div class="text-gray-600 text-sm italic">Press play to start streaming...</div>
+        }
+      </div>
+
+      <!-- Right: JSON + Controls -->
+      <div secondary class="flex flex-col h-full">
+        <!-- Streaming JSON (scrollable) -->
+        <div class="flex-1 overflow-y-auto p-4" #jsonPane>
+          <div class="text-[10px] text-gray-500 uppercase tracking-widest font-semibold mb-4">Streaming JSON</div>
+          <pre class="text-[11px] font-mono text-gray-300 leading-relaxed whitespace-pre-wrap break-all">{{ simulator.rawJson() }}<span class="text-indigo-400 animate-pulse">|</span></pre>
+          <div class="mt-3 flex justify-between text-[10px]">
+            <span class="text-indigo-400">{{ simulator.playing() ? 'Streaming...' : simulator.position() >= simulator.total() ? 'Complete' : 'Paused' }}</span>
+            <span class="text-gray-500">{{ percent() }}%</span>
+          </div>
         </div>
 
-        <!-- Right: JSON + Controls -->
-        <div class="w-full md:w-80 shrink-0 flex flex-col border-t md:border-t-0 md:border-l border-gray-800 bg-gray-900/50">
-          <!-- Streaming JSON (scrollable) -->
-          <div class="flex-1 overflow-y-auto p-4" #jsonPane>
-            <div class="text-[10px] text-gray-500 uppercase tracking-widest font-semibold mb-4">Streaming JSON</div>
-            <pre class="text-[11px] font-mono text-gray-300 leading-relaxed whitespace-pre-wrap break-all">{{ simulator.rawJson() }}<span class="text-indigo-400 animate-pulse">|</span></pre>
-            <div class="mt-3 flex justify-between text-[10px]">
-              <span class="text-indigo-400">{{ simulator.playing() ? 'Streaming...' : simulator.position() >= simulator.total() ? 'Complete' : 'Paused' }}</span>
-              <span class="text-gray-500">{{ percent() }}%</span>
-            </div>
-          </div>
-
-          <!-- Controls (pinned at bottom) -->
-          <div class="shrink-0 border-t border-gray-800 p-4">
-            <div class="text-[10px] text-gray-500 uppercase tracking-widest font-semibold mb-3">List Controls</div>
-            <div class="space-y-3">
-              <button
-                class="w-full text-xs px-3 py-1.5 rounded-md bg-indigo-500 text-white font-semibold hover:bg-indigo-400 transition-colors"
-                (click)="addItem()">
-                + Add Item
-              </button>
-              @if (getItems().length) {
-                <div class="space-y-1">
-                  @for (item of getItems(); track $index) {
-                    <div class="flex items-center justify-between text-xs">
-                      <span class="text-gray-300 truncate">{{ item }}</span>
-                      <button class="text-gray-500 hover:text-red-400 text-[10px] transition-colors"
-                              (click)="removeItem($index)">x</button>
-                    </div>
-                  }
-                </div>
-              }
-              <p class="text-[10px] text-gray-600 leading-relaxed">
-                Modify <code class="text-indigo-400/70 font-mono">/items</code> array in the store.
-              </p>
-            </div>
+        <!-- Controls (pinned at bottom) -->
+        <div class="shrink-0 border-t border-gray-800 p-4">
+          <div class="text-[10px] text-gray-500 uppercase tracking-widest font-semibold mb-3">List Controls</div>
+          <div class="space-y-3">
+            <button
+              class="w-full text-xs px-3 py-1.5 rounded-md bg-indigo-500 text-white font-semibold hover:bg-indigo-400 transition-colors"
+              (click)="addItem()">
+              + Add Item
+            </button>
+            @if (getItems().length) {
+              <div class="space-y-1">
+                @for (item of getItems(); track $index) {
+                  <div class="flex items-center justify-between text-xs">
+                    <span class="text-gray-300 truncate">{{ item }}</span>
+                    <button class="text-gray-500 hover:text-red-400 text-[10px] transition-colors"
+                            (click)="removeItem($index)">x</button>
+                  </div>
+                }
+              </div>
+            }
+            <p class="text-[10px] text-gray-600 leading-relaxed">
+              Modify <code class="text-indigo-400/70 font-mono">/items</code> array in the store.
+            </p>
           </div>
         </div>
       </div>
 
       <!-- Timeline bar -->
-      <streaming-timeline [simulator]="simulator" class="border-t border-gray-800" />
-    </div>
+      <streaming-timeline footer [simulator]="simulator" class="border-t border-gray-800" />
+    </example-split-layout>
   `,
 })
 export class RepeatLoopsComponent implements OnDestroy {

--- a/cockpit/render/spec-rendering/angular/src/app/spec-rendering.component.ts
+++ b/cockpit/render/spec-rendering/angular/src/app/spec-rendering.component.ts
@@ -9,6 +9,7 @@ import {
 import type { Spec } from '@json-render/core';
 import { StreamingSimulator } from '../../../../shared/streaming-simulator';
 import { StreamingTimelineComponent } from '../../../../shared/streaming-timeline.component';
+import { ExampleSplitLayoutComponent } from '@cacheplane/example-layouts';
 import { SPEC_RENDERING_SPECS } from './specs';
 
 // --- Inline view components registered in the demo registry ---
@@ -124,11 +125,11 @@ class DemoCardComponent {
 @Component({
   selector: 'app-spec-rendering',
   standalone: true,
-  imports: [RenderSpecComponent, StreamingTimelineComponent],
+  imports: [RenderSpecComponent, StreamingTimelineComponent, ExampleSplitLayoutComponent],
   template: `
-    <div class="flex flex-col h-full bg-gray-950 text-gray-100">
+    <example-split-layout>
       <!-- Spec picker -->
-      <div class="flex items-center gap-2 px-4 py-3 border-b border-gray-800">
+      <div header class="flex items-center gap-2 px-4 py-3">
         <span class="text-xs text-gray-500 uppercase tracking-wide font-semibold mr-2">Spec:</span>
         @for (spec of specs; track spec.label; let i = $index) {
           <button
@@ -140,35 +141,32 @@ class DemoCardComponent {
         }
       </div>
 
-      <!-- Split panes -->
-      <div class="flex flex-col md:flex-row flex-1 min-h-0">
-        <!-- Left: Live Render Output -->
-        <div class="flex-1 overflow-y-auto p-4 md:p-6 min-h-[200px] md:min-h-0">
-          <div class="text-[10px] text-gray-500 uppercase tracking-widest font-semibold mb-4">Live Render Output</div>
-          @if (simulator.spec(); as renderedSpec) {
-            <render-spec [spec]="renderedSpec" [registry]="registry" [store]="store" [loading]="simulator.playing()" />
-          } @else {
-            <div class="text-gray-600 text-sm italic">Press play to start streaming...</div>
-          }
-        </div>
+      <!-- Left: Live Render Output -->
+      <div primary>
+        <div class="text-[10px] text-gray-500 uppercase tracking-widest font-semibold mb-4">Live Render Output</div>
+        @if (simulator.spec(); as renderedSpec) {
+          <render-spec [spec]="renderedSpec" [registry]="registry" [store]="store" [loading]="simulator.playing()" />
+        } @else {
+          <div class="text-gray-600 text-sm italic">Press play to start streaming...</div>
+        }
+      </div>
 
-        <!-- Right: JSON + Controls -->
-        <div class="w-full md:w-80 shrink-0 flex flex-col border-t md:border-t-0 md:border-l border-gray-800 bg-gray-900/50">
-          <!-- Streaming JSON (scrollable) -->
-          <div class="flex-1 overflow-y-auto p-4" #jsonPane>
-            <div class="text-[10px] text-gray-500 uppercase tracking-widest font-semibold mb-4">Streaming JSON</div>
-            <pre class="text-[11px] font-mono text-gray-300 leading-relaxed whitespace-pre-wrap break-all">{{ simulator.rawJson() }}<span class="text-indigo-400 animate-pulse">|</span></pre>
-            <div class="mt-3 flex justify-between text-[10px]">
-              <span class="text-indigo-400">{{ simulator.playing() ? 'Streaming...' : simulator.position() >= simulator.total() ? 'Complete' : 'Paused' }}</span>
-              <span class="text-gray-500">{{ percent() }}%</span>
-            </div>
+      <!-- Right: JSON + Controls -->
+      <div secondary class="flex flex-col h-full">
+        <!-- Streaming JSON (scrollable) -->
+        <div class="flex-1 overflow-y-auto p-4" #jsonPane>
+          <div class="text-[10px] text-gray-500 uppercase tracking-widest font-semibold mb-4">Streaming JSON</div>
+          <pre class="text-[11px] font-mono text-gray-300 leading-relaxed whitespace-pre-wrap break-all">{{ simulator.rawJson() }}<span class="text-indigo-400 animate-pulse">|</span></pre>
+          <div class="mt-3 flex justify-between text-[10px]">
+            <span class="text-indigo-400">{{ simulator.playing() ? 'Streaming...' : simulator.position() >= simulator.total() ? 'Complete' : 'Paused' }}</span>
+            <span class="text-gray-500">{{ percent() }}%</span>
           </div>
         </div>
       </div>
 
       <!-- Timeline bar -->
-      <streaming-timeline [simulator]="simulator" class="border-t border-gray-800" />
-    </div>
+      <streaming-timeline footer [simulator]="simulator" class="border-t border-gray-800" />
+    </example-split-layout>
   `,
 })
 export class SpecRenderingComponent implements OnDestroy {

--- a/cockpit/render/state-management/angular/src/app/state-management.component.ts
+++ b/cockpit/render/state-management/angular/src/app/state-management.component.ts
@@ -9,6 +9,7 @@ import {
 import type { Spec } from '@json-render/core';
 import { StreamingSimulator } from '../../../../shared/streaming-simulator';
 import { StreamingTimelineComponent } from '../../../../shared/streaming-timeline.component';
+import { ExampleSplitLayoutComponent } from '@cacheplane/example-layouts';
 import { STATE_MANAGEMENT_SPECS } from './specs';
 
 // --- Inline view components ---
@@ -138,11 +139,11 @@ class DemoCardComponent {
 @Component({
   selector: 'app-state-management',
   standalone: true,
-  imports: [RenderSpecComponent, StreamingTimelineComponent],
+  imports: [RenderSpecComponent, StreamingTimelineComponent, ExampleSplitLayoutComponent],
   template: `
-    <div class="flex flex-col h-full bg-gray-950 text-gray-100">
+    <example-split-layout>
       <!-- Spec picker -->
-      <div class="flex items-center gap-2 px-4 py-3 border-b border-gray-800">
+      <div header class="flex items-center gap-2 px-4 py-3">
         <span class="text-xs text-gray-500 uppercase tracking-wide font-semibold mr-2">Spec:</span>
         @for (spec of specs; track spec.label; let i = $index) {
           <button
@@ -154,68 +155,65 @@ class DemoCardComponent {
         }
       </div>
 
-      <!-- Split panes -->
-      <div class="flex flex-col md:flex-row flex-1 min-h-0">
-        <!-- Left: Live Render Output -->
-        <div class="flex-1 overflow-y-auto p-4 md:p-6 min-h-[200px] md:min-h-0">
-          <div class="text-[10px] text-gray-500 uppercase tracking-widest font-semibold mb-4">Live Render Output</div>
-          @if (simulator.spec(); as renderedSpec) {
-            <render-spec [spec]="renderedSpec" [registry]="registry" [store]="store" [loading]="simulator.playing()" />
-          } @else {
-            <div class="text-gray-600 text-sm italic">Press play to start streaming...</div>
-          }
+      <!-- Left: Live Render Output -->
+      <div primary>
+        <div class="text-[10px] text-gray-500 uppercase tracking-widest font-semibold mb-4">Live Render Output</div>
+        @if (simulator.spec(); as renderedSpec) {
+          <render-spec [spec]="renderedSpec" [registry]="registry" [store]="store" [loading]="simulator.playing()" />
+        } @else {
+          <div class="text-gray-600 text-sm italic">Press play to start streaming...</div>
+        }
+      </div>
+
+      <!-- Right: JSON + Controls -->
+      <div secondary class="flex flex-col h-full">
+        <!-- Streaming JSON (scrollable) -->
+        <div class="flex-1 overflow-y-auto p-4" #jsonPane>
+          <div class="text-[10px] text-gray-500 uppercase tracking-widest font-semibold mb-4">Streaming JSON</div>
+          <pre class="text-[11px] font-mono text-gray-300 leading-relaxed whitespace-pre-wrap break-all">{{ simulator.rawJson() }}<span class="text-indigo-400 animate-pulse">|</span></pre>
+          <div class="mt-3 flex justify-between text-[10px]">
+            <span class="text-indigo-400">{{ simulator.playing() ? 'Streaming...' : simulator.position() >= simulator.total() ? 'Complete' : 'Paused' }}</span>
+            <span class="text-gray-500">{{ percent() }}%</span>
+          </div>
         </div>
 
-        <!-- Right: JSON + Controls -->
-        <div class="w-full md:w-80 shrink-0 flex flex-col border-t md:border-t-0 md:border-l border-gray-800 bg-gray-900/50">
-          <!-- Streaming JSON (scrollable) -->
-          <div class="flex-1 overflow-y-auto p-4" #jsonPane>
-            <div class="text-[10px] text-gray-500 uppercase tracking-widest font-semibold mb-4">Streaming JSON</div>
-            <pre class="text-[11px] font-mono text-gray-300 leading-relaxed whitespace-pre-wrap break-all">{{ simulator.rawJson() }}<span class="text-indigo-400 animate-pulse">|</span></pre>
-            <div class="mt-3 flex justify-between text-[10px]">
-              <span class="text-indigo-400">{{ simulator.playing() ? 'Streaming...' : simulator.position() >= simulator.total() ? 'Complete' : 'Paused' }}</span>
-              <span class="text-gray-500">{{ percent() }}%</span>
+        <!-- Controls (pinned at bottom) -->
+        <div class="shrink-0 border-t border-gray-800 p-4">
+          <div class="text-[10px] text-gray-500 uppercase tracking-widest font-semibold mb-3">State Controls</div>
+          <div class="space-y-3">
+            <div>
+              <label class="text-[10px] text-gray-500 uppercase font-semibold block mb-1">Name</label>
+              <input type="text"
+                     class="w-full px-2 py-1 text-xs rounded bg-gray-800 border border-gray-700 text-gray-200 focus:border-indigo-500 focus:outline-none"
+                     [value]="getState('/user/name')"
+                     (input)="store.set('/user/name', $any($event.target).value)" />
             </div>
-          </div>
-
-          <!-- Controls (pinned at bottom) -->
-          <div class="shrink-0 border-t border-gray-800 p-4">
-            <div class="text-[10px] text-gray-500 uppercase tracking-widest font-semibold mb-3">State Controls</div>
-            <div class="space-y-3">
-              <div>
-                <label class="text-[10px] text-gray-500 uppercase font-semibold block mb-1">Name</label>
-                <input type="text"
-                       class="w-full px-2 py-1 text-xs rounded bg-gray-800 border border-gray-700 text-gray-200 focus:border-indigo-500 focus:outline-none"
-                       [value]="getState('/user/name')"
-                       (input)="store.set('/user/name', $any($event.target).value)" />
-              </div>
-              <div>
-                <label class="text-[10px] text-gray-500 uppercase font-semibold block mb-1">Age</label>
-                <input type="number"
-                       class="w-full px-2 py-1 text-xs rounded bg-gray-800 border border-gray-700 text-gray-200 focus:border-indigo-500 focus:outline-none"
-                       [value]="getState('/user/age')"
-                       (input)="store.set('/user/age', +$any($event.target).value)" />
-              </div>
-              <div>
-                <label class="text-[10px] text-gray-500 uppercase font-semibold block mb-1">Theme</label>
-                <select class="w-full px-2 py-1 text-xs rounded bg-gray-800 border border-gray-700 text-gray-200 focus:border-indigo-500 focus:outline-none"
-                        [value]="getState('/settings/theme')"
-                        (change)="store.set('/settings/theme', $any($event.target).value)">
-                  <option value="dark">Dark</option>
-                  <option value="light">Light</option>
-                </select>
-              </div>
-              <p class="text-[10px] text-gray-600 leading-relaxed">
-                Edit values to update the state store. Rendered elements with <code class="text-indigo-400/70 font-mono">$state</code> bindings react.
-              </p>
+            <div>
+              <label class="text-[10px] text-gray-500 uppercase font-semibold block mb-1">Age</label>
+              <input type="number"
+                     class="w-full px-2 py-1 text-xs rounded bg-gray-800 border border-gray-700 text-gray-200 focus:border-indigo-500 focus:outline-none"
+                     [value]="getState('/user/age')"
+                     (input)="store.set('/user/age', +$any($event.target).value)" />
             </div>
+            <div>
+              <label class="text-[10px] text-gray-500 uppercase font-semibold block mb-1">Theme</label>
+              <select class="w-full px-2 py-1 text-xs rounded bg-gray-800 border border-gray-700 text-gray-200 focus:border-indigo-500 focus:outline-none"
+                      [value]="getState('/settings/theme')"
+                      (change)="store.set('/settings/theme', $any($event.target).value)">
+                <option value="dark">Dark</option>
+                <option value="light">Light</option>
+              </select>
+            </div>
+            <p class="text-[10px] text-gray-600 leading-relaxed">
+              Edit values to update the state store. Rendered elements with <code class="text-indigo-400/70 font-mono">$state</code> bindings react.
+            </p>
           </div>
         </div>
       </div>
 
       <!-- Timeline bar -->
-      <streaming-timeline [simulator]="simulator" class="border-t border-gray-800" />
-    </div>
+      <streaming-timeline footer [simulator]="simulator" class="border-t border-gray-800" />
+    </example-split-layout>
   `,
 })
 export class StateManagementComponent implements OnDestroy {

--- a/libs/example-layouts/ng-package.json
+++ b/libs/example-layouts/ng-package.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
+  "dest": "../../dist/libs/example-layouts",
+  "lib": {
+    "entryFile": "src/public-api.ts"
+  }
+}

--- a/libs/example-layouts/package.json
+++ b/libs/example-layouts/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@cacheplane/example-layouts",
+  "version": "0.0.1",
+  "peerDependencies": {
+    "@angular/core": "^20.0.0 || ^21.0.0",
+    "@angular/common": "^20.0.0 || ^21.0.0"
+  },
+  "license": "PolyForm-Noncommercial-1.0.0",
+  "sideEffects": false
+}

--- a/libs/example-layouts/project.json
+++ b/libs/example-layouts/project.json
@@ -1,0 +1,34 @@
+{
+  "name": "example-layouts",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/example-layouts/src",
+  "prefix": "example",
+  "projectType": "library",
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/angular:package",
+      "outputs": ["{workspaceRoot}/dist/{projectRoot}"],
+      "options": {
+        "project": "libs/example-layouts/ng-package.json",
+        "tsConfig": "libs/example-layouts/tsconfig.lib.json"
+      },
+      "configurations": {
+        "production": {
+          "tsConfig": "libs/example-layouts/tsconfig.lib.prod.json"
+        },
+        "development": {}
+      },
+      "defaultConfiguration": "production"
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint"
+    },
+    "test": {
+      "executor": "@nx/vite:test",
+      "options": {
+        "configFile": "libs/example-layouts/vite.config.mts"
+      }
+    }
+  }
+}

--- a/libs/example-layouts/src/lib/example-chat-layout.component.spec.ts
+++ b/libs/example-layouts/src/lib/example-chat-layout.component.spec.ts
@@ -1,0 +1,159 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { ExampleChatLayoutComponent } from './example-chat-layout.component';
+
+@Component({
+  standalone: true,
+  imports: [ExampleChatLayoutComponent],
+  template: `
+    <example-chat-layout>
+      <div main data-testid="main-content">Main Content</div>
+      <div sidebar data-testid="sidebar-content">Sidebar Content</div>
+    </example-chat-layout>
+  `,
+})
+class TestHostComponent {}
+
+@Component({
+  standalone: true,
+  imports: [ExampleChatLayoutComponent],
+  template: `
+    <example-chat-layout>
+      <div main data-testid="main-only">Main Only</div>
+    </example-chat-layout>
+  `,
+})
+class NoSidebarHostComponent {}
+
+@Component({
+  standalone: true,
+  imports: [ExampleChatLayoutComponent],
+  template: `
+    <example-chat-layout sidebarPosition="left" sidebarWidth="w-64">
+      <div main data-testid="main-content">Main</div>
+      <div sidebar data-testid="sidebar-content">Sidebar</div>
+    </example-chat-layout>
+  `,
+})
+class LeftSidebarHostComponent {}
+
+@Component({
+  standalone: true,
+  imports: [ExampleChatLayoutComponent],
+  template: `
+    <example-chat-layout sidebarWidth="w-80">
+      <div main data-testid="main-content">Main</div>
+      <div sidebar data-testid="sidebar-content">Sidebar</div>
+    </example-chat-layout>
+  `,
+})
+class CustomWidthHostComponent {}
+
+describe('ExampleChatLayoutComponent', () => {
+  it('should render main and sidebar content', async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(TestHostComponent);
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('[data-testid="main-content"]')?.textContent).toBe('Main Content');
+    expect(el.querySelector('[data-testid="sidebar-content"]')?.textContent).toBe('Sidebar Content');
+  });
+
+  it('should use flex-col md:flex-row for responsive layout', async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(TestHostComponent);
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    const flexContainer = el.querySelector('.flex.flex-col');
+    expect(flexContainer).toBeTruthy();
+    expect(flexContainer?.classList.contains('md:flex-row')).toBe(true);
+  });
+
+  it('should hide aside when no sidebar content is projected', async () => {
+    await TestBed.configureTestingModule({
+      imports: [NoSidebarHostComponent],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(NoSidebarHostComponent);
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('[data-testid="main-only"]')?.textContent).toBe('Main Only');
+    const aside = el.querySelector('aside');
+    expect(aside).toBeTruthy();
+    expect(aside?.children.length).toBe(0);
+  });
+
+  it('should apply md:flex-row-reverse for left sidebar position', async () => {
+    await TestBed.configureTestingModule({
+      imports: [LeftSidebarHostComponent],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(LeftSidebarHostComponent);
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    const flexContainer = el.querySelector('.flex.flex-col');
+    expect(flexContainer?.classList.contains('md:flex-row-reverse')).toBe(true);
+  });
+
+  it('should use border-r instead of border-l for left sidebar', async () => {
+    await TestBed.configureTestingModule({
+      imports: [LeftSidebarHostComponent],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(LeftSidebarHostComponent);
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    const aside = el.querySelector('aside');
+    expect(aside?.classList.contains('md:border-r')).toBe(true);
+    expect(aside?.classList.contains('md:border-l')).toBe(false);
+  });
+
+  it('should apply custom sidebar width class', async () => {
+    await TestBed.configureTestingModule({
+      imports: [CustomWidthHostComponent],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(CustomWidthHostComponent);
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    const aside = el.querySelector('aside');
+    expect(aside?.classList.contains('md:w-80')).toBe(true);
+  });
+
+  it('should apply default w-72 sidebar width', async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(TestHostComponent);
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    const aside = el.querySelector('aside');
+    expect(aside?.classList.contains('md:w-72')).toBe(true);
+  });
+
+  it('should set host to full viewport height', async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(TestHostComponent);
+    fixture.detectChanges();
+
+    const hostEl = fixture.nativeElement.querySelector('example-chat-layout') as HTMLElement;
+    expect(hostEl).toBeTruthy();
+  });
+});

--- a/libs/example-layouts/src/lib/example-chat-layout.component.ts
+++ b/libs/example-layouts/src/lib/example-chat-layout.component.ts
@@ -1,0 +1,61 @@
+import { Component, computed, Input, signal } from '@angular/core';
+
+@Component({
+  selector: 'example-chat-layout',
+  standalone: true,
+  styles: `
+    :host {
+      display: flex;
+      flex-direction: column;
+      height: 100vh;
+      height: 100dvh;
+    }
+    aside:empty {
+      display: none;
+    }
+  `,
+  template: `
+    <div [class]="containerClasses()">
+      <div class="flex-1 min-w-0 min-h-0 flex flex-col">
+        <ng-content select="[main]" />
+      </div>
+      <aside [class]="sidebarClasses()">
+        <ng-content select="[sidebar]" />
+      </aside>
+    </div>
+  `,
+})
+export class ExampleChatLayoutComponent {
+  private readonly _sidebarPosition = signal<'left' | 'right'>('right');
+  private readonly _sidebarWidth = signal<string>('w-72');
+
+  @Input()
+  set sidebarPosition(value: 'left' | 'right') {
+    this._sidebarPosition.set(value);
+  }
+  get sidebarPosition(): 'left' | 'right' {
+    return this._sidebarPosition();
+  }
+
+  @Input()
+  set sidebarWidth(value: string) {
+    this._sidebarWidth.set(value);
+  }
+  get sidebarWidth(): string {
+    return this._sidebarWidth();
+  }
+
+  protected readonly containerClasses = computed(() => {
+    const base = 'flex flex-col md:flex-row flex-1 min-h-0';
+    return this._sidebarPosition() === 'left'
+      ? `${base} md:flex-row-reverse`
+      : base;
+  });
+
+  protected readonly sidebarClasses = computed(() => {
+    const width = this._sidebarWidth();
+    const position = this._sidebarPosition();
+    const borderClass = position === 'left' ? 'md:border-r' : 'md:border-l';
+    return `w-full md:${width} shrink-0 border-t md:border-t-0 ${borderClass} border-gray-800 overflow-y-auto`;
+  });
+}

--- a/libs/example-layouts/src/lib/example-chat-layout.component.ts
+++ b/libs/example-layouts/src/lib/example-chat-layout.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, Input, signal } from '@angular/core';
+import { Component, computed, input } from '@angular/core';
 
 /**
  * Responsive chat-style layout with a main content area and optional sidebar.
@@ -35,29 +35,19 @@ import { Component, computed, Input, signal } from '@angular/core';
   `,
 })
 export class ExampleChatLayoutComponent {
-  private readonly _sidebarPosition = signal<'left' | 'right'>('right');
-  private readonly _sidebarWidth = signal('w-72');
-
-  @Input()
-  set sidebarPosition(value: 'left' | 'right') {
-    this._sidebarPosition.set(value);
-  }
-
-  @Input()
-  set sidebarWidth(value: string) {
-    this._sidebarWidth.set(value);
-  }
+  readonly sidebarPosition = input<'left' | 'right'>('right');
+  readonly sidebarWidth = input('w-72');
 
   protected readonly containerClasses = computed(() => {
     const base = 'flex flex-col md:flex-row flex-1 min-h-0';
-    return this._sidebarPosition() === 'left'
+    return this.sidebarPosition() === 'left'
       ? `${base} md:flex-row-reverse`
       : base;
   });
 
   protected readonly sidebarClasses = computed(() => {
-    const width = this._sidebarWidth();
-    const position = this._sidebarPosition();
+    const width = this.sidebarWidth();
+    const position = this.sidebarPosition();
     const borderClass = position === 'left' ? 'md:border-r' : 'md:border-l';
     return `w-full md:${width} shrink-0 border-t md:border-t-0 ${borderClass} border-gray-800 overflow-y-auto`;
   });

--- a/libs/example-layouts/src/lib/example-chat-layout.component.ts
+++ b/libs/example-layouts/src/lib/example-chat-layout.component.ts
@@ -1,5 +1,14 @@
 import { Component, computed, Input, signal } from '@angular/core';
 
+/**
+ * Responsive chat-style layout with a main content area and optional sidebar.
+ *
+ * Content projection slots:
+ * - `[main]` — primary content area (required)
+ * - `[sidebar]` — optional sidebar that stacks below on mobile, beside on desktop
+ *
+ * When no `[sidebar]` content is projected, the `<aside>` collapses via `:empty` CSS.
+ */
 @Component({
   selector: 'example-chat-layout',
   standalone: true,
@@ -27,22 +36,16 @@ import { Component, computed, Input, signal } from '@angular/core';
 })
 export class ExampleChatLayoutComponent {
   private readonly _sidebarPosition = signal<'left' | 'right'>('right');
-  private readonly _sidebarWidth = signal<string>('w-72');
+  private readonly _sidebarWidth = signal('w-72');
 
   @Input()
   set sidebarPosition(value: 'left' | 'right') {
     this._sidebarPosition.set(value);
   }
-  get sidebarPosition(): 'left' | 'right' {
-    return this._sidebarPosition();
-  }
 
   @Input()
   set sidebarWidth(value: string) {
     this._sidebarWidth.set(value);
-  }
-  get sidebarWidth(): string {
-    return this._sidebarWidth();
   }
 
   protected readonly containerClasses = computed(() => {

--- a/libs/example-layouts/src/lib/example-split-layout.component.spec.ts
+++ b/libs/example-layouts/src/lib/example-split-layout.component.spec.ts
@@ -1,0 +1,75 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { ExampleSplitLayoutComponent } from './example-split-layout.component';
+
+@Component({
+  standalone: true,
+  imports: [ExampleSplitLayoutComponent],
+  template: `
+    <example-split-layout>
+      <div header data-testid="header">Header</div>
+      <div primary data-testid="primary">Primary</div>
+      <div secondary data-testid="secondary">Secondary</div>
+      <div footer data-testid="footer">Footer</div>
+    </example-split-layout>
+  `,
+})
+class TestHostComponent {}
+
+describe('ExampleSplitLayoutComponent', () => {
+  it('should render all four content slots', async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(TestHostComponent);
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('[data-testid="header"]')?.textContent).toBe('Header');
+    expect(el.querySelector('[data-testid="primary"]')?.textContent).toBe('Primary');
+    expect(el.querySelector('[data-testid="secondary"]')?.textContent).toBe('Secondary');
+    expect(el.querySelector('[data-testid="footer"]')?.textContent).toBe('Footer');
+  });
+
+  it('should use responsive flex-col md:flex-row for split panes', async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(TestHostComponent);
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    const splitContainer = el.querySelector('.flex.flex-col.md\\:flex-row.flex-1.min-h-0');
+    expect(splitContainer).toBeTruthy();
+  });
+
+  it('should have header with bottom border', async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(TestHostComponent);
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    const headerContainer = el.querySelector('.shrink-0.border-b.border-gray-800');
+    expect(headerContainer).toBeTruthy();
+    expect(headerContainer?.querySelector('[data-testid="header"]')).toBeTruthy();
+  });
+
+  it('should have secondary pane with correct responsive classes', async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(TestHostComponent);
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    const secondary = el.querySelector('.w-full.md\\:w-80');
+    expect(secondary).toBeTruthy();
+    expect(secondary?.classList.contains('shrink-0')).toBe(true);
+  });
+});

--- a/libs/example-layouts/src/lib/example-split-layout.component.ts
+++ b/libs/example-layouts/src/lib/example-split-layout.component.ts
@@ -1,0 +1,35 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'example-split-layout',
+  standalone: true,
+  styles: `
+    :host {
+      display: flex;
+      flex-direction: column;
+      height: 100vh;
+      height: 100dvh;
+      background: rgb(3 7 18);
+      color: rgb(243 244 246);
+    }
+  `,
+  template: `
+    <div class="shrink-0 border-b border-gray-800">
+      <ng-content select="[header]" />
+    </div>
+
+    <div class="flex flex-col md:flex-row flex-1 min-h-0">
+      <div class="flex-1 overflow-y-auto p-4 md:p-6 min-h-[200px] md:min-h-0">
+        <ng-content select="[primary]" />
+      </div>
+      <div class="w-full md:w-80 shrink-0 flex flex-col border-t md:border-t-0 md:border-l border-gray-800 bg-gray-900/50">
+        <ng-content select="[secondary]" />
+      </div>
+    </div>
+
+    <div class="shrink-0">
+      <ng-content select="[footer]" />
+    </div>
+  `,
+})
+export class ExampleSplitLayoutComponent {}

--- a/libs/example-layouts/src/public-api.ts
+++ b/libs/example-layouts/src/public-api.ts
@@ -1,0 +1,2 @@
+export { ExampleChatLayoutComponent } from './lib/example-chat-layout.component';
+export { ExampleSplitLayoutComponent } from './lib/example-split-layout.component';

--- a/libs/example-layouts/src/test-setup.ts
+++ b/libs/example-layouts/src/test-setup.ts
@@ -1,0 +1,11 @@
+import { getTestBed } from '@angular/core/testing';
+import {
+  BrowserTestingModule,
+  platformBrowserTesting,
+} from '@angular/platform-browser/testing';
+
+getTestBed().initTestEnvironment(
+  BrowserTestingModule,
+  platformBrowserTesting(),
+  { teardown: { destroyAfterEach: true } },
+);

--- a/libs/example-layouts/tsconfig.json
+++ b/libs/example-layouts/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "module": "preserve",
+    "emitDeclarationOnly": false,
+    "composite": false,
+    "baseUrl": "."
+  },
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/example-layouts/tsconfig.lib.json
+++ b/libs/example-layouts/tsconfig.lib.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "lib": ["es2022", "dom"],
+    "types": []
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/example-layouts/tsconfig.lib.prod.json
+++ b/libs/example-layouts/tsconfig.lib.prod.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.lib.json",
+  "compilerOptions": {
+    "declarationMap": false
+  },
+  "angularCompilerOptions": {
+    "compilationMode": "partial"
+  }
+}

--- a/libs/example-layouts/tsconfig.spec.json
+++ b/libs/example-layouts/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": false,
+    "lib": ["es2022", "dom"],
+    "types": ["vitest/globals"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/libs/example-layouts/vite.config.mts
+++ b/libs/example-layouts/vite.config.mts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite';
+import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+
+export default defineConfig({
+  plugins: [nxViteTsPaths()],
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    include: ['src/**/*.spec.ts'],
+    setupFiles: ['src/test-setup.ts'],
+    passWithNoTests: true,
+  },
+});

--- a/libs/example-layouts/vite.config.mts
+++ b/libs/example-layouts/vite.config.mts
@@ -1,8 +1,9 @@
 import { defineConfig } from 'vite';
+import angular from '@analogjs/vite-plugin-angular';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
 
 export default defineConfig({
-  plugins: [nxViteTsPaths()],
+  plugins: [angular(), nxViteTsPaths()],
   test: {
     globals: true,
     environment: 'jsdom',

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "shiki": "^4.0.2"
       },
       "devDependencies": {
+        "@analogjs/vite-plugin-angular": "^2.4.4",
         "@angular-devkit/build-angular": "^21.2.6",
         "@angular-devkit/core": "~21.1.0",
         "@angular-devkit/schematics": "~21.1.0",
@@ -352,6 +353,33 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@analogjs/vite-plugin-angular": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@analogjs/vite-plugin-angular/-/vite-plugin-angular-2.4.4.tgz",
+      "integrity": "sha512-ql/97qdYzO1iN+gJBxvi1hzKPwQnvOHxV5geGSY5V/Oa89dpGKg4SCxtsqW7ohlVovZxvtmpIAaaUCPI58aF9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyglobby": "^0.2.14",
+        "ts-morph": "^21.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/brandonroberts"
+      },
+      "peerDependencies": {
+        "@angular-devkit/build-angular": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0",
+        "@angular/build": "^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@angular-devkit/build-angular": {
+          "optional": true
+        },
+        "@angular/build": {
+          "optional": true
+        }
       }
     },
     "node_modules/@angular-devkit/architect": {
@@ -18715,6 +18743,51 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@ts-morph/common": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.22.0.tgz",
+      "integrity": "sha512-HqNBuV/oIlMKdkLshXd1zKBqNQCsuPEsgQOkfFQ/eUKjRlwndXW1AjN9LVkBEIukm00gGXSRmfkl0Wv5VXLnlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-glob": "^3.3.2",
+        "minimatch": "^9.0.3",
+        "mkdirp": "^3.0.1",
+        "path-browserify": "^1.0.1"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@tufjs/canonical-json": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tufjs/canonical-json/-/canonical-json-2.0.0.tgz",
@@ -22408,6 +22481,13 @@
     "node_modules/cockpit": {
       "resolved": "apps/cockpit",
       "link": true
+    },
+    "node_modules/code-block-writer": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-12.0.0.tgz",
+      "integrity": "sha512-q4dMFMlXtKR3XNBHyMHt/3pwYNA69EDk00lloMOaaUMKPUXBw6lpXtbu3MMVG6/uOihGnRDOlkyqsONEUj60+w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/collapse-white-space": {
       "version": "2.1.0",
@@ -32476,6 +32556,13 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -37676,6 +37763,17 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/ts-morph": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-21.0.1.tgz",
+      "integrity": "sha512-dbDtVdEAncKctzrVZ+Nr7kHpHkv+0JDJb2MjjpBaj8bFeCkePU9rHfMklmhuLFnpeq/EJZk2IhStY6NzqgjOkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ts-morph/common": "~0.22.0",
+        "code-block-writer": "^12.0.0"
       }
     },
     "node_modules/tsconfig-paths": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "private": true,
   "devDependencies": {
+    "@analogjs/vite-plugin-angular": "^2.4.4",
     "@angular-devkit/build-angular": "^21.2.6",
     "@angular-devkit/core": "~21.1.0",
     "@angular-devkit/schematics": "~21.1.0",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -27,7 +27,8 @@
       "@cacheplane/render": ["libs/render/src/public-api.ts"],
       "@cacheplane/chat": ["libs/chat/src/public-api.ts"],
       "@cacheplane/partial-json": ["libs/partial-json/src/index.ts"],
-      "@cacheplane/a2ui": ["libs/a2ui/src/index.ts"]
+      "@cacheplane/a2ui": ["libs/a2ui/src/index.ts"],
+      "@cacheplane/example-layouts": ["libs/example-layouts/src/public-api.ts"]
     },
     "skipLibCheck": true,
     "strict": true,


### PR DESCRIPTION
## Summary
- New Nx Angular library `@cacheplane/example-layouts` with two standalone components: `ExampleChatLayoutComponent` (main + optional sidebar) and `ExampleSplitLayoutComponent` (header/primary/secondary/footer split panes)
- Migrated all 30 cockpit example apps (8 langgraph, 6 deep-agents, 10 chat, 6 render) to use the shared layouts
- All apps now have responsive mobile support — sidebars stack below on mobile (`flex-col md:flex-row`), no more fixed-width sidebars consuming 60-85% of a 375px screen

## Test Plan
- [ ] `npx nx test example-layouts` — 12 unit tests pass
- [ ] `npx nx run-many -t build --projects='cockpit-*-angular'` — all 30 apps build
- [ ] Chrome DevTools 375px: sidebar app (e.g. langgraph/memory) — sidebar stacks below
- [ ] Chrome DevTools 375px: left-sidebar app (chat/threads) — sidebar stacks below
- [ ] Chrome DevTools 375px: render app (render/spec-rendering) — panes stack vertically
- [ ] Chrome DevTools 375px: no-sidebar app (langgraph/streaming) — fills viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)