### PR TITLE
feat(website): update render & chat landing pages with A2UI specifics

### DIFF
--- a/apps/website/src/components/landing/chat-landing/ChatLandingComparison.tsx
+++ b/apps/website/src/components/landing/chat-landing/ChatLandingComparison.tsx
@@ -9,8 +9,8 @@ const ROWS = [
   { capability: 'Input handling', theirs: 'Sprint 2', ours: 'Included' },
   { capability: 'Accessibility (WCAG)', theirs: 'Sprint 2-3', ours: 'Included' },
   { capability: 'Theming / design system', theirs: 'Sprint 3', ours: 'Included (CSS custom properties)' },
-  { capability: 'Generative UI (json-render)', theirs: 'Sprint 4+', ours: 'Included (via @cacheplane/render)' },
-  { capability: 'Google A2UI spec', theirs: 'Sprint 5+', ours: 'Included' },
+  { capability: 'Generative UI (json-render)', theirs: 'Sprint 4+', ours: 'Included — Vercel json-render spec' },
+  { capability: 'Google A2UI spec', theirs: 'Sprint 5+', ours: '18 components, v0.9 validation, extensible handlers' },
   { capability: 'Debug tooling', theirs: 'Often never', ours: 'Included' },
   { capability: 'Time to production', theirs: '4-6 weeks', ours: 'Days' },
 ];

--- a/apps/website/src/components/landing/chat-landing/ChatLandingFeaturesGrid.tsx
+++ b/apps/website/src/components/landing/chat-landing/ChatLandingFeaturesGrid.tsx
@@ -6,7 +6,7 @@ import { tokens } from '@cacheplane/design-tokens';
 const FEATURES = [
   { title: 'Messages', desc: 'Streaming message display with token-by-token rendering. Markdown support, auto-scroll, and accessible message list.', iframePath: 'chat/core-capabilities/messages/overview/python' },
   { title: 'Input', desc: 'Chat input with send and interrupt controls. Keyboard shortcuts, disabled state during streaming, accessible labels.', iframePath: 'chat/core-capabilities/input/overview/python' },
-  { title: 'Generative UI', desc: 'Inline spec rendering in conversation. json-render and Google A2UI specs render as native Angular components within the chat.', iframePath: 'chat/core-capabilities/generative-ui/overview/python' },
+  { title: 'Generative UI', desc: 'Inline spec rendering in conversation. Vercel json-render specs and Google A2UI surfaces render as native Angular components — 18 built-in A2UI components, v0.9 CheckRule validation, and consumer-extensible action handlers.', iframePath: 'chat/core-capabilities/generative-ui/overview/python' },
   { title: 'Theming', desc: 'CSS custom property theming that integrates with your design system. Swap colors, fonts, spacing without touching component code.', iframePath: 'chat/core-capabilities/theming/overview/python' },
   { title: 'Debug', desc: 'Agent state inspector for development. View messages, tool calls, interrupts, and streaming state in real time.', iframePath: 'chat/core-capabilities/debug/overview/python' },
 ];

--- a/apps/website/src/components/landing/chat-landing/ChatLandingProblemSolution.tsx
+++ b/apps/website/src/components/landing/chat-landing/ChatLandingProblemSolution.tsx
@@ -14,10 +14,10 @@ const PAIN_POINTS = [
 
 const SOLUTIONS = [
   'Pre-built accessible components',
-  'json-render spec support via @cacheplane/render',
-  'Google A2UI spec support out of the box',
-  'Debug tooling included',
-  'CSS custom property theming',
+  'Vercel json-render spec via @cacheplane/render',
+  'Google A2UI spec — 18 built-in components, v0.9 CheckRule validation',
+  'Consumer-extensible action handlers for both specs',
+  'Debug tooling + CSS custom property theming included',
   'Every feature ships together — not incrementally',
 ];
 

--- a/apps/website/src/components/landing/render/RenderComparison.tsx
+++ b/apps/website/src/components/landing/render/RenderComparison.tsx
@@ -10,7 +10,8 @@ const ROWS = [
   { capability: 'Testing specs', theirs: 'Integration tests only', ours: 'Unit test specs in isolation' },
   { capability: 'Frontend/agent coupling', theirs: 'Tight — changes break both', ours: 'Decoupled via spec contract' },
   { capability: 'Iteration speed', theirs: 'Days per change', ours: 'Minutes per change' },
-  { capability: 'Open standard', theirs: 'Proprietary format', ours: 'Vercel json-render spec' },
+  { capability: 'Open standards', theirs: 'Proprietary format', ours: 'Vercel json-render + Google A2UI' },
+  { capability: 'A2UI components', theirs: 'Build from scratch', ours: '18 built-in, extensible catalog' },
 ];
 
 export function RenderComparison() {

--- a/apps/website/src/components/landing/render/RenderHero.tsx
+++ b/apps/website/src/components/landing/render/RenderHero.tsx
@@ -3,7 +3,7 @@
 import { motion } from 'framer-motion';
 import { tokens } from '@cacheplane/design-tokens';
 
-const BADGES = ['Angular 20+', 'Vercel json-render', 'JSON Patch streaming'];
+const BADGES = ['Angular 20+', 'Vercel json-render', 'Google A2UI', 'JSON Patch streaming'];
 
 export function RenderHero() {
   return (
@@ -31,7 +31,7 @@ export function RenderHero() {
             fontFamily: 'Inter, sans-serif', fontSize: 18, color: tokens.colors.textSecondary,
             maxWidth: '52ch', margin: '0 auto', lineHeight: 1.6, marginBottom: '2rem',
           }}>
-          Built on Vercel's json-render spec — an open standard you already trust. @cacheplane/render brings it to Angular with streaming JSON patches, component registries, and signal-native state.
+          Built on Vercel's json-render spec and Google's A2UI protocol — open standards you already trust. @cacheplane/render brings both to Angular with streaming JSON patches, component registries, and signal-native state.
         </motion.p>
 
         <motion.div initial={{ y: 14 }} animate={{ y: 0 }} transition={{ duration: 0.6, delay: 0.15 }}

--- a/apps/website/src/components/landing/render/RenderProblemSolution.tsx
+++ b/apps/website/src/components/landing/render/RenderProblemSolution.tsx
@@ -12,12 +12,12 @@ const PAIN_POINTS = [
 ];
 
 const SOLUTIONS = [
-  'Declarative UI specs via json-render standard',
-  'Hot-swappable component registry',
+  'Declarative UI specs — Vercel json-render + Google A2UI',
+  'Hot-swappable component registry with extensible handlers',
   'No frontend deploy for new capabilities',
   'Progressive JSON patch streaming',
-  'Signal-native state management',
-  'Vercel-backed open standard',
+  '18 built-in A2UI components with v0.9 CheckRule validation',
+  'Two open standards, one rendering engine',
 ];
 
 export function RenderProblemSolution() {


### PR DESCRIPTION
## Summary

- **Render page**: Add Google A2UI badge, update subheadline to reference both json-render + A2UI specs, add A2UI components row to comparison table, update solutions with 18 built-in components and v0.9 CheckRule validation
- **Chat page**: Detail 18 built-in A2UI components, v0.9 CheckRule validation, and consumer-extensible action handlers in features grid, comparison table, and problem/solution section

Reflects the A2UI work shipped in PRs #93, #94, #97.

## Test plan

- [x] `nx build website` — success
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)