### PR TITLE
fix(chat): use c-a2ui assistant ID matching standalone deployment

### DIFF
--- a/cockpit/chat/a2ui/angular/src/environments/environment.development.ts
+++ b/cockpit/chat/a2ui/angular/src/environments/environment.development.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: false,
   langGraphApiUrl: 'http://localhost:4511/api',
-  a2uiAssistantId: 'a2ui_form',
+  a2uiAssistantId: 'c-a2ui',
 };

--- a/cockpit/chat/a2ui/angular/src/environments/environment.ts
+++ b/cockpit/chat/a2ui/angular/src/environments/environment.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: true,
   langGraphApiUrl: '/api',
-  a2uiAssistantId: 'a2ui_form',
+  a2uiAssistantId: 'c-a2ui',
 };


### PR DESCRIPTION
PR #117 changed the a2ui assistant ID to `a2ui_form`, and the squash merge of PR #118 (which should have reverted it) failed to apply the change due to a merge conflict resolution error. This fixes it directly on a fresh branch from main.

The production proxy routes `chat/a2ui` → standalone `c-a2ui` LangGraph deployment, which registers the graph as `c-a2ui`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)