### PR TITLE
feat(website): wire whitepaper signup to Resend email pipeline + drip sequences

### DIFF
--- a/apps/website/lib/drip.ts
+++ b/apps/website/lib/drip.ts
@@ -1,7 +1,19 @@
 import { sendEmail, FROM } from './resend';
 import { dripWhitepaperFollowupHtml } from '../emails/drip-whitepaper-followup';
+import { dripAngularFollowupHtml } from '../emails/drip-angular-followup';
+import { dripRenderFollowupHtml } from '../emails/drip-render-followup';
+import { dripChatFollowupHtml } from '../emails/drip-chat-followup';
+
+export type PaperId = 'overview' | 'angular' | 'render' | 'chat';
 
 const DRIP_DAYS = [2, 5, 10, 20];
+
+const DRIP_GENERATORS: Record<PaperId, (day: number) => { subject: string; html: string }> = {
+  overview: dripWhitepaperFollowupHtml,
+  angular: dripAngularFollowupHtml,
+  render: dripRenderFollowupHtml,
+  chat: dripChatFollowupHtml,
+};
 
 function daysFromNow(days: number): string {
   const d = new Date();
@@ -11,10 +23,10 @@ function daysFromNow(days: number): string {
 }
 
 /** Schedule the whitepaper drip sequence for a contact. Best-effort. */
-export async function scheduleWhitepaperDrip(email: string) {
+export async function scheduleWhitepaperDrip(email: string, paper: PaperId = 'overview') {
+  const generator = DRIP_GENERATORS[paper] ?? DRIP_GENERATORS.overview;
   for (const day of DRIP_DAYS) {
-    const { subject, html } = dripWhitepaperFollowupHtml(day);
-    // Replace RECIPIENT placeholder with actual email for unsubscribe link
+    const { subject, html } = generator(day);
     const personalizedHtml = html.replace('email=RECIPIENT', `email=${encodeURIComponent(email)}`);
     try {
       await sendEmail({
@@ -25,7 +37,7 @@ export async function scheduleWhitepaperDrip(email: string) {
         scheduledAt: daysFromNow(day),
       });
     } catch (err) {
-      console.error(`[drip] Failed to schedule day-${day} email for ${email}:`, err);
+      console.error(`[drip] Failed to schedule day-${day} ${paper} email for ${email}:`, err);
     }
   }
 }

--- a/apps/website/public/assets/arch-diagram.svg
+++ b/apps/website/public/assets/arch-diagram.svg
@@ -25,18 +25,18 @@
   <line x1="270" y1="145" x2="330" y2="145" stroke="#6C8EFF" stroke-width="1.5" stroke-opacity="0.7"/>
   <polygon points="330,140 342,145 330,150" fill="#6C8EFF" opacity="0.7"/>
 
-  <!-- Box 2: streamResource() (x=342) -->
+  <!-- Box 2: agent() (x=342) -->
   <rect x="342" y="100" width="210" height="90" rx="6"
     fill="rgba(108,142,255,0.08)" stroke="rgba(108,142,255,0.45)" stroke-width="1.5"/>
   <text x="447" y="138" text-anchor="middle"
     font-family="'Courier New', monospace"
-    font-size="15" font-weight="700" fill="#6C8EFF">streamResource()</text>
+    font-size="15" font-weight="700" fill="#6C8EFF">agent()</text>
   <text x="447" y="158" text-anchor="middle"
     font-family="'Courier New', monospace"
-    font-size="11" fill="#4A527A">12 BehaviorSubjects</text>
+    font-size="11" fill="#4A527A">Signal-native state</text>
   <text x="447" y="175" text-anchor="middle"
     font-family="'Courier New', monospace"
-    font-size="11" fill="#4A527A">toSignal() at construction</text>
+    font-size="11" fill="#4A527A">@cacheplane/angular</text>
 
   <!-- Arrow 2 → 3 -->
   <line x1="552" y1="145" x2="612" y2="145" stroke="#6C8EFF" stroke-width="1.5" stroke-opacity="0.7"/>
@@ -79,14 +79,14 @@
     font-family="'Courier New', monospace"
     font-size="11" fill="#4A527A" opacity="0.8">SSE / stream events</text>
 
-  <!-- Return arrow: Bridge → streamResource (below) -->
+  <!-- Return arrow: Bridge → agent() (below) -->
   <line x1="624" y1="256" x2="470" y2="256" stroke="#6C8EFF" stroke-width="1" stroke-opacity="0.4" stroke-dasharray="5,4"/>
   <polygon points="470,251 458,256 470,261" fill="#6C8EFF" opacity="0.4"/>
   <text x="547" y="274" text-anchor="middle"
     font-family="'Courier New', monospace"
-    font-size="11" fill="#4A527A" opacity="0.8">BehaviorSubject.next()</text>
+    font-size="11" fill="#4A527A" opacity="0.8">Signal updates</text>
 
-  <!-- Return arrow: streamResource → Component (below) -->
+  <!-- Return arrow: agent() → Component (below) -->
   <line x1="342" y1="294" x2="188" y2="294" stroke="#6C8EFF" stroke-width="1" stroke-opacity="0.4" stroke-dasharray="5,4"/>
   <polygon points="188,289 176,294 188,299" fill="#6C8EFF" opacity="0.4"/>
   <text x="265" y="312" text-anchor="middle"
@@ -96,7 +96,7 @@
   <!-- Transport label (below bridge) -->
   <text x="729" y="340" text-anchor="middle"
     font-family="'Courier New', monospace"
-    font-size="11" fill="#4A527A" opacity="0.7">FetchStreamTransport | MockStreamTransport</text>
+    font-size="11" fill="#4A527A" opacity="0.7">FetchStreamTransport | MockAgentTransport</text>
 
   <!-- Bottom rule -->
   <line x1="60" y1="380" x2="1140" y2="380" stroke="#6C8EFF" stroke-width="1" stroke-opacity="0.12"/>

--- a/apps/website/public/assets/hero.svg
+++ b/apps/website/public/assets/hero.svg
@@ -4,7 +4,7 @@
   <!-- Decorative left rule -->
   <line x1="60" y1="80" x2="60" y2="220" stroke="#6C8EFF" stroke-width="1" stroke-opacity="0.35"/>
 
-  <!-- Wordmark: "stream-resource" -->
+  <!-- Wordmark -->
   <text
     x="88"
     y="182"
@@ -13,7 +13,7 @@
     font-weight="700"
     letter-spacing="-2"
     fill="#EEF1FF"
-  >stream-resource</text>
+  >cacheplane</text>
 
   <!-- Tagline -->
   <text
@@ -24,7 +24,7 @@
     font-style="italic"
     fill="#8B96C8"
     opacity="0.9"
-  >The Enterprise Agent Framework for LangChain and Angular</text>
+  >The Angular Agent Framework for LangGraph</text>
 
   <!-- Bottom horizontal rule -->
   <line x1="60" y1="252" x2="1140" y2="252" stroke="#6C8EFF" stroke-width="1" stroke-opacity="0.18"/>

--- a/apps/website/src/app/api/whitepaper-signup/route.ts
+++ b/apps/website/src/app/api/whitepaper-signup/route.ts
@@ -1,9 +1,31 @@
-// apps/website/src/app/api/whitepaper-signup/route.ts
 import { NextRequest, NextResponse } from 'next/server';
 import fs from 'fs';
 import path from 'path';
+import { sendEmail, FROM, addToAudience } from '../../../../lib/resend';
+import { loopsUpsertContact, loopsSendEvent } from '../../../../lib/loops';
+import { scheduleWhitepaperDrip, type PaperId } from '../../../../lib/drip';
+import { whitepaperDownloadHtml } from '../../../../emails/whitepaper-download';
+import { angularDownloadHtml } from '../../../../emails/angular-download';
+import { renderDownloadHtml } from '../../../../emails/render-download';
+import { chatDownloadHtml } from '../../../../emails/chat-download';
 
 const SIGNUPS_FILE = path.join(process.cwd(), 'data', 'whitepaper-signups.ndjson');
+
+const VALID_PAPERS: PaperId[] = ['overview', 'angular', 'render', 'chat'];
+
+const DOWNLOAD_EMAILS: Record<PaperId, (name?: string) => string> = {
+  overview: whitepaperDownloadHtml,
+  angular: angularDownloadHtml,
+  render: renderDownloadHtml,
+  chat: chatDownloadHtml,
+};
+
+const DOWNLOAD_SUBJECTS: Record<PaperId, string> = {
+  overview: 'Your Angular Agent Readiness Guide',
+  angular: 'Your Enterprise Guide to Agent Streaming',
+  render: 'Your Enterprise Guide to Generative UI',
+  chat: 'Your Enterprise Guide to Agent Chat Interfaces',
+};
 
 export async function POST(req: NextRequest) {
   let body: { name?: string; email?: string; paper?: string };
@@ -13,18 +35,40 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
   }
 
-  const { name = '', email = '', paper = 'overview' } = body;
+  const name = (body.name || '').trim().slice(0, 200);
+  const email = (body.email || '').trim().slice(0, 320);
+  const paper = (VALID_PAPERS.includes(body.paper as PaperId) ? body.paper : 'overview') as PaperId;
+
   if (!email || !email.includes('@')) {
     return NextResponse.json({ error: 'Valid email required' }, { status: 400 });
   }
 
-  const entry = JSON.stringify({ name: name.trim(), email: email.trim(), paper: paper.trim(), ts: new Date().toISOString() }) + '\n';
+  // Persist signup to NDJSON (always, even if email fails)
+  const entry = JSON.stringify({ name, email, paper, ts: new Date().toISOString() }) + '\n';
   try {
     fs.mkdirSync(path.dirname(SIGNUPS_FILE), { recursive: true });
     fs.appendFileSync(SIGNUPS_FILE, entry, 'utf8');
   } catch (err) {
     console.error('Failed to write signup:', err);
-    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  }
+
+  // Send download confirmation + schedule drip + sync contacts (best-effort)
+  try {
+    const downloadHtml = DOWNLOAD_EMAILS[paper](name || undefined);
+    await Promise.all([
+      sendEmail({
+        from: FROM,
+        to: email,
+        subject: DOWNLOAD_SUBJECTS[paper],
+        html: downloadHtml,
+      }),
+      scheduleWhitepaperDrip(email, paper),
+      addToAudience(email, name || undefined),
+      loopsUpsertContact({ email, firstName: name || undefined, source: `whitepaper-${paper}` }),
+      loopsSendEvent({ email, eventName: 'whitepaper_downloaded', properties: { paper } }),
+    ]);
+  } catch (err) {
+    console.error('[whitepaper-signup] email pipeline failed:', err);
   }
 
   return NextResponse.json({ ok: true });


### PR DESCRIPTION
## Summary

- Wire `/api/whitepaper-signup` route to the existing Resend email infrastructure (was only writing to NDJSON, never sending emails)
- Send library-specific download confirmation email on signup
- Schedule 4-email drip sequence (days 2, 5, 10, 20) via Resend's `scheduledAt`
- Add contact to Resend audience + sync to Loops with `whitepaper_downloaded` event
- Extend `drip.ts` to support all 4 paper types (overview, angular, render, chat)

## What was broken

The whitepaper signup route collected emails but never sent anything. The download confirmation templates, drip templates, and `scheduleWhitepaperDrip()` function all existed but were never called. The newsletter and leads routes were fully wired — this one was missed.

## Test plan

- [x] `nx lint website` — 0 errors, 0 warnings
- [x] `nx build website` — success
- [ ] CI green
- [ ] Manual test: submit whitepaper form, verify Resend dashboard shows scheduled emails

🤖 Generated with [Claude Code](https://claude.com/claude-code)