### PR TITLE
fix(website): prevent mobile horizontal overflow on docs pages

### DIFF
--- a/apps/website/src/app/global.css
+++ b/apps/website/src/app/global.css
@@ -86,6 +86,8 @@ html {
 /* rehype-pretty-code — docs code blocks */
 .docs-prose [data-rehype-pretty-code-figure] {
   margin: 1.5rem 0;
+  max-width: 100%;
+  overflow: hidden;
 }
 
 .docs-prose [data-rehype-pretty-code-figure] pre {
@@ -135,7 +137,8 @@ html {
   font-weight: 400;
 }
 
-.docs-prose { overflow-wrap: break-word; word-break: break-word; }
+.docs-prose { overflow-wrap: break-word; word-break: break-word; max-width: 100%; }
+.docs-prose > * { max-width: 100%; }
 .docs-prose h1 { font-size: 1.875rem; font-weight: 700; margin-top: 0; margin-bottom: 1rem; font-family: var(--font-garamond); }
 .docs-prose h2 { font-size: 1.5rem; font-weight: 600; margin-top: 2.5rem; margin-bottom: 1rem; font-family: var(--font-garamond); }
 .docs-prose h3 { font-size: 1.25rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.75rem; font-family: var(--font-garamond); }
@@ -143,7 +146,7 @@ html {
 .docs-prose ul, .docs-prose ol { margin-bottom: 1.25rem; }
 .docs-prose li { margin-bottom: 0.25rem; }
 
-.docs-prose table { width: 100%; border-collapse: collapse; font-size: 0.875rem; margin: 1.5rem 0; }
+.docs-prose table { width: 100%; border-collapse: collapse; font-size: 0.875rem; margin: 1.5rem 0; display: block; overflow-x: auto; }
 .docs-prose th { text-align: left; padding: 0.5rem 0.75rem; font-family: var(--font-mono); font-size: 0.75rem; text-transform: uppercase; color: #8b8fa3; border-bottom: 1px solid rgba(0, 64, 144, 0.15); }
 .docs-prose td { padding: 0.5rem 0.75rem; border-bottom: 1px solid rgba(0, 64, 144, 0.08); color: #555770; }
 .docs-prose td code { font-size: 0.8em; }

--- a/apps/website/src/components/docs/mdx/CodeBlock.tsx
+++ b/apps/website/src/components/docs/mdx/CodeBlock.tsx
@@ -30,8 +30,8 @@ export function Pre({ children, ...props }: React.HTMLAttributes<HTMLPreElement>
   };
 
   return (
-    <div style={{ position: 'relative' }}>
-      <pre ref={ref} {...props}>{children}</pre>
+    <div style={{ position: 'relative', maxWidth: '100%', overflow: 'hidden' }}>
+      <pre ref={ref} {...props} style={{ ...((props as Record<string, unknown>).style as React.CSSProperties), overflowX: 'auto' }}>{children}</pre>
       <button
         onClick={copy}
         aria-label={copied ? 'Copied' : 'Copy code'}


### PR DESCRIPTION
## Summary

Code blocks and tables were causing horizontal overflow on mobile docs pages. Fixes:

- `docs-prose` container + direct children get `max-width: 100%`
- rehype-pretty-code `figure` elements get `max-width: 100%` + `overflow: hidden`
- `Pre` component wrapper gets `max-width: 100%` + `overflow: hidden`, inner `pre` gets `overflow-x: auto`
- Tables get `display: block` + `overflow-x: auto` for horizontal scrolling

Tested on 375px viewport — `document.documentElement.scrollWidth === clientWidth` (no horizontal scroll).

## Test plan

- [x] `nx build website` — success
- [x] Puppeteer 375px viewport: no horizontal scroll possible
- [ ] CI green
- [ ] Manual check on mobile device

🤖 Generated with [Claude Code](https://claude.com/claude-code)