### PR TITLE
fix(website): mobile responsive padding and sizing for home page

### DIFF
--- a/apps/website/src/components/landing/PilotFooterCTA.tsx
+++ b/apps/website/src/components/landing/PilotFooterCTA.tsx
@@ -21,8 +21,15 @@ export function PilotFooterCTA() {
         padding: '0 2rem',
       }}
     >
-      <style>{`.pilot-footer-secondary-btn:hover { border-color: rgba(255,255,255,0.6) !important; }`}</style>
+      <style>{`
+        .pilot-footer-secondary-btn:hover { border-color: rgba(255,255,255,0.6) !important; }
+        @media (max-width: 767px) {
+          .pilot-footer-inner { padding-top: 4rem !important; padding-bottom: 4rem !important; }
+          .pilot-footer-heading { font-size: clamp(28px, 6vw, 42px) !important; }
+        }
+      `}</style>
       <motion.div
+        className="pilot-footer-inner"
         initial={{ opacity: 0, y: 20 }}
         whileInView={{ opacity: 1, y: 0 }}
         viewport={{ once: true }}
@@ -53,6 +60,7 @@ export function PilotFooterCTA() {
         {/* Heading */}
         <h2
           id="pilot-footer-cta-heading"
+          className="pilot-footer-heading"
           style={{
             fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
             fontSize: '42px',

--- a/apps/website/src/components/landing/PilotSolution.tsx
+++ b/apps/website/src/components/landing/PilotSolution.tsx
@@ -23,7 +23,12 @@ const STEPS = [
 
 export function PilotSolution() {
   return (
-    <section style={{ padding: '80px 32px' }}>
+    <section className="pilot-solution" style={{ padding: '80px 32px' }}>
+      <style>{`
+        @media (max-width: 767px) {
+          .pilot-solution { padding: 60px 20px !important; }
+        }
+      `}</style>
       <motion.div
         initial={{ opacity: 0, y: 16 }}
         whileInView={{ opacity: 1, y: 0 }}

--- a/apps/website/src/components/landing/TheStack.tsx
+++ b/apps/website/src/components/landing/TheStack.tsx
@@ -57,7 +57,13 @@ function Connector({ fromRgb, toRgb }: { fromRgb: string; toRgb: string }) {
 
 export function TheStack() {
   return (
-    <section style={{ padding: '80px 32px' }}>
+    <section className="the-stack" style={{ padding: '80px 32px' }}>
+      <style>{`
+        @media (max-width: 767px) {
+          .the-stack { padding: 60px 20px !important; }
+          .the-stack-card { padding: 24px 20px 20px !important; }
+        }
+      `}</style>
       <motion.div
         initial={{ opacity: 0, y: 16 }}
         whileInView={{ opacity: 1, y: 0 }}
@@ -109,6 +115,7 @@ export function TheStack() {
               />
             )}
             <motion.div
+              className="the-stack-card"
               initial={{ opacity: 0, y: 24 }}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}

--- a/apps/website/src/components/landing/WhitePaperSection.tsx
+++ b/apps/website/src/components/landing/WhitePaperSection.tsx
@@ -42,7 +42,7 @@ export function WhitePaperSection() {
   };
 
   return (
-    <section style={{ padding: '80px 32px' }}>
+    <section className="wp-section" style={{ padding: '80px 32px' }}>
       <style>{`
         .wp-grid {
           display: grid;
@@ -52,6 +52,7 @@ export function WhitePaperSection() {
           padding: 48px 56px;
         }
         @media (max-width: 767px) {
+          .wp-section { padding: 60px 20px !important; }
           .wp-grid {
             grid-template-columns: 1fr;
             gap: 32px;


### PR DESCRIPTION
## Summary

- Adds `@media (max-width: 767px)` breakpoints to all home page sections that were missing them
- **PilotSolution**: section padding reduced from `80px 32px` to `60px 20px` on mobile
- **TheStack**: section padding reduced to `60px 20px`, card padding reduced to `24px 20px 20px` on mobile
- **PilotFooterCTA**: heading font-size changed from fixed `42px` to `clamp(28px, 6vw, 42px)` on mobile, vertical padding reduced from `6rem` to `4rem`
- **WhitePaperSection**: outer section padding reduced to `60px 20px` on mobile (inner grid already had mobile styles)

All breakpoints follow the existing `767px` convention used by HeroTwoCol, ProblemSection, and ChatFeaturesSection.

## Test plan

- [x] `npx nx build website` passes
- [ ] Visual review at 375px viewport: no horizontal overflow, comfortable padding
- [ ] Visual review at 768px viewport: breakpoint transition is smooth
- [ ] PilotFooterCTA heading doesn't overflow on narrow viewports
- [ ] TheStack cards have comfortable padding on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)