### PR TITLE
fix(chat): add trailing newline to a2ui JSONL for parser compatibility

### DIFF
--- a/cockpit/chat/a2ui/python/src/graph.py
+++ b/cockpit/chat/a2ui/python/src/graph.py
@@ -66,7 +66,7 @@ CONTACT_FORM_JSONL = A2UI_PREFIX + "\n" + "\n".join([
              "action": {"event": {"name": "formSubmit", "context": {"formId": "contact"}}}},
         ],
     }}),
-])
+]) + "\n"  # Trailing newline required — parser processes at \n boundaries
 
 
 def build_a2ui_graph():

--- a/cockpit/langgraph/streaming/python/src/a2ui_graph.py
+++ b/cockpit/langgraph/streaming/python/src/a2ui_graph.py
@@ -66,7 +66,7 @@ CONTACT_FORM_JSONL = A2UI_PREFIX + "\n" + "\n".join([
              "action": {"event": {"name": "formSubmit", "context": {"formId": "contact"}}}},
         ],
     }}),
-])
+]) + "\n"  # Trailing newline required — parser processes at \n boundaries
 
 
 def build_a2ui_graph():


### PR DESCRIPTION
## Summary
The A2UI parser is line-based — it buffers content and processes at `\n` boundaries. The hardcoded JSONL ended without a trailing newline, leaving the `updateComponents` message (the last line) permanently stuck in the parser buffer. The surface was created but had zero components, so `surfaceToSpec()` returned null and the form never rendered.

**Root cause:** `"\n".join([...])` produces no trailing `\n` after the last element.
**Fix:** Append `+ "\n"` after the join.

Verified via Chrome DOM inspection: `a2ui-surface` existed in DOM with `<!---->` (empty) because `render-spec` never received a spec — surfaceToSpec returned null due to missing `root` component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)