### PR TITLE
[codex] Align production smoke checks with chat demos

### DIFF
--- a/apps/cockpit/e2e/production-smoke.spec.ts
+++ b/apps/cockpit/e2e/production-smoke.spec.ts
@@ -53,12 +53,27 @@ const RENDER_CAPABILITIES = [
   'render/computed-functions',
 ] as const;
 
+const CHAT_PRIMITIVE_CAPABILITIES = new Set([
+  'chat/messages',
+  'chat/input',
+  'chat/debug',
+]);
+
+const A2UI_CAPABILITIES = new Set([
+  'chat/a2ui',
+]);
+
 test.describe('Production: Angular example apps load', () => {
   for (const cap of CAPABILITIES) {
     test(`${cap} loads at examples URL`, async ({ page }) => {
       const url = `${EXAMPLES_URL}/${cap}/`;
       const res = await page.goto(url, { timeout: 15000 });
       expect(res?.status()).toBe(200);
+      if (CHAT_PRIMITIVE_CAPABILITIES.has(cap)) {
+        await expect(page.getByRole('search', { name: 'Message input' })).toBeVisible({ timeout: 10000 });
+        return;
+      }
+
       await expect(page.locator('chat')).toBeVisible({ timeout: 10000 });
     });
   }
@@ -93,6 +108,11 @@ test.describe('Production: send/receive smoke', () => {
       await expect(page.locator('chat')).toBeVisible({ timeout: 10000 });
       await page.fill('textarea[name="messageText"]', 'hello');
       await page.click('button[type="submit"]');
+      if (A2UI_CAPABILITIES.has(cap)) {
+        await expect(page.getByRole('heading', { name: 'Contact Us' })).toBeVisible({ timeout: 30000 });
+        return;
+      }
+
       await expect(page.locator('.chat-md').first()).toBeVisible({ timeout: 30000 });
     });
   }


### PR DESCRIPTION
## What changed
Updates the production smoke suite to use the actual readiness signals for the primitive chat demos.

`chat/messages`, `chat/input`, and `chat/debug` render message-input primitives directly instead of a `<chat>` host element, so the previous smoke check produced false failures even though the pages were healthy.

`chat/a2ui` also returns an A2UI form surface rather than a visible markdown chat bubble, so its send/receive smoke test now waits for the rendered `Contact Us` form heading instead of `.chat-md`.

## Why
The broader production smoke coverage already on `main` exposed three false negatives and one mismatched send/receive assertion. This patch keeps the smoke suite strict, but makes it route-aware where the UI contract differs.

## Verification
- `BASE_URL=https://cockpit.cacheplane.ai EXAMPLES_URL=https://examples.cacheplane.ai npx playwright test apps/cockpit/e2e/production-smoke.spec.ts --grep "chat/messages loads|chat/input loads|chat/debug loads" --reporter=list`
- `BASE_URL=https://cockpit.cacheplane.ai EXAMPLES_URL=https://examples.cacheplane.ai npx playwright test apps/cockpit/e2e/production-smoke.spec.ts --reporter=list`
- `OPENAI_API_KEY=... BASE_URL=https://cockpit.cacheplane.ai EXAMPLES_URL=https://examples.cacheplane.ai npx playwright test apps/cockpit/e2e/production-smoke.spec.ts --grep "chat/a2ui sends and receives a message" --reporter=list`
- `OPENAI_API_KEY=... BASE_URL=https://cockpit.cacheplane.ai EXAMPLES_URL=https://examples.cacheplane.ai npx playwright test apps/cockpit/e2e/production-smoke.spec.ts --grep "sends and receives a message" --reporter=list`
- `git diff --check`
