### PR TITLE
feat(chat): eliminate streaming jank with append-only markdown and frame-synced pipeline

### DIFF
--- a/libs/agent/src/lib/agent.fn.spec.ts
+++ b/libs/agent/src/lib/agent.fn.spec.ts
@@ -147,7 +147,7 @@ describe('agent', () => {
     expect(ref.messages()).toHaveLength(1);
 
     threadId.set('thread-2');
-    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 30));
 
     expect(ref.hasValue()).toBe(false);
     expect(ref.status()).toBe(ResourceStatus.Idle);

--- a/libs/agent/src/lib/agent.fn.ts
+++ b/libs/agent/src/lib/agent.fn.ts
@@ -123,8 +123,9 @@ export function agent<
     destroy$: destroy$.asObservable(),
   });
 
-  // Throttle helper
-  const ms = typeof options.throttle === 'number' ? options.throttle : 0;
+  // Throttle helper — default 16ms (~60fps) to batch SSE token updates into
+  // at most one signal update per frame, preventing change detection storms.
+  const ms = typeof options.throttle === 'number' ? options.throttle : 16;
   const maybeThrottle = <V>(obs: BehaviorSubject<V>) =>
     ms > 0
       ? obs.pipe(throttleTime(ms, asyncScheduler, { leading: true, trailing: true }))

--- a/libs/agent/src/lib/internals/stream-manager.bridge.spec.ts
+++ b/libs/agent/src/lib/internals/stream-manager.bridge.spec.ts
@@ -139,6 +139,88 @@ describe('createStreamManagerBridge', () => {
     }
   );
 
