### PR TITLE
fix(chat): correct generative-ui prompt — use root not rootKey

### DIFF
--- a/cockpit/chat/generative-ui/python/prompts/generative-ui.md
+++ b/cockpit/chat/generative-ui/python/prompts/generative-ui.md
@@ -9,7 +9,7 @@ A **Spec** is a JSON object with two required top-level keys:
 ```
 {
   "elements": { [key: string]: Element },
-  "rootKey":  string
+  "root":  string
 }
 ```
 
@@ -35,7 +35,7 @@ An **Element** has:
 
 1. Respond ONLY with valid JSON. No markdown. No code fences. No surrounding text.
 2. Every element referenced in a `children` array must exist as a key in `elements`.
-3. `rootKey` must reference a key that exists in `elements`.
+3. `root` must reference a key that exists in `elements`.
 4. Use `container` to group multiple cards together.
 5. Choose component types that best match the user's request.
 
@@ -43,4 +43,4 @@ An **Element** has:
 
 If the user asks "What's the weather in Chicago and New York?", respond exactly like:
 
-{"elements":{"root":{"type":"container","props":{},"children":["chicago","nyc"]},"chicago":{"type":"weather_card","props":{"city":"Chicago","temperature":45,"condition":"Partly Cloudy"}},"nyc":{"type":"weather_card","props":{"city":"New York","temperature":52,"condition":"Sunny"}}},"rootKey":"root"}
+{"elements":{"root":{"type":"container","props":{},"children":["chicago","nyc"]},"chicago":{"type":"weather_card","props":{"city":"Chicago","temperature":45,"condition":"Partly Cloudy"}},"nyc":{"type":"weather_card","props":{"city":"New York","temperature":52,"condition":"Sunny"}}},"root":"root"}

--- a/cockpit/langgraph/streaming/python/prompts/generative-ui.md
+++ b/cockpit/langgraph/streaming/python/prompts/generative-ui.md
@@ -9,7 +9,7 @@ A **Spec** is a JSON object with two required top-level keys:
 ```
 {
   "elements": { [key: string]: Element },
-  "rootKey":  string
+  "root":  string
 }
 ```
 
@@ -35,7 +35,7 @@ An **Element** has:
 
 1. Respond ONLY with valid JSON. No markdown. No code fences. No surrounding text.
 2. Every element referenced in a `children` array must exist as a key in `elements`.
-3. `rootKey` must reference a key that exists in `elements`.
+3. `root` must reference a key that exists in `elements`.
 4. Use `container` to group multiple cards together.
 5. Choose component types that best match the user's request.
 
@@ -43,4 +43,4 @@ An **Element** has:
 
 If the user asks "What's the weather in Chicago and New York?", respond exactly like:
 
-{"elements":{"root":{"type":"container","props":{},"children":["chicago","nyc"]},"chicago":{"type":"weather_card","props":{"city":"Chicago","temperature":45,"condition":"Partly Cloudy"}},"nyc":{"type":"weather_card","props":{"city":"New York","temperature":52,"condition":"Sunny"}}},"rootKey":"root"}
+{"elements":{"root":{"type":"container","props":{},"children":["chicago","nyc"]},"chicago":{"type":"weather_card","props":{"city":"Chicago","temperature":45,"condition":"Partly Cloudy"}},"nyc":{"type":"weather_card","props":{"city":"New York","temperature":52,"condition":"Sunny"}}},"root":"root"}


### PR DESCRIPTION
## Summary
The generative-ui system prompt instructed the LLM to produce JSON specs with `"rootKey"`, but `@json-render/core`'s `Spec` type expects `"root"`. `RenderSpecComponent` checks `spec()?.root` (line 50), so **all LLM-generated specs silently failed to render** — the `<render-spec>` component existed in the DOM with height 0px.

**Root cause:** Prompt schema mismatch. The prompt said `rootKey`, the renderer expects `root`.
**Fix:** Replace `rootKey` → `root` in both the source prompt and the streaming deployment copy.

## Verified by
- Inspected production DOM: `<render-spec>` contained `<!---->` (empty) because `spec()?.root` was undefined
- Network showed 200 responses with valid JSON — the backend is working correctly
- The `Spec` type in render-spec.component.ts and all test fixtures use `root`, not `rootKey`

## Test plan
- [ ] After deploy: send "Show me weather for London" → should render weather_card component
- [ ] After deploy: send "Show me stats" → should render stat_card components

🤖 Generated with [Claude Code](https://claude.com/claude-code)