### PR TITLE
fix(cockpit): preserve iframe across tab switches

### DIFF
--- a/apps/cockpit/src/components/cockpit-shell.tsx
+++ b/apps/cockpit/src/components/cockpit-shell.tsx
@@ -104,13 +104,14 @@ export function CockpitShell({
           </div>
         </header>
 
-        <div className="min-h-0">
-          {activeMode === 'Run' ? (
+        <div className="min-h-0 relative">
+          {/* RunMode stays mounted to preserve iframe state across tab switches */}
+          <div className={`h-full ${activeMode === 'Run' ? '' : 'invisible absolute inset-0'}`}>
             <RunMode
               entryTitle={entryTitle}
               runtimeUrl={contentBundle.runtimeUrl}
             />
-          ) : null}
+          </div>
           {activeMode === 'Code' ? (
             <CodeMode
               entryTitle={entryTitle}


### PR DESCRIPTION
## Summary
- Keep `RunMode` mounted when switching between Run/Code/Docs/API tabs so the iframe isn't destroyed and recreated
- Use `invisible absolute` CSS to hide RunMode when another tab is active, preserving iframe state
- Navigating to a different example still unmounts the entire shell, cleaning up the old iframe

## Test plan
- [ ] Open any example in Run mode, interact with it
- [ ] Switch to Code tab, then back to Run — iframe state should be preserved
- [ ] Navigate to a different example — iframe should load fresh
- [ ] Verify no layout issues with the hidden iframe layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)