+  it.each(['messages/partial', 'messages/complete'] as const)(
+    'filters metadata from normalized SDK %s events (messages array path)',
+    async (type) => {
+      const transport = new MockAgentTransport();
+      const subjects = makeSubjects();
+      const destroy$ = new Subject<void>();
+      const bridge = createStreamManagerBridge({
+        options: { apiUrl: '', assistantId: 'test', transport },
+        subjects,
+        threadId$: of(null),
+        destroy$: destroy$.asObservable(),
+      });
+
+      bridge.submit({});
+      // Simulate post-normalizeSdkEvent shape: messages array includes metadata
+      // This is what FetchStreamTransport produces in production
+      transport.emit([{
+        type,
+        messages: [
+          { id: 'ai-1', type: 'ai', content: 'Hello' },
+          { langgraph_node: 'chatbot', langgraph_triggers: ['start:chatbot'] },
+        ],
+        data: [
+          { id: 'ai-1', type: 'ai', content: 'Hello' },
+          { langgraph_node: 'chatbot', langgraph_triggers: ['start:chatbot'] },
+        ],
+      } as any]);
+      transport.close();
+
+      await new Promise(r => setTimeout(r, 10));
+
+      // Only the real message should be in messages$, not the metadata
+      expect(subjects.messages$.value).toHaveLength(1);
+      expect(subjects.messages$.value[0]).toMatchObject({ id: 'ai-1', content: 'Hello' });
+      destroy$.next();
+    }
+  );
+
+  it('does not accumulate metadata across multiple messages/partial events', async () => {
+    const transport = new MockAgentTransport();
+    const subjects = makeSubjects();
+    const destroy$ = new Subject<void>();
+    const bridge = createStreamManagerBridge({
+      options: { apiUrl: '', assistantId: 'test', transport },
+      subjects,
+      threadId$: of(null),
+      destroy$: destroy$.asObservable(),
+    });
+
+    bridge.submit({});
+
+    // First values event — sets up the human message
+    transport.emit([{
+      type: 'values',
+      values: { messages: [{ id: 'h-1', type: 'human', content: 'hi' }] },
+    } as any]);
+
+    // Simulate multiple messages/partial events (production SDK shape)
+    for (let i = 0; i < 5; i++) {
+      transport.emit([{
+        type: 'messages/partial',
+        messages: [
+          { id: 'ai-1', type: 'ai', content: 'Hello'.slice(0, i + 1) },
+          { langgraph_node: 'chatbot' },
+        ],
+        data: [
+          { id: 'ai-1', type: 'ai', content: 'Hello'.slice(0, i + 1) },
+          { langgraph_node: 'chatbot' },
+        ],
+      } as any]);
+    }
+
+    transport.close();
+    await new Promise(r => setTimeout(r, 10));
+
+    // Should only have human + AI messages, no accumulated metadata
+    expect(subjects.messages$.value).toHaveLength(2);
+    expect(subjects.messages$.value[0]).toMatchObject({ id: 'h-1', content: 'hi' });
+    expect(subjects.messages$.value[1]).toMatchObject({ id: 'ai-1', content: 'Hello' });
+    destroy$.next();
+  });
+
   it('ignores late events from the previous stream after threadId changes', async () => {
     const transport = new MockAgentTransport();
     const subjects = makeSubjects();

--- a/libs/agent/src/lib/internals/stream-manager.bridge.ts
+++ b/libs/agent/src/lib/internals/stream-manager.bridge.ts
@@ -80,6 +80,14 @@ export function createStreamManagerBridge<T, ResolvedBag extends BagTemplate = B
     subjects.error$.next(undefined);
     lastPayload = payload;
 
+    // Optimistically inject human messages so they appear immediately
+    // without waiting for the server to echo them back.
+    const inputMessages = (payload as Record<string, unknown>)?.['messages'];
+    if (Array.isArray(inputMessages) && inputMessages.length > 0) {
+      const existing = subjects.messages$.value;
+      subjects.messages$.next([...existing, ...inputMessages as BaseMessage[]]);
+    }
+
     try {
       const iter = transport.stream(
         options.assistantId,

--- a/libs/agent/src/lib/internals/stream-manager.bridge.ts
+++ b/libs/agent/src/lib/internals/stream-manager.bridge.ts
@@ -255,7 +255,10 @@ function isMessagesEvent(type: StreamEvent['type']): boolean {
 function normalizeMessages(event: StreamEvent): unknown[] | null {
   const directMessages = event['messages'];
   if (Array.isArray(directMessages)) {
-    return directMessages;
+    // Filter out non-message metadata objects (e.g. { langgraph_node, langgraph_triggers })
+    // that the LangGraph SDK includes alongside real messages in messages/* events.
+    const filtered = directMessages.filter(isMessageLike);
+    return filtered.length > 0 ? filtered : null;
   }
 
   const data = event['data'];

--- a/libs/chat/src/lib/compositions/chat/chat.component.ts
+++ b/libs/chat/src/lib/compositions/chat/chat.component.ts
@@ -10,9 +10,7 @@ import {
   viewChild,
   ElementRef,
   ChangeDetectionStrategy,
-  inject,
 } from '@angular/core';
-import { DomSanitizer } from '@angular/platform-browser';
 import type { AgentRef } from '@cacheplane/angular';
 import type { ViewRegistry, RenderEvent } from '@cacheplane/render';
 import type { StateStore } from '@json-render/core';
@@ -28,7 +26,8 @@ import { toRenderRegistry } from '@cacheplane/render';
 import { createContentClassifier, type ContentClassifier } from '../../streaming/content-classifier';
 import { messageContent } from '../shared/message-utils';
 import { CHAT_THEME_STYLES } from '../../styles/chat-theme';
-import { CHAT_MARKDOWN_STYLES, renderMarkdown } from '../../styles/chat-markdown';
+import { CHAT_MARKDOWN_STYLES } from '../../styles/chat-markdown';
+import { ChatStreamingMdComponent } from '../../streaming/streaming-markdown.component';
 import { A2uiSurfaceComponent } from '../../a2ui/surface.component';
 import type { ChatRenderEvent } from './chat-render-event';
 import { KeyValuePipe } from '@angular/common';
@@ -45,6 +44,7 @@ import { KeyValuePipe } from '@angular/common';
     ChatInterruptComponent,
     ChatThreadListComponent,
     ChatGenerativeUiComponent,
+    ChatStreamingMdComponent,
     A2uiSurfaceComponent,
     KeyValuePipe,
   ],
@@ -129,11 +129,12 @@ import { KeyValuePipe } from '@angular/common';
                   >A</div>
                   <div class="flex-1 min-w-0 flex flex-col gap-2">
                     @if (classified.markdown(); as md) {
-                      <div
+                      <chat-streaming-md
                         class="chat-md break-words text-[length:var(--chat-font-size)] leading-[var(--chat-line-height)]"
                         style="color: var(--chat-text);"
-                        [innerHTML]="renderMd(md)"
-                      ></div>
+                        [content]="md"
+                        [streaming]="ref().isLoading()"
+                      />
                     }
 
                     @if (classified.spec(); as spec) {
@@ -214,7 +215,6 @@ import { KeyValuePipe } from '@angular/common';
   `,
 })
 export class ChatComponent {
-  private readonly sanitizer = inject(DomSanitizer);
 
   readonly ref = input.required<AgentRef<any, any>>();
   readonly views = input<ViewRegistry | undefined>(undefined);
@@ -251,7 +251,13 @@ export class ChatComponent {
     // - During streaming partials, only scroll if user is near bottom
     effect(() => {
       const count = this.messageCount();
-      this.ref().isLoading(); // track
+      // Track last message content to trigger scroll during streaming partials
+      const msgs = this.ref().messages();
+      const lastContent = msgs.length > 0
+        ? (msgs[msgs.length - 1] as unknown as Record<string, unknown>)['content']
+        : undefined;
+      void lastContent; // consume the tracked value
+
       const el = this.scrollContainer()?.nativeElement;
       if (!el) return;
 
@@ -282,10 +288,6 @@ export class ChatComponent {
       c.dispose();
     }
     this.classifiers.clear();
-  }
-
-  renderMd(content: string) {
-    return renderMarkdown(content, this.sanitizer);
   }
 
   onSpecEvent(event: RenderEvent, messageIndex: number): void {

--- a/libs/chat/src/lib/primitives/chat-typing-indicator/chat-typing-indicator.component.ts
+++ b/libs/chat/src/lib/primitives/chat-typing-indicator/chat-typing-indicator.component.ts
@@ -49,5 +49,14 @@ export function isTyping(ref: AgentRef<any, any>): boolean {
 })
 export class ChatTypingIndicatorComponent {
   readonly ref = input.required<AgentRef<any, any>>();
-  readonly visible = computed(() => this.ref().isLoading());
+  readonly visible = computed(() => {
+    if (!this.ref().isLoading()) return false;
+    const msgs = this.ref().messages();
+    if (msgs.length === 0) return true;
+    const last = msgs[msgs.length - 1];
+    const type = typeof last._getType === 'function'
+      ? last._getType()
+      : (last as unknown as Record<string, unknown>)['type'] as string;
+    return type !== 'ai';
+  });
 }

--- a/libs/chat/src/lib/streaming/content-classifier.ts
+++ b/libs/chat/src/lib/streaming/content-classifier.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
-import { signal, type Signal } from '@angular/core';
+import { signal, untracked, type Signal } from '@angular/core';
 import type { Spec } from '@json-render/core';
 import { createPartialJsonParser } from '@cacheplane/partial-json';
 import { createParseTreeStore, type ElementAccumulationState, type ParseTreeStore } from './parse-tree-store';
@@ -98,82 +98,88 @@ export function createContentClassifier(): ContentClassifier {
   }
 
   function update(content: string): void {
-    const currentType = typeSignal();
+    // Wrap in untracked() because this is called during template rendering
+    // (via classifyMessage in ChatComponent's AI message template). Angular's
+    // NG0600 forbids writing signals during change detection; untracked()
+    // opts out of the reactive graph for this imperative push-based update.
+    untracked(() => {
+      const currentType = typeSignal();
 
-    if (currentType === 'undetermined') {
-      const detected = detectType(content);
-      if (detected === 'undetermined') return;
+      if (currentType === 'undetermined') {
+        const detected = detectType(content);
+        if (detected === 'undetermined') return;
 
-      typeSignal.set(detected);
+        typeSignal.set(detected);
 
-      if (detected === 'markdown') {
+        if (detected === 'markdown') {
+          markdownSignal.set(content);
+          processedLength = content.length;
+        } else if (detected === 'json-render') {
+          streamingSignal.set(true);
+          // Find where JSON starts (skip whitespace)
+          jsonStartIndex = 0;
+          for (let i = 0; i < content.length; i++) {
+            if (content[i] !== ' ' && content[i] !== '\t' && content[i] !== '\n' && content[i] !== '\r') {
+              jsonStartIndex = i;
+              break;
+            }
+          }
+          const jsonContent = content.slice(jsonStartIndex);
+          try {
+            initJsonStore(jsonContent);
+          } catch (err) {
+            errorsSignal.update(prev => [...prev, err instanceof Error ? err.message : String(err)]);
+          }
+          processedLength = content.length;
+        } else if (detected === 'a2ui') {
+          streamingSignal.set(true);
+          a2uiParser = createA2uiMessageParser();
+          a2uiStore = createA2uiSurfaceStore();
+          jsonStartIndex = content.indexOf(A2UI_PREFIX) + A2UI_PREFIX.length;
+          const a2uiContent = content.slice(jsonStartIndex);
+          if (a2uiContent.length > 0) {
+            try {
+              const msgs = a2uiParser.push(a2uiContent);
+              for (const msg of msgs) a2uiStore.apply(msg);
+              a2uiSurfacesSignal.set(a2uiStore.surfaces());
+            } catch (err) {
+              errorsSignal.update(prev => [...prev, err instanceof Error ? err.message : String(err)]);
+            }
+          }
+          processedLength = content.length;
+        }
+        return;
+      }
+
+      // Compute delta
+      const delta = content.slice(processedLength);
+      processedLength = content.length;
+
+      if (delta.length === 0) return;
+
+      if (currentType === 'markdown' || currentType === 'mixed') {
         markdownSignal.set(content);
-        processedLength = content.length;
-      } else if (detected === 'json-render') {
-        streamingSignal.set(true);
-        // Find where JSON starts (skip whitespace)
-        jsonStartIndex = 0;
-        for (let i = 0; i < content.length; i++) {
-          if (content[i] !== ' ' && content[i] !== '\t' && content[i] !== '\n' && content[i] !== '\r') {
-            jsonStartIndex = i;
-            break;
+      } else if (currentType === 'json-render') {
+        if (store) {
+          try {
+            store.push(delta);
+            syncJsonSignals();
+          } catch (err) {
+            errorsSignal.update(prev => [...prev, err instanceof Error ? err.message : String(err)]);
           }
         }
-        const jsonContent = content.slice(jsonStartIndex);
-        try {
-          initJsonStore(jsonContent);
-        } catch (err) {
-          errorsSignal.update(prev => [...prev, err instanceof Error ? err.message : String(err)]);
-        }
-        processedLength = content.length;
-      } else if (detected === 'a2ui') {
-        streamingSignal.set(true);
-        a2uiParser = createA2uiMessageParser();
-        a2uiStore = createA2uiSurfaceStore();
-        jsonStartIndex = content.indexOf(A2UI_PREFIX) + A2UI_PREFIX.length;
-        const a2uiContent = content.slice(jsonStartIndex);
-        if (a2uiContent.length > 0) {
+      } else if (currentType === 'a2ui') {
+        if (a2uiParser && a2uiStore) {
           try {
-            const msgs = a2uiParser.push(a2uiContent);
+            const msgs = a2uiParser.push(delta);
             for (const msg of msgs) a2uiStore.apply(msg);
             a2uiSurfacesSignal.set(a2uiStore.surfaces());
           } catch (err) {
             errorsSignal.update(prev => [...prev, err instanceof Error ? err.message : String(err)]);
           }
         }
-        processedLength = content.length;
       }
-      return;
-    }
-
-    // Compute delta
-    const delta = content.slice(processedLength);
-    processedLength = content.length;
-
-    if (delta.length === 0) return;
-
-    if (currentType === 'markdown' || currentType === 'mixed') {
-      markdownSignal.set(content);
-    } else if (currentType === 'json-render') {
-      if (store) {
-        try {
-          store.push(delta);
-          syncJsonSignals();
-        } catch (err) {
-          errorsSignal.update(prev => [...prev, err instanceof Error ? err.message : String(err)]);
-        }
-      }
-    } else if (currentType === 'a2ui') {
-      if (a2uiParser && a2uiStore) {
-        try {
-          const msgs = a2uiParser.push(delta);
-          for (const msg of msgs) a2uiStore.apply(msg);
-          a2uiSurfacesSignal.set(a2uiStore.surfaces());
-        } catch (err) {
-          errorsSignal.update(prev => [...prev, err instanceof Error ? err.message : String(err)]);
-        }
-      }
-    }
+    });
   }
 
   function dispose(): void {

--- a/libs/chat/src/lib/streaming/streaming-markdown.component.ts
+++ b/libs/chat/src/lib/streaming/streaming-markdown.component.ts
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+import {
+  Component,
+  input,
+  effect,
+  ElementRef,
+  inject,
+  ChangeDetectionStrategy,
+  untracked,
+} from '@angular/core';
+import { DomSanitizer } from '@angular/platform-browser';
+import { createStreamingMarkdownRenderer, type StreamingMarkdownRenderer } from './streaming-markdown';
+import { renderMarkdownToString } from '../styles/chat-markdown';
+
+/**
+ * Renders markdown content using a streaming append-only DOM renderer
+ * during active streaming, then switches to a full marked.parse() render
+ * once the content stabilises (no new content for a frame).
+ *
+ * This eliminates the jank caused by full innerHTML replacement on every
+ * SSE token — the streaming renderer only appends new DOM nodes.
+ */
+@Component({
+  selector: 'chat-streaming-md',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: '',
+  styles: `:host { display: block; }`,
+})
+export class ChatStreamingMdComponent {
+  private readonly el = inject(ElementRef).nativeElement as HTMLElement;
+  private readonly sanitizer = inject(DomSanitizer);
+
+  /** Full markdown content (updated on every partial) */
+  readonly content = input.required<string>();
+  /** Whether the parent stream is still loading */
+  readonly streaming = input<boolean>(false);
+
+  private renderer: StreamingMarkdownRenderer | null = null;
+  private lastContent = '';
+  private finalised = false;
+
+  constructor() {
+    effect(() => {
+      const content = this.content();
+      const isStreaming = this.streaming();
+
+      untracked(() => this.render(content, isStreaming));
+    });
+  }
+
+  private render(content: string, isStreaming: boolean): void {
+    if (!content) return;
+
+    if (isStreaming) {
+      // Streaming mode: use append-only renderer with deltas
+      if (!this.renderer) {
+        this.renderer = createStreamingMarkdownRenderer();
+        this.el.textContent = '';
+        this.el.appendChild(this.renderer.container);
+        this.finalised = false;
+      }
+
+      // Compute delta from last known content
+      const delta = content.slice(this.lastContent.length);
+      this.lastContent = content;
+
+      if (delta) {
+        this.renderer.push(delta);
+      }
+    } else {
+      // Stream complete: do a single high-quality marked.parse() render
+      if (!this.finalised || content !== this.lastContent) {
+        this.lastContent = content;
+        this.finalised = true;
+        this.renderer = null;
+
+        this.el.innerHTML = renderMarkdownToString(content, this.sanitizer);
+      }
+    }
+  }
+}

--- a/libs/chat/src/lib/streaming/streaming-markdown.spec.ts
+++ b/libs/chat/src/lib/streaming/streaming-markdown.spec.ts
@@ -1,0 +1,405 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  createStreamingMarkdownRenderer,
+  type StreamingMarkdownRenderer,
+} from './streaming-markdown';
+
+describe('StreamingMarkdownRenderer', () => {
+  let renderer: StreamingMarkdownRenderer;
+
+  beforeEach(() => {
+    renderer = createStreamingMarkdownRenderer();
+  });
+
+  describe('container', () => {
+    it('should have class chat-md', () => {
+      expect(renderer.container.className).toBe('chat-md');
+    });
+
+    it('should be a div element', () => {
+      expect(renderer.container.tagName).toBe('DIV');
+    });
+  });
+
+  describe('plain text renders as paragraph', () => {
+    it('should wrap plain text in a <p> tag', () => {
+      renderer.push('Hello world');
+      renderer.finish();
+      const p = renderer.container.querySelector('p');
+      expect(p).not.toBeNull();
+      expect(p!.textContent).toBe('Hello world');
+    });
+
+    it('should create separate paragraphs for text separated by blank lines', () => {
+      renderer.push('First paragraph\n\nSecond paragraph');
+      renderer.finish();
+      const paragraphs = renderer.container.querySelectorAll('p');
+      expect(paragraphs).toHaveLength(2);
+      expect(paragraphs[0].textContent).toBe('First paragraph');
+      expect(paragraphs[1].textContent).toBe('Second paragraph');
+    });
+
+    it('should join consecutive non-blank lines in the same paragraph', () => {
+      renderer.push('Line one\nLine two');
+      renderer.finish();
+      const paragraphs = renderer.container.querySelectorAll('p');
+      expect(paragraphs).toHaveLength(1);
+      expect(paragraphs[0].textContent).toBe('Line one Line two');
+    });
+  });
+
+  describe('bold and italic inline formatting', () => {
+    it('should render **text** as <strong>', () => {
+      renderer.push('This is **bold** text');
+      renderer.finish();
+      const strong = renderer.container.querySelector('strong');
+      expect(strong).not.toBeNull();
+      expect(strong!.textContent).toBe('bold');
+    });
+
+    it('should render *text* as <em>', () => {
+      renderer.push('This is *italic* text');
+      renderer.finish();
+      const em = renderer.container.querySelector('em');
+      expect(em).not.toBeNull();
+      expect(em!.textContent).toBe('italic');
+    });
+
+    it('should handle bold and italic in the same line', () => {
+      renderer.push('**bold** and *italic*');
+      renderer.finish();
+      expect(renderer.container.querySelector('strong')!.textContent).toBe('bold');
+      expect(renderer.container.querySelector('em')!.textContent).toBe('italic');
+    });
+
+    it('should handle nested bold inside text', () => {
+      renderer.push('Start **middle** end');
+      renderer.finish();
+      const p = renderer.container.querySelector('p')!;
+      expect(p.innerHTML).toBe('Start <strong>middle</strong> end');
+    });
+  });
+
+  describe('headers (h1-h4)', () => {
+    it('should render # as h1', () => {
+      renderer.push('# Heading 1');
+      renderer.finish();
+      const h1 = renderer.container.querySelector('h1');
+      expect(h1).not.toBeNull();
+      expect(h1!.textContent).toBe('Heading 1');
+    });
+
+    it('should render ## as h2', () => {
+      renderer.push('## Heading 2');
+      renderer.finish();
+      const h2 = renderer.container.querySelector('h2');
+      expect(h2).not.toBeNull();
+      expect(h2!.textContent).toBe('Heading 2');
+    });
+
+    it('should render ### as h3', () => {
+      renderer.push('### Heading 3');
+      renderer.finish();
+      const h3 = renderer.container.querySelector('h3');
+      expect(h3).not.toBeNull();
+      expect(h3!.textContent).toBe('Heading 3');
+    });
+
+    it('should render #### as h4', () => {
+      renderer.push('#### Heading 4');
+      renderer.finish();
+      const h4 = renderer.container.querySelector('h4');
+      expect(h4).not.toBeNull();
+      expect(h4!.textContent).toBe('Heading 4');
+    });
+
+    it('should support inline formatting in headers', () => {
+      renderer.push('## A **bold** heading');
+      renderer.finish();
+      const h2 = renderer.container.querySelector('h2')!;
+      expect(h2.querySelector('strong')!.textContent).toBe('bold');
+    });
+  });
+
+  describe('unordered and ordered lists', () => {
+    it('should render - items as <ul><li>', () => {
+      renderer.push('- Item 1\n- Item 2\n- Item 3');
+      renderer.finish();
+      const ul = renderer.container.querySelector('ul');
+      expect(ul).not.toBeNull();
+      const items = ul!.querySelectorAll('li');
+      expect(items).toHaveLength(3);
+      expect(items[0].textContent).toBe('Item 1');
+      expect(items[1].textContent).toBe('Item 2');
+      expect(items[2].textContent).toBe('Item 3');
+    });
+
+    it('should render * items as <ul><li>', () => {
+      renderer.push('* Alpha\n* Beta');
+      renderer.finish();
+      const ul = renderer.container.querySelector('ul');
+      expect(ul).not.toBeNull();
+      expect(ul!.querySelectorAll('li')).toHaveLength(2);
+    });
+
+    it('should render numbered items as <ol><li>', () => {
+      renderer.push('1. First\n2. Second\n3. Third');
+      renderer.finish();
+      const ol = renderer.container.querySelector('ol');
+      expect(ol).not.toBeNull();
+      const items = ol!.querySelectorAll('li');
+      expect(items).toHaveLength(3);
+      expect(items[0].textContent).toBe('First');
+    });
+
+    it('should keep consecutive list items in one <ul>', () => {
+      renderer.push('- A\n- B\n- C');
+      renderer.finish();
+      const lists = renderer.container.querySelectorAll('ul');
+      expect(lists).toHaveLength(1);
+    });
+
+    it('should support inline formatting in list items', () => {
+      renderer.push('- **Bold item**\n- *Italic item*');
+      renderer.finish();
+      const items = renderer.container.querySelectorAll('li');
+      expect(items[0].querySelector('strong')!.textContent).toBe('Bold item');
+      expect(items[1].querySelector('em')!.textContent).toBe('Italic item');
+    });
+  });
+
+  describe('fenced code blocks', () => {
+    it('should buffer code blocks until closing fence', () => {
+      renderer.push('```\nconst x = 1;\nconst y = 2;\n```');
+      renderer.finish();
+      const pre = renderer.container.querySelector('pre');
+      expect(pre).not.toBeNull();
+      const code = pre!.querySelector('code');
+      expect(code).not.toBeNull();
+      expect(code!.textContent).toBe('const x = 1;\nconst y = 2;');
+    });
+
+    it('should set language class when specified', () => {
+      renderer.push('```typescript\nconst x: number = 1;\n```');
+      renderer.finish();
+      const code = renderer.container.querySelector('code');
+      expect(code!.className).toBe('language-typescript');
+    });
+
+    it('should not render code block content until fence is closed', () => {
+      renderer.push('```\nline 1\nline 2');
+      // No closing fence yet — code block should not appear
+      expect(renderer.container.querySelector('pre')).toBeNull();
+      renderer.push('\n```');
+      renderer.finish();
+      expect(renderer.container.querySelector('pre')).not.toBeNull();
+    });
+
+    it('should handle code blocks streamed character by character', () => {
+      const input = '```js\nalert("hi");\n```\n';
+      for (const ch of input) {
+        renderer.push(ch);
+      }
+      renderer.finish();
+      const code = renderer.container.querySelector('code');
+      expect(code).not.toBeNull();
+      expect(code!.textContent).toBe('alert("hi");');
+      expect(code!.className).toBe('language-js');
+    });
+  });
+
+  describe('mixed content (paragraph, list, paragraph)', () => {
+    it('should handle transitions between block types', () => {
+      renderer.push('Some intro text.\n\n- Item A\n- Item B\n\nClosing text.');
+      renderer.finish();
+
+      const children = renderer.container.children;
+      expect(children[0].tagName).toBe('P');
+      expect(children[0].textContent).toBe('Some intro text.');
+      expect(children[1].tagName).toBe('UL');
+      expect(children[1].querySelectorAll('li')).toHaveLength(2);
+      expect(children[2].tagName).toBe('P');
+      expect(children[2].textContent).toBe('Closing text.');
+    });
+
+    it('should handle heading followed by paragraph followed by list', () => {
+      renderer.push('# Title\n\nA paragraph.\n\n- One\n- Two');
+      renderer.finish();
+
+      const children = renderer.container.children;
+      expect(children[0].tagName).toBe('H1');
+      expect(children[1].tagName).toBe('P');
+      expect(children[2].tagName).toBe('UL');
+    });
+  });
+
+  describe('streaming simulation', () => {
+    it('should produce same output when pushed one char at a time vs all at once', () => {
+      const input = '# Hello\n\nThis is **bold** and *italic*.\n\n- Item 1\n- Item 2\n\n```js\nconst x = 1;\n```\n';
+
+      // Render all at once
+      const allAtOnce = createStreamingMarkdownRenderer();
+      allAtOnce.push(input);
+      allAtOnce.finish();
+
+      // Render one char at a time
+      const charByChar = createStreamingMarkdownRenderer();
+      for (const ch of input) {
+        charByChar.push(ch);
+      }
+      charByChar.finish();
+
+      expect(charByChar.container.innerHTML).toBe(allAtOnce.container.innerHTML);
+    });
+
+    it('should produce same output when pushed in random chunks', () => {
+      const input = '## Sub-heading\n\nSome text with `inline code` here.\n\n1. First\n2. Second\n';
+
+      const allAtOnce = createStreamingMarkdownRenderer();
+      allAtOnce.push(input);
+      allAtOnce.finish();
+
+      // Push in chunks of varying sizes
+      const chunked = createStreamingMarkdownRenderer();
+      let pos = 0;
+      const chunkSizes = [3, 7, 1, 12, 5, 2, 8, 4, 100];
+      for (const size of chunkSizes) {
+        if (pos >= input.length) break;
+        chunked.push(input.slice(pos, pos + size));
+        pos += size;
+      }
+      if (pos < input.length) {
+        chunked.push(input.slice(pos));
+      }
+      chunked.finish();
+
+      expect(chunked.container.innerHTML).toBe(allAtOnce.container.innerHTML);
+    });
+  });
+
+  describe('links render as anchor tags', () => {
+    it('should render [text](url) as <a>', () => {
+      renderer.push('Visit [Google](https://google.com) today');
+      renderer.finish();
+      const a = renderer.container.querySelector('a');
+      expect(a).not.toBeNull();
+      expect(a!.textContent).toBe('Google');
+      expect(a!.href).toBe('https://google.com/');
+    });
+
+    it('should handle multiple links in one line', () => {
+      renderer.push('[A](https://a.com) and [B](https://b.com)');
+      renderer.finish();
+      const links = renderer.container.querySelectorAll('a');
+      expect(links).toHaveLength(2);
+      expect(links[0].textContent).toBe('A');
+      expect(links[1].textContent).toBe('B');
+    });
+  });
+
+  describe('blockquotes', () => {
+    it('should render > text as <blockquote>', () => {
+      renderer.push('> This is a quote');
+      renderer.finish();
+      const bq = renderer.container.querySelector('blockquote');
+      expect(bq).not.toBeNull();
+      expect(bq!.textContent).toBe('This is a quote');
+    });
+
+    it('should group consecutive blockquote lines', () => {
+      renderer.push('> Line one\n> Line two');
+      renderer.finish();
+      const bqs = renderer.container.querySelectorAll('blockquote');
+      expect(bqs).toHaveLength(1);
+      const paragraphs = bqs[0].querySelectorAll('p');
+      expect(paragraphs).toHaveLength(2);
+    });
+
+    it('should support inline formatting inside blockquotes', () => {
+      renderer.push('> This is **important**');
+      renderer.finish();
+      const strong = renderer.container.querySelector('blockquote strong');
+      expect(strong).not.toBeNull();
+      expect(strong!.textContent).toBe('important');
+    });
+  });
+
+  describe('inline code', () => {
+    it('should render `text` as <code>', () => {
+      renderer.push('Use the `forEach` method');
+      renderer.finish();
+      const code = renderer.container.querySelector('code');
+      expect(code).not.toBeNull();
+      expect(code!.textContent).toBe('forEach');
+    });
+
+    it('should handle multiple inline code spans', () => {
+      renderer.push('`a` and `b` and `c`');
+      renderer.finish();
+      const codes = renderer.container.querySelectorAll('code');
+      expect(codes).toHaveLength(3);
+      expect(codes[0].textContent).toBe('a');
+      expect(codes[1].textContent).toBe('b');
+      expect(codes[2].textContent).toBe('c');
+    });
+  });
+
+  describe('tables', () => {
+    it('should render a simple table', () => {
+      renderer.push('| Name | Age |\n| --- | --- |\n| Alice | 30 |\n| Bob | 25 |');
+      renderer.finish();
+      const table = renderer.container.querySelector('table');
+      expect(table).not.toBeNull();
+      const ths = table!.querySelectorAll('th');
+      expect(ths).toHaveLength(2);
+      expect(ths[0].textContent).toBe('Name');
+      expect(ths[1].textContent).toBe('Age');
+      const tds = table!.querySelectorAll('td');
+      expect(tds).toHaveLength(4);
+      expect(tds[0].textContent).toBe('Alice');
+    });
+
+    it('should handle column alignment', () => {
+      renderer.push('| Left | Center | Right |\n| :--- | :---: | ---: |\n| a | b | c |');
+      renderer.finish();
+      const ths = renderer.container.querySelectorAll('th');
+      expect(ths[0].style.textAlign).toBe('left');
+      expect(ths[1].style.textAlign).toBe('center');
+      expect(ths[2].style.textAlign).toBe('right');
+    });
+  });
+
+  describe('reset', () => {
+    it('should clear the container and all state', () => {
+      renderer.push('# Hello\n\nSome text');
+      renderer.finish();
+      expect(renderer.container.children.length).toBeGreaterThan(0);
+
+      renderer.reset();
+      expect(renderer.container.children.length).toBe(0);
+      expect(renderer.container.innerHTML).toBe('');
+
+      // Should work correctly after reset
+      renderer.push('New content');
+      renderer.finish();
+      expect(renderer.container.querySelector('p')!.textContent).toBe('New content');
+    });
+  });
+
+  describe('finish', () => {
+    it('should flush buffered content without trailing newline', () => {
+      renderer.push('No trailing newline');
+      renderer.finish();
+      expect(renderer.container.querySelector('p')!.textContent).toBe('No trailing newline');
+    });
+
+    it('should close unclosed code blocks on finish', () => {
+      renderer.push('```\nunclosed code');
+      renderer.finish();
+      const pre = renderer.container.querySelector('pre');
+      expect(pre).not.toBeNull();
+      expect(pre!.querySelector('code')!.textContent).toBe('unclosed code');
+    });
+  });
+});

