### PR TITLE
fix(chat): wrap content classifier in untracked() to fix NG0600 streaming crash

### DIFF
--- a/libs/agent/src/lib/internals/stream-manager.bridge.spec.ts
+++ b/libs/agent/src/lib/internals/stream-manager.bridge.spec.ts
@@ -139,6 +139,88 @@ describe('createStreamManagerBridge', () => {
     }
   );
 
+  it.each(['messages/partial', 'messages/complete'] as const)(
+    'filters metadata from normalized SDK %s events (messages array path)',
+    async (type) => {
+      const transport = new MockAgentTransport();
+      const subjects = makeSubjects();
+      const destroy$ = new Subject<void>();
+      const bridge = createStreamManagerBridge({
+        options: { apiUrl: '', assistantId: 'test', transport },
+        subjects,
+        threadId$: of(null),
+        destroy$: destroy$.asObservable(),
+      });
+
+      bridge.submit({});
+      // Simulate post-normalizeSdkEvent shape: messages array includes metadata
+      // This is what FetchStreamTransport produces in production
+      transport.emit([{
+        type,
+        messages: [
+          { id: 'ai-1', type: 'ai', content: 'Hello' },
+          { langgraph_node: 'chatbot', langgraph_triggers: ['start:chatbot'] },
+        ],
+        data: [
+          { id: 'ai-1', type: 'ai', content: 'Hello' },
+          { langgraph_node: 'chatbot', langgraph_triggers: ['start:chatbot'] },
+        ],
+      } as any]);
+      transport.close();
+
+      await new Promise(r => setTimeout(r, 10));
+
+      // Only the real message should be in messages$, not the metadata
+      expect(subjects.messages$.value).toHaveLength(1);
+      expect(subjects.messages$.value[0]).toMatchObject({ id: 'ai-1', content: 'Hello' });
+      destroy$.next();
+    }
+  );
+
+  it('does not accumulate metadata across multiple messages/partial events', async () => {
+    const transport = new MockAgentTransport();
+    const subjects = makeSubjects();
+    const destroy$ = new Subject<void>();
+    const bridge = createStreamManagerBridge({
+      options: { apiUrl: '', assistantId: 'test', transport },
+      subjects,
+      threadId$: of(null),
+      destroy$: destroy$.asObservable(),
+    });
+
+    bridge.submit({});
+
+    // First values event — sets up the human message
+    transport.emit([{
+      type: 'values',
+      values: { messages: [{ id: 'h-1', type: 'human', content: 'hi' }] },
+    } as any]);
+
+    // Simulate multiple messages/partial events (production SDK shape)
+    for (let i = 0; i < 5; i++) {
+      transport.emit([{
+        type: 'messages/partial',
+        messages: [
+          { id: 'ai-1', type: 'ai', content: 'Hello'.slice(0, i + 1) },
+          { langgraph_node: 'chatbot' },
+        ],
+        data: [
+          { id: 'ai-1', type: 'ai', content: 'Hello'.slice(0, i + 1) },
+          { langgraph_node: 'chatbot' },
+        ],
+      } as any]);
+    }
+
+    transport.close();
+    await new Promise(r => setTimeout(r, 10));
+
+    // Should only have human + AI messages, no accumulated metadata
+    expect(subjects.messages$.value).toHaveLength(2);
+    expect(subjects.messages$.value[0]).toMatchObject({ id: 'h-1', content: 'hi' });
+    expect(subjects.messages$.value[1]).toMatchObject({ id: 'ai-1', content: 'Hello' });
+    destroy$.next();
+  });
+
   it('ignores late events from the previous stream after threadId changes', async () => {
     const transport = new MockAgentTransport();
     const subjects = makeSubjects();

--- a/libs/agent/src/lib/internals/stream-manager.bridge.ts
+++ b/libs/agent/src/lib/internals/stream-manager.bridge.ts
@@ -255,7 +255,10 @@ function isMessagesEvent(type: StreamEvent['type']): boolean {
 function normalizeMessages(event: StreamEvent): unknown[] | null {
   const directMessages = event['messages'];
   if (Array.isArray(directMessages)) {
-    return directMessages;
+    // Filter out non-message metadata objects (e.g. { langgraph_node, langgraph_triggers })
+    // that the LangGraph SDK includes alongside real messages in messages/* events.
+    const filtered = directMessages.filter(isMessageLike);
+    return filtered.length > 0 ? filtered : null;
   }
 
   const data = event['data'];

--- a/libs/chat/src/lib/streaming/content-classifier.ts
+++ b/libs/chat/src/lib/streaming/content-classifier.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
-import { signal, type Signal } from '@angular/core';
+import { signal, untracked, type Signal } from '@angular/core';
 import type { Spec } from '@json-render/core';
 import { createPartialJsonParser } from '@cacheplane/partial-json';
 import { createParseTreeStore, type ElementAccumulationState, type ParseTreeStore } from './parse-tree-store';
@@ -98,82 +98,88 @@ export function createContentClassifier(): ContentClassifier {
   }
 
   function update(content: string): void {
-    const currentType = typeSignal();
+    // Wrap in untracked() because this is called during template rendering
+    // (via classifyMessage in ChatComponent's AI message template). Angular's
+    // NG0600 forbids writing signals during change detection; untracked()
+    // opts out of the reactive graph for this imperative push-based update.
+    untracked(() => {
+      const currentType = typeSignal();
 
-    if (currentType === 'undetermined') {
-      const detected = detectType(content);
-      if (detected === 'undetermined') return;
+      if (currentType === 'undetermined') {
+        const detected = detectType(content);
+        if (detected === 'undetermined') return;
 
-      typeSignal.set(detected);
+        typeSignal.set(detected);
 
-      if (detected === 'markdown') {
+        if (detected === 'markdown') {
+          markdownSignal.set(content);
+          processedLength = content.length;
+        } else if (detected === 'json-render') {
+          streamingSignal.set(true);
+          // Find where JSON starts (skip whitespace)
+          jsonStartIndex = 0;
+          for (let i = 0; i < content.length; i++) {
+            if (content[i] !== ' ' && content[i] !== '\t' && content[i] !== '\n' && content[i] !== '\r') {
+              jsonStartIndex = i;
+              break;
+            }
+          }
+          const jsonContent = content.slice(jsonStartIndex);
+          try {
+            initJsonStore(jsonContent);
+          } catch (err) {
+            errorsSignal.update(prev => [...prev, err instanceof Error ? err.message : String(err)]);
+          }
+          processedLength = content.length;
+        } else if (detected === 'a2ui') {
+          streamingSignal.set(true);
+          a2uiParser = createA2uiMessageParser();
+          a2uiStore = createA2uiSurfaceStore();
+          jsonStartIndex = content.indexOf(A2UI_PREFIX) + A2UI_PREFIX.length;
+          const a2uiContent = content.slice(jsonStartIndex);
+          if (a2uiContent.length > 0) {
+            try {
+              const msgs = a2uiParser.push(a2uiContent);
+              for (const msg of msgs) a2uiStore.apply(msg);
+              a2uiSurfacesSignal.set(a2uiStore.surfaces());
+            } catch (err) {
+              errorsSignal.update(prev => [...prev, err instanceof Error ? err.message : String(err)]);
+            }
+          }
+          processedLength = content.length;
+        }
+        return;
+      }
+
+      // Compute delta
+      const delta = content.slice(processedLength);
+      processedLength = content.length;
+
+      if (delta.length === 0) return;
+
+      if (currentType === 'markdown' || currentType === 'mixed') {
         markdownSignal.set(content);
-        processedLength = content.length;
-      } else if (detected === 'json-render') {
-        streamingSignal.set(true);
-        // Find where JSON starts (skip whitespace)
-        jsonStartIndex = 0;
-        for (let i = 0; i < content.length; i++) {
-          if (content[i] !== ' ' && content[i] !== '\t' && content[i] !== '\n' && content[i] !== '\r') {
-            jsonStartIndex = i;
-            break;
+      } else if (currentType === 'json-render') {
+        if (store) {
+          try {
+            store.push(delta);
+            syncJsonSignals();
+          } catch (err) {
+            errorsSignal.update(prev => [...prev, err instanceof Error ? err.message : String(err)]);
           }
         }
-        const jsonContent = content.slice(jsonStartIndex);
-        try {
-          initJsonStore(jsonContent);
-        } catch (err) {
-          errorsSignal.update(prev => [...prev, err instanceof Error ? err.message : String(err)]);
-        }
-        processedLength = content.length;
-      } else if (detected === 'a2ui') {
-        streamingSignal.set(true);
-        a2uiParser = createA2uiMessageParser();
-        a2uiStore = createA2uiSurfaceStore();
-        jsonStartIndex = content.indexOf(A2UI_PREFIX) + A2UI_PREFIX.length;
-        const a2uiContent = content.slice(jsonStartIndex);
-        if (a2uiContent.length > 0) {
+      } else if (currentType === 'a2ui') {
+        if (a2uiParser && a2uiStore) {
           try {
-            const msgs = a2uiParser.push(a2uiContent);
+            const msgs = a2uiParser.push(delta);
             for (const msg of msgs) a2uiStore.apply(msg);
             a2uiSurfacesSignal.set(a2uiStore.surfaces());
           } catch (err) {
             errorsSignal.update(prev => [...prev, err instanceof Error ? err.message : String(err)]);
           }
         }
-        processedLength = content.length;
       }
-      return;
-    }
-
-    // Compute delta
-    const delta = content.slice(processedLength);
-    processedLength = content.length;
-
-    if (delta.length === 0) return;
-
-    if (currentType === 'markdown' || currentType === 'mixed') {
-      markdownSignal.set(content);
-    } else if (currentType === 'json-render') {
-      if (store) {
-        try {
-          store.push(delta);
-          syncJsonSignals();
-        } catch (err) {
-          errorsSignal.update(prev => [...prev, err instanceof Error ? err.message : String(err)]);
-        }
-      }
-    } else if (currentType === 'a2ui') {
-      if (a2uiParser && a2uiStore) {
-        try {
-          const msgs = a2uiParser.push(delta);
-          for (const msg of msgs) a2uiStore.apply(msg);
-          a2uiSurfacesSignal.set(a2uiStore.surfaces());
-        } catch (err) {
-          errorsSignal.update(prev => [...prev, err instanceof Error ? err.message : String(err)]);
-        }
-      }
-    }
+    });
   }
 
   function dispose(): void {


### PR DESCRIPTION
## Summary
- **Bug:** `classifyMessage()` is called during Angular template rendering (via `@let classified = classifyMessage(content, index)` in the AI message template). The classifier's `update()` method writes to signals (`typeSignal.set()`, `markdownSignal.set()`, etc.), which Angular 21's stricter signal write guards flag as **NG0600** — writing signals during change detection is forbidden. This crashes the entire streaming render loop, causing the "flicker then nothing" behavior.
- **Fix:** Wrap `update()` body in `untracked()` to opt out of the reactive graph for this imperative push-based API. The template reads the classifier's signals *after* the update call returns, so reactivity is preserved.
- **Verified:** Multi-turn streaming conversation against production LangGraph backend — markdown renders correctly, streaming works, zero console errors.

## Context
This is the **actual root cause** of the streaming chat being broken. PR #102 (metadata filtering) was a contributing issue but the NG0600 signal write error was the primary crash preventing any content from rendering.

## Test plan
- [x] `nx test chat` — 175/175 pass
- [x] Multi-turn conversation in Chrome with real LangGraph backend — streaming, markdown rendering, and error-free console verified via screenshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)