--- a/libs/chat/src/lib/streaming/streaming-markdown.ts
+++ b/libs/chat/src/lib/streaming/streaming-markdown.ts
@@ -1,0 +1,485 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+export interface StreamingMarkdownRenderer {
+  /** Push a text delta (not full content). Appends to the live DOM. */
+  push(delta: string): void;
+  /** Get the container element with all rendered content */
+  readonly container: HTMLElement;
+  /** Reset for a new message */
+  reset(): void;
+  /** Signal the stream is complete — flush any buffered content */
+  finish(): void;
+}
+
+// ---------------------------------------------------------------------------
+// Inline formatting parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse inline markdown formatting and append DOM nodes to the given parent.
+ * Handles: **bold**, *italic*, `code`, [text](url)
+ */
+function parseInline(text: string, parent: Node): void {
+  let i = 0;
+  let plainStart = i;
+
+  const flushPlain = (end: number): void => {
+    if (end > plainStart) {
+      parent.appendChild(document.createTextNode(text.slice(plainStart, end)));
+    }
+  };
+
+  while (i < text.length) {
+    // Bold **...**
+    if (text[i] === '*' && text[i + 1] === '*') {
+      const closeIdx = text.indexOf('**', i + 2);
+      if (closeIdx !== -1) {
+        flushPlain(i);
+        const strong = document.createElement('strong');
+        parseInline(text.slice(i + 2, closeIdx), strong);
+        parent.appendChild(strong);
+        i = closeIdx + 2;
+        plainStart = i;
+        continue;
+      }
+    }
+
+    // Italic *...*  (but not **)
+    if (text[i] === '*' && text[i + 1] !== '*') {
+      // Find closing * that is not part of **
+      let closeIdx = -1;
+      for (let j = i + 1; j < text.length; j++) {
+        if (text[j] === '*' && text[j + 1] !== '*' && (j === 0 || text[j - 1] !== '*')) {
+          closeIdx = j;
+          break;
+        }
+      }
+      if (closeIdx !== -1) {
+        flushPlain(i);
+        const em = document.createElement('em');
+        parseInline(text.slice(i + 1, closeIdx), em);
+        parent.appendChild(em);
+        i = closeIdx + 1;
+        plainStart = i;
+        continue;
+      }
+    }
+
+    // Inline code `...`
+    if (text[i] === '`') {
+      const closeIdx = text.indexOf('`', i + 1);
+      if (closeIdx !== -1) {
+        flushPlain(i);
+        const code = document.createElement('code');
+        code.textContent = text.slice(i + 1, closeIdx);
+        parent.appendChild(code);
+        i = closeIdx + 1;
+        plainStart = i;
+        continue;
+      }
+    }
+
+    // Link [text](url)
+    if (text[i] === '[') {
+      const closeBracket = text.indexOf(']', i + 1);
+      if (closeBracket !== -1 && text[closeBracket + 1] === '(') {
+        const closeParen = text.indexOf(')', closeBracket + 2);
+        if (closeParen !== -1) {
+          flushPlain(i);
+          const linkText = text.slice(i + 1, closeBracket);
+          const href = text.slice(closeBracket + 2, closeParen);
+          const a = document.createElement('a');
+          a.href = href;
+          parseInline(linkText, a);
+          parent.appendChild(a);
+          i = closeParen + 1;
+          plainStart = i;
+          continue;
+        }
+      }
+    }
+
+    i++;
+  }
+
+  flushPlain(i);
+}
+
+// ---------------------------------------------------------------------------
+// Table parsing
+// ---------------------------------------------------------------------------
+
+interface TableData {
+  headers: string[];
+  alignments: ('left' | 'center' | 'right' | null)[];
+  rows: string[][];
+}
+
+function parseTableLines(lines: string[]): TableData | null {
+  if (lines.length < 2) return null;
+
+  const parseCells = (line: string): string[] => {
+    let trimmed = line.trim();
+    if (trimmed.startsWith('|')) trimmed = trimmed.slice(1);
+    if (trimmed.endsWith('|')) trimmed = trimmed.slice(0, -1);
+    return trimmed.split('|').map((c) => c.trim());
+  };
+
+  const headers = parseCells(lines[0]);
+  const separatorCells = parseCells(lines[1]);
+
+  // Validate separator row (must contain only dashes, colons, spaces)
+  const isSeparator = separatorCells.every((cell) => /^:?-+:?$/.test(cell));
+  if (!isSeparator) return null;
+
+  const alignments = separatorCells.map((cell): 'left' | 'center' | 'right' | null => {
+    const left = cell.startsWith(':');
+    const right = cell.endsWith(':');
+    if (left && right) return 'center';
+    if (right) return 'right';
+    if (left) return 'left';
+    return null;
+  });
+
+  const rows = lines.slice(2).map(parseCells);
+
+  return { headers, alignments, rows };
+}
+
+function renderTable(data: TableData): HTMLTableElement {
+  const table = document.createElement('table');
+
+  const thead = document.createElement('thead');
+  const headerRow = document.createElement('tr');
+  for (let i = 0; i < data.headers.length; i++) {
+    const th = document.createElement('th');
+    if (data.alignments[i]) {
+      th.style.textAlign = data.alignments[i]!;
+    }
+    parseInline(data.headers[i], th);
+    headerRow.appendChild(th);
+  }
+  thead.appendChild(headerRow);
+  table.appendChild(thead);
+
+  if (data.rows.length > 0) {
+    const tbody = document.createElement('tbody');
+    for (const row of data.rows) {
+      const tr = document.createElement('tr');
+      for (let i = 0; i < row.length; i++) {
+        const td = document.createElement('td');
+        if (data.alignments[i]) {
+          td.style.textAlign = data.alignments[i]!;
+        }
+        parseInline(row[i], td);
+        tr.appendChild(td);
+      }
+      tbody.appendChild(tr);
+    }
+    table.appendChild(tbody);
+  }
+
+  return table;
+}
+
+// ---------------------------------------------------------------------------
+// Line type detection
+// ---------------------------------------------------------------------------
+
+type LineType =
+  | 'heading'
+  | 'ul'
+  | 'ol'
+  | 'blockquote'
+  | 'fence'
+  | 'table-row'
+  | 'blank'
+  | 'paragraph';
+
+function classifyLine(line: string): LineType {
+  if (line.trim() === '') return 'blank';
+  if (/^```/.test(line)) return 'fence';
+  if (/^#{1,4}\s/.test(line)) return 'heading';
+  if (/^[-*]\s/.test(line)) return 'ul';
+  if (/^\d+\.\s/.test(line)) return 'ol';
+  if (/^>\s?/.test(line)) return 'blockquote';
+  if (/^\|/.test(line)) return 'table-row';
+  return 'paragraph';
+}
+
+// ---------------------------------------------------------------------------
+// Streaming markdown renderer
+// ---------------------------------------------------------------------------
+
+export function createStreamingMarkdownRenderer(): StreamingMarkdownRenderer {
+  const container = document.createElement('div');
+  container.className = 'chat-md';
+
+  // Internal state
+  let buffer = '';
+  let inCodeBlock = false;
+  let codeBlockLang = '';
+  let codeBlockContent = '';
+
+  // Current open block-level element tracking
+  let currentParagraph: HTMLParagraphElement | null = null;
+  let currentList: HTMLUListElement | HTMLOListElement | null = null;
+  let currentListType: 'ul' | 'ol' | null = null;
+  let currentBlockquote: HTMLQuoteElement | null = null;
+
+  // Table buffering
+  let tableBuffer: string[] = [];
+  let inTable = false;
+
+  // ---------------------------------------------------------------------------
+  // Block-level element management
+  // ---------------------------------------------------------------------------
+
+  function closeParagraph(): void {
+    currentParagraph = null;
+  }
+
+  function closeList(): void {
+    currentList = null;
+    currentListType = null;
+  }
+
+  function closeBlockquote(): void {
+    currentBlockquote = null;
+  }
+
+  function flushTable(): void {
+    if (tableBuffer.length === 0) return;
+    const data = parseTableLines(tableBuffer);
+    if (data) {
+      container.appendChild(renderTable(data));
+    } else {
+      // Not a valid table — render lines as paragraphs
+      for (const line of tableBuffer) {
+        const p = document.createElement('p');
+        parseInline(line, p);
+        container.appendChild(p);
+      }
+    }
+    tableBuffer = [];
+    inTable = false;
+  }
+
+  function closeAllBlocks(): void {
+    closeParagraph();
+    closeList();
+    closeBlockquote();
+    if (inTable) flushTable();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Line processing
+  // ---------------------------------------------------------------------------
+
+  function processLine(line: string): void {
+    // Inside fenced code block — buffer until closing fence
+    if (inCodeBlock) {
+      if (/^```/.test(line)) {
+        // Close code block — render it
+        inCodeBlock = false;
+        const pre = document.createElement('pre');
+        const code = document.createElement('code');
+        if (codeBlockLang) {
+          code.className = `language-${codeBlockLang}`;
+        }
+        code.textContent = codeBlockContent;
+        pre.appendChild(code);
+        container.appendChild(pre);
+        codeBlockContent = '';
+        codeBlockLang = '';
+      } else {
+        codeBlockContent += (codeBlockContent ? '\n' : '') + line;
+      }
+      return;
+    }
+
+    const type = classifyLine(line);
+
+    // Table continuity: if we're in a table and get a non-table, non-blank line, flush
+    if (inTable && type !== 'table-row' && type !== 'blank') {
+      flushTable();
+    }
+
+    switch (type) {
+      case 'blank': {
+        if (inTable) {
+          flushTable();
+        }
+        closeAllBlocks();
+        break;
+      }
+
+      case 'fence': {
+        closeAllBlocks();
+        inCodeBlock = true;
+        const langMatch = line.match(/^```(\w*)/);
+        codeBlockLang = langMatch ? langMatch[1] : '';
+        break;
+      }
+
+      case 'heading': {
+        closeAllBlocks();
+        const match = line.match(/^(#{1,4})\s+(.*)/);
+        if (match) {
+          const level = match[1].length as 1 | 2 | 3 | 4;
+          const tag = `h${level}` as 'h1' | 'h2' | 'h3' | 'h4';
+          const heading = document.createElement(tag);
+          parseInline(match[2], heading);
+          container.appendChild(heading);
+        }
+        break;
+      }
+
+      case 'ul': {
+        closeParagraph();
+        closeBlockquote();
+        if (inTable) flushTable();
+
+        if (!currentList || currentListType !== 'ul') {
+          closeList();
+          currentList = document.createElement('ul');
+          currentListType = 'ul';
+          container.appendChild(currentList);
+        }
+        const li = document.createElement('li');
+        const content = line.replace(/^[-*]\s/, '');
+        parseInline(content, li);
+        currentList.appendChild(li);
+        break;
+      }
+
+      case 'ol': {
+        closeParagraph();
+        closeBlockquote();
+        if (inTable) flushTable();
+
+        if (!currentList || currentListType !== 'ol') {
+          closeList();
+          currentList = document.createElement('ol');
+          currentListType = 'ol';
+          container.appendChild(currentList);
+        }
+        const li = document.createElement('li');
+        const content = line.replace(/^\d+\.\s/, '');
+        parseInline(content, li);
+        currentList.appendChild(li);
+        break;
+      }
+
+      case 'blockquote': {
+        closeParagraph();
+        closeList();
+        if (inTable) flushTable();
+
+        if (!currentBlockquote) {
+          currentBlockquote = document.createElement('blockquote');
+          container.appendChild(currentBlockquote);
+        }
+        const content = line.replace(/^>\s?/, '');
+        const p = document.createElement('p');
+        parseInline(content, p);
+        currentBlockquote.appendChild(p);
+        break;
+      }
+
+      case 'table-row': {
+        closeParagraph();
+        closeList();
+        closeBlockquote();
+        inTable = true;
+        tableBuffer.push(line);
+        break;
+      }
+
+      case 'paragraph': {
+        closeList();
+        closeBlockquote();
+        if (inTable) flushTable();
+
+        if (!currentParagraph) {
+          currentParagraph = document.createElement('p');
+          container.appendChild(currentParagraph);
+        } else {
+          // Continuation of paragraph — add a space or newline
+          currentParagraph.appendChild(document.createTextNode(' '));
+        }
+        parseInline(line, currentParagraph);
+        break;
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  function push(delta: string): void {
+    buffer += delta;
+
+    // Process complete lines from the buffer
+    let newlineIdx: number;
+    while ((newlineIdx = buffer.indexOf('\n')) !== -1) {
+      const line = buffer.slice(0, newlineIdx);
+      buffer = buffer.slice(newlineIdx + 1);
+      processLine(line);
+    }
+  }
+
+  function finish(): void {
+    // Flush remaining buffer as a final line
+    if (buffer.length > 0) {
+      processLine(buffer);
+      buffer = '';
+    }
+
+    // Close any open code block
+    if (inCodeBlock) {
+      const pre = document.createElement('pre');
+      const code = document.createElement('code');
+      if (codeBlockLang) {
+        code.className = `language-${codeBlockLang}`;
+      }
+      code.textContent = codeBlockContent;
+      pre.appendChild(code);
+      container.appendChild(pre);
+      inCodeBlock = false;
+      codeBlockContent = '';
+      codeBlockLang = '';
+    }
+
+    // Flush table if buffered
+    if (inTable) {
+      flushTable();
+    }
+
+    closeAllBlocks();
+  }
+
+  function reset(): void {
+    container.innerHTML = '';
+    buffer = '';
+    inCodeBlock = false;
+    codeBlockLang = '';
+    codeBlockContent = '';
+    currentParagraph = null;
+    currentList = null;
+    currentListType = null;
+    currentBlockquote = null;
+    tableBuffer = [];
+    inTable = false;
+  }
+
+  return {
+    push,
+    get container() {
+      return container;
+    },
+    reset,
+    finish,
+  };
+}

--- a/libs/chat/src/lib/styles/chat-markdown.ts
+++ b/libs/chat/src/lib/styles/chat-markdown.ts
@@ -47,6 +47,18 @@ export function renderMarkdown(content: string, sanitizer: DomSanitizer): SafeHt
 }
 
 /**
+ * Renders markdown to a sanitized HTML string (not SafeHtml).
+ * Used by the streaming markdown component for direct innerHTML assignment.
+ */
+export function renderMarkdownToString(content: string, sanitizer: DomSanitizer): string {
+  if (markedParse) {
+    const html = markedParse(content);
+    return sanitizer.sanitize(SecurityContext.HTML, html) ?? '';
+  }
+  return plainTextToHtml(content);
+}
+
+/**
  * CSS for styling rendered markdown HTML.
  * Uses .chat-md class prefix to avoid global conflicts.
  * Must be included in a component with ViewEncapsulation.None or via ::ng-deep.


### PR DESCRIPTION
## Summary
Architectural fix for streaming chat jank. Five changes that address the root causes:

- **Streaming markdown renderer**: New append-only DOM renderer that processes text deltas incrementally — never uses innerHTML during streaming. Switches to `marked.parse()` for a polished final render once streaming completes. 38 new tests.
- **Frame-synced signal pipeline**: Default throttle changed from 0 to 16ms (~60fps), batching SSE token updates so change detection fires at most once per frame.
- **Typing indicator**: Now shows only during time-to-first-token, not the entire stream duration.
- **Optimistic human message**: Human bubble appears instantly on submit instead of waiting for server echo.
- **Auto-scroll**: Triggers on message content changes instead of loading state transitions.

## Before → After
- Every SSE token caused: `BehaviorSubject.next()` → `toSignal()` → change detection → `marked.parse(fullContent)` → `sanitize()` → full innerHTML replacement → DOM teardown/rebuild
- Now: tokens batch to ~60fps, streaming renderer only appends new DOM nodes, final render does one `marked.parse()` call

## Test plan
- [x] `nx test agent` — 35/35 pass
- [x] `nx test chat` — 214/214 pass (38 new streaming markdown tests)
- [x] Multi-turn streaming conversation in Chrome — bold, lists, code blocks, paragraphs all render correctly
- [x] Zero console errors (no NG0600, no SafeValue warnings)
- [x] Optimistic human message appears immediately
- [x] Typing indicator shows only before first AI token

🤖 Generated with [Claude Code](https://claude.com/claude-code)