### PR TITLE
feat(website): align product landing pages with home page narrative

### DIFF
--- a/apps/website/src/app/angular/page.tsx
+++ b/apps/website/src/app/angular/page.tsx
@@ -5,6 +5,7 @@ import { AngularFeaturesGrid } from '../../components/landing/angular/AngularFea
 import { AngularCodeShowcase } from '../../components/landing/angular/AngularCodeShowcase';
 import { AngularComparison } from '../../components/landing/angular/AngularComparison';
 import { AngularWhitePaperGate } from '../../components/landing/angular/AngularWhitePaperGate';
+import { AngularStackSiblings } from '../../components/landing/angular/AngularStackSiblings';
 import { AngularFooterCTA } from '../../components/landing/angular/AngularFooterCTA';
 import { tokens } from '@cacheplane/design-tokens';
 
@@ -25,6 +26,7 @@ export default function AngularPage() {
       <AngularCodeShowcase />
       <AngularComparison />
       <AngularWhitePaperGate />
+      <AngularStackSiblings />
       <AngularFooterCTA />
     </div>
   );

--- a/apps/website/src/app/chat/page.tsx
+++ b/apps/website/src/app/chat/page.tsx
@@ -5,6 +5,7 @@ import { ChatLandingFeaturesGrid } from '../../components/landing/chat-landing/C
 import { ChatLandingCodeShowcase } from '../../components/landing/chat-landing/ChatLandingCodeShowcase';
 import { ChatLandingComparison } from '../../components/landing/chat-landing/ChatLandingComparison';
 import { ChatLandingWhitePaperGate } from '../../components/landing/chat-landing/ChatLandingWhitePaperGate';
+import { ChatLandingStackSiblings } from '../../components/landing/chat-landing/ChatLandingStackSiblings';
 import { ChatLandingFooterCTA } from '../../components/landing/chat-landing/ChatLandingFooterCTA';
 import { tokens } from '@cacheplane/design-tokens';
 
@@ -25,6 +26,7 @@ export default function ChatPage() {
       <ChatLandingCodeShowcase />
       <ChatLandingComparison />
       <ChatLandingWhitePaperGate />
+      <ChatLandingStackSiblings />
       <ChatLandingFooterCTA />
     </div>
   );

--- a/apps/website/src/app/render/page.tsx
+++ b/apps/website/src/app/render/page.tsx
@@ -5,6 +5,7 @@ import { RenderFeaturesGrid } from '../../components/landing/render/RenderFeatur
 import { RenderCodeShowcase } from '../../components/landing/render/RenderCodeShowcase';
 import { RenderComparison } from '../../components/landing/render/RenderComparison';
 import { RenderWhitePaperGate } from '../../components/landing/render/RenderWhitePaperGate';
+import { RenderStackSiblings } from '../../components/landing/render/RenderStackSiblings';
 import { RenderFooterCTA } from '../../components/landing/render/RenderFooterCTA';
 import { tokens } from '@cacheplane/design-tokens';
 
@@ -25,6 +26,7 @@ export default function RenderPage() {
       <RenderCodeShowcase />
       <RenderComparison />
       <RenderWhitePaperGate />
+      <RenderStackSiblings />
       <RenderFooterCTA />
     </div>
   );

--- a/apps/website/src/app/solutions/[slug]/page.tsx
+++ b/apps/website/src/app/solutions/[slug]/page.tsx
@@ -1,0 +1,104 @@
+import { notFound } from 'next/navigation';
+import { tokens } from '@cacheplane/design-tokens';
+import { getSolutionBySlug, getAllSolutionSlugs } from '../../../lib/solutions-data';
+import { SolutionHero } from '../../../components/landing/solutions/SolutionHero';
+import { SolutionProblem } from '../../../components/landing/solutions/SolutionProblem';
+import { SolutionArchitecture } from '../../../components/landing/solutions/SolutionArchitecture';
+import { SolutionProofPoints } from '../../../components/landing/solutions/SolutionProofPoints';
+import { SolutionFooterCTA } from '../../../components/landing/solutions/SolutionFooterCTA';
+import { WhitePaperSection } from '../../../components/landing/WhitePaperSection';
+
+interface PageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export function generateStaticParams() {
+  return getAllSolutionSlugs().map(slug => ({ slug }));
+}
+
+export async function generateMetadata({ params }: PageProps) {
+  const { slug } = await params;
+  const solution = getSolutionBySlug(slug);
+  if (!solution) return {};
+  return {
+    title: solution.metaTitle,
+    description: solution.metaDescription,
+  };
+}
+
+export default async function SolutionPage({ params }: PageProps) {
+  const { slug } = await params;
+  const solution = getSolutionBySlug(slug);
+  if (!solution) notFound();
+
+  return (
+    <div style={{ background: tokens.gradient.bgFlow, position: 'relative', overflow: 'hidden' }}>
+      {/* Ambient gradient blobs */}
+      <div
+        style={{
+          position: 'absolute',
+          width: 600,
+          height: 600,
+          borderRadius: '50%',
+          background: `radial-gradient(circle, rgba(${solution.rgb}, 0.12) 0%, transparent 70%)`,
+          top: -200,
+          left: -150,
+          filter: 'blur(80px)',
+          pointerEvents: 'none',
+        }}
+        aria-hidden="true"
+      />
+      <div
+        style={{
+          position: 'absolute',
+          width: 500,
+          height: 500,
+          borderRadius: '50%',
+          background: tokens.gradient.cool,
+          top: 800,
+          right: -100,
+          filter: 'blur(80px)',
+          pointerEvents: 'none',
+        }}
+        aria-hidden="true"
+      />
+      <div
+        style={{
+          position: 'absolute',
+          width: 400,
+          height: 400,
+          borderRadius: '50%',
+          background: `radial-gradient(circle, rgba(${solution.rgb}, 0.08) 0%, transparent 70%)`,
+          top: 2200,
+          left: -100,
+          filter: 'blur(80px)',
+          pointerEvents: 'none',
+        }}
+        aria-hidden="true"
+      />
+
+      <SolutionHero solution={solution} />
+      <SolutionProblem
+        color={solution.color}
+        rgb={solution.rgb}
+        painPoints={solution.painPoints}
+      />
+      <SolutionArchitecture
+        color={solution.color}
+        intro={solution.architectureIntro}
+        layers={solution.architectureLayers}
+      />
+      <SolutionProofPoints
+        color={solution.color}
+        rgb={solution.rgb}
+        proofPoints={solution.proofPoints}
+      />
+      <WhitePaperSection />
+      <SolutionFooterCTA
+        color={solution.color}
+        headline={solution.ctaHeadline}
+        subtext={solution.ctaSubtext}
+      />
+    </div>
+  );
+}

--- a/apps/website/src/app/solutions/[slug]/page.tsx
+++ b/apps/website/src/app/solutions/[slug]/page.tsx
@@ -80,7 +80,6 @@ export default async function SolutionPage({ params }: PageProps) {
       <SolutionHero solution={solution} />
       <SolutionProblem
         color={solution.color}
-        rgb={solution.rgb}
         painPoints={solution.painPoints}
       />
       <SolutionArchitecture
@@ -90,7 +89,6 @@ export default async function SolutionPage({ params }: PageProps) {
       />
       <SolutionProofPoints
         color={solution.color}
-        rgb={solution.rgb}
         proofPoints={solution.proofPoints}
       />
       <WhitePaperSection />

--- a/apps/website/src/app/solutions/page.tsx
+++ b/apps/website/src/app/solutions/page.tsx
@@ -1,0 +1,100 @@
+import { tokens } from '@cacheplane/design-tokens';
+import { SolutionsGrid } from '../../components/landing/solutions/SolutionsGrid';
+import { WhitePaperSection } from '../../components/landing/WhitePaperSection';
+import { PilotFooterCTA } from '../../components/landing/PilotFooterCTA';
+
+export const metadata = {
+  title: 'Solutions — Angular Agent Framework',
+  description: 'See how Angular Agent Framework solves enterprise challenges — compliance, analytics, and customer support.',
+};
+
+export default function SolutionsIndexPage() {
+  return (
+    <div style={{ background: tokens.gradient.bgFlow, position: 'relative', overflow: 'hidden' }}>
+      {/* Ambient gradient blobs */}
+      <div
+        style={{
+          position: 'absolute',
+          width: 600,
+          height: 600,
+          borderRadius: '50%',
+          background: tokens.gradient.warm,
+          top: -200,
+          left: -150,
+          filter: 'blur(80px)',
+          pointerEvents: 'none',
+        }}
+        aria-hidden="true"
+      />
+      <div
+        style={{
+          position: 'absolute',
+          width: 500,
+          height: 500,
+          borderRadius: '50%',
+          background: tokens.gradient.cool,
+          top: 800,
+          right: -100,
+          filter: 'blur(80px)',
+          pointerEvents: 'none',
+        }}
+        aria-hidden="true"
+      />
+
+      {/* Hero */}
+      <section style={{ position: 'relative', overflow: 'hidden', padding: '0 2rem' }}>
+        <div
+          style={{
+            maxWidth: '56rem',
+            margin: '0 auto',
+            textAlign: 'center',
+            position: 'relative',
+            zIndex: 1,
+          }}
+          className="py-24 md:py-32"
+        >
+          <p
+            style={{
+              fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+              fontSize: 11,
+              letterSpacing: '0.08em',
+              color: tokens.colors.accent,
+              textTransform: 'uppercase',
+              marginBottom: '1.5rem',
+            }}
+          >
+            Solutions
+          </p>
+          <h1
+            style={{
+              fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+              fontSize: 'clamp(36px, 5vw, 56px)',
+              fontWeight: 700,
+              lineHeight: 1.1,
+              color: tokens.colors.textPrimary,
+              marginBottom: '1.25rem',
+            }}
+          >
+            AI agents built for how enterprises actually work
+          </h1>
+          <p
+            style={{
+              fontFamily: 'Inter, sans-serif',
+              fontSize: 18,
+              color: tokens.colors.textSecondary,
+              maxWidth: '52ch',
+              margin: '0 auto',
+              lineHeight: 1.6,
+            }}
+          >
+            Angular Agent Framework gives your team the streaming, generative UI, and human-in-the-loop patterns that enterprise use cases demand.
+          </p>
+        </div>
+      </section>
+
+      <SolutionsGrid />
+      <WhitePaperSection />
+      <PilotFooterCTA />
+    </div>
+  );
+}

--- a/apps/website/src/components/landing/angular/AngularCodeShowcase.tsx
+++ b/apps/website/src/components/landing/angular/AngularCodeShowcase.tsx
@@ -32,7 +32,8 @@ const SNIPPETS = [
 
 export async function AngularCodeShowcase() {
   return (
-    <section style={{ padding: '80px 32px' }}>
+    <section className="angular-code" style={{ padding: '80px 32px' }}>
+      <style>{`@media (max-width: 767px) { .angular-code { padding: 60px 20px !important; } }`}</style>
       <div style={{ textAlign: 'center', marginBottom: 48 }}>
         <p style={{
           fontFamily: 'var(--font-mono,"JetBrains Mono",monospace)',

--- a/apps/website/src/components/landing/angular/AngularComparison.tsx
+++ b/apps/website/src/components/landing/angular/AngularComparison.tsx
@@ -17,7 +17,12 @@ const ROWS = [
 
 export function AngularComparison() {
   return (
-    <section style={{ padding: '80px 32px' }}>
+    <section className="angular-comparison" style={{ padding: '80px 32px' }}>
+      <style>{`
+        @media (max-width: 767px) {
+          .angular-comparison { padding: 60px 20px !important; }
+        }
+      `}</style>
       <motion.div
         initial={{ opacity: 0, y: 16 }}
         whileInView={{ opacity: 1, y: 0 }}

--- a/apps/website/src/components/landing/angular/AngularFeaturesGrid.tsx
+++ b/apps/website/src/components/landing/angular/AngularFeaturesGrid.tsx
@@ -15,7 +15,8 @@ const FEATURES = [
 
 export function AngularFeaturesGrid() {
   return (
-    <section style={{ padding: '80px 32px' }}>
+    <section className="angular-features" style={{ padding: '80px 32px' }}>
+      <style>{`@media (max-width: 767px) { .angular-features { padding: 60px 20px !important; } }`}</style>
       <motion.div
         initial={{ opacity: 0, y: 16 }}
         whileInView={{ opacity: 1, y: 0 }}

--- a/apps/website/src/components/landing/angular/AngularFooterCTA.tsx
+++ b/apps/website/src/components/landing/angular/AngularFooterCTA.tsx
@@ -1,60 +1,111 @@
 // apps/website/src/components/landing/angular/AngularFooterCTA.tsx
 'use client';
+
+import { motion } from 'framer-motion';
+import Link from 'next/link';
 import { tokens } from '@cacheplane/design-tokens';
 
 export function AngularFooterCTA() {
   return (
-    <section style={{ padding: '5rem 2rem' }}>
-      <div style={{
-        maxWidth: '42rem', margin: '0 auto', textAlign: 'center',
-        background: tokens.glass.bg, border: `1px solid ${tokens.colors.accentBorder}`,
-        borderRadius: 16, padding: 48,
-        backdropFilter: `blur(${tokens.glass.blur})`,
-      }}>
-        <h2 style={{
-          fontFamily: "'EB Garamond', serif", fontSize: 'clamp(24px, 4vw, 32px)',
-          fontWeight: 700, color: tokens.colors.textPrimary, marginBottom: 16,
+    <section
+      aria-labelledby="angular-footer-cta-heading"
+      style={{
+        background: 'linear-gradient(135deg, #1a1a2e 0%, #0d1b3e 100%)',
+        padding: '0 2rem',
+      }}
+    >
+      <style>{`
+        .angular-footer-secondary-btn:hover { border-color: rgba(255,255,255,0.6) !important; }
+        @media (max-width: 767px) {
+          .angular-footer-inner { padding-top: 4rem !important; padding-bottom: 4rem !important; }
+          .angular-footer-heading { font-size: clamp(28px, 6vw, 42px) !important; }
+        }
+      `}</style>
+      <motion.div
+        className="angular-footer-inner"
+        initial={{ opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.5 }}
+        style={{
+          maxWidth: '48rem',
+          margin: '0 auto',
+          paddingTop: '6rem',
+          paddingBottom: '6rem',
+          textAlign: 'center',
+        }}
+      >
+        <p style={{
+          fontFamily: 'var(--font-mono, monospace)',
+          fontSize: '11px', fontWeight: 500, letterSpacing: '0.12em',
+          textTransform: 'uppercase', color: 'rgba(255, 255, 255, 0.5)',
+          marginBottom: '1rem',
         }}>
+          Ready when you are
+        </p>
+
+        <h2
+          id="angular-footer-cta-heading"
+          className="angular-footer-heading"
+          style={{
+            fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+            fontSize: '42px', fontWeight: 400, lineHeight: 1.15,
+            color: '#ffffff', marginBottom: '1.25rem',
+          }}
+        >
           Ready to ship your LangGraph agent?
         </h2>
+
         <p style={{
-          fontFamily: 'Inter, sans-serif', fontSize: 16, lineHeight: 1.7,
-          color: tokens.colors.textSecondary, marginBottom: 32,
+          fontFamily: 'var(--font-inter, Inter, sans-serif)',
+          fontSize: '17px', lineHeight: 1.6,
+          color: 'rgba(255, 255, 255, 0.7)', marginBottom: '2.5rem',
         }}>
-          Download the enterprise guide, explore the docs, or start the pilot program.
+          The Angular Agent Framework closes the last-mile gap. Start with a conversation.
         </p>
-        <div style={{ display: 'flex', gap: 12, justifyContent: 'center', flexWrap: 'wrap' }}>
-          <a href="/whitepapers/angular.pdf" download
+
+        <div style={{
+          display: 'flex', gap: '1rem', justifyContent: 'center',
+          flexWrap: 'wrap', marginBottom: '1.5rem',
+        }}>
+          <Link
+            href="/pilot-to-prod"
             style={{
               display: 'inline-block', padding: '0.875rem 2rem',
-              background: tokens.colors.accent, color: '#fff',
-              fontFamily: 'Inter, sans-serif', fontSize: 15, fontWeight: 600,
-              textDecoration: 'none', borderRadius: 6,
-            }}>
+              background: '#ffffff', color: tokens.colors.accent,
+              fontFamily: 'var(--font-inter, Inter, sans-serif)',
+              fontSize: '15px', fontWeight: 600, textDecoration: 'none',
+              borderRadius: '6px', transition: 'box-shadow 0.2s ease',
+            }}
+          >
+            Start Your Pilot →
+          </Link>
+
+          <a
+            href="/whitepapers/angular.pdf"
+            download
+            className="angular-footer-secondary-btn"
+            style={{
+              display: 'inline-block', padding: '0.875rem 2rem',
+              background: 'transparent', color: '#ffffff',
+              fontFamily: 'var(--font-inter, Inter, sans-serif)',
+              fontSize: '15px', fontWeight: 600, textDecoration: 'none',
+              borderRadius: '6px', border: '1px solid rgba(255, 255, 255, 0.3)',
+              transition: 'border-color 0.2s ease',
+            }}
+          >
             Download the Guide
           </a>
-          <a href="/pilot-to-prod"
-            style={{
-              display: 'inline-block', padding: '0.875rem 2rem',
-              background: tokens.glass.bg, color: tokens.colors.accent,
-              fontFamily: 'Inter, sans-serif', fontSize: 15, fontWeight: 600,
-              textDecoration: 'none', borderRadius: 6,
-              border: `1px solid ${tokens.colors.accentBorder}`,
-            }}>
-            Pilot Program →
-          </a>
-          <a href="/docs"
-            style={{
-              display: 'inline-block', padding: '0.875rem 2rem',
-              background: 'transparent', color: tokens.colors.textSecondary,
-              fontFamily: 'Inter, sans-serif', fontSize: 15, fontWeight: 600,
-              textDecoration: 'none', borderRadius: 6,
-              border: `1px solid ${tokens.glass.border}`,
-            }}>
-            View Docs
-          </a>
         </div>
-      </div>
+
+        <p style={{
+          fontFamily: 'var(--font-mono, monospace)',
+          fontSize: '10px', letterSpacing: '0.08em',
+          color: 'rgba(255, 255, 255, 0.4)',
+        }}>
+          App deployment license · $20,000 · 3-month co-pilot engagement
+        </p>
+      </motion.div>
     </section>
   );
 }

--- a/apps/website/src/components/landing/angular/AngularHero.tsx
+++ b/apps/website/src/components/landing/angular/AngularHero.tsx
@@ -1,14 +1,35 @@
 // apps/website/src/components/landing/angular/AngularHero.tsx
 'use client';
 import { motion } from 'framer-motion';
+import Link from 'next/link';
 import { tokens } from '@cacheplane/design-tokens';
 
 const BADGES = ['Angular 20+', 'LangGraph', 'LangChain', 'DeepAgent'];
 
 export function AngularHero() {
   return (
-    <section aria-labelledby="angular-hero-heading" style={{ position: 'relative', overflow: 'hidden', padding: '0 2rem' }}>
+    <section className="angular-hero" aria-labelledby="angular-hero-heading" style={{ position: 'relative', overflow: 'hidden', padding: '0 2rem' }}>
+      <style>{`
+        @media (max-width: 767px) {
+          .angular-hero { padding: 0 1.25rem !important; }
+        }
+      `}</style>
       <div style={{ maxWidth: '56rem', margin: '0 auto', textAlign: 'center', position: 'relative', zIndex: 1 }} className="py-24 md:py-32">
+        {/* Stack breadcrumb */}
+        <motion.div initial={{ y: 16 }} animate={{ y: 0 }} transition={{ duration: 0.5 }}>
+          <div style={{
+            display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 0,
+            fontFamily: "'JetBrains Mono', monospace", fontSize: 10, letterSpacing: '0.08em',
+            textTransform: 'uppercase', marginBottom: '0.75rem',
+          }}>
+            <span style={{ color: tokens.colors.accent, fontWeight: 700 }}>Agent</span>
+            <span style={{ color: tokens.colors.textMuted, margin: '0 6px' }}>→</span>
+            <Link href="/render" style={{ color: tokens.colors.textMuted, fontWeight: 500, textDecoration: 'none' }}>Render</Link>
+            <span style={{ color: tokens.colors.textMuted, margin: '0 6px' }}>→</span>
+            <Link href="/chat" style={{ color: tokens.colors.textMuted, fontWeight: 500, textDecoration: 'none' }}>Chat</Link>
+          </div>
+        </motion.div>
+
         <motion.div initial={{ y: 16 }} animate={{ y: 0 }} transition={{ duration: 0.5 }}>
           <span style={{
             fontFamily: "'JetBrains Mono', monospace", fontSize: 11, letterSpacing: '0.08em',
@@ -45,7 +66,7 @@ export function AngularHero() {
             }}>
             Download the Guide
           </a>
-          <a href="/docs"
+          <Link href="/docs"
             style={{
               display: 'inline-flex', alignItems: 'center', gap: 6,
               background: tokens.glass.bg, backdropFilter: `blur(${tokens.glass.blur})`,
@@ -55,7 +76,7 @@ export function AngularHero() {
               textDecoration: 'none', border: `1px solid ${tokens.colors.accentBorder}`, minHeight: 44,
             }}>
             View Docs
-          </a>
+          </Link>
         </motion.div>
 
         <motion.div initial={{ y: 14 }} animate={{ y: 0 }} transition={{ duration: 0.6, delay: 0.2 }}

--- a/apps/website/src/components/landing/angular/AngularProblemSolution.tsx
+++ b/apps/website/src/components/landing/angular/AngularProblemSolution.tsx
@@ -22,7 +22,8 @@ const SOLUTIONS = [
 
 export function AngularProblemSolution() {
   return (
-    <section style={{ padding: '80px 32px' }}>
+    <section className="angular-problem" style={{ padding: '80px 32px' }}>
+      <style>{`@media (max-width: 767px) { .angular-problem { padding: 60px 20px !important; } }`}</style>
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         whileInView={{ opacity: 1, y: 0 }}

--- a/apps/website/src/components/landing/angular/AngularStackSiblings.tsx
+++ b/apps/website/src/components/landing/angular/AngularStackSiblings.tsx
@@ -1,0 +1,123 @@
+'use client';
+import { motion } from 'framer-motion';
+import Link from 'next/link';
+import { tokens } from '@cacheplane/design-tokens';
+
+const SIBLINGS = [
+  {
+    tag: 'Gen UI',
+    pkg: '@cacheplane/render',
+    color: tokens.colors.renderGreen,
+    rgb: '26,122,64',
+    headline: 'Agents that render UI — on open standards',
+    href: '/render',
+    ctaLabel: 'Explore Render',
+  },
+  {
+    tag: 'Chat',
+    pkg: '@cacheplane/chat',
+    color: tokens.colors.chatPurple,
+    rgb: '90,0,200',
+    headline: 'Production chat UI in days, not sprints',
+    href: '/chat',
+    ctaLabel: 'Explore Chat',
+  },
+];
+
+export function AngularStackSiblings() {
+  return (
+    <section className="angular-stack-siblings" style={{ padding: '80px 32px' }}>
+      <style>{`
+        @media (max-width: 767px) {
+          .angular-stack-siblings { padding: 60px 20px !important; }
+          .angular-stack-siblings-grid { grid-template-columns: 1fr !important; }
+        }
+      `}</style>
+      <motion.div
+        initial={{ opacity: 0, y: 16 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.5 }}
+        style={{ textAlign: 'center', marginBottom: 36 }}
+      >
+        <p style={{
+          fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+          fontSize: '0.7rem', textTransform: 'uppercase', letterSpacing: '0.12em',
+          fontWeight: 700, color: tokens.colors.accent, marginBottom: 14,
+        }}>
+          The Cacheplane Stack
+        </p>
+        <p style={{
+          fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+          fontStyle: 'italic', fontSize: '1.05rem',
+          color: tokens.colors.textSecondary, maxWidth: 520, margin: '0 auto',
+        }}>
+          This library is part of a cohesive three-layer architecture.
+        </p>
+      </motion.div>
+
+      <div
+        className="angular-stack-siblings-grid"
+        style={{
+          display: 'grid', gridTemplateColumns: '1fr 1fr',
+          gap: 16, maxWidth: 860, margin: '0 auto',
+        }}
+      >
+        {SIBLINGS.map((lib, i) => (
+          <motion.div
+            key={lib.pkg}
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.5, delay: i * 0.1 }}
+            style={{
+              padding: '24px 20px',
+              borderRadius: 14,
+              background: `rgba(${lib.rgb}, 0.03)`,
+              border: `1px solid rgba(${lib.rgb}, 0.15)`,
+              borderLeft: `3px solid ${lib.color}`,
+              display: 'flex', flexDirection: 'column', gap: 10,
+            }}
+          >
+            <span style={{
+              display: 'inline-block', alignSelf: 'flex-start',
+              fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+              fontSize: '0.58rem', fontWeight: 700, textTransform: 'uppercase',
+              letterSpacing: '0.07em', padding: '2px 9px', borderRadius: 5,
+              color: '#fff', background: lib.color,
+            }}>
+              {lib.tag}
+            </span>
+
+            <p style={{
+              fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+              fontSize: '0.76rem', fontWeight: 700, color: lib.color, margin: 0,
+            }}>
+              {lib.pkg}
+            </p>
+
+            <h3 style={{
+              fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+              fontSize: '1.15rem', fontWeight: 700,
+              color: tokens.colors.textPrimary, lineHeight: 1.25, margin: 0,
+            }}>
+              {lib.headline}
+            </h3>
+
+            <Link
+              href={lib.href}
+              style={{
+                fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+                fontSize: '0.72rem', fontWeight: 700, color: lib.color,
+                textDecoration: 'none', marginTop: 4,
+                display: 'inline-flex', alignItems: 'center', gap: 4,
+              }}
+            >
+              {lib.ctaLabel} →
+            </Link>
+          </motion.div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/website/src/components/landing/angular/AngularWhitePaperGate.tsx
+++ b/apps/website/src/components/landing/angular/AngularWhitePaperGate.tsx
@@ -37,7 +37,12 @@ export function AngularWhitePaperGate() {
   };
 
   return (
-    <section id="angular-whitepaper-gate" style={{ padding: '80px 32px' }}>
+    <section id="angular-whitepaper-gate" className="angular-wp-gate" style={{ padding: '80px 32px' }}>
+      <style>{`
+        @media (max-width: 767px) {
+          .angular-wp-gate { padding: 60px 20px !important; }
+        }
+      `}</style>
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         whileInView={{ opacity: 1, y: 0 }}
@@ -57,7 +62,7 @@ export function AngularWhitePaperGate() {
             fontSize: '0.68rem', textTransform: 'uppercase', letterSpacing: '0.12em',
             fontWeight: 700, color: tokens.colors.accent, marginBottom: 14,
           }}>
-            Free Download
+            Agent Guide
           </p>
           <h2 style={{
             fontFamily: 'var(--font-garamond,"EB Garamond",Georgia,serif)',
@@ -71,7 +76,13 @@ export function AngularWhitePaperGate() {
             fontStyle: 'italic', fontSize: '1rem', color: tokens.colors.textSecondary,
             lineHeight: 1.55, marginBottom: 28,
           }}>
-            Six chapters covering the last-mile problem, the agent() API, thread persistence, interrupts, full LangGraph feature coverage, and deterministic testing.
+            Six chapters covering the last-mile gap, the agent() API, thread persistence, interrupts, time-travel, and deterministic testing with MockAgentTransport.
+          </p>
+          <p style={{
+            fontFamily: 'Inter, sans-serif', fontSize: '0.8rem',
+            color: tokens.colors.textMuted, marginBottom: 20,
+          }}>
+            Part of the Cacheplane Angular Agent Framework.
           </p>
           <a href="/whitepapers/angular.pdf" download="cacheplane-angular-enterprise-guide.pdf"
             style={{

--- a/apps/website/src/components/landing/chat-landing/ChatLandingCodeShowcase.tsx
+++ b/apps/website/src/components/landing/chat-landing/ChatLandingCodeShowcase.tsx
@@ -33,7 +33,8 @@ const SNIPPETS = [
 
 export async function ChatLandingCodeShowcase() {
   return (
-    <section style={{ padding: '80px 32px' }}>
+    <section className="chat-code" style={{ padding: '80px 32px' }}>
+      <style>{`@media (max-width: 767px) { .chat-code { padding: 60px 20px !important; } }`}</style>
       <div style={{ textAlign: 'center', marginBottom: 48 }}>
         <p style={{
           fontFamily: 'var(--font-mono,"JetBrains Mono",monospace)',

--- a/apps/website/src/components/landing/chat-landing/ChatLandingComparison.tsx
+++ b/apps/website/src/components/landing/chat-landing/ChatLandingComparison.tsx
@@ -17,7 +17,12 @@ const ROWS = [
 
 export function ChatLandingComparison() {
   return (
-    <section style={{ padding: '80px 32px' }}>
+    <section className="chat-comparison" style={{ padding: '80px 32px' }}>
+      <style>{`
+        @media (max-width: 767px) {
+          .chat-comparison { padding: 60px 20px !important; }
+        }
+      `}</style>
       <motion.div
         initial={{ opacity: 0, y: 16 }}
         whileInView={{ opacity: 1, y: 0 }}

--- a/apps/website/src/components/landing/chat-landing/ChatLandingFeaturesGrid.tsx
+++ b/apps/website/src/components/landing/chat-landing/ChatLandingFeaturesGrid.tsx
@@ -14,7 +14,8 @@ const FEATURES = [
 
 export function ChatLandingFeaturesGrid() {
   return (
-    <section style={{ padding: '80px 32px' }}>
+    <section className="chat-features" style={{ padding: '80px 32px' }}>
+      <style>{`@media (max-width: 767px) { .chat-features { padding: 60px 20px !important; } }`}</style>
       <motion.div
         initial={{ opacity: 0, y: 16 }}
         whileInView={{ opacity: 1, y: 0 }}

--- a/apps/website/src/components/landing/chat-landing/ChatLandingFooterCTA.tsx
+++ b/apps/website/src/components/landing/chat-landing/ChatLandingFooterCTA.tsx
@@ -1,60 +1,111 @@
 // apps/website/src/components/landing/chat-landing/ChatLandingFooterCTA.tsx
 'use client';
+
+import { motion } from 'framer-motion';
+import Link from 'next/link';
 import { tokens } from '@cacheplane/design-tokens';
 
 export function ChatLandingFooterCTA() {
   return (
-    <section style={{ padding: '5rem 2rem' }}>
-      <div style={{
-        maxWidth: '42rem', margin: '0 auto', textAlign: 'center',
-        background: tokens.glass.bg, border: '1px solid rgba(90,0,200,0.2)',
-        borderRadius: 16, padding: 48,
-        backdropFilter: `blur(${tokens.glass.blur})`,
-      }}>
-        <h2 style={{
-          fontFamily: "'EB Garamond', serif", fontSize: 'clamp(24px, 4vw, 32px)',
-          fontWeight: 700, color: tokens.colors.textPrimary, marginBottom: 16,
+    <section
+      aria-labelledby="chat-footer-cta-heading"
+      style={{
+        background: 'linear-gradient(135deg, #1a1a2e 0%, #0d1b3e 100%)',
+        padding: '0 2rem',
+      }}
+    >
+      <style>{`
+        .chat-footer-secondary-btn:hover { border-color: rgba(255,255,255,0.6) !important; }
+        @media (max-width: 767px) {
+          .chat-footer-inner { padding-top: 4rem !important; padding-bottom: 4rem !important; }
+          .chat-footer-heading { font-size: clamp(28px, 6vw, 42px) !important; }
+        }
+      `}</style>
+      <motion.div
+        className="chat-footer-inner"
+        initial={{ opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.5 }}
+        style={{
+          maxWidth: '48rem',
+          margin: '0 auto',
+          paddingTop: '6rem',
+          paddingBottom: '6rem',
+          textAlign: 'center',
+        }}
+      >
+        <p style={{
+          fontFamily: 'var(--font-mono, monospace)',
+          fontSize: '11px', fontWeight: 500, letterSpacing: '0.12em',
+          textTransform: 'uppercase', color: 'rgba(255, 255, 255, 0.5)',
+          marginBottom: '1rem',
         }}>
+          Ready when you are
+        </p>
+
+        <h2
+          id="chat-footer-cta-heading"
+          className="chat-footer-heading"
+          style={{
+            fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+            fontSize: '42px', fontWeight: 400, lineHeight: 1.15,
+            color: '#ffffff', marginBottom: '1.25rem',
+          }}
+        >
           Ready to ship your agent chat?
         </h2>
+
         <p style={{
-          fontFamily: 'Inter, sans-serif', fontSize: 16, lineHeight: 1.7,
-          color: tokens.colors.textSecondary, marginBottom: 32,
+          fontFamily: 'var(--font-inter, Inter, sans-serif)',
+          fontSize: '17px', lineHeight: 1.6,
+          color: 'rgba(255, 255, 255, 0.7)', marginBottom: '2.5rem',
         }}>
-          Download the enterprise guide, explore the docs, or start the pilot program.
+          Production chat UI in days, not sprints. Start with a conversation.
         </p>
-        <div style={{ display: 'flex', gap: 12, justifyContent: 'center', flexWrap: 'wrap' }}>
-          <a href="/whitepapers/chat.pdf" download
+
+        <div style={{
+          display: 'flex', gap: '1rem', justifyContent: 'center',
+          flexWrap: 'wrap', marginBottom: '1.5rem',
+        }}>
+          <Link
+            href="/pilot-to-prod"
             style={{
               display: 'inline-block', padding: '0.875rem 2rem',
-              background: tokens.colors.chatPurple, color: '#fff',
-              fontFamily: 'Inter, sans-serif', fontSize: 15, fontWeight: 600,
-              textDecoration: 'none', borderRadius: 6,
-            }}>
+              background: '#ffffff', color: tokens.colors.accent,
+              fontFamily: 'var(--font-inter, Inter, sans-serif)',
+              fontSize: '15px', fontWeight: 600, textDecoration: 'none',
+              borderRadius: '6px', transition: 'box-shadow 0.2s ease',
+            }}
+          >
+            Start Your Pilot →
+          </Link>
+
+          <a
+            href="/whitepapers/chat.pdf"
+            download
+            className="chat-footer-secondary-btn"
+            style={{
+              display: 'inline-block', padding: '0.875rem 2rem',
+              background: 'transparent', color: '#ffffff',
+              fontFamily: 'var(--font-inter, Inter, sans-serif)',
+              fontSize: '15px', fontWeight: 600, textDecoration: 'none',
+              borderRadius: '6px', border: '1px solid rgba(255, 255, 255, 0.3)',
+              transition: 'border-color 0.2s ease',
+            }}
+          >
             Download the Guide
           </a>
-          <a href="/pilot-to-prod"
-            style={{
-              display: 'inline-block', padding: '0.875rem 2rem',
-              background: tokens.glass.bg, color: tokens.colors.chatPurple,
-              fontFamily: 'Inter, sans-serif', fontSize: 15, fontWeight: 600,
-              textDecoration: 'none', borderRadius: 6,
-              border: '1px solid rgba(90,0,200,0.2)',
-            }}>
-            Pilot Program →
-          </a>
-          <a href="/docs"
-            style={{
-              display: 'inline-block', padding: '0.875rem 2rem',
-              background: 'transparent', color: tokens.colors.textSecondary,
-              fontFamily: 'Inter, sans-serif', fontSize: 15, fontWeight: 600,
-              textDecoration: 'none', borderRadius: 6,
-              border: `1px solid ${tokens.glass.border}`,
-            }}>
-            View Docs
-          </a>
         </div>
-      </div>
+
+        <p style={{
+          fontFamily: 'var(--font-mono, monospace)',
+          fontSize: '10px', letterSpacing: '0.08em',
+          color: 'rgba(255, 255, 255, 0.4)',
+        }}>
+          App deployment license · $20,000 · 3-month co-pilot engagement
+        </p>
+      </motion.div>
     </section>
   );
 }

--- a/apps/website/src/components/landing/chat-landing/ChatLandingHero.tsx
+++ b/apps/website/src/components/landing/chat-landing/ChatLandingHero.tsx
@@ -1,14 +1,35 @@
 // apps/website/src/components/landing/chat-landing/ChatLandingHero.tsx
 'use client';
 import { motion } from 'framer-motion';
+import Link from 'next/link';
 import { tokens } from '@cacheplane/design-tokens';
 
 const BADGES = ['Angular 20+', 'Vercel json-render', 'Google A2UI', 'WCAG accessible'];
 
 export function ChatLandingHero() {
   return (
-    <section aria-labelledby="chat-hero-heading" style={{ position: 'relative', overflow: 'hidden', padding: '0 2rem' }}>
+    <section className="chat-hero" aria-labelledby="chat-hero-heading" style={{ position: 'relative', overflow: 'hidden', padding: '0 2rem' }}>
+      <style>{`
+        @media (max-width: 767px) {
+          .chat-hero { padding: 0 1.25rem !important; }
+        }
+      `}</style>
       <div style={{ maxWidth: '56rem', margin: '0 auto', textAlign: 'center', position: 'relative', zIndex: 1 }} className="py-24 md:py-32">
+        {/* Stack breadcrumb */}
+        <motion.div initial={{ y: 16 }} animate={{ y: 0 }} transition={{ duration: 0.5 }}>
+          <div style={{
+            display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 0,
+            fontFamily: "'JetBrains Mono', monospace", fontSize: 10, letterSpacing: '0.08em',
+            textTransform: 'uppercase', marginBottom: '0.75rem',
+          }}>
+            <Link href="/angular" style={{ color: tokens.colors.textMuted, fontWeight: 500, textDecoration: 'none' }}>Agent</Link>
+            <span style={{ color: tokens.colors.textMuted, margin: '0 6px' }}>→</span>
+            <Link href="/render" style={{ color: tokens.colors.textMuted, fontWeight: 500, textDecoration: 'none' }}>Render</Link>
+            <span style={{ color: tokens.colors.textMuted, margin: '0 6px' }}>→</span>
+            <span style={{ color: tokens.colors.chatPurple, fontWeight: 700 }}>Chat</span>
+          </div>
+        </motion.div>
+
         <motion.div initial={{ y: 16 }} animate={{ y: 0 }} transition={{ duration: 0.5 }}>
           <span style={{
             fontFamily: "'JetBrains Mono', monospace", fontSize: 11, letterSpacing: '0.08em',
@@ -45,7 +66,7 @@ export function ChatLandingHero() {
             }}>
             Download the Guide
           </a>
-          <a href="/docs"
+          <Link href="/docs"
             style={{
               display: 'inline-flex', alignItems: 'center', gap: 6,
               background: tokens.glass.bg, backdropFilter: `blur(${tokens.glass.blur})`,
@@ -55,7 +76,7 @@ export function ChatLandingHero() {
               textDecoration: 'none', border: '1px solid rgba(90,0,200,0.2)', minHeight: 44,
             }}>
             View Docs
-          </a>
+          </Link>
         </motion.div>
 
         <motion.div initial={{ y: 14 }} animate={{ y: 0 }} transition={{ duration: 0.6, delay: 0.2 }}

--- a/apps/website/src/components/landing/chat-landing/ChatLandingProblemSolution.tsx
+++ b/apps/website/src/components/landing/chat-landing/ChatLandingProblemSolution.tsx
@@ -23,7 +23,8 @@ const SOLUTIONS = [
 
 export function ChatLandingProblemSolution() {
   return (
-    <section style={{ padding: '80px 32px' }}>
+    <section className="chat-problem" style={{ padding: '80px 32px' }}>
+      <style>{`@media (max-width: 767px) { .chat-problem { padding: 60px 20px !important; } }`}</style>
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         whileInView={{ opacity: 1, y: 0 }}

--- a/apps/website/src/components/landing/chat-landing/ChatLandingStackSiblings.tsx
+++ b/apps/website/src/components/landing/chat-landing/ChatLandingStackSiblings.tsx
@@ -1,0 +1,123 @@
+'use client';
+import { motion } from 'framer-motion';
+import Link from 'next/link';
+import { tokens } from '@cacheplane/design-tokens';
+
+const SIBLINGS = [
+  {
+    tag: 'Agent',
+    pkg: '@cacheplane/angular',
+    color: tokens.colors.accent,
+    rgb: '0,64,144',
+    headline: 'The reactive bridge to LangGraph',
+    href: '/angular',
+    ctaLabel: 'Explore Agent',
+  },
+  {
+    tag: 'Gen UI',
+    pkg: '@cacheplane/render',
+    color: tokens.colors.renderGreen,
+    rgb: '26,122,64',
+    headline: 'Agents that render UI — on open standards',
+    href: '/render',
+    ctaLabel: 'Explore Render',
+  },
+];
+
+export function ChatLandingStackSiblings() {
+  return (
+    <section className="chat-stack-siblings" style={{ padding: '80px 32px' }}>
+      <style>{`
+        @media (max-width: 767px) {
+          .chat-stack-siblings { padding: 60px 20px !important; }
+          .chat-stack-siblings-grid { grid-template-columns: 1fr !important; }
+        }
+      `}</style>
+      <motion.div
+        initial={{ opacity: 0, y: 16 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.5 }}
+        style={{ textAlign: 'center', marginBottom: 36 }}
+      >
+        <p style={{
+          fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+          fontSize: '0.7rem', textTransform: 'uppercase', letterSpacing: '0.12em',
+          fontWeight: 700, color: tokens.colors.accent, marginBottom: 14,
+        }}>
+          The Cacheplane Stack
+        </p>
+        <p style={{
+          fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+          fontStyle: 'italic', fontSize: '1.05rem',
+          color: tokens.colors.textSecondary, maxWidth: 520, margin: '0 auto',
+        }}>
+          This library is part of a cohesive three-layer architecture.
+        </p>
+      </motion.div>
+
+      <div
+        className="chat-stack-siblings-grid"
+        style={{
+          display: 'grid', gridTemplateColumns: '1fr 1fr',
+          gap: 16, maxWidth: 860, margin: '0 auto',
+        }}
+      >
+        {SIBLINGS.map((lib, i) => (
+          <motion.div
+            key={lib.pkg}
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.5, delay: i * 0.1 }}
+            style={{
+              padding: '24px 20px',
+              borderRadius: 14,
+              background: `rgba(${lib.rgb}, 0.03)`,
+              border: `1px solid rgba(${lib.rgb}, 0.15)`,
+              borderLeft: `3px solid ${lib.color}`,
+              display: 'flex', flexDirection: 'column', gap: 10,
+            }}
+          >
+            <span style={{
+              display: 'inline-block', alignSelf: 'flex-start',
+              fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+              fontSize: '0.58rem', fontWeight: 700, textTransform: 'uppercase',
+              letterSpacing: '0.07em', padding: '2px 9px', borderRadius: 5,
+              color: '#fff', background: lib.color,
+            }}>
+              {lib.tag}
+            </span>
+
+            <p style={{
+              fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+              fontSize: '0.76rem', fontWeight: 700, color: lib.color, margin: 0,
+            }}>
+              {lib.pkg}
+            </p>
+
+            <h3 style={{
+              fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+              fontSize: '1.15rem', fontWeight: 700,
+              color: tokens.colors.textPrimary, lineHeight: 1.25, margin: 0,
+            }}>
+              {lib.headline}
+            </h3>
+
+            <Link
+              href={lib.href}
+              style={{
+                fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+                fontSize: '0.72rem', fontWeight: 700, color: lib.color,
+                textDecoration: 'none', marginTop: 4,
+                display: 'inline-flex', alignItems: 'center', gap: 4,
+              }}
+            >
+              {lib.ctaLabel} →
+            </Link>
+          </motion.div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/website/src/components/landing/chat-landing/ChatLandingWhitePaperGate.tsx
+++ b/apps/website/src/components/landing/chat-landing/ChatLandingWhitePaperGate.tsx
@@ -37,7 +37,12 @@ export function ChatLandingWhitePaperGate() {
   };
 
   return (
-    <section id="chat-whitepaper-gate" style={{ padding: '80px 32px' }}>
+    <section id="chat-whitepaper-gate" className="chat-wp-gate" style={{ padding: '80px 32px' }}>
+      <style>{`
+        @media (max-width: 767px) {
+          .chat-wp-gate { padding: 60px 20px !important; }
+        }
+      `}</style>
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         whileInView={{ opacity: 1, y: 0 }}
@@ -57,7 +62,7 @@ export function ChatLandingWhitePaperGate() {
             fontSize: '0.68rem', textTransform: 'uppercase', letterSpacing: '0.12em',
             fontWeight: 700, color: tokens.colors.chatPurple, marginBottom: 14,
           }}>
-            Free Download
+            Chat Guide
           </p>
           <h2 style={{
             fontFamily: 'var(--font-garamond,"EB Garamond",Georgia,serif)',
@@ -71,7 +76,13 @@ export function ChatLandingWhitePaperGate() {
             fontStyle: 'italic', fontSize: '1rem', color: tokens.colors.textSecondary,
             lineHeight: 1.55, marginBottom: 28,
           }}>
-            Five chapters covering the sprint tax, batteries-included components, theming and design system integration, generative UI in chat, and debug tooling.
+            Five chapters covering the sprint tax, batteries-included components, theming and design system integration, generative UI with Vercel json-render, Google A2UI support, and debug tooling.
+          </p>
+          <p style={{
+            fontFamily: 'Inter, sans-serif', fontSize: '0.8rem',
+            color: tokens.colors.textMuted, marginBottom: 20,
+          }}>
+            Part of the Cacheplane Angular Agent Framework.
           </p>
           <a href="/whitepapers/chat.pdf" download="cacheplane-chat-enterprise-guide.pdf"
             style={{

--- a/apps/website/src/components/landing/render/RenderCodeShowcase.tsx
+++ b/apps/website/src/components/landing/render/RenderCodeShowcase.tsx
@@ -24,7 +24,8 @@ const SNIPPETS = [
 
 export async function RenderCodeShowcase() {
   return (
-    <section style={{ padding: '80px 32px' }}>
+    <section className="render-code" style={{ padding: '80px 32px' }}>
+      <style>{`@media (max-width: 767px) { .render-code { padding: 60px 20px !important; } }`}</style>
       <div style={{ textAlign: 'center', marginBottom: 48 }}>
         <p style={{
           fontFamily: 'var(--font-mono,"JetBrains Mono",monospace)',

--- a/apps/website/src/components/landing/render/RenderComparison.tsx
+++ b/apps/website/src/components/landing/render/RenderComparison.tsx
@@ -16,7 +16,12 @@ const ROWS = [
 
 export function RenderComparison() {
   return (
-    <section style={{ padding: '80px 32px' }}>
+    <section className="render-comparison" style={{ padding: '80px 32px' }}>
+      <style>{`
+        @media (max-width: 767px) {
+          .render-comparison { padding: 60px 20px !important; }
+        }
+      `}</style>
       <motion.div
         initial={{ opacity: 0, y: 16 }}
         whileInView={{ opacity: 1, y: 0 }}

--- a/apps/website/src/components/landing/render/RenderFeaturesGrid.tsx
+++ b/apps/website/src/components/landing/render/RenderFeaturesGrid.tsx
@@ -15,7 +15,8 @@ const FEATURES = [
 
 export function RenderFeaturesGrid() {
   return (
-    <section style={{ padding: '80px 32px' }}>
+    <section className="render-features" style={{ padding: '80px 32px' }}>
+      <style>{`@media (max-width: 767px) { .render-features { padding: 60px 20px !important; } }`}</style>
       <motion.div
         initial={{ opacity: 0, y: 16 }}
         whileInView={{ opacity: 1, y: 0 }}

--- a/apps/website/src/components/landing/render/RenderFooterCTA.tsx
+++ b/apps/website/src/components/landing/render/RenderFooterCTA.tsx
@@ -1,60 +1,111 @@
 // apps/website/src/components/landing/render/RenderFooterCTA.tsx
 'use client';
+
+import { motion } from 'framer-motion';
+import Link from 'next/link';
 import { tokens } from '@cacheplane/design-tokens';
 
 export function RenderFooterCTA() {
   return (
-    <section style={{ padding: '5rem 2rem' }}>
-      <div style={{
-        maxWidth: '42rem', margin: '0 auto', textAlign: 'center',
-        background: tokens.glass.bg, border: `1px solid ${tokens.colors.accentBorder}`,
-        borderRadius: 16, padding: 48,
-        backdropFilter: `blur(${tokens.glass.blur})`,
-      }}>
-        <h2 style={{
-          fontFamily: "'EB Garamond', serif", fontSize: 'clamp(24px, 4vw, 32px)',
-          fontWeight: 700, color: tokens.colors.textPrimary, marginBottom: 16,
-        }}>
-          Ready to decouple your agent UI?
-        </h2>
+    <section
+      aria-labelledby="render-footer-cta-heading"
+      style={{
+        background: 'linear-gradient(135deg, #1a1a2e 0%, #0d1b3e 100%)',
+        padding: '0 2rem',
+      }}
+    >
+      <style>{`
+        .render-footer-secondary-btn:hover { border-color: rgba(255,255,255,0.6) !important; }
+        @media (max-width: 767px) {
+          .render-footer-inner { padding-top: 4rem !important; padding-bottom: 4rem !important; }
+          .render-footer-heading { font-size: clamp(28px, 6vw, 42px) !important; }
+        }
+      `}</style>
+      <motion.div
+        className="render-footer-inner"
+        initial={{ opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.5 }}
+        style={{
+          maxWidth: '48rem',
+          margin: '0 auto',
+          paddingTop: '6rem',
+          paddingBottom: '6rem',
+          textAlign: 'center',
+        }}
+      >
         <p style={{
-          fontFamily: 'Inter, sans-serif', fontSize: 16, lineHeight: 1.7,
-          color: tokens.colors.textSecondary, marginBottom: 32,
+          fontFamily: 'var(--font-mono, monospace)',
+          fontSize: '11px', fontWeight: 500, letterSpacing: '0.12em',
+          textTransform: 'uppercase', color: 'rgba(255, 255, 255, 0.5)',
+          marginBottom: '1rem',
         }}>
-          Download the enterprise guide, explore the docs, or start the pilot program.
+          Ready when you are
         </p>
-        <div style={{ display: 'flex', gap: 12, justifyContent: 'center', flexWrap: 'wrap' }}>
-          <a href="/whitepapers/render.pdf" download
+
+        <h2
+          id="render-footer-cta-heading"
+          className="render-footer-heading"
+          style={{
+            fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+            fontSize: '42px', fontWeight: 400, lineHeight: 1.15,
+            color: '#ffffff', marginBottom: '1.25rem',
+          }}
+        >
+          Ready to ship your generative UI?
+        </h2>
+
+        <p style={{
+          fontFamily: 'var(--font-inter, Inter, sans-serif)',
+          fontSize: '17px', lineHeight: 1.6,
+          color: 'rgba(255, 255, 255, 0.7)', marginBottom: '2.5rem',
+        }}>
+          Decouple your agent&apos;s UI layer with open standards. Start with a conversation.
+        </p>
+
+        <div style={{
+          display: 'flex', gap: '1rem', justifyContent: 'center',
+          flexWrap: 'wrap', marginBottom: '1.5rem',
+        }}>
+          <Link
+            href="/pilot-to-prod"
             style={{
               display: 'inline-block', padding: '0.875rem 2rem',
-              background: tokens.colors.renderGreen, color: '#fff',
-              fontFamily: 'Inter, sans-serif', fontSize: 15, fontWeight: 600,
-              textDecoration: 'none', borderRadius: 6,
-            }}>
+              background: '#ffffff', color: tokens.colors.accent,
+              fontFamily: 'var(--font-inter, Inter, sans-serif)',
+              fontSize: '15px', fontWeight: 600, textDecoration: 'none',
+              borderRadius: '6px', transition: 'box-shadow 0.2s ease',
+            }}
+          >
+            Start Your Pilot →
+          </Link>
+
+          <a
+            href="/whitepapers/render.pdf"
+            download
+            className="render-footer-secondary-btn"
+            style={{
+              display: 'inline-block', padding: '0.875rem 2rem',
+              background: 'transparent', color: '#ffffff',
+              fontFamily: 'var(--font-inter, Inter, sans-serif)',
+              fontSize: '15px', fontWeight: 600, textDecoration: 'none',
+              borderRadius: '6px', border: '1px solid rgba(255, 255, 255, 0.3)',
+              transition: 'border-color 0.2s ease',
+            }}
+          >
             Download the Guide
           </a>
-          <a href="/pilot-to-prod"
-            style={{
-              display: 'inline-block', padding: '0.875rem 2rem',
-              background: tokens.glass.bg, color: tokens.colors.accent,
-              fontFamily: 'Inter, sans-serif', fontSize: 15, fontWeight: 600,
-              textDecoration: 'none', borderRadius: 6,
-              border: `1px solid ${tokens.colors.accentBorder}`,
-            }}>
-            Pilot Program →
-          </a>
-          <a href="/docs"
-            style={{
-              display: 'inline-block', padding: '0.875rem 2rem',
-              background: 'transparent', color: tokens.colors.textSecondary,
-              fontFamily: 'Inter, sans-serif', fontSize: 15, fontWeight: 600,
-              textDecoration: 'none', borderRadius: 6,
-              border: `1px solid ${tokens.glass.border}`,
-            }}>
-            View Docs
-          </a>
         </div>
-      </div>
+
+        <p style={{
+          fontFamily: 'var(--font-mono, monospace)',
+          fontSize: '10px', letterSpacing: '0.08em',
+          color: 'rgba(255, 255, 255, 0.4)',
+        }}>
+          App deployment license · $20,000 · 3-month co-pilot engagement
+        </p>
+      </motion.div>
     </section>
   );
 }

--- a/apps/website/src/components/landing/render/RenderHero.tsx
+++ b/apps/website/src/components/landing/render/RenderHero.tsx
@@ -1,14 +1,35 @@
 // apps/website/src/components/landing/render/RenderHero.tsx
 'use client';
 import { motion } from 'framer-motion';
+import Link from 'next/link';
 import { tokens } from '@cacheplane/design-tokens';
 
 const BADGES = ['Angular 20+', 'Vercel json-render', 'Google A2UI', 'JSON Patch streaming'];
 
 export function RenderHero() {
   return (
-    <section aria-labelledby="render-hero-heading" style={{ position: 'relative', overflow: 'hidden', padding: '0 2rem' }}>
+    <section className="render-hero" aria-labelledby="render-hero-heading" style={{ position: 'relative', overflow: 'hidden', padding: '0 2rem' }}>
+      <style>{`
+        @media (max-width: 767px) {
+          .render-hero { padding: 0 1.25rem !important; }
+        }
+      `}</style>
       <div style={{ maxWidth: '56rem', margin: '0 auto', textAlign: 'center', position: 'relative', zIndex: 1 }} className="py-24 md:py-32">
+        {/* Stack breadcrumb */}
+        <motion.div initial={{ y: 16 }} animate={{ y: 0 }} transition={{ duration: 0.5 }}>
+          <div style={{
+            display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 0,
+            fontFamily: "'JetBrains Mono', monospace", fontSize: 10, letterSpacing: '0.08em',
+            textTransform: 'uppercase', marginBottom: '0.75rem',
+          }}>
+            <Link href="/angular" style={{ color: tokens.colors.textMuted, fontWeight: 500, textDecoration: 'none' }}>Agent</Link>
+            <span style={{ color: tokens.colors.textMuted, margin: '0 6px' }}>→</span>
+            <span style={{ color: tokens.colors.renderGreen, fontWeight: 700 }}>Render</span>
+            <span style={{ color: tokens.colors.textMuted, margin: '0 6px' }}>→</span>
+            <Link href="/chat" style={{ color: tokens.colors.textMuted, fontWeight: 500, textDecoration: 'none' }}>Chat</Link>
+          </div>
+        </motion.div>
+
         <motion.div initial={{ y: 16 }} animate={{ y: 0 }} transition={{ duration: 0.5 }}>
           <span style={{
             fontFamily: "'JetBrains Mono', monospace", fontSize: 11, letterSpacing: '0.08em',
@@ -45,7 +66,7 @@ export function RenderHero() {
             }}>
             Download the Guide
           </a>
-          <a href="/docs"
+          <Link href="/docs"
             style={{
               display: 'inline-flex', alignItems: 'center', gap: 6,
               background: tokens.glass.bg, backdropFilter: `blur(${tokens.glass.blur})`,
@@ -55,7 +76,7 @@ export function RenderHero() {
               textDecoration: 'none', border: `1px solid ${tokens.colors.accentBorder}`, minHeight: 44,
             }}>
             View Docs
-          </a>
+          </Link>
         </motion.div>
 
         <motion.div initial={{ y: 14 }} animate={{ y: 0 }} transition={{ duration: 0.6, delay: 0.2 }}

--- a/apps/website/src/components/landing/render/RenderProblemSolution.tsx
+++ b/apps/website/src/components/landing/render/RenderProblemSolution.tsx
@@ -22,7 +22,8 @@ const SOLUTIONS = [
 
 export function RenderProblemSolution() {
   return (
-    <section style={{ padding: '80px 32px' }}>
+    <section className="render-problem" style={{ padding: '80px 32px' }}>
+      <style>{`@media (max-width: 767px) { .render-problem { padding: 60px 20px !important; } }`}</style>
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         whileInView={{ opacity: 1, y: 0 }}

--- a/apps/website/src/components/landing/render/RenderStackSiblings.tsx
+++ b/apps/website/src/components/landing/render/RenderStackSiblings.tsx
@@ -1,0 +1,123 @@
+'use client';
+import { motion } from 'framer-motion';
+import Link from 'next/link';
+import { tokens } from '@cacheplane/design-tokens';
+
+const SIBLINGS = [
+  {
+    tag: 'Agent',
+    pkg: '@cacheplane/angular',
+    color: tokens.colors.accent,
+    rgb: '0,64,144',
+    headline: 'The reactive bridge to LangGraph',
+    href: '/angular',
+    ctaLabel: 'Explore Agent',
+  },
+  {
+    tag: 'Chat',
+    pkg: '@cacheplane/chat',
+    color: tokens.colors.chatPurple,
+    rgb: '90,0,200',
+    headline: 'Production chat UI in days, not sprints',
+    href: '/chat',
+    ctaLabel: 'Explore Chat',
+  },
+];
+
+export function RenderStackSiblings() {
+  return (
+    <section className="render-stack-siblings" style={{ padding: '80px 32px' }}>
+      <style>{`
+        @media (max-width: 767px) {
+          .render-stack-siblings { padding: 60px 20px !important; }
+          .render-stack-siblings-grid { grid-template-columns: 1fr !important; }
+        }
+      `}</style>
+      <motion.div
+        initial={{ opacity: 0, y: 16 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.5 }}
+        style={{ textAlign: 'center', marginBottom: 36 }}
+      >
+        <p style={{
+          fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+          fontSize: '0.7rem', textTransform: 'uppercase', letterSpacing: '0.12em',
+          fontWeight: 700, color: tokens.colors.accent, marginBottom: 14,
+        }}>
+          The Cacheplane Stack
+        </p>
+        <p style={{
+          fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+          fontStyle: 'italic', fontSize: '1.05rem',
+          color: tokens.colors.textSecondary, maxWidth: 520, margin: '0 auto',
+        }}>
+          This library is part of a cohesive three-layer architecture.
+        </p>
+      </motion.div>
+
+      <div
+        className="render-stack-siblings-grid"
+        style={{
+          display: 'grid', gridTemplateColumns: '1fr 1fr',
+          gap: 16, maxWidth: 860, margin: '0 auto',
+        }}
+      >
+        {SIBLINGS.map((lib, i) => (
+          <motion.div
+            key={lib.pkg}
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.5, delay: i * 0.1 }}
+            style={{
+              padding: '24px 20px',
+              borderRadius: 14,
+              background: `rgba(${lib.rgb}, 0.03)`,
+              border: `1px solid rgba(${lib.rgb}, 0.15)`,
+              borderLeft: `3px solid ${lib.color}`,
+              display: 'flex', flexDirection: 'column', gap: 10,
+            }}
+          >
+            <span style={{
+              display: 'inline-block', alignSelf: 'flex-start',
+              fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+              fontSize: '0.58rem', fontWeight: 700, textTransform: 'uppercase',
+              letterSpacing: '0.07em', padding: '2px 9px', borderRadius: 5,
+              color: '#fff', background: lib.color,
+            }}>
+              {lib.tag}
+            </span>
+
+            <p style={{
+              fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+              fontSize: '0.76rem', fontWeight: 700, color: lib.color, margin: 0,
+            }}>
+              {lib.pkg}
+            </p>
+
+            <h3 style={{
+              fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+              fontSize: '1.15rem', fontWeight: 700,
+              color: tokens.colors.textPrimary, lineHeight: 1.25, margin: 0,
+            }}>
+              {lib.headline}
+            </h3>
+
+            <Link
+              href={lib.href}
+              style={{
+                fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+                fontSize: '0.72rem', fontWeight: 700, color: lib.color,
+                textDecoration: 'none', marginTop: 4,
+                display: 'inline-flex', alignItems: 'center', gap: 4,
+              }}
+            >
+              {lib.ctaLabel} →
+            </Link>
+          </motion.div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/website/src/components/landing/render/RenderWhitePaperGate.tsx
+++ b/apps/website/src/components/landing/render/RenderWhitePaperGate.tsx
@@ -37,7 +37,12 @@ export function RenderWhitePaperGate() {
   };
 
   return (
-    <section id="render-whitepaper-gate" style={{ padding: '80px 32px' }}>
+    <section id="render-whitepaper-gate" className="render-wp-gate" style={{ padding: '80px 32px' }}>
+      <style>{`
+        @media (max-width: 767px) {
+          .render-wp-gate { padding: 60px 20px !important; }
+        }
+      `}</style>
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         whileInView={{ opacity: 1, y: 0 }}
@@ -57,7 +62,7 @@ export function RenderWhitePaperGate() {
             fontSize: '0.68rem', textTransform: 'uppercase', letterSpacing: '0.12em',
             fontWeight: 700, color: tokens.colors.accent, marginBottom: 14,
           }}>
-            Free Download
+            Render Guide
           </p>
           <h2 style={{
             fontFamily: 'var(--font-garamond,"EB Garamond",Georgia,serif)',
@@ -71,7 +76,13 @@ export function RenderWhitePaperGate() {
             fontStyle: 'italic', fontSize: '1rem', color: tokens.colors.textSecondary,
             lineHeight: 1.55, marginBottom: 28,
           }}>
-            Five chapters covering the coupling problem, declarative UI specs with Vercel's json-render standard, the component registry, streaming JSON patches, and state management.
+            Five chapters covering the coupling problem, declarative UI specs with Vercel's json-render standard and Google's A2UI protocol, the component registry, streaming JSON patches, and signal-native state management.
+          </p>
+          <p style={{
+            fontFamily: 'Inter, sans-serif', fontSize: '0.8rem',
+            color: tokens.colors.textMuted, marginBottom: 20,
+          }}>
+            Part of the Cacheplane Angular Agent Framework.
           </p>
           <a href="/whitepapers/render.pdf" download="cacheplane-render-enterprise-guide.pdf"
             style={{

--- a/apps/website/src/components/landing/solutions/SolutionArchitecture.tsx
+++ b/apps/website/src/components/landing/solutions/SolutionArchitecture.tsx
@@ -1,0 +1,176 @@
+'use client';
+import { motion } from 'framer-motion';
+import Link from 'next/link';
+import { tokens } from '@cacheplane/design-tokens';
+import type { ArchitectureLayer } from '../../../lib/solutions-data';
+
+const LIBRARY_META: Record<string, { color: string; rgb: string; href: string }> = {
+  Agent: { color: tokens.colors.accent, rgb: '0,64,144', href: '/angular' },
+  Render: { color: tokens.colors.renderGreen, rgb: '26,122,64', href: '/render' },
+  Chat: { color: tokens.colors.chatPurple, rgb: '90,0,200', href: '/chat' },
+};
+
+interface SolutionArchitectureProps {
+  color: string;
+  intro: string;
+  layers: ArchitectureLayer[];
+}
+
+function Connector({ fromRgb, toRgb }: { fromRgb: string; toRgb: string }) {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'center', padding: '2px 0' }}>
+      <div
+        style={{
+          width: 2,
+          height: 28,
+          background: `linear-gradient(to bottom, rgba(${fromRgb}, 0.3), rgba(${toRgb}, 0.3))`,
+          borderRadius: 1,
+        }}
+      />
+    </div>
+  );
+}
+
+export function SolutionArchitecture({ color, intro, layers }: SolutionArchitectureProps) {
+  return (
+    <section className="solution-arch" style={{ padding: '80px 32px' }}>
+      <style>{`
+        @media (max-width: 767px) {
+          .solution-arch { padding: 60px 20px !important; }
+          .solution-arch-card { padding: 24px 20px 20px !important; }
+        }
+      `}</style>
+      <motion.div
+        initial={{ opacity: 0, y: 16 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.5 }}
+        style={{ textAlign: 'center', marginBottom: 48 }}
+      >
+        <p
+          style={{
+            fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+            fontSize: '0.7rem',
+            textTransform: 'uppercase',
+            letterSpacing: '0.12em',
+            fontWeight: 700,
+            color,
+            marginBottom: 14,
+          }}
+        >
+          The Architecture
+        </p>
+        <h2
+          style={{
+            fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+            fontSize: 'clamp(26px, 3.5vw, 46px)',
+            fontWeight: 800,
+            lineHeight: 1.1,
+            color: tokens.colors.textPrimary,
+            marginBottom: 10,
+          }}
+        >
+          Three libraries. One solution.
+        </h2>
+        <p
+          style={{
+            fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+            fontStyle: 'italic',
+            fontSize: '1.05rem',
+            color: tokens.colors.textSecondary,
+            maxWidth: 560,
+            margin: '0 auto',
+          }}
+        >
+          {intro}
+        </p>
+      </motion.div>
+
+      <div style={{ maxWidth: 860, margin: '0 auto', display: 'flex', flexDirection: 'column' }}>
+        {layers.map((layer, i) => {
+          const meta = LIBRARY_META[layer.library];
+          const prevMeta = i > 0 ? LIBRARY_META[layers[i - 1].library] : null;
+          return (
+            <div key={layer.library}>
+              {i > 0 && prevMeta && (
+                <Connector fromRgb={prevMeta.rgb} toRgb={meta.rgb} />
+              )}
+              <motion.div
+                className="solution-arch-card"
+                initial={{ opacity: 0, y: 24 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true }}
+                transition={{ duration: 0.5, delay: i * 0.1 }}
+                style={{
+                  background: `rgba(${meta.rgb}, 0.03)`,
+                  border: `1px solid rgba(${meta.rgb}, 0.15)`,
+                  borderRadius: 14,
+                  padding: '28px 28px 24px',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: 10,
+                }}
+              >
+                <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                  <span
+                    style={{
+                      fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+                      fontSize: '0.58rem',
+                      fontWeight: 700,
+                      textTransform: 'uppercase',
+                      letterSpacing: '0.07em',
+                      padding: '2px 9px',
+                      borderRadius: 5,
+                      color: '#fff',
+                      background: meta.color,
+                    }}
+                  >
+                    {layer.library}
+                  </span>
+                  <span
+                    style={{
+                      fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+                      fontSize: '0.76rem',
+                      fontWeight: 700,
+                      color: meta.color,
+                    }}
+                  >
+                    {layer.pkg}
+                  </span>
+                </div>
+
+                <p
+                  style={{
+                    fontFamily: 'Inter, sans-serif',
+                    fontSize: '0.88rem',
+                    color: tokens.colors.textSecondary,
+                    lineHeight: 1.6,
+                    margin: 0,
+                  }}
+                >
+                  {layer.role}
+                </p>
+
+                <Link
+                  href={meta.href}
+                  style={{
+                    fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+                    fontSize: '0.72rem',
+                    fontWeight: 700,
+                    color: meta.color,
+                    textDecoration: 'none',
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 4,
+                  }}
+                >
+                  Explore {layer.library} →
+                </Link>
+              </motion.div>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/apps/website/src/components/landing/solutions/SolutionFooterCTA.tsx
+++ b/apps/website/src/components/landing/solutions/SolutionFooterCTA.tsx
@@ -1,0 +1,138 @@
+'use client';
+import { motion } from 'framer-motion';
+import Link from 'next/link';
+
+interface SolutionFooterCTAProps {
+  color: string;
+  headline: string;
+  subtext: string;
+}
+
+export function SolutionFooterCTA({ color, headline, subtext }: SolutionFooterCTAProps) {
+  return (
+    <section
+      style={{
+        background: 'linear-gradient(135deg, #1a1a2e 0%, #0d1b3e 100%)',
+        padding: '0 2rem',
+      }}
+    >
+      <style>{`
+        .solution-footer-secondary:hover { border-color: rgba(255,255,255,0.6) !important; }
+        @media (max-width: 767px) {
+          .solution-footer-inner { padding-top: 4rem !important; padding-bottom: 4rem !important; }
+        }
+      `}</style>
+      <motion.div
+        className="solution-footer-inner"
+        initial={{ opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.5 }}
+        style={{
+          maxWidth: '48rem',
+          margin: '0 auto',
+          paddingTop: '6rem',
+          paddingBottom: '6rem',
+          textAlign: 'center',
+        }}
+      >
+        <p
+          style={{
+            fontFamily: 'var(--font-mono, monospace)',
+            fontSize: '11px',
+            fontWeight: 500,
+            letterSpacing: '0.12em',
+            textTransform: 'uppercase',
+            color: 'rgba(255, 255, 255, 0.5)',
+            marginBottom: '1rem',
+          }}
+        >
+          Ready when you are
+        </p>
+
+        <h2
+          style={{
+            fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+            fontSize: 'clamp(28px, 4vw, 42px)',
+            fontWeight: 400,
+            lineHeight: 1.15,
+            color: '#ffffff',
+            marginBottom: '1.25rem',
+          }}
+        >
+          {headline}
+        </h2>
+
+        <p
+          style={{
+            fontFamily: 'var(--font-inter, Inter, sans-serif)',
+            fontSize: '17px',
+            lineHeight: 1.6,
+            color: 'rgba(255, 255, 255, 0.7)',
+            marginBottom: '2.5rem',
+          }}
+        >
+          {subtext}
+        </p>
+
+        <div
+          style={{
+            display: 'flex',
+            gap: '1rem',
+            justifyContent: 'center',
+            flexWrap: 'wrap',
+            marginBottom: '1.5rem',
+          }}
+        >
+          <Link
+            href="/pilot-to-prod"
+            style={{
+              display: 'inline-block',
+              padding: '0.875rem 2rem',
+              background: '#ffffff',
+              color,
+              fontFamily: 'var(--font-inter, Inter, sans-serif)',
+              fontSize: '15px',
+              fontWeight: 600,
+              textDecoration: 'none',
+              borderRadius: '6px',
+            }}
+          >
+            Start Your Pilot →
+          </Link>
+          <a
+            href="/whitepaper.pdf"
+            download
+            className="solution-footer-secondary"
+            style={{
+              display: 'inline-block',
+              padding: '0.875rem 2rem',
+              background: 'transparent',
+              color: '#ffffff',
+              fontFamily: 'var(--font-inter, Inter, sans-serif)',
+              fontSize: '15px',
+              fontWeight: 600,
+              textDecoration: 'none',
+              borderRadius: '6px',
+              border: '1px solid rgba(255, 255, 255, 0.3)',
+              transition: 'border-color 0.2s ease',
+            }}
+          >
+            Download the Guide
+          </a>
+        </div>
+
+        <p
+          style={{
+            fontFamily: 'var(--font-mono, monospace)',
+            fontSize: '10px',
+            letterSpacing: '0.08em',
+            color: 'rgba(255, 255, 255, 0.4)',
+          }}
+        >
+          App deployment license · $20,000 · 3-month co-pilot engagement
+        </p>
+      </motion.div>
+    </section>
+  );
+}

--- a/apps/website/src/components/landing/solutions/SolutionHero.tsx
+++ b/apps/website/src/components/landing/solutions/SolutionHero.tsx
@@ -1,0 +1,136 @@
+'use client';
+import { motion } from 'framer-motion';
+import Link from 'next/link';
+import { tokens } from '@cacheplane/design-tokens';
+import type { SolutionConfig } from '../../../lib/solutions-data';
+
+interface SolutionHeroProps {
+  solution: SolutionConfig;
+}
+
+export function SolutionHero({ solution }: SolutionHeroProps) {
+  return (
+    <section
+      aria-labelledby="solution-hero-heading"
+      style={{ position: 'relative', overflow: 'hidden', padding: '0 2rem' }}
+    >
+      <div
+        style={{
+          maxWidth: '56rem',
+          margin: '0 auto',
+          textAlign: 'center',
+          position: 'relative',
+          zIndex: 1,
+        }}
+        className="py-24 md:py-32"
+      >
+        <motion.div initial={{ y: 16 }} animate={{ y: 0 }} transition={{ duration: 0.5 }}>
+          <span
+            style={{
+              fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+              fontSize: 11,
+              letterSpacing: '0.08em',
+              color: solution.color,
+              textTransform: 'uppercase',
+              display: 'inline-block',
+              marginBottom: '1.5rem',
+            }}
+          >
+            {solution.eyebrow}
+          </span>
+        </motion.div>
+
+        <motion.h1
+          id="solution-hero-heading"
+          initial={{ y: 20 }}
+          animate={{ y: 0 }}
+          transition={{ duration: 0.6, delay: 0.05 }}
+          style={{
+            fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+            fontSize: 'clamp(36px, 5vw, 56px)',
+            fontWeight: 700,
+            lineHeight: 1.1,
+            color: tokens.colors.textPrimary,
+            margin: 0,
+            marginBottom: '1.25rem',
+            whiteSpace: 'pre-line',
+          }}
+        >
+          {solution.title}
+        </motion.h1>
+
+        <motion.p
+          initial={{ y: 14 }}
+          animate={{ y: 0 }}
+          transition={{ duration: 0.6, delay: 0.1 }}
+          style={{
+            fontFamily: 'Inter, sans-serif',
+            fontSize: 18,
+            color: tokens.colors.textSecondary,
+            maxWidth: '52ch',
+            margin: '0 auto',
+            lineHeight: 1.6,
+            marginBottom: '2rem',
+          }}
+        >
+          {solution.subtitle}
+        </motion.p>
+
+        <motion.div
+          initial={{ y: 14 }}
+          animate={{ y: 0 }}
+          transition={{ duration: 0.6, delay: 0.15 }}
+          style={{
+            display: 'flex',
+            gap: '0.75rem',
+            justifyContent: 'center',
+            flexWrap: 'wrap',
+          }}
+        >
+          <Link
+            href="/pilot-to-prod"
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 6,
+              background: solution.color,
+              color: '#fff',
+              fontFamily: 'Inter, sans-serif',
+              fontSize: 15,
+              fontWeight: 600,
+              padding: '0.875rem 1.75rem',
+              borderRadius: 8,
+              textDecoration: 'none',
+              minHeight: 44,
+            }}
+          >
+            Start a Pilot
+          </Link>
+          <a
+            href="/whitepaper.pdf"
+            download
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 6,
+              background: tokens.glass.bg,
+              backdropFilter: `blur(${tokens.glass.blur})`,
+              WebkitBackdropFilter: `blur(${tokens.glass.blur})`,
+              color: solution.color,
+              fontFamily: 'Inter, sans-serif',
+              fontSize: 15,
+              fontWeight: 600,
+              padding: '0.875rem 1.75rem',
+              borderRadius: 8,
+              textDecoration: 'none',
+              border: `1px solid rgba(${solution.rgb}, 0.25)`,
+              minHeight: 44,
+            }}
+          >
+            Download the Guide
+          </a>
+        </motion.div>
+      </div>
+    </section>
+  );
+}

--- a/apps/website/src/components/landing/solutions/SolutionHero.tsx
+++ b/apps/website/src/components/landing/solutions/SolutionHero.tsx
@@ -24,7 +24,7 @@ export function SolutionHero({ solution }: SolutionHeroProps) {
         }}
         className="py-24 md:py-32"
       >
-        <motion.div initial={{ y: 16 }} animate={{ y: 0 }} transition={{ duration: 0.5 }}>
+        <motion.div initial={{ opacity: 0, y: 16 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.5 }}>
           <span
             style={{
               fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
@@ -42,8 +42,8 @@ export function SolutionHero({ solution }: SolutionHeroProps) {
 
         <motion.h1
           id="solution-hero-heading"
-          initial={{ y: 20 }}
-          animate={{ y: 0 }}
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6, delay: 0.05 }}
           style={{
             fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
@@ -60,8 +60,8 @@ export function SolutionHero({ solution }: SolutionHeroProps) {
         </motion.h1>
 
         <motion.p
-          initial={{ y: 14 }}
-          animate={{ y: 0 }}
+          initial={{ opacity: 0, y: 14 }}
+          animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6, delay: 0.1 }}
           style={{
             fontFamily: 'Inter, sans-serif',
@@ -77,8 +77,8 @@ export function SolutionHero({ solution }: SolutionHeroProps) {
         </motion.p>
 
         <motion.div
-          initial={{ y: 14 }}
-          animate={{ y: 0 }}
+          initial={{ opacity: 0, y: 14 }}
+          animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6, delay: 0.15 }}
           style={{
             display: 'flex',

--- a/apps/website/src/components/landing/solutions/SolutionProblem.tsx
+++ b/apps/website/src/components/landing/solutions/SolutionProblem.tsx
@@ -5,7 +5,6 @@ import type { SolutionPainPoint } from '../../../lib/solutions-data';
 
 interface SolutionProblemProps {
   color: string;
-  rgb: string;
   painPoints: SolutionPainPoint[];
 }
 

--- a/apps/website/src/components/landing/solutions/SolutionProblem.tsx
+++ b/apps/website/src/components/landing/solutions/SolutionProblem.tsx
@@ -1,0 +1,108 @@
+'use client';
+import { motion } from 'framer-motion';
+import { tokens } from '@cacheplane/design-tokens';
+import type { SolutionPainPoint } from '../../../lib/solutions-data';
+
+interface SolutionProblemProps {
+  color: string;
+  rgb: string;
+  painPoints: SolutionPainPoint[];
+}
+
+export function SolutionProblem({ color, painPoints }: SolutionProblemProps) {
+  return (
+    <section className="solution-problem" style={{ padding: '80px 32px' }}>
+      <style>{`
+        @media (max-width: 767px) {
+          .solution-problem { padding: 60px 20px !important; }
+        }
+      `}</style>
+      <motion.div
+        initial={{ opacity: 0, y: 16 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.5 }}
+        style={{ textAlign: 'center', marginBottom: 48 }}
+      >
+        <p
+          style={{
+            fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+            fontSize: '0.7rem',
+            textTransform: 'uppercase',
+            letterSpacing: '0.12em',
+            fontWeight: 700,
+            color,
+            marginBottom: 14,
+          }}
+        >
+          The Problem
+        </p>
+        <h2
+          style={{
+            fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+            fontSize: 'clamp(26px, 3.5vw, 46px)',
+            fontWeight: 800,
+            lineHeight: 1.1,
+            color: tokens.colors.textPrimary,
+            marginBottom: 10,
+          }}
+        >
+          Why teams stall
+        </h2>
+      </motion.div>
+
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(min(260px, 100%), 1fr))',
+          gap: 20,
+          maxWidth: 900,
+          margin: '0 auto',
+        }}
+      >
+        {painPoints.map((point, i) => (
+          <motion.div
+            key={point.title}
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ delay: i * 0.1, duration: 0.5 }}
+            style={{
+              padding: '28px 24px',
+              borderRadius: 16,
+              background: tokens.glass.bg,
+              backdropFilter: `blur(${tokens.glass.blur})`,
+              WebkitBackdropFilter: `blur(${tokens.glass.blur})`,
+              border: `1px solid ${tokens.glass.border}`,
+              boxShadow: tokens.glass.shadow,
+            }}
+          >
+            <h3
+              style={{
+                fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+                fontSize: '1.15rem',
+                fontWeight: 700,
+                color: tokens.colors.textPrimary,
+                marginBottom: 10,
+                lineHeight: 1.25,
+              }}
+            >
+              {point.title}
+            </h3>
+            <p
+              style={{
+                fontFamily: 'Inter, sans-serif',
+                fontSize: '0.88rem',
+                color: tokens.colors.textSecondary,
+                lineHeight: 1.6,
+                margin: 0,
+              }}
+            >
+              {point.description}
+            </p>
+          </motion.div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/website/src/components/landing/solutions/SolutionProofPoints.tsx
+++ b/apps/website/src/components/landing/solutions/SolutionProofPoints.tsx
@@ -5,7 +5,6 @@ import type { ProofPoint } from '../../../lib/solutions-data';
 
 interface SolutionProofPointsProps {
   color: string;
-  rgb: string;
   proofPoints: ProofPoint[];
 }
 

--- a/apps/website/src/components/landing/solutions/SolutionProofPoints.tsx
+++ b/apps/website/src/components/landing/solutions/SolutionProofPoints.tsx
@@ -1,0 +1,107 @@
+'use client';
+import { motion } from 'framer-motion';
+import { tokens } from '@cacheplane/design-tokens';
+import type { ProofPoint } from '../../../lib/solutions-data';
+
+interface SolutionProofPointsProps {
+  color: string;
+  rgb: string;
+  proofPoints: ProofPoint[];
+}
+
+export function SolutionProofPoints({ color, proofPoints }: SolutionProofPointsProps) {
+  return (
+    <section className="solution-proof" style={{ padding: '80px 32px' }}>
+      <style>{`
+        @media (max-width: 767px) {
+          .solution-proof { padding: 60px 20px !important; }
+        }
+      `}</style>
+      <motion.div
+        initial={{ opacity: 0, y: 16 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.5 }}
+        style={{ textAlign: 'center', marginBottom: 48 }}
+      >
+        <p
+          style={{
+            fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+            fontSize: '0.7rem',
+            textTransform: 'uppercase',
+            letterSpacing: '0.12em',
+            fontWeight: 700,
+            color,
+            marginBottom: 14,
+          }}
+        >
+          The Results
+        </p>
+        <h2
+          style={{
+            fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+            fontSize: 'clamp(26px, 3.5vw, 46px)',
+            fontWeight: 800,
+            lineHeight: 1.1,
+            color: tokens.colors.textPrimary,
+          }}
+        >
+          What you can expect
+        </h2>
+      </motion.div>
+
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+          gap: 20,
+          maxWidth: 840,
+          margin: '0 auto',
+        }}
+      >
+        {proofPoints.map((point, i) => (
+          <motion.div
+            key={point.metric}
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ delay: i * 0.1, duration: 0.5 }}
+            style={{
+              padding: '32px 24px',
+              textAlign: 'center',
+              borderRadius: 18,
+              background: tokens.glass.bg,
+              backdropFilter: `blur(${tokens.glass.blur})`,
+              WebkitBackdropFilter: `blur(${tokens.glass.blur})`,
+              border: `1px solid ${tokens.glass.border}`,
+              boxShadow: tokens.glass.shadow,
+            }}
+          >
+            <div
+              style={{
+                fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+                fontSize: '3rem',
+                fontWeight: 800,
+                lineHeight: 1,
+                color,
+                marginBottom: 10,
+              }}
+            >
+              {point.metric}
+            </div>
+            <p
+              style={{
+                fontSize: '0.85rem',
+                color: tokens.colors.textSecondary,
+                lineHeight: 1.5,
+                margin: 0,
+              }}
+            >
+              {point.label}
+            </p>
+          </motion.div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/website/src/components/landing/solutions/SolutionsGrid.tsx
+++ b/apps/website/src/components/landing/solutions/SolutionsGrid.tsx
@@ -1,0 +1,172 @@
+'use client';
+import { motion } from 'framer-motion';
+import Link from 'next/link';
+import { tokens } from '@cacheplane/design-tokens';
+import { SOLUTIONS } from '../../../lib/solutions-data';
+
+export function SolutionsGrid() {
+  return (
+    <section className="solutions-grid" style={{ padding: '80px 32px' }}>
+      <style>{`
+        @media (max-width: 767px) {
+          .solutions-grid { padding: 60px 20px !important; }
+        }
+      `}</style>
+      <motion.div
+        initial={{ opacity: 0, y: 16 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.5 }}
+        style={{ textAlign: 'center', marginBottom: 48 }}
+      >
+        <p
+          style={{
+            fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+            fontSize: '0.7rem',
+            textTransform: 'uppercase',
+            letterSpacing: '0.12em',
+            fontWeight: 700,
+            color: tokens.colors.accent,
+            marginBottom: 14,
+          }}
+        >
+          By Use Case
+        </p>
+        <h2
+          style={{
+            fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+            fontSize: 'clamp(26px, 3.5vw, 46px)',
+            fontWeight: 800,
+            lineHeight: 1.1,
+            color: tokens.colors.textPrimary,
+            marginBottom: 10,
+          }}
+        >
+          Enterprise solutions
+        </h2>
+        <p
+          style={{
+            fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+            fontStyle: 'italic',
+            fontSize: '1.05rem',
+            color: tokens.colors.textSecondary,
+            maxWidth: 520,
+            margin: '0 auto',
+          }}
+        >
+          See how Angular Agent Framework solves real enterprise problems — from compliance to customer support.
+        </p>
+      </motion.div>
+
+      <div
+        style={{
+          maxWidth: 1000,
+          margin: '0 auto',
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(min(280px, 100%), 1fr))',
+          gap: 24,
+        }}
+      >
+        {SOLUTIONS.map((sol, i) => (
+          <motion.div
+            key={sol.slug}
+            initial={{ opacity: 0, y: 24 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.5, delay: i * 0.1 }}
+            style={{
+              background: `rgba(${sol.rgb}, 0.03)`,
+              border: `1px solid rgba(${sol.rgb}, 0.15)`,
+              borderRadius: 14,
+              padding: '28px 24px 24px',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 12,
+            }}
+          >
+            <span
+              style={{
+                display: 'inline-block',
+                alignSelf: 'flex-start',
+                fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+                fontSize: '0.58rem',
+                fontWeight: 700,
+                textTransform: 'uppercase',
+                letterSpacing: '0.07em',
+                padding: '2px 9px',
+                borderRadius: 5,
+                color: '#fff',
+                background: sol.color,
+              }}
+            >
+              {sol.eyebrow}
+            </span>
+
+            <h3
+              style={{
+                fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+                fontSize: '1.2rem',
+                fontWeight: 700,
+                color: tokens.colors.textPrimary,
+                lineHeight: 1.25,
+                margin: 0,
+                whiteSpace: 'pre-line',
+              }}
+            >
+              {sol.title}
+            </h3>
+
+            <p
+              style={{
+                fontFamily: 'Inter, sans-serif',
+                fontSize: '0.88rem',
+                color: tokens.colors.textSecondary,
+                lineHeight: 1.6,
+                margin: 0,
+              }}
+            >
+              {sol.subtitle}
+            </p>
+
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 5, marginTop: 4 }}>
+              {sol.proofPoints.map(pp => (
+                <span
+                  key={pp.metric}
+                  style={{
+                    fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+                    fontSize: '0.58rem',
+                    padding: '2px 8px',
+                    borderRadius: 4,
+                    background: `rgba(${sol.rgb}, 0.07)`,
+                    color: sol.color,
+                    border: `1px solid rgba(${sol.rgb}, 0.15)`,
+                  }}
+                >
+                  {pp.metric} {pp.label.split(' — ')[0]}
+                </span>
+              ))}
+            </div>
+
+            <Link
+              href={`/solutions/${sol.slug}`}
+              style={{
+                fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+                fontSize: '0.72rem',
+                fontWeight: 700,
+                color: sol.color,
+                textDecoration: 'none',
+                marginTop: 'auto',
+                paddingTop: 8,
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 4,
+              }}
+            >
+              Learn more →
+            </Link>
+          </motion.div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/website/src/components/shared/Footer.tsx
+++ b/apps/website/src/components/shared/Footer.tsx
@@ -100,7 +100,7 @@ export function Footer() {
         transition={{ duration: 0.5 }}>
 
         {/* Top section: brand + columns */}
-        <div className="grid grid-cols-1 md:grid-cols-5 gap-10 md:gap-8">
+        <div className="grid grid-cols-1 md:grid-cols-6 gap-10 md:gap-8">
           {/* Brand */}
           <div className="md:col-span-2">
             <p className="font-garamond text-xl font-bold mb-2" style={{ color: tokens.colors.textPrimary }}>🛩️ Angular Agent Framework</p>
@@ -182,6 +182,26 @@ export function Footer() {
               onMouseEnter={(e) => (e.currentTarget.style.color = tokens.colors.accent)}
               onMouseLeave={(e) => (e.currentTarget.style.color = tokens.colors.textSecondary)}>
               Chat
+            </Link>
+          </div>
+
+          {/* Solutions column */}
+          <div className="flex flex-col gap-2.5 text-sm">
+            <span className="font-mono text-xs uppercase tracking-wider mb-1" style={{ color: tokens.colors.accent }}>Solutions</span>
+            <Link href="/solutions/compliance" className="transition-colors" style={{ color: tokens.colors.textSecondary }}
+              onMouseEnter={(e) => (e.currentTarget.style.color = tokens.colors.accent)}
+              onMouseLeave={(e) => (e.currentTarget.style.color = tokens.colors.textSecondary)}>
+              Compliance
+            </Link>
+            <Link href="/solutions/analytics" className="transition-colors" style={{ color: tokens.colors.textSecondary }}
+              onMouseEnter={(e) => (e.currentTarget.style.color = tokens.colors.accent)}
+              onMouseLeave={(e) => (e.currentTarget.style.color = tokens.colors.textSecondary)}>
+              Analytics
+            </Link>
+            <Link href="/solutions/customer-support" className="transition-colors" style={{ color: tokens.colors.textSecondary }}
+              onMouseEnter={(e) => (e.currentTarget.style.color = tokens.colors.accent)}
+              onMouseLeave={(e) => (e.currentTarget.style.color = tokens.colors.textSecondary)}>
+              Customer Support
             </Link>
           </div>
 

--- a/apps/website/src/components/shared/Nav.tsx
+++ b/apps/website/src/components/shared/Nav.tsx
@@ -8,6 +8,7 @@ import { docsConfig } from '../../lib/docs-config';
 const links = [
   { label: 'Pilot to Prod', href: '/pilot-to-prod', external: false },
   { label: 'Docs', href: '/docs', external: false },
+  { label: 'Solutions', href: '/solutions', external: false },
   { label: 'API', href: '/docs/agent/api/agent', external: false },
   { label: 'Examples', href: 'https://cockpit.cacheplane.ai', external: true },
   { label: 'Pricing', href: '/pricing', external: false },

--- a/apps/website/src/lib/solutions-data.ts
+++ b/apps/website/src/lib/solutions-data.ts
@@ -1,0 +1,190 @@
+export interface SolutionPainPoint {
+  title: string;
+  description: string;
+}
+
+export interface ArchitectureLayer {
+  library: string;
+  pkg: string;
+  role: string;
+}
+
+export interface ProofPoint {
+  metric: string;
+  label: string;
+}
+
+export interface SolutionConfig {
+  slug: string;
+  color: string;
+  rgb: string;
+  eyebrow: string;
+  title: string;
+  subtitle: string;
+  painPoints: SolutionPainPoint[];
+  architectureIntro: string;
+  architectureLayers: ArchitectureLayer[];
+  proofPoints: ProofPoint[];
+  ctaHeadline: string;
+  ctaSubtext: string;
+  metaTitle: string;
+  metaDescription: string;
+}
+
+export const SOLUTIONS: SolutionConfig[] = [
+  {
+    slug: 'compliance',
+    color: '#D4850F',
+    rgb: '212,133,15',
+    eyebrow: 'Compliance & Audit',
+    title: 'AI agents your compliance\nteam will actually approve',
+    subtitle: 'Human-in-the-loop approvals, immutable audit trails, and deterministic testing — built into the framework, not bolted on.',
+    painPoints: [
+      {
+        title: 'Black-box AI decisions',
+        description: 'Regulators require explainability. Most agent frameworks stream opaque outputs with no audit trail.',
+      },
+      {
+        title: 'No human gate before action',
+        description: 'SOX, HIPAA, and GDPR demand human approval before consequential actions. Retrofitting interrupts is a rewrite.',
+      },
+      {
+        title: 'Untestable agent behavior',
+        description: 'Compliance needs reproducible test evidence. Non-deterministic LLM calls make that nearly impossible without the right tooling.',
+      },
+    ],
+    architectureIntro: 'Three libraries give your compliance team what they need — without slowing your engineering team down.',
+    architectureLayers: [
+      {
+        library: 'Agent',
+        pkg: '@cacheplane/angular',
+        role: 'Signal-native streaming with first-class interrupt support. Every agent action can require human approval before execution. Thread persistence gives you a complete, immutable history of every decision.',
+      },
+      {
+        library: 'Render',
+        pkg: '@cacheplane/render',
+        role: 'Approval workflows rendered as structured UI — not chat messages. The agent proposes an action, renders a confirmation card, and waits for the human gate before proceeding.',
+      },
+      {
+        library: 'Chat',
+        pkg: '@cacheplane/chat',
+        role: 'Debug overlay shows every tool call, interrupt, and state transition. Your compliance team can review exactly what happened, when, and why — in a UI they can understand.',
+      },
+    ],
+    proofPoints: [
+      { metric: '100%', label: 'Audit trail coverage — every agent action logged' },
+      { metric: '0', label: 'Unapproved actions — interrupt gates block execution' },
+      { metric: '<5 min', label: 'Time to reproduce any agent decision for auditors' },
+    ],
+    ctaHeadline: 'Ship compliant AI agents — without the compliance tax',
+    ctaSubtext: 'Download the guide or start a pilot. Your compliance team will thank you.',
+    metaTitle: 'Compliance & Audit — Angular Agent Framework Solutions',
+    metaDescription: 'Ship AI agents with human-in-the-loop approvals, audit trails, and deterministic testing. Built for SOX, HIPAA, and GDPR.',
+  },
+  {
+    slug: 'analytics',
+    color: '#0F7B8D',
+    rgb: '15,123,141',
+    eyebrow: 'Analytics & BI',
+    title: 'Natural language queries.\nReal-time dashboards.',
+    subtitle: 'Your users ask questions in plain English. The agent queries, visualizes, and streams results — all inside your Angular app.',
+    painPoints: [
+      {
+        title: 'BI tools users won\'t adopt',
+        description: 'Complex dashboards with steep learning curves. Business users want answers, not another tool to learn.',
+      },
+      {
+        title: 'Static reports, stale data',
+        description: 'Pre-built dashboards can\'t answer ad-hoc questions. By the time a report is built, the question has changed.',
+      },
+      {
+        title: 'Chat-only AI interfaces',
+        description: 'Text answers aren\'t enough for data. Users need charts, tables, and interactive visualizations — streamed in real time.',
+      },
+    ],
+    architectureIntro: 'Three libraries turn your LangGraph agent into a conversational BI tool your business users will actually use.',
+    architectureLayers: [
+      {
+        library: 'Agent',
+        pkg: '@cacheplane/angular',
+        role: 'Streams query results token-by-token as the LangGraph agent reasons over your data. Thread persistence means users can refine questions without re-running expensive queries.',
+      },
+      {
+        library: 'Render',
+        pkg: '@cacheplane/render',
+        role: 'The agent emits chart specs, data tables, and KPI cards as structured render specs. Your Angular components render them with streaming JSON patches — live-updating visualizations as data arrives.',
+      },
+      {
+        library: 'Chat',
+        pkg: '@cacheplane/chat',
+        role: 'Pre-built generative UI panel renders charts and tables inline with the conversation. Users ask follow-up questions and see updated visualizations without leaving the chat.',
+      },
+    ],
+    proofPoints: [
+      { metric: '10x', label: 'Faster time-to-insight vs. traditional BI dashboards' },
+      { metric: '0', label: 'SQL required — business users query in plain English' },
+      { metric: '<2s', label: 'First visual streamed — no waiting for full query completion' },
+    ],
+    ctaHeadline: 'Turn your data into conversations',
+    ctaSubtext: 'Download the guide or start a pilot. Ship a conversational BI experience in weeks, not quarters.',
+    metaTitle: 'Analytics & BI — Angular Agent Framework Solutions',
+    metaDescription: 'Build conversational BI with natural language queries, real-time streaming charts, and generative UI — all in Angular.',
+  },
+  {
+    slug: 'customer-support',
+    color: '#5B4FCF',
+    rgb: '91,79,207',
+    eyebrow: 'Customer Support',
+    title: 'AI agents that know when\nto escalate to a human',
+    subtitle: 'Resolve tickets autonomously, surface context instantly, and hand off to humans seamlessly — with full conversation history.',
+    painPoints: [
+      {
+        title: 'Chatbots that frustrate customers',
+        description: 'Scripted chatbots can\'t handle nuance. Customers get stuck in loops, abandon the chat, and call the support line anyway.',
+      },
+      {
+        title: 'Agents without guardrails',
+        description: 'Autonomous agents that can\'t escalate are a liability. One wrong refund, one leaked detail, and trust is gone.',
+      },
+      {
+        title: 'Context lost on handoff',
+        description: 'When a bot hands off to a human, the conversation history disappears. The customer repeats everything. CSAT drops.',
+      },
+    ],
+    architectureIntro: 'Three libraries give your support agents superpowers — and your customers a seamless experience.',
+    architectureLayers: [
+      {
+        library: 'Agent',
+        pkg: '@cacheplane/angular',
+        role: 'LangGraph interrupts let the agent pause before sensitive actions — refunds, account changes, escalations. Thread persistence preserves the full conversation across bot-to-human handoffs.',
+      },
+      {
+        library: 'Render',
+        pkg: '@cacheplane/render',
+        role: 'The agent renders structured UI — order summaries, refund confirmations, knowledge base cards — instead of dumping text. Customers see clean, actionable information.',
+      },
+      {
+        library: 'Chat',
+        pkg: '@cacheplane/chat',
+        role: 'Production-ready chat UI with streaming messages, tool call visibility, and interrupt panels. When the agent escalates, the human agent sees the full debug overlay with every step the AI took.',
+      },
+    ],
+    proofPoints: [
+      { metric: '70%', label: 'Tickets resolved autonomously — without human intervention' },
+      { metric: '0', label: 'Context lost on handoff — full thread history preserved' },
+      { metric: '3x', label: 'Faster resolution for escalated tickets with AI-prepared context' },
+    ],
+    ctaHeadline: 'Support agents that make your team better',
+    ctaSubtext: 'Download the guide or start a pilot. Resolve more tickets, escalate smarter, and keep your customers happy.',
+    metaTitle: 'Customer Support — Angular Agent Framework Solutions',
+    metaDescription: 'Build AI support agents with human escalation, full context handoff, and production-ready chat UI in Angular.',
+  },
+];
+
+export function getSolutionBySlug(slug: string): SolutionConfig | undefined {
+  return SOLUTIONS.find(s => s.slug === slug);
+}
+
+export function getAllSolutionSlugs(): string[] {
+  return SOLUTIONS.map(s => s.slug);
+}

--- a/docs/superpowers/plans/2026-04-13-solutions-landing-pages.md
+++ b/docs/superpowers/plans/2026-04-13-solutions-landing-pages.md
@@ -1,0 +1,1537 @@
+# Solutions Landing Pages Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build 4 new pages — `/solutions` (index), `/solutions/compliance`, `/solutions/analytics`, `/solutions/customer-support` — as enterprise GTM-focused landing pages showing how all 3 Cacheplane libraries work together for specific use cases.
+
+**Architecture:** A shared data layer (`SolutionConfig` type) drives parameterized React components. Individual solution pages use a Next.js dynamic `[slug]` route with `generateStaticParams()`. All components follow the existing glassmorphism design system using `@cacheplane/design-tokens`. Each solution has a unique accent color (Amber, Teal, Blue-violet) while maintaining the site's visual language.
+
+**Tech Stack:** Next.js 15 (App Router, static export), React 19, Framer Motion, `@cacheplane/design-tokens`
+
+---
+
+## File Structure
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Create | `apps/website/src/lib/solutions-data.ts` | `SolutionConfig` type + 3 solution data objects |
+| Create | `apps/website/src/components/landing/solutions/SolutionHero.tsx` | Hero section with eyebrow, headline, subtitle, CTA |
+| Create | `apps/website/src/components/landing/solutions/SolutionProblem.tsx` | Pain-point cards section |
+| Create | `apps/website/src/components/landing/solutions/SolutionArchitecture.tsx` | 3-library architecture visual |
+| Create | `apps/website/src/components/landing/solutions/SolutionProofPoints.tsx` | Proof point metric cards |
+| Create | `apps/website/src/components/landing/solutions/SolutionFooterCTA.tsx` | Dark footer CTA (mirrors PilotFooterCTA pattern) |
+| Create | `apps/website/src/components/landing/solutions/SolutionsGrid.tsx` | Card grid for `/solutions` index page |
+| Create | `apps/website/src/app/solutions/page.tsx` | Index page at `/solutions` |
+| Create | `apps/website/src/app/solutions/[slug]/page.tsx` | Dynamic route for individual solution pages |
+| Modify | `apps/website/src/components/shared/Nav.tsx:8-14` | Add "Solutions" link to nav |
+| Modify | `apps/website/src/components/shared/Footer.tsx:136-166` | Add Solutions column to footer |
+
+---
+
+### Task 1: Solutions Data Layer
+
+**Files:**
+- Create: `apps/website/src/lib/solutions-data.ts`
+
+- [ ] **Step 1: Create the solutions data file with types and all 3 configs**
+
+```typescript
+// apps/website/src/lib/solutions-data.ts
+
+export interface SolutionPainPoint {
+  title: string;
+  description: string;
+}
+
+export interface ArchitectureLayer {
+  library: string;
+  pkg: string;
+  role: string;
+}
+
+export interface ProofPoint {
+  metric: string;
+  label: string;
+}
+
+export interface SolutionConfig {
+  slug: string;
+  color: string;
+  rgb: string;
+  eyebrow: string;
+  title: string;
+  subtitle: string;
+  painPoints: SolutionPainPoint[];
+  architectureIntro: string;
+  architectureLayers: ArchitectureLayer[];
+  proofPoints: ProofPoint[];
+  ctaHeadline: string;
+  ctaSubtext: string;
+  metaTitle: string;
+  metaDescription: string;
+}
+
+export const SOLUTIONS: SolutionConfig[] = [
+  {
+    slug: 'compliance',
+    color: '#D4850F',
+    rgb: '212,133,15',
+    eyebrow: 'Compliance & Audit',
+    title: 'AI agents your compliance\nteam will actually approve',
+    subtitle: 'Human-in-the-loop approvals, immutable audit trails, and deterministic testing — built into the framework, not bolted on.',
+    painPoints: [
+      {
+        title: 'Black-box AI decisions',
+        description: 'Regulators require explainability. Most agent frameworks stream opaque outputs with no audit trail.',
+      },
+      {
+        title: 'No human gate before action',
+        description: 'SOX, HIPAA, and GDPR demand human approval before consequential actions. Retrofitting interrupts is a rewrite.',
+      },
+      {
+        title: 'Untestable agent behavior',
+        description: 'Compliance needs reproducible test evidence. Non-deterministic LLM calls make that nearly impossible without the right tooling.',
+      },
+    ],
+    architectureIntro: 'Three libraries give your compliance team what they need — without slowing your engineering team down.',
+    architectureLayers: [
+      {
+        library: 'Agent',
+        pkg: '@cacheplane/angular',
+        role: 'Signal-native streaming with first-class interrupt support. Every agent action can require human approval before execution. Thread persistence gives you a complete, immutable history of every decision.',
+      },
+      {
+        library: 'Render',
+        pkg: '@cacheplane/render',
+        role: 'Approval workflows rendered as structured UI — not chat messages. The agent proposes an action, renders a confirmation card, and waits for the human gate before proceeding.',
+      },
+      {
+        library: 'Chat',
+        pkg: '@cacheplane/chat',
+        role: 'Debug overlay shows every tool call, interrupt, and state transition. Your compliance team can review exactly what happened, when, and why — in a UI they can understand.',
+      },
+    ],
+    proofPoints: [
+      { metric: '100%', label: 'Audit trail coverage — every agent action logged' },
+      { metric: '0', label: 'Unapproved actions — interrupt gates block execution' },
+      { metric: '<5 min', label: 'Time to reproduce any agent decision for auditors' },
+    ],
+    ctaHeadline: 'Ship compliant AI agents — without the compliance tax',
+    ctaSubtext: 'Download the guide or start a pilot. Your compliance team will thank you.',
+    metaTitle: 'Compliance & Audit — Angular Agent Framework Solutions',
+    metaDescription: 'Ship AI agents with human-in-the-loop approvals, audit trails, and deterministic testing. Built for SOX, HIPAA, and GDPR.',
+  },
+  {
+    slug: 'analytics',
+    color: '#0F7B8D',
+    rgb: '15,123,141',
+    eyebrow: 'Analytics & BI',
+    title: 'Natural language queries.\nReal-time dashboards.',
+    subtitle: 'Your users ask questions in plain English. The agent queries, visualizes, and streams results — all inside your Angular app.',
+    painPoints: [
+      {
+        title: 'BI tools users won\'t adopt',
+        description: 'Complex dashboards with steep learning curves. Business users want answers, not another tool to learn.',
+      },
+      {
+        title: 'Static reports, stale data',
+        description: 'Pre-built dashboards can\'t answer ad-hoc questions. By the time a report is built, the question has changed.',
+      },
+      {
+        title: 'Chat-only AI interfaces',
+        description: 'Text answers aren\'t enough for data. Users need charts, tables, and interactive visualizations — streamed in real time.',
+      },
+    ],
+    architectureIntro: 'Three libraries turn your LangGraph agent into a conversational BI tool your business users will actually use.',
+    architectureLayers: [
+      {
+        library: 'Agent',
+        pkg: '@cacheplane/angular',
+        role: 'Streams query results token-by-token as the LangGraph agent reasons over your data. Thread persistence means users can refine questions without re-running expensive queries.',
+      },
+      {
+        library: 'Render',
+        pkg: '@cacheplane/render',
+        role: 'The agent emits chart specs, data tables, and KPI cards as structured render specs. Your Angular components render them with streaming JSON patches — live-updating visualizations as data arrives.',
+      },
+      {
+        library: 'Chat',
+        pkg: '@cacheplane/chat',
+        role: 'Pre-built generative UI panel renders charts and tables inline with the conversation. Users ask follow-up questions and see updated visualizations without leaving the chat.',
+      },
+    ],
+    proofPoints: [
+      { metric: '10x', label: 'Faster time-to-insight vs. traditional BI dashboards' },
+      { metric: '0', label: 'SQL required — business users query in plain English' },
+      { metric: '<2s', label: 'First visual streamed — no waiting for full query completion' },
+    ],
+    ctaHeadline: 'Turn your data into conversations',
+    ctaSubtext: 'Download the guide or start a pilot. Ship a conversational BI experience in weeks, not quarters.',
+    metaTitle: 'Analytics & BI — Angular Agent Framework Solutions',
+    metaDescription: 'Build conversational BI with natural language queries, real-time streaming charts, and generative UI — all in Angular.',
+  },
+  {
+    slug: 'customer-support',
+    color: '#5B4FCF',
+    rgb: '91,79,207',
+    eyebrow: 'Customer Support',
+    title: 'AI agents that know when\nto escalate to a human',
+    subtitle: 'Resolve tickets autonomously, surface context instantly, and hand off to humans seamlessly — with full conversation history.',
+    painPoints: [
+      {
+        title: 'Chatbots that frustrate customers',
+        description: 'Scripted chatbots can\'t handle nuance. Customers get stuck in loops, abandon the chat, and call the support line anyway.',
+      },
+      {
+        title: 'Agents without guardrails',
+        description: 'Autonomous agents that can\'t escalate are a liability. One wrong refund, one leaked detail, and trust is gone.',
+      },
+      {
+        title: 'Context lost on handoff',
+        description: 'When a bot hands off to a human, the conversation history disappears. The customer repeats everything. CSAT drops.',
+      },
+    ],
+    architectureIntro: 'Three libraries give your support agents superpowers — and your customers a seamless experience.',
+    architectureLayers: [
+      {
+        library: 'Agent',
+        pkg: '@cacheplane/angular',
+        role: 'LangGraph interrupts let the agent pause before sensitive actions — refunds, account changes, escalations. Thread persistence preserves the full conversation across bot-to-human handoffs.',
+      },
+      {
+        library: 'Render',
+        pkg: '@cacheplane/render',
+        role: 'The agent renders structured UI — order summaries, refund confirmations, knowledge base cards — instead of dumping text. Customers see clean, actionable information.',
+      },
+      {
+        library: 'Chat',
+        pkg: '@cacheplane/chat',
+        role: 'Production-ready chat UI with streaming messages, tool call visibility, and interrupt panels. When the agent escalates, the human agent sees the full debug overlay with every step the AI took.',
+      },
+    ],
+    proofPoints: [
+      { metric: '70%', label: 'Tickets resolved autonomously — without human intervention' },
+      { metric: '0', label: 'Context lost on handoff — full thread history preserved' },
+      { metric: '3x', label: 'Faster resolution for escalated tickets with AI-prepared context' },
+    ],
+    ctaHeadline: 'Support agents that make your team better',
+    ctaSubtext: 'Download the guide or start a pilot. Resolve more tickets, escalate smarter, and keep your customers happy.',
+    metaTitle: 'Customer Support — Angular Agent Framework Solutions',
+    metaDescription: 'Build AI support agents with human escalation, full context handoff, and production-ready chat UI in Angular.',
+  },
+];
+
+export function getSolutionBySlug(slug: string): SolutionConfig | undefined {
+  return SOLUTIONS.find(s => s.slug === slug);
+}
+
+export function getAllSolutionSlugs(): string[] {
+  return SOLUTIONS.map(s => s.slug);
+}
+```
+
+- [ ] **Step 2: Verify the file compiles**
+
+Run: `cd apps/website && npx tsc --noEmit src/lib/solutions-data.ts 2>&1 | head -20`
+Expected: No errors (or use `npx next build` later for full check)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/website/src/lib/solutions-data.ts
+git commit -m "feat(website): add solutions data layer with SolutionConfig type and 3 configs"
+```
+
+---
+
+### Task 2: SolutionHero Component
+
+**Files:**
+- Create: `apps/website/src/components/landing/solutions/SolutionHero.tsx`
+
+- [ ] **Step 1: Create the SolutionHero component**
+
+This component follows the `AngularHero` pattern — centered text with eyebrow, headline, subtitle, and dual CTAs. It accepts a `SolutionConfig` and uses the solution's accent color.
+
+```tsx
+// apps/website/src/components/landing/solutions/SolutionHero.tsx
+'use client';
+import { motion } from 'framer-motion';
+import Link from 'next/link';
+import { tokens } from '@cacheplane/design-tokens';
+import type { SolutionConfig } from '../../../lib/solutions-data';
+
+interface SolutionHeroProps {
+  solution: SolutionConfig;
+}
+
+export function SolutionHero({ solution }: SolutionHeroProps) {
+  return (
+    <section
+      aria-labelledby="solution-hero-heading"
+      style={{ position: 'relative', overflow: 'hidden', padding: '0 2rem' }}
+    >
+      <div
+        style={{
+          maxWidth: '56rem',
+          margin: '0 auto',
+          textAlign: 'center',
+          position: 'relative',
+          zIndex: 1,
+        }}
+        className="py-24 md:py-32"
+      >
+        <motion.div initial={{ y: 16 }} animate={{ y: 0 }} transition={{ duration: 0.5 }}>
+          <span
+            style={{
+              fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+              fontSize: 11,
+              letterSpacing: '0.08em',
+              color: solution.color,
+              textTransform: 'uppercase',
+              display: 'inline-block',
+              marginBottom: '1.5rem',
+            }}
+          >
+            {solution.eyebrow}
+          </span>
+        </motion.div>
+
+        <motion.h1
+          id="solution-hero-heading"
+          initial={{ y: 20 }}
+          animate={{ y: 0 }}
+          transition={{ duration: 0.6, delay: 0.05 }}
+          style={{
+            fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+            fontSize: 'clamp(36px, 5vw, 56px)',
+            fontWeight: 700,
+            lineHeight: 1.1,
+            color: tokens.colors.textPrimary,
+            margin: 0,
+            marginBottom: '1.25rem',
+            whiteSpace: 'pre-line',
+          }}
+        >
+          {solution.title}
+        </motion.h1>
+
+        <motion.p
+          initial={{ y: 14 }}
+          animate={{ y: 0 }}
+          transition={{ duration: 0.6, delay: 0.1 }}
+          style={{
+            fontFamily: 'Inter, sans-serif',
+            fontSize: 18,
+            color: tokens.colors.textSecondary,
+            maxWidth: '52ch',
+            margin: '0 auto',
+            lineHeight: 1.6,
+            marginBottom: '2rem',
+          }}
+        >
+          {solution.subtitle}
+        </motion.p>
+
+        <motion.div
+          initial={{ y: 14 }}
+          animate={{ y: 0 }}
+          transition={{ duration: 0.6, delay: 0.15 }}
+          style={{
+            display: 'flex',
+            gap: '0.75rem',
+            justifyContent: 'center',
+            flexWrap: 'wrap',
+          }}
+        >
+          <Link
+            href="/pilot-to-prod"
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 6,
+              background: solution.color,
+              color: '#fff',
+              fontFamily: 'Inter, sans-serif',
+              fontSize: 15,
+              fontWeight: 600,
+              padding: '0.875rem 1.75rem',
+              borderRadius: 8,
+              textDecoration: 'none',
+              minHeight: 44,
+            }}
+          >
+            Start a Pilot
+          </Link>
+          <a
+            href="/whitepaper.pdf"
+            download
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 6,
+              background: tokens.glass.bg,
+              backdropFilter: `blur(${tokens.glass.blur})`,
+              WebkitBackdropFilter: `blur(${tokens.glass.blur})`,
+              color: solution.color,
+              fontFamily: 'Inter, sans-serif',
+              fontSize: 15,
+              fontWeight: 600,
+              padding: '0.875rem 1.75rem',
+              borderRadius: 8,
+              textDecoration: 'none',
+              border: `1px solid rgba(${solution.rgb}, 0.25)`,
+              minHeight: 44,
+            }}
+          >
+            Download the Guide
+          </a>
+        </motion.div>
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/website/src/components/landing/solutions/SolutionHero.tsx
+git commit -m "feat(website): add SolutionHero component"
+```
+
+---
+
+### Task 3: SolutionProblem Component
+
+**Files:**
+- Create: `apps/website/src/components/landing/solutions/SolutionProblem.tsx`
+
+- [ ] **Step 1: Create the SolutionProblem component**
+
+Displays 3 pain-point cards in a responsive grid. Follows the `ProblemSection` stat-card pattern (glass cards) but uses the solution's accent color.
+
+```tsx
+// apps/website/src/components/landing/solutions/SolutionProblem.tsx
+'use client';
+import { motion } from 'framer-motion';
+import { tokens } from '@cacheplane/design-tokens';
+import type { SolutionPainPoint } from '../../../lib/solutions-data';
+
+interface SolutionProblemProps {
+  color: string;
+  rgb: string;
+  painPoints: SolutionPainPoint[];
+}
+
+export function SolutionProblem({ color, rgb, painPoints }: SolutionProblemProps) {
+  return (
+    <section className="solution-problem" style={{ padding: '80px 32px' }}>
+      <style>{`
+        @media (max-width: 767px) {
+          .solution-problem { padding: 60px 20px !important; }
+        }
+      `}</style>
+      <motion.div
+        initial={{ opacity: 0, y: 16 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.5 }}
+        style={{ textAlign: 'center', marginBottom: 48 }}
+      >
+        <p
+          style={{
+            fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+            fontSize: '0.7rem',
+            textTransform: 'uppercase',
+            letterSpacing: '0.12em',
+            fontWeight: 700,
+            color,
+            marginBottom: 14,
+          }}
+        >
+          The Problem
+        </p>
+        <h2
+          style={{
+            fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+            fontSize: 'clamp(26px, 3.5vw, 46px)',
+            fontWeight: 800,
+            lineHeight: 1.1,
+            color: tokens.colors.textPrimary,
+            marginBottom: 10,
+          }}
+        >
+          Why teams stall
+        </h2>
+      </motion.div>
+
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(min(260px, 100%), 1fr))',
+          gap: 20,
+          maxWidth: 900,
+          margin: '0 auto',
+        }}
+      >
+        {painPoints.map((point, i) => (
+          <motion.div
+            key={point.title}
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ delay: i * 0.1, duration: 0.5 }}
+            style={{
+              padding: '28px 24px',
+              borderRadius: 16,
+              background: tokens.glass.bg,
+              backdropFilter: `blur(${tokens.glass.blur})`,
+              WebkitBackdropFilter: `blur(${tokens.glass.blur})`,
+              border: `1px solid ${tokens.glass.border}`,
+              boxShadow: tokens.glass.shadow,
+            }}
+          >
+            <h3
+              style={{
+                fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+                fontSize: '1.15rem',
+                fontWeight: 700,
+                color: tokens.colors.textPrimary,
+                marginBottom: 10,
+                lineHeight: 1.25,
+              }}
+            >
+              {point.title}
+            </h3>
+            <p
+              style={{
+                fontFamily: 'Inter, sans-serif',
+                fontSize: '0.88rem',
+                color: tokens.colors.textSecondary,
+                lineHeight: 1.6,
+                margin: 0,
+              }}
+            >
+              {point.description}
+            </p>
+          </motion.div>
+        ))}
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/website/src/components/landing/solutions/SolutionProblem.tsx
+git commit -m "feat(website): add SolutionProblem component"
+```
+
+---
+
+### Task 4: SolutionArchitecture Component
+
+**Files:**
+- Create: `apps/website/src/components/landing/solutions/SolutionArchitecture.tsx`
+
+- [ ] **Step 1: Create the SolutionArchitecture component**
+
+Shows how the 3 libraries work together for this use case. Follows the `TheStack` vertical card + connector pattern, but with solution-specific colors and descriptions.
+
+```tsx
+// apps/website/src/components/landing/solutions/SolutionArchitecture.tsx
+'use client';
+import { motion } from 'framer-motion';
+import Link from 'next/link';
+import { tokens } from '@cacheplane/design-tokens';
+import type { ArchitectureLayer } from '../../../lib/solutions-data';
+
+const LIBRARY_META: Record<string, { color: string; rgb: string; href: string }> = {
+  Agent: { color: tokens.colors.accent, rgb: '0,64,144', href: '/angular' },
+  Render: { color: tokens.colors.renderGreen, rgb: '26,122,64', href: '/render' },
+  Chat: { color: tokens.colors.chatPurple, rgb: '90,0,200', href: '/chat' },
+};
+
+interface SolutionArchitectureProps {
+  color: string;
+  intro: string;
+  layers: ArchitectureLayer[];
+}
+
+function Connector({ fromRgb, toRgb }: { fromRgb: string; toRgb: string }) {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'center', padding: '2px 0' }}>
+      <div
+        style={{
+          width: 2,
+          height: 28,
+          background: `linear-gradient(to bottom, rgba(${fromRgb}, 0.3), rgba(${toRgb}, 0.3))`,
+          borderRadius: 1,
+        }}
+      />
+    </div>
+  );
+}
+
+export function SolutionArchitecture({ color, intro, layers }: SolutionArchitectureProps) {
+  return (
+    <section className="solution-arch" style={{ padding: '80px 32px' }}>
+      <style>{`
+        @media (max-width: 767px) {
+          .solution-arch { padding: 60px 20px !important; }
+          .solution-arch-card { padding: 24px 20px 20px !important; }
+        }
+      `}</style>
+      <motion.div
+        initial={{ opacity: 0, y: 16 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.5 }}
+        style={{ textAlign: 'center', marginBottom: 48 }}
+      >
+        <p
+          style={{
+            fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+            fontSize: '0.7rem',
+            textTransform: 'uppercase',
+            letterSpacing: '0.12em',
+            fontWeight: 700,
+            color,
+            marginBottom: 14,
+          }}
+        >
+          The Architecture
+        </p>
+        <h2
+          style={{
+            fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+            fontSize: 'clamp(26px, 3.5vw, 46px)',
+            fontWeight: 800,
+            lineHeight: 1.1,
+            color: tokens.colors.textPrimary,
+            marginBottom: 10,
+          }}
+        >
+          Three libraries. One solution.
+        </h2>
+        <p
+          style={{
+            fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+            fontStyle: 'italic',
+            fontSize: '1.05rem',
+            color: tokens.colors.textSecondary,
+            maxWidth: 560,
+            margin: '0 auto',
+          }}
+        >
+          {intro}
+        </p>
+      </motion.div>
+
+      <div style={{ maxWidth: 860, margin: '0 auto', display: 'flex', flexDirection: 'column' }}>
+        {layers.map((layer, i) => {
+          const meta = LIBRARY_META[layer.library];
+          const prevMeta = i > 0 ? LIBRARY_META[layers[i - 1].library] : null;
+          return (
+            <div key={layer.library}>
+              {i > 0 && prevMeta && (
+                <Connector fromRgb={prevMeta.rgb} toRgb={meta.rgb} />
+              )}
+              <motion.div
+                className="solution-arch-card"
+                initial={{ opacity: 0, y: 24 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true }}
+                transition={{ duration: 0.5, delay: i * 0.1 }}
+                style={{
+                  background: `rgba(${meta.rgb}, 0.03)`,
+                  border: `1px solid rgba(${meta.rgb}, 0.15)`,
+                  borderRadius: 14,
+                  padding: '28px 28px 24px',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: 10,
+                }}
+              >
+                <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                  <span
+                    style={{
+                      fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+                      fontSize: '0.58rem',
+                      fontWeight: 700,
+                      textTransform: 'uppercase',
+                      letterSpacing: '0.07em',
+                      padding: '2px 9px',
+                      borderRadius: 5,
+                      color: '#fff',
+                      background: meta.color,
+                    }}
+                  >
+                    {layer.library}
+                  </span>
+                  <span
+                    style={{
+                      fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+                      fontSize: '0.76rem',
+                      fontWeight: 700,
+                      color: meta.color,
+                    }}
+                  >
+                    {layer.pkg}
+                  </span>
+                </div>
+
+                <p
+                  style={{
+                    fontFamily: 'Inter, sans-serif',
+                    fontSize: '0.88rem',
+                    color: tokens.colors.textSecondary,
+                    lineHeight: 1.6,
+                    margin: 0,
+                  }}
+                >
+                  {layer.role}
+                </p>
+
+                <Link
+                  href={meta.href}
+                  style={{
+                    fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+                    fontSize: '0.72rem',
+                    fontWeight: 700,
+                    color: meta.color,
+                    textDecoration: 'none',
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 4,
+                  }}
+                >
+                  Explore {layer.library} →
+                </Link>
+              </motion.div>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/website/src/components/landing/solutions/SolutionArchitecture.tsx
+git commit -m "feat(website): add SolutionArchitecture component"
+```
+
+---
+
+### Task 5: SolutionProofPoints Component
+
+**Files:**
+- Create: `apps/website/src/components/landing/solutions/SolutionProofPoints.tsx`
+
+- [ ] **Step 1: Create the SolutionProofPoints component**
+
+Displays 3 metric cards in a grid. Uses the solution's accent color for the large metric numbers.
+
+```tsx
+// apps/website/src/components/landing/solutions/SolutionProofPoints.tsx
+'use client';
+import { motion } from 'framer-motion';
+import { tokens } from '@cacheplane/design-tokens';
+import type { ProofPoint } from '../../../lib/solutions-data';
+
+interface SolutionProofPointsProps {
+  color: string;
+  rgb: string;
+  proofPoints: ProofPoint[];
+}
+
+export function SolutionProofPoints({ color, rgb, proofPoints }: SolutionProofPointsProps) {
+  return (
+    <section className="solution-proof" style={{ padding: '80px 32px' }}>
+      <style>{`
+        @media (max-width: 767px) {
+          .solution-proof { padding: 60px 20px !important; }
+        }
+      `}</style>
+      <motion.div
+        initial={{ opacity: 0, y: 16 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.5 }}
+        style={{ textAlign: 'center', marginBottom: 48 }}
+      >
+        <p
+          style={{
+            fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+            fontSize: '0.7rem',
+            textTransform: 'uppercase',
+            letterSpacing: '0.12em',
+            fontWeight: 700,
+            color,
+            marginBottom: 14,
+          }}
+        >
+          The Results
+        </p>
+        <h2
+          style={{
+            fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+            fontSize: 'clamp(26px, 3.5vw, 46px)',
+            fontWeight: 800,
+            lineHeight: 1.1,
+            color: tokens.colors.textPrimary,
+          }}
+        >
+          What you can expect
+        </h2>
+      </motion.div>
+
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+          gap: 20,
+          maxWidth: 840,
+          margin: '0 auto',
+        }}
+      >
+        {proofPoints.map((point, i) => (
+          <motion.div
+            key={point.metric}
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ delay: i * 0.1, duration: 0.5 }}
+            style={{
+              padding: '32px 24px',
+              textAlign: 'center',
+              borderRadius: 18,
+              background: tokens.glass.bg,
+              backdropFilter: `blur(${tokens.glass.blur})`,
+              WebkitBackdropFilter: `blur(${tokens.glass.blur})`,
+              border: `1px solid ${tokens.glass.border}`,
+              boxShadow: tokens.glass.shadow,
+            }}
+          >
+            <div
+              style={{
+                fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+                fontSize: '3rem',
+                fontWeight: 800,
+                lineHeight: 1,
+                color,
+                marginBottom: 10,
+              }}
+            >
+              {point.metric}
+            </div>
+            <p
+              style={{
+                fontSize: '0.85rem',
+                color: tokens.colors.textSecondary,
+                lineHeight: 1.5,
+                margin: 0,
+              }}
+            >
+              {point.label}
+            </p>
+          </motion.div>
+        ))}
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/website/src/components/landing/solutions/SolutionProofPoints.tsx
+git commit -m "feat(website): add SolutionProofPoints component"
+```
+
+---
+
+### Task 6: SolutionFooterCTA + WhitePaper Gate
+
+**Files:**
+- Create: `apps/website/src/components/landing/solutions/SolutionFooterCTA.tsx`
+
+- [ ] **Step 1: Create the SolutionFooterCTA component**
+
+Dark-background CTA section matching the `PilotFooterCTA` pattern. Includes both a whitepaper download and pilot CTA.
+
+```tsx
+// apps/website/src/components/landing/solutions/SolutionFooterCTA.tsx
+'use client';
+import { motion } from 'framer-motion';
+import Link from 'next/link';
+
+interface SolutionFooterCTAProps {
+  color: string;
+  headline: string;
+  subtext: string;
+}
+
+export function SolutionFooterCTA({ color, headline, subtext }: SolutionFooterCTAProps) {
+  return (
+    <section
+      style={{
+        background: 'linear-gradient(135deg, #1a1a2e 0%, #0d1b3e 100%)',
+        padding: '0 2rem',
+      }}
+    >
+      <style>{`
+        .solution-footer-secondary:hover { border-color: rgba(255,255,255,0.6) !important; }
+        @media (max-width: 767px) {
+          .solution-footer-inner { padding-top: 4rem !important; padding-bottom: 4rem !important; }
+        }
+      `}</style>
+      <motion.div
+        className="solution-footer-inner"
+        initial={{ opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.5 }}
+        style={{
+          maxWidth: '48rem',
+          margin: '0 auto',
+          paddingTop: '6rem',
+          paddingBottom: '6rem',
+          textAlign: 'center',
+        }}
+      >
+        <p
+          style={{
+            fontFamily: 'var(--font-mono, monospace)',
+            fontSize: '11px',
+            fontWeight: 500,
+            letterSpacing: '0.12em',
+            textTransform: 'uppercase',
+            color: 'rgba(255, 255, 255, 0.5)',
+            marginBottom: '1rem',
+          }}
+        >
+          Ready when you are
+        </p>
+
+        <h2
+          style={{
+            fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+            fontSize: 'clamp(28px, 4vw, 42px)',
+            fontWeight: 400,
+            lineHeight: 1.15,
+            color: '#ffffff',
+            marginBottom: '1.25rem',
+          }}
+        >
+          {headline}
+        </h2>
+
+        <p
+          style={{
+            fontFamily: 'var(--font-inter, Inter, sans-serif)',
+            fontSize: '17px',
+            lineHeight: 1.6,
+            color: 'rgba(255, 255, 255, 0.7)',
+            marginBottom: '2.5rem',
+          }}
+        >
+          {subtext}
+        </p>
+
+        <div
+          style={{
+            display: 'flex',
+            gap: '1rem',
+            justifyContent: 'center',
+            flexWrap: 'wrap',
+            marginBottom: '1.5rem',
+          }}
+        >
+          <Link
+            href="/pilot-to-prod"
+            style={{
+              display: 'inline-block',
+              padding: '0.875rem 2rem',
+              background: '#ffffff',
+              color,
+              fontFamily: 'var(--font-inter, Inter, sans-serif)',
+              fontSize: '15px',
+              fontWeight: 600,
+              textDecoration: 'none',
+              borderRadius: '6px',
+            }}
+          >
+            Start Your Pilot →
+          </Link>
+          <a
+            href="/whitepaper.pdf"
+            download
+            className="solution-footer-secondary"
+            style={{
+              display: 'inline-block',
+              padding: '0.875rem 2rem',
+              background: 'transparent',
+              color: '#ffffff',
+              fontFamily: 'var(--font-inter, Inter, sans-serif)',
+              fontSize: '15px',
+              fontWeight: 600,
+              textDecoration: 'none',
+              borderRadius: '6px',
+              border: '1px solid rgba(255, 255, 255, 0.3)',
+              transition: 'border-color 0.2s ease',
+            }}
+          >
+            Download the Guide
+          </a>
+        </div>
+
+        <p
+          style={{
+            fontFamily: 'var(--font-mono, monospace)',
+            fontSize: '10px',
+            letterSpacing: '0.08em',
+            color: 'rgba(255, 255, 255, 0.4)',
+          }}
+        >
+          App deployment license · $20,000 · 3-month co-pilot engagement
+        </p>
+      </motion.div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/website/src/components/landing/solutions/SolutionFooterCTA.tsx
+git commit -m "feat(website): add SolutionFooterCTA component"
+```
+
+---
+
+### Task 7: Dynamic Solution Page Route
+
+**Files:**
+- Create: `apps/website/src/app/solutions/[slug]/page.tsx`
+
+- [ ] **Step 1: Create the dynamic route page**
+
+Uses `generateStaticParams()` to statically generate all 3 solution pages. Composes all solution section components. Follows the `angular/page.tsx` pattern with ambient gradient blobs.
+
+```tsx
+// apps/website/src/app/solutions/[slug]/page.tsx
+import { notFound } from 'next/navigation';
+import { tokens } from '@cacheplane/design-tokens';
+import { getSolutionBySlug, getAllSolutionSlugs } from '../../../lib/solutions-data';
+import { SolutionHero } from '../../../components/landing/solutions/SolutionHero';
+import { SolutionProblem } from '../../../components/landing/solutions/SolutionProblem';
+import { SolutionArchitecture } from '../../../components/landing/solutions/SolutionArchitecture';
+import { SolutionProofPoints } from '../../../components/landing/solutions/SolutionProofPoints';
+import { SolutionFooterCTA } from '../../../components/landing/solutions/SolutionFooterCTA';
+import { WhitePaperSection } from '../../../components/landing/WhitePaperSection';
+
+interface PageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export function generateStaticParams() {
+  return getAllSolutionSlugs().map(slug => ({ slug }));
+}
+
+export async function generateMetadata({ params }: PageProps) {
+  const { slug } = await params;
+  const solution = getSolutionBySlug(slug);
+  if (!solution) return {};
+  return {
+    title: solution.metaTitle,
+    description: solution.metaDescription,
+  };
+}
+
+export default async function SolutionPage({ params }: PageProps) {
+  const { slug } = await params;
+  const solution = getSolutionBySlug(slug);
+  if (!solution) notFound();
+
+  return (
+    <div style={{ background: tokens.gradient.bgFlow, position: 'relative', overflow: 'hidden' }}>
+      {/* Ambient gradient blobs */}
+      <div
+        style={{
+          position: 'absolute',
+          width: 600,
+          height: 600,
+          borderRadius: '50%',
+          background: `radial-gradient(circle, rgba(${solution.rgb}, 0.12) 0%, transparent 70%)`,
+          top: -200,
+          left: -150,
+          filter: 'blur(80px)',
+          pointerEvents: 'none',
+        }}
+        aria-hidden="true"
+      />
+      <div
+        style={{
+          position: 'absolute',
+          width: 500,
+          height: 500,
+          borderRadius: '50%',
+          background: tokens.gradient.cool,
+          top: 800,
+          right: -100,
+          filter: 'blur(80px)',
+          pointerEvents: 'none',
+        }}
+        aria-hidden="true"
+      />
+      <div
+        style={{
+          position: 'absolute',
+          width: 400,
+          height: 400,
+          borderRadius: '50%',
+          background: `radial-gradient(circle, rgba(${solution.rgb}, 0.08) 0%, transparent 70%)`,
+          top: 2200,
+          left: -100,
+          filter: 'blur(80px)',
+          pointerEvents: 'none',
+        }}
+        aria-hidden="true"
+      />
+
+      <SolutionHero solution={solution} />
+      <SolutionProblem
+        color={solution.color}
+        rgb={solution.rgb}
+        painPoints={solution.painPoints}
+      />
+      <SolutionArchitecture
+        color={solution.color}
+        intro={solution.architectureIntro}
+        layers={solution.architectureLayers}
+      />
+      <SolutionProofPoints
+        color={solution.color}
+        rgb={solution.rgb}
+        proofPoints={solution.proofPoints}
+      />
+      <WhitePaperSection />
+      <SolutionFooterCTA
+        color={solution.color}
+        headline={solution.ctaHeadline}
+        subtext={solution.ctaSubtext}
+      />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify the page builds**
+
+Run: `cd apps/website && npx next build 2>&1 | tail -30`
+Expected: Build succeeds. Routes `/solutions/compliance`, `/solutions/analytics`, `/solutions/customer-support` appear in the output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/website/src/app/solutions/[slug]/page.tsx
+git commit -m "feat(website): add dynamic solution page route with generateStaticParams"
+```
+
+---
+
+### Task 8: Solutions Index Page + SolutionsGrid
+
+**Files:**
+- Create: `apps/website/src/components/landing/solutions/SolutionsGrid.tsx`
+- Create: `apps/website/src/app/solutions/page.tsx`
+
+- [ ] **Step 1: Create the SolutionsGrid component**
+
+Card grid showing all 3 solutions with colored accents. Each card links to its detail page.
+
+```tsx
+// apps/website/src/components/landing/solutions/SolutionsGrid.tsx
+'use client';
+import { motion } from 'framer-motion';
+import Link from 'next/link';
+import { tokens } from '@cacheplane/design-tokens';
+import { SOLUTIONS } from '../../../lib/solutions-data';
+
+export function SolutionsGrid() {
+  return (
+    <section className="solutions-grid" style={{ padding: '80px 32px' }}>
+      <style>{`
+        @media (max-width: 767px) {
+          .solutions-grid { padding: 60px 20px !important; }
+        }
+      `}</style>
+      <motion.div
+        initial={{ opacity: 0, y: 16 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.5 }}
+        style={{ textAlign: 'center', marginBottom: 48 }}
+      >
+        <p
+          style={{
+            fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+            fontSize: '0.7rem',
+            textTransform: 'uppercase',
+            letterSpacing: '0.12em',
+            fontWeight: 700,
+            color: tokens.colors.accent,
+            marginBottom: 14,
+          }}
+        >
+          By Use Case
+        </p>
+        <h2
+          style={{
+            fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+            fontSize: 'clamp(26px, 3.5vw, 46px)',
+            fontWeight: 800,
+            lineHeight: 1.1,
+            color: tokens.colors.textPrimary,
+            marginBottom: 10,
+          }}
+        >
+          Enterprise solutions
+        </h2>
+        <p
+          style={{
+            fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+            fontStyle: 'italic',
+            fontSize: '1.05rem',
+            color: tokens.colors.textSecondary,
+            maxWidth: 520,
+            margin: '0 auto',
+          }}
+        >
+          See how Angular Agent Framework solves real enterprise problems — from compliance to customer support.
+        </p>
+      </motion.div>
+
+      <div
+        style={{
+          maxWidth: 1000,
+          margin: '0 auto',
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(min(280px, 100%), 1fr))',
+          gap: 24,
+        }}
+      >
+        {SOLUTIONS.map((sol, i) => (
+          <motion.div
+            key={sol.slug}
+            initial={{ opacity: 0, y: 24 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.5, delay: i * 0.1 }}
+            style={{
+              background: `rgba(${sol.rgb}, 0.03)`,
+              border: `1px solid rgba(${sol.rgb}, 0.15)`,
+              borderRadius: 14,
+              padding: '28px 24px 24px',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 12,
+            }}
+          >
+            <span
+              style={{
+                display: 'inline-block',
+                alignSelf: 'flex-start',
+                fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+                fontSize: '0.58rem',
+                fontWeight: 700,
+                textTransform: 'uppercase',
+                letterSpacing: '0.07em',
+                padding: '2px 9px',
+                borderRadius: 5,
+                color: '#fff',
+                background: sol.color,
+              }}
+            >
+              {sol.eyebrow}
+            </span>
+
+            <h3
+              style={{
+                fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+                fontSize: '1.2rem',
+                fontWeight: 700,
+                color: tokens.colors.textPrimary,
+                lineHeight: 1.25,
+                margin: 0,
+                whiteSpace: 'pre-line',
+              }}
+            >
+              {sol.title}
+            </h3>
+
+            <p
+              style={{
+                fontFamily: 'Inter, sans-serif',
+                fontSize: '0.88rem',
+                color: tokens.colors.textSecondary,
+                lineHeight: 1.6,
+                margin: 0,
+              }}
+            >
+              {sol.subtitle}
+            </p>
+
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 5, marginTop: 4 }}>
+              {sol.proofPoints.map(pp => (
+                <span
+                  key={pp.metric}
+                  style={{
+                    fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+                    fontSize: '0.58rem',
+                    padding: '2px 8px',
+                    borderRadius: 4,
+                    background: `rgba(${sol.rgb}, 0.07)`,
+                    color: sol.color,
+                    border: `1px solid rgba(${sol.rgb}, 0.15)`,
+                  }}
+                >
+                  {pp.metric} {pp.label.split(' — ')[0]}
+                </span>
+              ))}
+            </div>
+
+            <Link
+              href={`/solutions/${sol.slug}`}
+              style={{
+                fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+                fontSize: '0.72rem',
+                fontWeight: 700,
+                color: sol.color,
+                textDecoration: 'none',
+                marginTop: 'auto',
+                paddingTop: 8,
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 4,
+              }}
+            >
+              Learn more →
+            </Link>
+          </motion.div>
+        ))}
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 2: Create the solutions index page**
+
+```tsx
+// apps/website/src/app/solutions/page.tsx
+import { tokens } from '@cacheplane/design-tokens';
+import { SolutionsGrid } from '../../components/landing/solutions/SolutionsGrid';
+import { WhitePaperSection } from '../../components/landing/WhitePaperSection';
+import { PilotFooterCTA } from '../../components/landing/PilotFooterCTA';
+
+export const metadata = {
+  title: 'Solutions — Angular Agent Framework',
+  description: 'See how Angular Agent Framework solves enterprise challenges — compliance, analytics, and customer support.',
+};
+
+export default function SolutionsIndexPage() {
+  return (
+    <div style={{ background: tokens.gradient.bgFlow, position: 'relative', overflow: 'hidden' }}>
+      {/* Ambient gradient blobs */}
+      <div
+        style={{
+          position: 'absolute',
+          width: 600,
+          height: 600,
+          borderRadius: '50%',
+          background: tokens.gradient.warm,
+          top: -200,
+          left: -150,
+          filter: 'blur(80px)',
+          pointerEvents: 'none',
+        }}
+        aria-hidden="true"
+      />
+      <div
+        style={{
+          position: 'absolute',
+          width: 500,
+          height: 500,
+          borderRadius: '50%',
+          background: tokens.gradient.cool,
+          top: 800,
+          right: -100,
+          filter: 'blur(80px)',
+          pointerEvents: 'none',
+        }}
+        aria-hidden="true"
+      />
+
+      {/* Hero */}
+      <section style={{ position: 'relative', overflow: 'hidden', padding: '0 2rem' }}>
+        <div
+          style={{
+            maxWidth: '56rem',
+            margin: '0 auto',
+            textAlign: 'center',
+            position: 'relative',
+            zIndex: 1,
+          }}
+          className="py-24 md:py-32"
+        >
+          <p
+            style={{
+              fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+              fontSize: 11,
+              letterSpacing: '0.08em',
+              color: tokens.colors.accent,
+              textTransform: 'uppercase',
+              marginBottom: '1.5rem',
+            }}
+          >
+            Solutions
+          </p>
+          <h1
+            style={{
+              fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+              fontSize: 'clamp(36px, 5vw, 56px)',
+              fontWeight: 700,
+              lineHeight: 1.1,
+              color: tokens.colors.textPrimary,
+              marginBottom: '1.25rem',
+            }}
+          >
+            AI agents built for how enterprises actually work
+          </h1>
+          <p
+            style={{
+              fontFamily: 'Inter, sans-serif',
+              fontSize: 18,
+              color: tokens.colors.textSecondary,
+              maxWidth: '52ch',
+              margin: '0 auto',
+              lineHeight: 1.6,
+            }}
+          >
+            Angular Agent Framework gives your team the streaming, generative UI, and human-in-the-loop patterns that enterprise use cases demand.
+          </p>
+        </div>
+      </section>
+
+      <SolutionsGrid />
+      <WhitePaperSection />
+      <PilotFooterCTA />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Verify both pages build**
+
+Run: `cd apps/website && npx next build 2>&1 | tail -30`
+Expected: Build succeeds. Route `/solutions` appears in the output alongside the individual solution routes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/website/src/components/landing/solutions/SolutionsGrid.tsx apps/website/src/app/solutions/page.tsx
+git commit -m "feat(website): add solutions index page with SolutionsGrid"
+```
+
+---
+
+### Task 9: Nav and Footer Updates
+
+**Files:**
+- Modify: `apps/website/src/components/shared/Nav.tsx:8-14`
+- Modify: `apps/website/src/components/shared/Footer.tsx:136-166`
+
+- [ ] **Step 1: Add "Solutions" link to the Nav**
+
+In `apps/website/src/components/shared/Nav.tsx`, add a "Solutions" entry to the `links` array between "Docs" and "API":
+
+Replace:
+```typescript
+const links = [
+  { label: 'Pilot to Prod', href: '/pilot-to-prod', external: false },
+  { label: 'Docs', href: '/docs', external: false },
+  { label: 'API', href: '/docs/agent/api/agent', external: false },
+  { label: 'Examples', href: 'https://cockpit.cacheplane.ai', external: true },
+  { label: 'Pricing', href: '/pricing', external: false },
+];
+```
+
+With:
+```typescript
+const links = [
+  { label: 'Pilot to Prod', href: '/pilot-to-prod', external: false },
+  { label: 'Docs', href: '/docs', external: false },
+  { label: 'Solutions', href: '/solutions', external: false },
+  { label: 'API', href: '/docs/agent/api/agent', external: false },
+  { label: 'Examples', href: 'https://cockpit.cacheplane.ai', external: true },
+  { label: 'Pricing', href: '/pricing', external: false },
+];
+```
+
+- [ ] **Step 2: Add Solutions column to the Footer**
+
+In `apps/website/src/components/shared/Footer.tsx`, add a new "Solutions" column between the "Libraries" column and the "Resources" column. Find the `{/* Resources column */}` comment and insert before it:
+
+```tsx
+          {/* Solutions column */}
+          <div className="flex flex-col gap-2.5 text-sm">
+            <span className="font-mono text-xs uppercase tracking-wider mb-1" style={{ color: tokens.colors.accent }}>Solutions</span>
+            <Link href="/solutions/compliance" className="transition-colors" style={{ color: tokens.colors.textSecondary }}
+              onMouseEnter={(e) => (e.currentTarget.style.color = tokens.colors.accent)}
+              onMouseLeave={(e) => (e.currentTarget.style.color = tokens.colors.textSecondary)}>
+              Compliance
+            </Link>
+            <Link href="/solutions/analytics" className="transition-colors" style={{ color: tokens.colors.textSecondary }}
+              onMouseEnter={(e) => (e.currentTarget.style.color = tokens.colors.accent)}
+              onMouseLeave={(e) => (e.currentTarget.style.color = tokens.colors.textSecondary)}>
+              Analytics
+            </Link>
+            <Link href="/solutions/customer-support" className="transition-colors" style={{ color: tokens.colors.textSecondary }}
+              onMouseEnter={(e) => (e.currentTarget.style.color = tokens.colors.accent)}
+              onMouseLeave={(e) => (e.currentTarget.style.color = tokens.colors.textSecondary)}>
+              Customer Support
+            </Link>
+          </div>
+```
+
+Also update the grid from `md:grid-cols-5` to `md:grid-cols-6` since there's now an extra column. In the same file, change:
+```html
+<div className="grid grid-cols-1 md:grid-cols-5 gap-10 md:gap-8">
+```
+to:
+```html
+<div className="grid grid-cols-1 md:grid-cols-6 gap-10 md:gap-8">
+```
+
+- [ ] **Step 3: Verify the build**
+
+Run: `cd apps/website && npx next build 2>&1 | tail -30`
+Expected: Build succeeds without errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/website/src/components/shared/Nav.tsx apps/website/src/components/shared/Footer.tsx
+git commit -m "feat(website): add Solutions to nav and footer"
+```

--- a/docs/superpowers/plans/2026-04-14-landing-page-alignment.md
+++ b/docs/superpowers/plans/2026-04-14-landing-page-alignment.md
@@ -1,0 +1,1523 @@
+# Product Landing Page Alignment — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Align the three product landing pages (`/angular`, `/render`, `/chat`) with the home page's narrative funnel — stronger footer CTAs, stack awareness, refreshed whitepaper copy, and mobile responsiveness.
+
+**Architecture:** Evolutionary changes to existing components. Three new StackSiblings components. No shared abstractions — each page keeps its own components with inline data.
+
+**Tech Stack:** Next.js 16 App Router, React 19, framer-motion, `@cacheplane/design-tokens`, Next.js `<Link>`
+
+**Spec:** `docs/superpowers/specs/2026-04-13-landing-page-alignment-design.md`
+
+---
+
+### Task 1: Angular Hero — Stack Breadcrumb + Link Fixes
+
+**Files:**
+- Modify: `apps/website/src/components/landing/angular/AngularHero.tsx`
+
+- [ ] **Step 1: Add stack breadcrumb and fix internal links**
+
+Replace the full content of `AngularHero.tsx` with:
+
+```tsx
+// apps/website/src/components/landing/angular/AngularHero.tsx
+'use client';
+import { motion } from 'framer-motion';
+import Link from 'next/link';
+import { tokens } from '@cacheplane/design-tokens';
+
+const BADGES = ['Angular 20+', 'LangGraph', 'LangChain', 'DeepAgent'];
+
+export function AngularHero() {
+  return (
+    <section className="angular-hero" aria-labelledby="angular-hero-heading" style={{ position: 'relative', overflow: 'hidden', padding: '0 2rem' }}>
+      <style>{`
+        @media (max-width: 767px) {
+          .angular-hero { padding: 0 1.25rem !important; }
+        }
+      `}</style>
+      <div style={{ maxWidth: '56rem', margin: '0 auto', textAlign: 'center', position: 'relative', zIndex: 1 }} className="py-24 md:py-32">
+        {/* Stack breadcrumb */}
+        <motion.div initial={{ y: 16 }} animate={{ y: 0 }} transition={{ duration: 0.5 }}>
+          <div style={{
+            display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 0,
+            fontFamily: "'JetBrains Mono', monospace", fontSize: 10, letterSpacing: '0.08em',
+            textTransform: 'uppercase', marginBottom: '0.75rem',
+          }}>
+            <span style={{ color: tokens.colors.accent, fontWeight: 700 }}>Agent</span>
+            <span style={{ color: tokens.colors.textMuted, margin: '0 6px' }}>→</span>
+            <Link href="/render" style={{ color: tokens.colors.textMuted, fontWeight: 500, textDecoration: 'none' }}>Render</Link>
+            <span style={{ color: tokens.colors.textMuted, margin: '0 6px' }}>→</span>
+            <Link href="/chat" style={{ color: tokens.colors.textMuted, fontWeight: 500, textDecoration: 'none' }}>Chat</Link>
+          </div>
+        </motion.div>
+
+        <motion.div initial={{ y: 16 }} animate={{ y: 0 }} transition={{ duration: 0.5 }}>
+          <span style={{
+            fontFamily: "'JetBrains Mono', monospace", fontSize: 11, letterSpacing: '0.08em',
+            color: tokens.colors.accent, textTransform: 'uppercase', display: 'inline-block', marginBottom: '1.5rem',
+          }}>
+            @cacheplane/angular
+          </span>
+        </motion.div>
+
+        <motion.h1 id="angular-hero-heading" initial={{ y: 20 }} animate={{ y: 0 }} transition={{ duration: 0.6, delay: 0.05 }}
+          style={{
+            fontFamily: "'EB Garamond', serif", fontSize: 'clamp(36px, 5vw, 56px)', fontWeight: 700,
+            lineHeight: 1.1, color: tokens.colors.textPrimary, margin: 0, marginBottom: '1.25rem',
+          }}>
+          Ship LangGraph agents in Angular — without building the plumbing
+        </motion.h1>
+
+        <motion.p initial={{ y: 14 }} animate={{ y: 0 }} transition={{ duration: 0.6, delay: 0.1 }}
+          style={{
+            fontFamily: 'Inter, sans-serif', fontSize: 18, color: tokens.colors.textSecondary,
+            maxWidth: '52ch', margin: '0 auto', lineHeight: 1.6, marginBottom: '2rem',
+          }}>
+          Signal-native streaming, thread persistence, interrupts, and deterministic testing. The complete agent primitive layer for Angular 20+.
+        </motion.p>
+
+        <motion.div initial={{ y: 14 }} animate={{ y: 0 }} transition={{ duration: 0.6, delay: 0.15 }}
+          style={{ display: 'flex', gap: '0.75rem', justifyContent: 'center', flexWrap: 'wrap', marginBottom: '1.5rem' }}>
+          <a href="/whitepapers/angular.pdf" download
+            style={{
+              display: 'inline-flex', alignItems: 'center', gap: 6,
+              background: tokens.colors.accent, color: '#fff', fontFamily: 'Inter, sans-serif',
+              fontSize: 15, fontWeight: 600, padding: '0.875rem 1.75rem', borderRadius: 8,
+              textDecoration: 'none', boxShadow: tokens.glow.button, minHeight: 44,
+            }}>
+            Download the Guide
+          </a>
+          <Link href="/docs"
+            style={{
+              display: 'inline-flex', alignItems: 'center', gap: 6,
+              background: tokens.glass.bg, backdropFilter: `blur(${tokens.glass.blur})`,
+              WebkitBackdropFilter: `blur(${tokens.glass.blur})`,
+              color: tokens.colors.accent, fontFamily: 'Inter, sans-serif',
+              fontSize: 15, fontWeight: 600, padding: '0.875rem 1.75rem', borderRadius: 8,
+              textDecoration: 'none', border: `1px solid ${tokens.colors.accentBorder}`, minHeight: 44,
+            }}>
+            View Docs
+          </Link>
+        </motion.div>
+
+        <motion.div initial={{ y: 14 }} animate={{ y: 0 }} transition={{ duration: 0.6, delay: 0.2 }}
+          style={{ display: 'flex', gap: 8, justifyContent: 'center', flexWrap: 'wrap' }}>
+          {BADGES.map(badge => (
+            <span key={badge} style={{
+              fontFamily: "'JetBrains Mono', monospace", fontSize: 10, letterSpacing: '0.06em',
+              color: tokens.colors.textMuted, textTransform: 'uppercase',
+              padding: '3px 10px', borderRadius: 4,
+              background: 'rgba(0,64,144,0.04)', border: '1px solid rgba(0,64,144,0.1)',
+            }}>
+              {badge}
+            </span>
+          ))}
+        </motion.div>
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 2: Verify the dev server compiles**
+
+Run: `cd /Users/blove/repos/stream-resource && npx nx dev website`
+Expected: No compilation errors for `/angular` route.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/website/src/components/landing/angular/AngularHero.tsx
+git commit -m "feat(website): add stack breadcrumb and fix Link usage in AngularHero"
+```
+
+---
+
+### Task 2: Render Hero — Stack Breadcrumb + Link Fixes
+
+**Files:**
+- Modify: `apps/website/src/components/landing/render/RenderHero.tsx`
+
+- [ ] **Step 1: Add stack breadcrumb and fix internal links**
+
+Replace the full content of `RenderHero.tsx` with:
+
+```tsx
+// apps/website/src/components/landing/render/RenderHero.tsx
+'use client';
+import { motion } from 'framer-motion';
+import Link from 'next/link';
+import { tokens } from '@cacheplane/design-tokens';
+
+const BADGES = ['Angular 20+', 'Vercel json-render', 'Google A2UI', 'JSON Patch streaming'];
+
+export function RenderHero() {
+  return (
+    <section className="render-hero" aria-labelledby="render-hero-heading" style={{ position: 'relative', overflow: 'hidden', padding: '0 2rem' }}>
+      <style>{`
+        @media (max-width: 767px) {
+          .render-hero { padding: 0 1.25rem !important; }
+        }
+      `}</style>
+      <div style={{ maxWidth: '56rem', margin: '0 auto', textAlign: 'center', position: 'relative', zIndex: 1 }} className="py-24 md:py-32">
+        {/* Stack breadcrumb */}
+        <motion.div initial={{ y: 16 }} animate={{ y: 0 }} transition={{ duration: 0.5 }}>
+          <div style={{
+            display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 0,
+            fontFamily: "'JetBrains Mono', monospace", fontSize: 10, letterSpacing: '0.08em',
+            textTransform: 'uppercase', marginBottom: '0.75rem',
+          }}>
+            <Link href="/angular" style={{ color: tokens.colors.textMuted, fontWeight: 500, textDecoration: 'none' }}>Agent</Link>
+            <span style={{ color: tokens.colors.textMuted, margin: '0 6px' }}>→</span>
+            <span style={{ color: tokens.colors.renderGreen, fontWeight: 700 }}>Render</span>
+            <span style={{ color: tokens.colors.textMuted, margin: '0 6px' }}>→</span>
+            <Link href="/chat" style={{ color: tokens.colors.textMuted, fontWeight: 500, textDecoration: 'none' }}>Chat</Link>
+          </div>
+        </motion.div>
+
+        <motion.div initial={{ y: 16 }} animate={{ y: 0 }} transition={{ duration: 0.5 }}>
+          <span style={{
+            fontFamily: "'JetBrains Mono', monospace", fontSize: 11, letterSpacing: '0.08em',
+            color: tokens.colors.accent, textTransform: 'uppercase', display: 'inline-block', marginBottom: '1.5rem',
+          }}>
+            @cacheplane/render
+          </span>
+        </motion.div>
+
+        <motion.h1 id="render-hero-heading" initial={{ y: 20 }} animate={{ y: 0 }} transition={{ duration: 0.6, delay: 0.05 }}
+          style={{
+            fontFamily: "'EB Garamond', serif", fontSize: 'clamp(36px, 5vw, 56px)', fontWeight: 700,
+            lineHeight: 1.1, color: tokens.colors.textPrimary, margin: 0, marginBottom: '1.25rem',
+          }}>
+          Agents that render UI — without coupling to your frontend
+        </motion.h1>
+
+        <motion.p initial={{ y: 14 }} animate={{ y: 0 }} transition={{ duration: 0.6, delay: 0.1 }}
+          style={{
+            fontFamily: 'Inter, sans-serif', fontSize: 18, color: tokens.colors.textSecondary,
+            maxWidth: '52ch', margin: '0 auto', lineHeight: 1.6, marginBottom: '2rem',
+          }}>
+          Built on Vercel's json-render spec and Google's A2UI protocol — open standards you already trust. @cacheplane/render brings both to Angular with streaming JSON patches, component registries, and signal-native state.
+        </motion.p>
+
+        <motion.div initial={{ y: 14 }} animate={{ y: 0 }} transition={{ duration: 0.6, delay: 0.15 }}
+          style={{ display: 'flex', gap: '0.75rem', justifyContent: 'center', flexWrap: 'wrap', marginBottom: '1.5rem' }}>
+          <a href="/whitepapers/render.pdf" download
+            style={{
+              display: 'inline-flex', alignItems: 'center', gap: 6,
+              background: tokens.colors.renderGreen, color: '#fff', fontFamily: 'Inter, sans-serif',
+              fontSize: 15, fontWeight: 600, padding: '0.875rem 1.75rem', borderRadius: 8,
+              textDecoration: 'none', boxShadow: tokens.glow.button, minHeight: 44,
+            }}>
+            Download the Guide
+          </a>
+          <Link href="/docs"
+            style={{
+              display: 'inline-flex', alignItems: 'center', gap: 6,
+              background: tokens.glass.bg, backdropFilter: `blur(${tokens.glass.blur})`,
+              WebkitBackdropFilter: `blur(${tokens.glass.blur})`,
+              color: tokens.colors.accent, fontFamily: 'Inter, sans-serif',
+              fontSize: 15, fontWeight: 600, padding: '0.875rem 1.75rem', borderRadius: 8,
+              textDecoration: 'none', border: `1px solid ${tokens.colors.accentBorder}`, minHeight: 44,
+            }}>
+            View Docs
+          </Link>
+        </motion.div>
+
+        <motion.div initial={{ y: 14 }} animate={{ y: 0 }} transition={{ duration: 0.6, delay: 0.2 }}
+          style={{ display: 'flex', gap: 8, justifyContent: 'center', flexWrap: 'wrap' }}>
+          {BADGES.map(badge => (
+            <span key={badge} style={{
+              fontFamily: "'JetBrains Mono', monospace", fontSize: 10, letterSpacing: '0.06em',
+              color: tokens.colors.textMuted, textTransform: 'uppercase',
+              padding: '3px 10px', borderRadius: 4,
+              background: 'rgba(26,122,64,0.04)', border: '1px solid rgba(26,122,64,0.1)',
+            }}>
+              {badge}
+            </span>
+          ))}
+        </motion.div>
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/website/src/components/landing/render/RenderHero.tsx
+git commit -m "feat(website): add stack breadcrumb and fix Link usage in RenderHero"
+```
+
+---
+
+### Task 3: Chat Hero — Stack Breadcrumb + Link Fixes
+
+**Files:**
+- Modify: `apps/website/src/components/landing/chat-landing/ChatLandingHero.tsx`
+
+- [ ] **Step 1: Add stack breadcrumb and fix internal links**
+
+Replace the full content of `ChatLandingHero.tsx` with:
+
+```tsx
+// apps/website/src/components/landing/chat-landing/ChatLandingHero.tsx
+'use client';
+import { motion } from 'framer-motion';
+import Link from 'next/link';
+import { tokens } from '@cacheplane/design-tokens';
+
+const BADGES = ['Angular 20+', 'Vercel json-render', 'Google A2UI', 'WCAG accessible'];
+
+export function ChatLandingHero() {
+  return (
+    <section className="chat-hero" aria-labelledby="chat-hero-heading" style={{ position: 'relative', overflow: 'hidden', padding: '0 2rem' }}>
+      <style>{`
+        @media (max-width: 767px) {
+          .chat-hero { padding: 0 1.25rem !important; }
+        }
+      `}</style>
+      <div style={{ maxWidth: '56rem', margin: '0 auto', textAlign: 'center', position: 'relative', zIndex: 1 }} className="py-24 md:py-32">
+        {/* Stack breadcrumb */}
+        <motion.div initial={{ y: 16 }} animate={{ y: 0 }} transition={{ duration: 0.5 }}>
+          <div style={{
+            display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 0,
+            fontFamily: "'JetBrains Mono', monospace", fontSize: 10, letterSpacing: '0.08em',
+            textTransform: 'uppercase', marginBottom: '0.75rem',
+          }}>
+            <Link href="/angular" style={{ color: tokens.colors.textMuted, fontWeight: 500, textDecoration: 'none' }}>Agent</Link>
+            <span style={{ color: tokens.colors.textMuted, margin: '0 6px' }}>→</span>
+            <Link href="/render" style={{ color: tokens.colors.textMuted, fontWeight: 500, textDecoration: 'none' }}>Render</Link>
+            <span style={{ color: tokens.colors.textMuted, margin: '0 6px' }}>→</span>
+            <span style={{ color: tokens.colors.chatPurple, fontWeight: 700 }}>Chat</span>
+          </div>
+        </motion.div>
+
+        <motion.div initial={{ y: 16 }} animate={{ y: 0 }} transition={{ duration: 0.5 }}>
+          <span style={{
+            fontFamily: "'JetBrains Mono', monospace", fontSize: 11, letterSpacing: '0.08em',
+            color: tokens.colors.chatPurple, textTransform: 'uppercase', display: 'inline-block', marginBottom: '1.5rem',
+          }}>
+            @cacheplane/chat
+          </span>
+        </motion.div>
+
+        <motion.h1 id="chat-hero-heading" initial={{ y: 20 }} animate={{ y: 0 }} transition={{ duration: 0.6, delay: 0.05 }}
+          style={{
+            fontFamily: "'EB Garamond', serif", fontSize: 'clamp(36px, 5vw, 56px)', fontWeight: 700,
+            lineHeight: 1.1, color: tokens.colors.textPrimary, margin: 0, marginBottom: '1.25rem',
+          }}>
+          Production agent chat UI in days, not sprints
+        </motion.h1>
+
+        <motion.p initial={{ y: 14 }} animate={{ y: 0 }} transition={{ duration: 0.6, delay: 0.1 }}
+          style={{
+            fontFamily: 'Inter, sans-serif', fontSize: 18, color: tokens.colors.textSecondary,
+            maxWidth: '52ch', margin: '0 auto', lineHeight: 1.6, marginBottom: '2rem',
+          }}>
+          The batteries-included Angular chat library. Built on the agent framework, Vercel's json-render spec, and Google's A2UI spec. Every feature included — debug, theming, generative UI, streaming — from day one.
+        </motion.p>
+
+        <motion.div initial={{ y: 14 }} animate={{ y: 0 }} transition={{ duration: 0.6, delay: 0.15 }}
+          style={{ display: 'flex', gap: '0.75rem', justifyContent: 'center', flexWrap: 'wrap', marginBottom: '1.5rem' }}>
+          <a href="/whitepapers/chat.pdf" download
+            style={{
+              display: 'inline-flex', alignItems: 'center', gap: 6,
+              background: tokens.colors.chatPurple, color: '#fff', fontFamily: 'Inter, sans-serif',
+              fontSize: 15, fontWeight: 600, padding: '0.875rem 1.75rem', borderRadius: 8,
+              textDecoration: 'none', boxShadow: tokens.glow.button, minHeight: 44,
+            }}>
+            Download the Guide
+          </a>
+          <Link href="/docs"
+            style={{
+              display: 'inline-flex', alignItems: 'center', gap: 6,
+              background: tokens.glass.bg, backdropFilter: `blur(${tokens.glass.blur})`,
+              WebkitBackdropFilter: `blur(${tokens.glass.blur})`,
+              color: tokens.colors.chatPurple, fontFamily: 'Inter, sans-serif',
+              fontSize: 15, fontWeight: 600, padding: '0.875rem 1.75rem', borderRadius: 8,
+              textDecoration: 'none', border: '1px solid rgba(90,0,200,0.2)', minHeight: 44,
+            }}>
+            View Docs
+          </Link>
+        </motion.div>
+
+        <motion.div initial={{ y: 14 }} animate={{ y: 0 }} transition={{ duration: 0.6, delay: 0.2 }}
+          style={{ display: 'flex', gap: 8, justifyContent: 'center', flexWrap: 'wrap' }}>
+          {BADGES.map(badge => (
+            <span key={badge} style={{
+              fontFamily: "'JetBrains Mono', monospace", fontSize: 10, letterSpacing: '0.06em',
+              color: tokens.colors.textMuted, textTransform: 'uppercase',
+              padding: '3px 10px', borderRadius: 4,
+              background: 'rgba(90,0,200,0.04)', border: '1px solid rgba(90,0,200,0.1)',
+            }}>
+              {badge}
+            </span>
+          ))}
+        </motion.div>
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/website/src/components/landing/chat-landing/ChatLandingHero.tsx
+git commit -m "feat(website): add stack breadcrumb and fix Link usage in ChatLandingHero"
+```
+
+---
+
+### Task 4: Angular Footer CTA — Dark Design Upgrade
+
+**Files:**
+- Modify: `apps/website/src/components/landing/angular/AngularFooterCTA.tsx`
+
+- [ ] **Step 1: Replace with dark design**
+
+Replace the full content of `AngularFooterCTA.tsx` with:
+
+```tsx
+// apps/website/src/components/landing/angular/AngularFooterCTA.tsx
+'use client';
+
+import { motion } from 'framer-motion';
+import Link from 'next/link';
+import { tokens } from '@cacheplane/design-tokens';
+
+export function AngularFooterCTA() {
+  return (
+    <section
+      aria-labelledby="angular-footer-cta-heading"
+      style={{
+        background: 'linear-gradient(135deg, #1a1a2e 0%, #0d1b3e 100%)',
+        padding: '0 2rem',
+      }}
+    >
+      <style>{`
+        .angular-footer-secondary-btn:hover { border-color: rgba(255,255,255,0.6) !important; }
+        @media (max-width: 767px) {
+          .angular-footer-inner { padding-top: 4rem !important; padding-bottom: 4rem !important; }
+          .angular-footer-heading { font-size: clamp(28px, 6vw, 42px) !important; }
+        }
+      `}</style>
+      <motion.div
+        className="angular-footer-inner"
+        initial={{ opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.5 }}
+        style={{
+          maxWidth: '48rem',
+          margin: '0 auto',
+          paddingTop: '6rem',
+          paddingBottom: '6rem',
+          textAlign: 'center',
+        }}
+      >
+        <p style={{
+          fontFamily: 'var(--font-mono, monospace)',
+          fontSize: '11px', fontWeight: 500, letterSpacing: '0.12em',
+          textTransform: 'uppercase', color: 'rgba(255, 255, 255, 0.5)',
+          marginBottom: '1rem',
+        }}>
+          Ready when you are
+        </p>
+
+        <h2
+          id="angular-footer-cta-heading"
+          className="angular-footer-heading"
+          style={{
+            fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+            fontSize: '42px', fontWeight: 400, lineHeight: 1.15,
+            color: '#ffffff', marginBottom: '1.25rem',
+          }}
+        >
+          Ready to ship your LangGraph agent?
+        </h2>
+
+        <p style={{
+          fontFamily: 'var(--font-inter, Inter, sans-serif)',
+          fontSize: '17px', lineHeight: 1.6,
+          color: 'rgba(255, 255, 255, 0.7)', marginBottom: '2.5rem',
+        }}>
+          The Angular Agent Framework closes the last-mile gap. Start with a conversation.
+        </p>
+
+        <div style={{
+          display: 'flex', gap: '1rem', justifyContent: 'center',
+          flexWrap: 'wrap', marginBottom: '1.5rem',
+        }}>
+          <Link
+            href="/pilot-to-prod"
+            style={{
+              display: 'inline-block', padding: '0.875rem 2rem',
+              background: '#ffffff', color: tokens.colors.accent,
+              fontFamily: 'var(--font-inter, Inter, sans-serif)',
+              fontSize: '15px', fontWeight: 600, textDecoration: 'none',
+              borderRadius: '6px', transition: 'box-shadow 0.2s ease',
+            }}
+          >
+            Start Your Pilot →
+          </Link>
+
+          <a
+            href="/whitepapers/angular.pdf"
+            download
+            className="angular-footer-secondary-btn"
+            style={{
+              display: 'inline-block', padding: '0.875rem 2rem',
+              background: 'transparent', color: '#ffffff',
+              fontFamily: 'var(--font-inter, Inter, sans-serif)',
+              fontSize: '15px', fontWeight: 600, textDecoration: 'none',
+              borderRadius: '6px', border: '1px solid rgba(255, 255, 255, 0.3)',
+              transition: 'border-color 0.2s ease',
+            }}
+          >
+            Download the Guide
+          </a>
+        </div>
+
+        <p style={{
+          fontFamily: 'var(--font-mono, monospace)',
+          fontSize: '10px', letterSpacing: '0.08em',
+          color: 'rgba(255, 255, 255, 0.4)',
+        }}>
+          App deployment license · $20,000 · 3-month co-pilot engagement
+        </p>
+      </motion.div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/website/src/components/landing/angular/AngularFooterCTA.tsx
+git commit -m "feat(website): upgrade AngularFooterCTA to dark design with pilot primary CTA"
+```
+
+---
+
+### Task 5: Render Footer CTA — Dark Design Upgrade
+
+**Files:**
+- Modify: `apps/website/src/components/landing/render/RenderFooterCTA.tsx`
+
+- [ ] **Step 1: Replace with dark design**
+
+Replace the full content of `RenderFooterCTA.tsx` with:
+
+```tsx
+// apps/website/src/components/landing/render/RenderFooterCTA.tsx
+'use client';
+
+import { motion } from 'framer-motion';
+import Link from 'next/link';
+import { tokens } from '@cacheplane/design-tokens';
+
+export function RenderFooterCTA() {
+  return (
+    <section
+      aria-labelledby="render-footer-cta-heading"
+      style={{
+        background: 'linear-gradient(135deg, #1a1a2e 0%, #0d1b3e 100%)',
+        padding: '0 2rem',
+      }}
+    >
+      <style>{`
+        .render-footer-secondary-btn:hover { border-color: rgba(255,255,255,0.6) !important; }
+        @media (max-width: 767px) {
+          .render-footer-inner { padding-top: 4rem !important; padding-bottom: 4rem !important; }
+          .render-footer-heading { font-size: clamp(28px, 6vw, 42px) !important; }
+        }
+      `}</style>
+      <motion.div
+        className="render-footer-inner"
+        initial={{ opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.5 }}
+        style={{
+          maxWidth: '48rem',
+          margin: '0 auto',
+          paddingTop: '6rem',
+          paddingBottom: '6rem',
+          textAlign: 'center',
+        }}
+      >
+        <p style={{
+          fontFamily: 'var(--font-mono, monospace)',
+          fontSize: '11px', fontWeight: 500, letterSpacing: '0.12em',
+          textTransform: 'uppercase', color: 'rgba(255, 255, 255, 0.5)',
+          marginBottom: '1rem',
+        }}>
+          Ready when you are
+        </p>
+
+        <h2
+          id="render-footer-cta-heading"
+          className="render-footer-heading"
+          style={{
+            fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+            fontSize: '42px', fontWeight: 400, lineHeight: 1.15,
+            color: '#ffffff', marginBottom: '1.25rem',
+          }}
+        >
+          Ready to ship your generative UI?
+        </h2>
+
+        <p style={{
+          fontFamily: 'var(--font-inter, Inter, sans-serif)',
+          fontSize: '17px', lineHeight: 1.6,
+          color: 'rgba(255, 255, 255, 0.7)', marginBottom: '2.5rem',
+        }}>
+          Decouple your agent&apos;s UI layer with open standards. Start with a conversation.
+        </p>
+
+        <div style={{
+          display: 'flex', gap: '1rem', justifyContent: 'center',
+          flexWrap: 'wrap', marginBottom: '1.5rem',
+        }}>
+          <Link
+            href="/pilot-to-prod"
+            style={{
+              display: 'inline-block', padding: '0.875rem 2rem',
+              background: '#ffffff', color: tokens.colors.accent,
+              fontFamily: 'var(--font-inter, Inter, sans-serif)',
+              fontSize: '15px', fontWeight: 600, textDecoration: 'none',
+              borderRadius: '6px', transition: 'box-shadow 0.2s ease',
+            }}
+          >
+            Start Your Pilot →
+          </Link>
+
+          <a
+            href="/whitepapers/render.pdf"
+            download
+            className="render-footer-secondary-btn"
+            style={{
+              display: 'inline-block', padding: '0.875rem 2rem',
+              background: 'transparent', color: '#ffffff',
+              fontFamily: 'var(--font-inter, Inter, sans-serif)',
+              fontSize: '15px', fontWeight: 600, textDecoration: 'none',
+              borderRadius: '6px', border: '1px solid rgba(255, 255, 255, 0.3)',
+              transition: 'border-color 0.2s ease',
+            }}
+          >
+            Download the Guide
+          </a>
+        </div>
+
+        <p style={{
+          fontFamily: 'var(--font-mono, monospace)',
+          fontSize: '10px', letterSpacing: '0.08em',
+          color: 'rgba(255, 255, 255, 0.4)',
+        }}>
+          App deployment license · $20,000 · 3-month co-pilot engagement
+        </p>
+      </motion.div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/website/src/components/landing/render/RenderFooterCTA.tsx
+git commit -m "feat(website): upgrade RenderFooterCTA to dark design with pilot primary CTA"
+```
+
+---
+
+### Task 6: Chat Footer CTA — Dark Design Upgrade
+
+**Files:**
+- Modify: `apps/website/src/components/landing/chat-landing/ChatLandingFooterCTA.tsx`
+
+- [ ] **Step 1: Replace with dark design**
+
+Replace the full content of `ChatLandingFooterCTA.tsx` with:
+
+```tsx
+// apps/website/src/components/landing/chat-landing/ChatLandingFooterCTA.tsx
+'use client';
+
+import { motion } from 'framer-motion';
+import Link from 'next/link';
+import { tokens } from '@cacheplane/design-tokens';
+
+export function ChatLandingFooterCTA() {
+  return (
+    <section
+      aria-labelledby="chat-footer-cta-heading"
+      style={{
+        background: 'linear-gradient(135deg, #1a1a2e 0%, #0d1b3e 100%)',
+        padding: '0 2rem',
+      }}
+    >
+      <style>{`
+        .chat-footer-secondary-btn:hover { border-color: rgba(255,255,255,0.6) !important; }
+        @media (max-width: 767px) {
+          .chat-footer-inner { padding-top: 4rem !important; padding-bottom: 4rem !important; }
+          .chat-footer-heading { font-size: clamp(28px, 6vw, 42px) !important; }
+        }
+      `}</style>
+      <motion.div
+        className="chat-footer-inner"
+        initial={{ opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.5 }}
+        style={{
+          maxWidth: '48rem',
+          margin: '0 auto',
+          paddingTop: '6rem',
+          paddingBottom: '6rem',
+          textAlign: 'center',
+        }}
+      >
+        <p style={{
+          fontFamily: 'var(--font-mono, monospace)',
+          fontSize: '11px', fontWeight: 500, letterSpacing: '0.12em',
+          textTransform: 'uppercase', color: 'rgba(255, 255, 255, 0.5)',
+          marginBottom: '1rem',
+        }}>
+          Ready when you are
+        </p>
+
+        <h2
+          id="chat-footer-cta-heading"
+          className="chat-footer-heading"
+          style={{
+            fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+            fontSize: '42px', fontWeight: 400, lineHeight: 1.15,
+            color: '#ffffff', marginBottom: '1.25rem',
+          }}
+        >
+          Ready to ship your agent chat?
+        </h2>
+
+        <p style={{
+          fontFamily: 'var(--font-inter, Inter, sans-serif)',
+          fontSize: '17px', lineHeight: 1.6,
+          color: 'rgba(255, 255, 255, 0.7)', marginBottom: '2.5rem',
+        }}>
+          Production chat UI in days, not sprints. Start with a conversation.
+        </p>
+
+        <div style={{
+          display: 'flex', gap: '1rem', justifyContent: 'center',
+          flexWrap: 'wrap', marginBottom: '1.5rem',
+        }}>
+          <Link
+            href="/pilot-to-prod"
+            style={{
+              display: 'inline-block', padding: '0.875rem 2rem',
+              background: '#ffffff', color: tokens.colors.accent,
+              fontFamily: 'var(--font-inter, Inter, sans-serif)',
+              fontSize: '15px', fontWeight: 600, textDecoration: 'none',
+              borderRadius: '6px', transition: 'box-shadow 0.2s ease',
+            }}
+          >
+            Start Your Pilot →
+          </Link>
+
+          <a
+            href="/whitepapers/chat.pdf"
+            download
+            className="chat-footer-secondary-btn"
+            style={{
+              display: 'inline-block', padding: '0.875rem 2rem',
+              background: 'transparent', color: '#ffffff',
+              fontFamily: 'var(--font-inter, Inter, sans-serif)',
+              fontSize: '15px', fontWeight: 600, textDecoration: 'none',
+              borderRadius: '6px', border: '1px solid rgba(255, 255, 255, 0.3)',
+              transition: 'border-color 0.2s ease',
+            }}
+          >
+            Download the Guide
+          </a>
+        </div>
+
+        <p style={{
+          fontFamily: 'var(--font-mono, monospace)',
+          fontSize: '10px', letterSpacing: '0.08em',
+          color: 'rgba(255, 255, 255, 0.4)',
+        }}>
+          App deployment license · $20,000 · 3-month co-pilot engagement
+        </p>
+      </motion.div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/website/src/components/landing/chat-landing/ChatLandingFooterCTA.tsx
+git commit -m "feat(website): upgrade ChatLandingFooterCTA to dark design with pilot primary CTA"
+```
+
+---
+
+### Task 7: WhitePaperGate Copy Refresh — All Three Pages
+
+**Files:**
+- Modify: `apps/website/src/components/landing/angular/AngularWhitePaperGate.tsx`
+- Modify: `apps/website/src/components/landing/render/RenderWhitePaperGate.tsx`
+- Modify: `apps/website/src/components/landing/chat-landing/ChatLandingWhitePaperGate.tsx`
+
+- [ ] **Step 1: Update AngularWhitePaperGate copy**
+
+In `apps/website/src/components/landing/angular/AngularWhitePaperGate.tsx`:
+
+Change the eyebrow text from `Free Download` to `Agent Guide` (line 61).
+
+Change the subtitle (lines 73-74) from:
+```
+Six chapters covering the last-mile problem, the agent() API, thread persistence, interrupts, full LangGraph feature coverage, and deterministic testing.
+```
+to:
+```
+Six chapters covering the last-mile gap, the agent() API, thread persistence, interrupts, time-travel, and deterministic testing with MockAgentTransport.
+```
+
+Add after the closing `</p>` of the subtitle (after line 75), before the download link:
+```tsx
+            <p style={{
+              fontFamily: 'Inter, sans-serif', fontSize: '0.8rem',
+              color: tokens.colors.textMuted, marginBottom: 20,
+            }}>
+              Part of the Cacheplane Angular Agent Framework.
+            </p>
+```
+
+Also add `className="angular-wp-gate"` to the `<section>` and a mobile media query:
+```tsx
+    <section id="angular-whitepaper-gate" className="angular-wp-gate" style={{ padding: '80px 32px' }}>
+      <style>{`
+        @media (max-width: 767px) {
+          .angular-wp-gate { padding: 60px 20px !important; }
+        }
+      `}</style>
+```
+
+- [ ] **Step 2: Update RenderWhitePaperGate copy**
+
+In `apps/website/src/components/landing/render/RenderWhitePaperGate.tsx`:
+
+Change the eyebrow text from `Free Download` to `Render Guide`.
+
+Change the subtitle from:
+```
+Five chapters covering the coupling problem, declarative UI specs with Vercel's json-render standard, the component registry, streaming JSON patches, and state management.
+```
+to:
+```
+Five chapters covering the coupling problem, declarative UI specs with Vercel's json-render standard and Google's A2UI protocol, the component registry, streaming JSON patches, and signal-native state management.
+```
+
+Add the same "Part of the Cacheplane Angular Agent Framework." paragraph after the subtitle.
+
+Add `className="render-wp-gate"` and mobile media query matching the Angular pattern.
+
+- [ ] **Step 3: Update ChatLandingWhitePaperGate copy**
+
+In `apps/website/src/components/landing/chat-landing/ChatLandingWhitePaperGate.tsx`:
+
+Change the eyebrow text from `Free Download` to `Chat Guide`.
+
+Change the subtitle from:
+```
+Five chapters covering the sprint tax, batteries-included components, theming and design system integration, generative UI in chat, and debug tooling.
+```
+to:
+```
+Five chapters covering the sprint tax, batteries-included components, theming and design system integration, generative UI with Vercel json-render, Google A2UI support, and debug tooling.
+```
+
+Add the same "Part of the Cacheplane Angular Agent Framework." paragraph after the subtitle.
+
+Add `className="chat-wp-gate"` and mobile media query matching the Angular pattern.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/website/src/components/landing/angular/AngularWhitePaperGate.tsx \
+  apps/website/src/components/landing/render/RenderWhitePaperGate.tsx \
+  apps/website/src/components/landing/chat-landing/ChatLandingWhitePaperGate.tsx
+git commit -m "feat(website): refresh WhitePaperGate copy and add mobile breakpoints"
+```
+
+---
+
+### Task 8: Stack Siblings — Angular
+
+**Files:**
+- Create: `apps/website/src/components/landing/angular/AngularStackSiblings.tsx`
+- Modify: `apps/website/src/app/angular/page.tsx`
+
+- [ ] **Step 1: Create AngularStackSiblings component**
+
+Create `apps/website/src/components/landing/angular/AngularStackSiblings.tsx`:
+
+```tsx
+'use client';
+import { motion } from 'framer-motion';
+import Link from 'next/link';
+import { tokens } from '@cacheplane/design-tokens';
+
+const SIBLINGS = [
+  {
+    tag: 'Gen UI',
+    pkg: '@cacheplane/render',
+    color: tokens.colors.renderGreen,
+    rgb: '26,122,64',
+    headline: 'Agents that render UI — on open standards',
+    href: '/render',
+    ctaLabel: 'Explore Render',
+  },
+  {
+    tag: 'Chat',
+    pkg: '@cacheplane/chat',
+    color: tokens.colors.chatPurple,
+    rgb: '90,0,200',
+    headline: 'Production chat UI in days, not sprints',
+    href: '/chat',
+    ctaLabel: 'Explore Chat',
+  },
+];
+
+export function AngularStackSiblings() {
+  return (
+    <section className="angular-stack-siblings" style={{ padding: '80px 32px' }}>
+      <style>{`
+        @media (max-width: 767px) {
+          .angular-stack-siblings { padding: 60px 20px !important; }
+          .angular-stack-siblings-grid { grid-template-columns: 1fr !important; }
+        }
+      `}</style>
+      <motion.div
+        initial={{ opacity: 0, y: 16 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.5 }}
+        style={{ textAlign: 'center', marginBottom: 36 }}
+      >
+        <p style={{
+          fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+          fontSize: '0.7rem', textTransform: 'uppercase', letterSpacing: '0.12em',
+          fontWeight: 700, color: tokens.colors.accent, marginBottom: 14,
+        }}>
+          The Cacheplane Stack
+        </p>
+        <p style={{
+          fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+          fontStyle: 'italic', fontSize: '1.05rem',
+          color: tokens.colors.textSecondary, maxWidth: 520, margin: '0 auto',
+        }}>
+          This library is part of a cohesive three-layer architecture.
+        </p>
+      </motion.div>
+
+      <div
+        className="angular-stack-siblings-grid"
+        style={{
+          display: 'grid', gridTemplateColumns: '1fr 1fr',
+          gap: 16, maxWidth: 860, margin: '0 auto',
+        }}
+      >
+        {SIBLINGS.map((lib, i) => (
+          <motion.div
+            key={lib.pkg}
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.5, delay: i * 0.1 }}
+            style={{
+              padding: '24px 20px',
+              borderRadius: 14,
+              background: `rgba(${lib.rgb}, 0.03)`,
+              border: `1px solid rgba(${lib.rgb}, 0.15)`,
+              borderLeft: `3px solid ${lib.color}`,
+              display: 'flex', flexDirection: 'column', gap: 10,
+            }}
+          >
+            <span style={{
+              display: 'inline-block', alignSelf: 'flex-start',
+              fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+              fontSize: '0.58rem', fontWeight: 700, textTransform: 'uppercase',
+              letterSpacing: '0.07em', padding: '2px 9px', borderRadius: 5,
+              color: '#fff', background: lib.color,
+            }}>
+              {lib.tag}
+            </span>
+
+            <p style={{
+              fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+              fontSize: '0.76rem', fontWeight: 700, color: lib.color, margin: 0,
+            }}>
+              {lib.pkg}
+            </p>
+
+            <h3 style={{
+              fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+              fontSize: '1.15rem', fontWeight: 700,
+              color: tokens.colors.textPrimary, lineHeight: 1.25, margin: 0,
+            }}>
+              {lib.headline}
+            </h3>
+
+            <Link
+              href={lib.href}
+              style={{
+                fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+                fontSize: '0.72rem', fontWeight: 700, color: lib.color,
+                textDecoration: 'none', marginTop: 4,
+                display: 'inline-flex', alignItems: 'center', gap: 4,
+              }}
+            >
+              {lib.ctaLabel} →
+            </Link>
+          </motion.div>
+        ))}
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 2: Add AngularStackSiblings to page layout**
+
+In `apps/website/src/app/angular/page.tsx`, add the import and insert between WhitePaperGate and FooterCTA:
+
+Add import:
+```tsx
+import { AngularStackSiblings } from '../../components/landing/angular/AngularStackSiblings';
+```
+
+Insert `<AngularStackSiblings />` between `<AngularWhitePaperGate />` and `<AngularFooterCTA />`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/website/src/components/landing/angular/AngularStackSiblings.tsx \
+  apps/website/src/app/angular/page.tsx
+git commit -m "feat(website): add AngularStackSiblings section to /angular page"
+```
+
+---
+
+### Task 9: Stack Siblings — Render
+
+**Files:**
+- Create: `apps/website/src/components/landing/render/RenderStackSiblings.tsx`
+- Modify: `apps/website/src/app/render/page.tsx`
+
+- [ ] **Step 1: Create RenderStackSiblings component**
+
+Create `apps/website/src/components/landing/render/RenderStackSiblings.tsx`:
+
+```tsx
+'use client';
+import { motion } from 'framer-motion';
+import Link from 'next/link';
+import { tokens } from '@cacheplane/design-tokens';
+
+const SIBLINGS = [
+  {
+    tag: 'Agent',
+    pkg: '@cacheplane/angular',
+    color: tokens.colors.accent,
+    rgb: '0,64,144',
+    headline: 'The reactive bridge to LangGraph',
+    href: '/angular',
+    ctaLabel: 'Explore Agent',
+  },
+  {
+    tag: 'Chat',
+    pkg: '@cacheplane/chat',
+    color: tokens.colors.chatPurple,
+    rgb: '90,0,200',
+    headline: 'Production chat UI in days, not sprints',
+    href: '/chat',
+    ctaLabel: 'Explore Chat',
+  },
+];
+
+export function RenderStackSiblings() {
+  return (
+    <section className="render-stack-siblings" style={{ padding: '80px 32px' }}>
+      <style>{`
+        @media (max-width: 767px) {
+          .render-stack-siblings { padding: 60px 20px !important; }
+          .render-stack-siblings-grid { grid-template-columns: 1fr !important; }
+        }
+      `}</style>
+      <motion.div
+        initial={{ opacity: 0, y: 16 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.5 }}
+        style={{ textAlign: 'center', marginBottom: 36 }}
+      >
+        <p style={{
+          fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+          fontSize: '0.7rem', textTransform: 'uppercase', letterSpacing: '0.12em',
+          fontWeight: 700, color: tokens.colors.accent, marginBottom: 14,
+        }}>
+          The Cacheplane Stack
+        </p>
+        <p style={{
+          fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+          fontStyle: 'italic', fontSize: '1.05rem',
+          color: tokens.colors.textSecondary, maxWidth: 520, margin: '0 auto',
+        }}>
+          This library is part of a cohesive three-layer architecture.
+        </p>
+      </motion.div>
+
+      <div
+        className="render-stack-siblings-grid"
+        style={{
+          display: 'grid', gridTemplateColumns: '1fr 1fr',
+          gap: 16, maxWidth: 860, margin: '0 auto',
+        }}
+      >
+        {SIBLINGS.map((lib, i) => (
+          <motion.div
+            key={lib.pkg}
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.5, delay: i * 0.1 }}
+            style={{
+              padding: '24px 20px',
+              borderRadius: 14,
+              background: `rgba(${lib.rgb}, 0.03)`,
+              border: `1px solid rgba(${lib.rgb}, 0.15)`,
+              borderLeft: `3px solid ${lib.color}`,
+              display: 'flex', flexDirection: 'column', gap: 10,
+            }}
+          >
+            <span style={{
+              display: 'inline-block', alignSelf: 'flex-start',
+              fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+              fontSize: '0.58rem', fontWeight: 700, textTransform: 'uppercase',
+              letterSpacing: '0.07em', padding: '2px 9px', borderRadius: 5,
+              color: '#fff', background: lib.color,
+            }}>
+              {lib.tag}
+            </span>
+
+            <p style={{
+              fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+              fontSize: '0.76rem', fontWeight: 700, color: lib.color, margin: 0,
+            }}>
+              {lib.pkg}
+            </p>
+
+            <h3 style={{
+              fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+              fontSize: '1.15rem', fontWeight: 700,
+              color: tokens.colors.textPrimary, lineHeight: 1.25, margin: 0,
+            }}>
+              {lib.headline}
+            </h3>
+
+            <Link
+              href={lib.href}
+              style={{
+                fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+                fontSize: '0.72rem', fontWeight: 700, color: lib.color,
+                textDecoration: 'none', marginTop: 4,
+                display: 'inline-flex', alignItems: 'center', gap: 4,
+              }}
+            >
+              {lib.ctaLabel} →
+            </Link>
+          </motion.div>
+        ))}
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 2: Add RenderStackSiblings to page layout**
+
+In `apps/website/src/app/render/page.tsx`, add the import and insert between WhitePaperGate and FooterCTA:
+
+Add import:
+```tsx
+import { RenderStackSiblings } from '../../components/landing/render/RenderStackSiblings';
+```
+
+Insert `<RenderStackSiblings />` between `<RenderWhitePaperGate />` and `<RenderFooterCTA />`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/website/src/components/landing/render/RenderStackSiblings.tsx \
+  apps/website/src/app/render/page.tsx
+git commit -m "feat(website): add RenderStackSiblings section to /render page"
+```
+
+---
+
+### Task 10: Stack Siblings — Chat
+
+**Files:**
+- Create: `apps/website/src/components/landing/chat-landing/ChatLandingStackSiblings.tsx`
+- Modify: `apps/website/src/app/chat/page.tsx`
+
+- [ ] **Step 1: Create ChatLandingStackSiblings component**
+
+Create `apps/website/src/components/landing/chat-landing/ChatLandingStackSiblings.tsx`:
+
+```tsx
+'use client';
+import { motion } from 'framer-motion';
+import Link from 'next/link';
+import { tokens } from '@cacheplane/design-tokens';
+
+const SIBLINGS = [
+  {
+    tag: 'Agent',
+    pkg: '@cacheplane/angular',
+    color: tokens.colors.accent,
+    rgb: '0,64,144',
+    headline: 'The reactive bridge to LangGraph',
+    href: '/angular',
+    ctaLabel: 'Explore Agent',
+  },
+  {
+    tag: 'Gen UI',
+    pkg: '@cacheplane/render',
+    color: tokens.colors.renderGreen,
+    rgb: '26,122,64',
+    headline: 'Agents that render UI — on open standards',
+    href: '/render',
+    ctaLabel: 'Explore Render',
+  },
+];
+
+export function ChatLandingStackSiblings() {
+  return (
+    <section className="chat-stack-siblings" style={{ padding: '80px 32px' }}>
+      <style>{`
+        @media (max-width: 767px) {
+          .chat-stack-siblings { padding: 60px 20px !important; }
+          .chat-stack-siblings-grid { grid-template-columns: 1fr !important; }
+        }
+      `}</style>
+      <motion.div
+        initial={{ opacity: 0, y: 16 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.5 }}
+        style={{ textAlign: 'center', marginBottom: 36 }}
+      >
+        <p style={{
+          fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+          fontSize: '0.7rem', textTransform: 'uppercase', letterSpacing: '0.12em',
+          fontWeight: 700, color: tokens.colors.accent, marginBottom: 14,
+        }}>
+          The Cacheplane Stack
+        </p>
+        <p style={{
+          fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+          fontStyle: 'italic', fontSize: '1.05rem',
+          color: tokens.colors.textSecondary, maxWidth: 520, margin: '0 auto',
+        }}>
+          This library is part of a cohesive three-layer architecture.
+        </p>
+      </motion.div>
+
+      <div
+        className="chat-stack-siblings-grid"
+        style={{
+          display: 'grid', gridTemplateColumns: '1fr 1fr',
+          gap: 16, maxWidth: 860, margin: '0 auto',
+        }}
+      >
+        {SIBLINGS.map((lib, i) => (
+          <motion.div
+            key={lib.pkg}
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.5, delay: i * 0.1 }}
+            style={{
+              padding: '24px 20px',
+              borderRadius: 14,
+              background: `rgba(${lib.rgb}, 0.03)`,
+              border: `1px solid rgba(${lib.rgb}, 0.15)`,
+              borderLeft: `3px solid ${lib.color}`,
+              display: 'flex', flexDirection: 'column', gap: 10,
+            }}
+          >
+            <span style={{
+              display: 'inline-block', alignSelf: 'flex-start',
+              fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+              fontSize: '0.58rem', fontWeight: 700, textTransform: 'uppercase',
+              letterSpacing: '0.07em', padding: '2px 9px', borderRadius: 5,
+              color: '#fff', background: lib.color,
+            }}>
+              {lib.tag}
+            </span>
+
+            <p style={{
+              fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+              fontSize: '0.76rem', fontWeight: 700, color: lib.color, margin: 0,
+            }}>
+              {lib.pkg}
+            </p>
+
+            <h3 style={{
+              fontFamily: 'var(--font-garamond, "EB Garamond", Georgia, serif)',
+              fontSize: '1.15rem', fontWeight: 700,
+              color: tokens.colors.textPrimary, lineHeight: 1.25, margin: 0,
+            }}>
+              {lib.headline}
+            </h3>
+
+            <Link
+              href={lib.href}
+              style={{
+                fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+                fontSize: '0.72rem', fontWeight: 700, color: lib.color,
+                textDecoration: 'none', marginTop: 4,
+                display: 'inline-flex', alignItems: 'center', gap: 4,
+              }}
+            >
+              {lib.ctaLabel} →
+            </Link>
+          </motion.div>
+        ))}
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 2: Add ChatLandingStackSiblings to page layout**
+
+In `apps/website/src/app/chat/page.tsx`, add the import and insert between WhitePaperGate and FooterCTA:
+
+Add import:
+```tsx
+import { ChatLandingStackSiblings } from '../../components/landing/chat-landing/ChatLandingStackSiblings';
+```
+
+Insert `<ChatLandingStackSiblings />` between `<ChatLandingWhitePaperGate />` and `<ChatLandingFooterCTA />`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/website/src/components/landing/chat-landing/ChatLandingStackSiblings.tsx \
+  apps/website/src/app/chat/page.tsx
+git commit -m "feat(website): add ChatLandingStackSiblings section to /chat page"
+```
+
+---
+
+### Task 11: Mobile Breakpoints — ProblemSolution (All Three)
+
+**Files:**
+- Modify: `apps/website/src/components/landing/angular/AngularProblemSolution.tsx`
+- Modify: `apps/website/src/components/landing/render/RenderProblemSolution.tsx`
+- Modify: `apps/website/src/components/landing/chat-landing/ChatLandingProblemSolution.tsx`
+
+- [ ] **Step 1: Add mobile breakpoint to AngularProblemSolution**
+
+In `AngularProblemSolution.tsx`, add `className="angular-problem"` to the `<section>` tag and add a `<style>` tag inside the section:
+
+```tsx
+    <section className="angular-problem" style={{ padding: '80px 32px' }}>
+      <style>{`
+        @media (max-width: 767px) {
+          .angular-problem { padding: 60px 20px !important; }
+        }
+      `}</style>
+```
+
+- [ ] **Step 2: Add mobile breakpoint to RenderProblemSolution**
+
+Same pattern with `className="render-problem"`.
+
+- [ ] **Step 3: Add mobile breakpoint to ChatLandingProblemSolution**
+
+Same pattern with `className="chat-problem"`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/website/src/components/landing/angular/AngularProblemSolution.tsx \
+  apps/website/src/components/landing/render/RenderProblemSolution.tsx \
+  apps/website/src/components/landing/chat-landing/ChatLandingProblemSolution.tsx
+git commit -m "feat(website): add mobile breakpoints to ProblemSolution sections"
+```
+
+---
+
+### Task 12: Mobile Breakpoints — FeaturesGrid (All Three)
+
+**Files:**
+- Modify: `apps/website/src/components/landing/angular/AngularFeaturesGrid.tsx`
+- Modify: `apps/website/src/components/landing/render/RenderFeaturesGrid.tsx`
+- Modify: `apps/website/src/components/landing/chat-landing/ChatLandingFeaturesGrid.tsx`
+
+- [ ] **Step 1: Add mobile breakpoint to AngularFeaturesGrid**
+
+Add `className="angular-features"` to the `<section>` tag and add a `<style>` tag:
+
+```tsx
+    <section className="angular-features" style={{ padding: '80px 32px' }}>
+      <style>{`
+        @media (max-width: 767px) {
+          .angular-features { padding: 60px 20px !important; }
+        }
+      `}</style>
+```
+
+- [ ] **Step 2: Add mobile breakpoint to RenderFeaturesGrid**
+
+Same pattern with `className="render-features"`.
+
+- [ ] **Step 3: Add mobile breakpoint to ChatLandingFeaturesGrid**
+
+Same pattern with `className="chat-features"`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/website/src/components/landing/angular/AngularFeaturesGrid.tsx \
+  apps/website/src/components/landing/render/RenderFeaturesGrid.tsx \
+  apps/website/src/components/landing/chat-landing/ChatLandingFeaturesGrid.tsx
+git commit -m "feat(website): add mobile breakpoints to FeaturesGrid sections"
+```
+
+---
+
+### Task 13: Mobile Breakpoints — CodeShowcase (All Three)
+
+**Files:**
+- Modify: `apps/website/src/components/landing/angular/AngularCodeShowcase.tsx`
+- Modify: `apps/website/src/components/landing/render/RenderCodeShowcase.tsx`
+- Modify: `apps/website/src/components/landing/chat-landing/ChatLandingCodeShowcase.tsx`
+
+**Note:** These are `async` server components (no `'use client'`). We cannot use inline `<style>` tags the same way since they are server-rendered. Instead, wrap the style tag in a fragment — server components can render `<style>` tags directly.
+
+- [ ] **Step 1: Add mobile breakpoint to AngularCodeShowcase**
+
+Add `className="angular-code"` to the `<section>` tag and add a `<style>` tag:
+
+```tsx
+    <section className="angular-code" style={{ padding: '80px 32px' }}>
+      <style>{`
+        @media (max-width: 767px) {
+          .angular-code { padding: 60px 20px !important; }
+        }
+      `}</style>
+```
+
+- [ ] **Step 2: Add mobile breakpoint to RenderCodeShowcase**
+
+Same pattern with `className="render-code"`.
+
+- [ ] **Step 3: Add mobile breakpoint to ChatLandingCodeShowcase**
+
+Same pattern with `className="chat-code"`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/website/src/components/landing/angular/AngularCodeShowcase.tsx \
+  apps/website/src/components/landing/render/RenderCodeShowcase.tsx \
+  apps/website/src/components/landing/chat-landing/ChatLandingCodeShowcase.tsx
+git commit -m "feat(website): add mobile breakpoints to CodeShowcase sections"
+```
+
+---
+
+### Task 14: Mobile Breakpoints — Comparison (All Three)
+
+**Files:**
+- Modify: `apps/website/src/components/landing/angular/AngularComparison.tsx`
+- Modify: `apps/website/src/components/landing/render/RenderComparison.tsx`
+- Modify: `apps/website/src/components/landing/chat-landing/ChatLandingComparison.tsx`
+
+- [ ] **Step 1: Add mobile breakpoint to AngularComparison**
+
+Add `className="angular-comparison"` to the `<section>` tag and add a `<style>` tag with reduced cell padding:
+
+```tsx
+    <section className="angular-comparison" style={{ padding: '80px 32px' }}>
+      <style>{`
+        @media (max-width: 767px) {
+          .angular-comparison { padding: 60px 20px !important; }
+          .angular-comparison .comparison-cell { padding: 10px 12px !important; }
+        }
+      `}</style>
+```
+
+Also add `className="comparison-cell"` to the grid row divs (both the header and each row's container).
+
+- [ ] **Step 2: Add mobile breakpoint to RenderComparison**
+
+Same pattern with `className="render-comparison"`.
+
+- [ ] **Step 3: Add mobile breakpoint to ChatLandingComparison**
+
+Same pattern with `className="chat-comparison"`.
+
+- [ ] **Step 4: Verify the Comparison content is still accurate**
+
+Check if A2UI component count in RenderComparison and ChatLandingComparison is still "18". Grep the codebase:
+
+Run: `grep -r "A2UI" apps/website/src/components/landing/ --include="*.tsx" | grep -i "component"`
+
+Update the count if it has changed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/website/src/components/landing/angular/AngularComparison.tsx \
+  apps/website/src/components/landing/render/RenderComparison.tsx \
+  apps/website/src/components/landing/chat-landing/ChatLandingComparison.tsx
+git commit -m "feat(website): add mobile breakpoints to Comparison sections"
+```
+
+---
+
+### Task 15: Build Verification and Final Review
+
+**Files:**
+- None modified — verification only
+
+- [ ] **Step 1: Run the build**
+
+Run: `cd /Users/blove/repos/stream-resource && npx nx build website`
+Expected: Build succeeds with no errors.
+
+- [ ] **Step 2: Verify all three pages render**
+
+Run the dev server and check:
+- `/angular` — stack breadcrumb visible, dark footer CTA, stack siblings section, mobile breakpoints
+- `/render` — same pattern with green accents
+- `/chat` — same pattern with purple accents
+
+- [ ] **Step 3: Verify mobile responsiveness**
+
+Check each page at 375px viewport width. All sections should have reduced padding and comparison tables should scroll horizontally.

--- a/docs/superpowers/specs/2026-04-13-landing-page-alignment-design.md
+++ b/docs/superpowers/specs/2026-04-13-landing-page-alignment-design.md
@@ -1,0 +1,293 @@
+# Product Landing Page Alignment — Design Spec
+
+**Date:** 2026-04-13
+**Scope:** `/angular`, `/render`, `/chat` product landing pages
+**Philosophy:** Evolve, don't rebuild. Layer home page patterns into existing pages where they strengthen the narrative.
+
+---
+
+## Summary
+
+The home page was recently restructured into a 7-section narrative funnel with a strong dark footer CTA, unified stack section, and pilot program prominence. The three product landing pages (`/angular`, `/render`, `/chat`) still use the original patterns: weak glass-card footer CTAs, no stack awareness, no mobile breakpoints, and isolated messaging. This spec aligns the product pages with the home page's narrative without rebuilding them.
+
+## Changes Overview
+
+| Change | Scope | New Files |
+|--------|-------|-----------|
+| Hero stack breadcrumb | 3 files modified | None |
+| WhitePaperGate copy refresh | 3 files modified | None |
+| Footer CTA dark design upgrade | 3 files rewritten | None |
+| Stack siblings section | 3 new components | 3 files created |
+| Comparison light refresh | 3 files modified | None |
+| Mobile responsiveness | All product page components | None |
+| Internal route fix (`<a>` → `<Link>`) | Heroes + any other internal links | None |
+
+## Files Changed
+
+### Modified (existing)
+- `apps/website/src/components/landing/angular/AngularHero.tsx`
+- `apps/website/src/components/landing/angular/AngularWhitePaperGate.tsx`
+- `apps/website/src/components/landing/angular/AngularFooterCTA.tsx`
+- `apps/website/src/components/landing/angular/AngularComparison.tsx`
+- `apps/website/src/components/landing/angular/AngularProblemSolution.tsx`
+- `apps/website/src/components/landing/angular/AngularFeaturesGrid.tsx`
+- `apps/website/src/components/landing/angular/AngularCodeShowcase.tsx`
+- `apps/website/src/components/landing/render/RenderHero.tsx`
+- `apps/website/src/components/landing/render/RenderWhitePaperGate.tsx`
+- `apps/website/src/components/landing/render/RenderFooterCTA.tsx`
+- `apps/website/src/components/landing/render/RenderComparison.tsx`
+- `apps/website/src/components/landing/render/RenderProblemSolution.tsx`
+- `apps/website/src/components/landing/render/RenderFeaturesGrid.tsx`
+- `apps/website/src/components/landing/render/RenderCodeShowcase.tsx`
+- `apps/website/src/components/landing/chat-landing/ChatLandingHero.tsx`
+- `apps/website/src/components/landing/chat-landing/ChatLandingWhitePaperGate.tsx`
+- `apps/website/src/components/landing/chat-landing/ChatLandingFooterCTA.tsx`
+- `apps/website/src/components/landing/chat-landing/ChatLandingComparison.tsx`
+- `apps/website/src/components/landing/chat-landing/ChatLandingProblemSolution.tsx`
+- `apps/website/src/components/landing/chat-landing/ChatLandingFeaturesGrid.tsx`
+- `apps/website/src/components/landing/chat-landing/ChatLandingCodeShowcase.tsx`
+- `apps/website/src/app/angular/page.tsx`
+- `apps/website/src/app/render/page.tsx`
+- `apps/website/src/app/chat/page.tsx`
+
+### Created (new)
+- `apps/website/src/components/landing/angular/AngularStackSiblings.tsx`
+- `apps/website/src/components/landing/render/RenderStackSiblings.tsx`
+- `apps/website/src/components/landing/chat-landing/ChatLandingStackSiblings.tsx`
+
+---
+
+## Section 1: Hero — Stack Breadcrumb
+
+### What Changes
+
+Add a stack position indicator above the `@cacheplane/<pkg>` eyebrow in each hero. Shows all three libraries with the current page bolded/highlighted in its brand color, siblings muted and linked.
+
+### Per-Page Rendering
+
+- **Angular:** **Agent** (bold, `tokens.colors.accent`) → Render (muted, link to `/render`) → Chat (muted, link to `/chat`)
+- **Render:** Agent (muted, link to `/angular`) → **Render** (bold, `tokens.colors.renderGreen`) → Chat (muted, link to `/chat`)
+- **Chat:** Agent (muted, link to `/angular`) → Render (muted, link to `/render`) → **Chat** (bold, `tokens.colors.chatPurple`)
+
+### Styling
+
+- Font: `JetBrains Mono`, 10px, uppercase, `letterSpacing: 0.08em`
+- Current page: brand color, `fontWeight: 700`, not a link
+- Siblings: `tokens.colors.textMuted`, `fontWeight: 500`, Next.js `<Link>`, `textDecoration: none`
+- Arrow separator: ` → ` in `tokens.colors.textMuted`
+- Placed above the existing `@cacheplane/<pkg>` eyebrow with `marginBottom: 0.75rem`
+- Wrapped in a `motion.div` matching the existing eyebrow animation
+
+### Technical Fixes (while in heroes)
+
+- Replace `<a href="/docs">` with `<Link href="/docs">` (internal route)
+- Add `import Link from 'next/link'`
+
+### What Stays
+
+Headlines, subtexts, CTA buttons, badge rows — all unchanged.
+
+---
+
+## Section 2: WhitePaperGate — Page-Specific Copy Refresh
+
+### What Changes
+
+Keep per-page WhitePaperGate components. Refresh eyebrow and subtitle copy to better connect each guide to the library's value prop and the unified framework.
+
+### Copy Changes
+
+**Angular (`AngularWhitePaperGate`):**
+- Eyebrow: "Free Download" → "Agent Guide"
+- Title: unchanged — "The Enterprise Guide to Agent Streaming in Angular"
+- Subtitle: "Six chapters covering the last-mile gap, the agent() API, thread persistence, interrupts, time-travel, and deterministic testing with MockAgentTransport."
+- Add after subtitle: "Part of the Cacheplane Angular Agent Framework." (Inter, 0.8rem, `tokens.colors.textMuted`)
+
+**Render (`RenderWhitePaperGate`):**
+- Eyebrow: "Free Download" → "Render Guide"
+- Title: unchanged — "The Enterprise Guide to Generative UI in Angular"
+- Subtitle: "Five chapters covering the coupling problem, declarative UI specs with Vercel's json-render standard and Google's A2UI protocol, the component registry, streaming JSON patches, and signal-native state management."
+- Add after subtitle: "Part of the Cacheplane Angular Agent Framework."
+
+**Chat (`ChatLandingWhitePaperGate`):**
+- Eyebrow: "Free Download" → "Chat Guide"
+- Title: unchanged — "The Enterprise Guide to Agent Chat Interfaces in Angular"
+- Subtitle: "Five chapters covering the sprint tax, batteries-included components, theming and design system integration, generative UI with Vercel json-render, Google A2UI support, and debug tooling."
+- Add after subtitle: "Part of the Cacheplane Angular Agent Framework."
+
+### What Stays
+
+Layout (2-column glassmorphism grid), email signup form, download button, all IDs and aria labels, styling.
+
+---
+
+## Section 3: Footer CTA — Dark Design Upgrade
+
+### What Changes
+
+Replace all three weak glass-card footer CTAs with the strong dark design from the home page's `PilotFooterCTA`.
+
+### Design Pattern
+
+Matches `apps/website/src/components/landing/PilotFooterCTA.tsx`:
+- Background: `linear-gradient(135deg, #1a1a2e 0%, #0d1b3e 100%)`
+- White text, centered layout, `maxWidth: 48rem`
+- Mono eyebrow (11px, uppercase, `rgba(255,255,255,0.5)`)
+- Garamond heading (42px, white, `fontWeight: 400`)
+- Inter subtext (17px, `rgba(255,255,255,0.7)`)
+- Primary CTA: white background button → `/pilot-to-prod` via Next.js `<Link>`
+- Secondary CTA: ghost border button → page-specific PDF download via `<a download>`
+- Fine print: mono 10px, `rgba(255,255,255,0.4)`
+- `framer-motion` `whileInView` animation
+- `aria-labelledby` on the heading
+
+### Per-Page Customization
+
+| | Angular | Render | Chat |
+|---|---|---|---|
+| Eyebrow | Ready when you are | Ready when you are | Ready when you are |
+| Heading | Ready to ship your LangGraph agent? | Ready to ship your generative UI? | Ready to ship your agent chat? |
+| Subtext | The Angular Agent Framework closes the last-mile gap. Start with a conversation. | Decouple your agent's UI layer with open standards. Start with a conversation. | Production chat UI in days, not sprints. Start with a conversation. |
+| Primary CTA | Start Your Pilot → (`/pilot-to-prod`) | Start Your Pilot → (`/pilot-to-prod`) | Start Your Pilot → (`/pilot-to-prod`) |
+| Secondary CTA | Download the Guide (`/whitepapers/angular.pdf`) | Download the Guide (`/whitepapers/render.pdf`) | Download the Guide (`/whitepapers/chat.pdf`) |
+| Fine print | App deployment license · $20,000 · 3-month co-pilot engagement | Same | Same |
+
+### Mobile Breakpoint
+
+```css
+@media (max-width: 767px) {
+  .angular-footer-inner { padding-top: 4rem !important; padding-bottom: 4rem !important; }
+  .angular-footer-heading { font-size: clamp(28px, 6vw, 42px) !important; }
+}
+```
+
+(Same pattern for render and chat with appropriate class name prefixes.)
+
+### What's Removed
+
+The old three-button glass-card design (Download Guide / Pilot Program / View Docs) is fully replaced.
+
+---
+
+## Section 4: Stack Siblings Section (New)
+
+### What Changes
+
+New section between WhitePaperGate and FooterCTA on each page. Shows the other two libraries as compact cards.
+
+### Layout
+
+- Section eyebrow: "The Cacheplane Stack" — JetBrains Mono, 0.7rem, uppercase, `tokens.colors.accent`
+- Subtitle: "This library is part of a cohesive three-layer architecture." — EB Garamond, italic, 1.05rem, `tokens.colors.textSecondary`
+- Two cards in a `1fr 1fr` CSS grid, `gap: 16px`, `maxWidth: 860px`
+
+### Card Design
+
+Each card is a compact version of TheStack cards:
+- `borderLeft: 3px solid <sibling brand color>`
+- `borderRadius: 14px`
+- `background: rgba(<sibling rgb>, 0.03)`
+- `border: 1px solid rgba(<sibling rgb>, 0.15)`
+- `padding: 24px 20px`
+- Tag pill: sibling's tag ("Agent" / "Gen UI" / "Chat") in white on sibling's brand color background
+- Package name: JetBrains Mono, 0.76rem, sibling's brand color
+- Headline: one line from TheStack data (EB Garamond, 1.15rem)
+- CTA: "Explore Agent →" / "Explore Render →" / "Explore Chat →" — Next.js `<Link>`, JetBrains Mono, 0.72rem, sibling's brand color
+
+No description paragraph or differentiator pills — keep it compact.
+
+Sibling data is defined inline in each StackSiblings component (not imported from TheStack) to avoid cross-dependencies between landing page sections.
+
+### Per-Page Data
+
+| Page | Card 1 | Card 2 |
+|---|---|---|
+| `/angular` | Render (green, `@cacheplane/render`, "Agents that render UI — on open standards") | Chat (purple, `@cacheplane/chat`, "Production chat UI in days, not sprints") |
+| `/render` | Agent (blue, `@cacheplane/angular`, "The reactive bridge to LangGraph") | Chat (purple, `@cacheplane/chat`, "Production chat UI in days, not sprints") |
+| `/chat` | Agent (blue, `@cacheplane/angular`, "The reactive bridge to LangGraph") | Render (green, `@cacheplane/render`, "Agents that render UI — on open standards") |
+
+### Mobile Breakpoint
+
+```css
+@media (max-width: 767px) {
+  .angular-stack-siblings { padding: 60px 20px !important; }
+  .angular-stack-siblings-grid { grid-template-columns: 1fr !important; }
+}
+```
+
+### Page Layout Integration
+
+Each page's `page.tsx` adds the StackSiblings component between WhitePaperGate and FooterCTA:
+
+```
+Hero → ProblemSolution → FeaturesGrid → CodeShowcase → Comparison → WhitePaperGate → StackSiblings → FooterCTA
+```
+
+---
+
+## Section 5: Comparison — Light Content Refresh
+
+### What Changes
+
+Verify-and-update pass only. No structural or styling changes.
+
+### Angular (`AngularComparison`)
+
+- Current 9 rows are accurate and well-calibrated. No changes expected.
+- Verify `useStream()` parity claim is still the right framing.
+
+### Render (`RenderComparison`)
+
+- Row "A2UI components": verify "18 built-in" count is current. Update number if changed.
+- All other rows accurate.
+
+### Chat (`ChatLandingComparison`)
+
+- Row "Google A2UI spec": verify "18 components, v0.9 validation" is current. Update if changed.
+- All other rows accurate.
+
+### What Stays
+
+Table structure, glassmorphism styling, animation, column layout — all unchanged.
+
+---
+
+## Section 6: Mobile Responsiveness
+
+### What Changes
+
+All product page components currently have zero `@media` breakpoints. Add consistent mobile support using the home page convention.
+
+### Convention
+
+- Breakpoint: `@media (max-width: 767px)`
+- Implementation: CSS-in-JS `<style>` tags with `className` targeting
+- Section padding: reduce to `60px 20px` from `80px 32px`
+
+### Per-Component
+
+| Component Pattern | Mobile Changes |
+|---|---|
+| Hero (3 files) | Add `className`, section padding `60px 20px`. Heading already uses `clamp()`. Badge row wraps via `flexWrap`. |
+| ProblemSolution (3 files) | Add `className`, section padding `60px 20px`. Grid columns already use `auto-fit` so they collapse. |
+| FeaturesGrid (3 files) | Add `className`, section padding `60px 20px`. Grid already responsive via `auto-fit`. |
+| CodeShowcase (3 files) | Add `className`, section padding `60px 20px`. Verify code blocks have `overflow-x: auto`. |
+| Comparison (3 files) | Add `className`, section padding `60px 20px`. Container already has `overflow: auto`. Reduce cell padding to `10px 12px` from `14px 24px`. |
+| WhitePaperGate (3 files) | Add `className`, section padding `60px 20px`. Grid already collapses via `auto-fit minmax(min(320px, 100%), 1fr)`. Reduce inner padding to `24px 16px`. |
+| StackSiblings (3 new files) | Built with mobile breakpoint from the start (Section 4). |
+| FooterCTA (3 files) | Built with mobile breakpoint from the start (Section 3). |
+
+### What Stays
+
+No font size overrides where `clamp()` is already used. No layout restructuring — existing `auto-fit` grids and `flexWrap` handle collapse naturally. This is primarily a padding/spacing pass.
+
+---
+
+## Out of Scope
+
+- ProblemSolution sections: no content or structural changes
+- FeaturesGrid sections: no content or structural changes (cockpit iframes stay)
+- CodeShowcase sections: no content or structural changes
+- Home page components: already done in previous iteration
+- `/pilot-to-prod` page: not part of this spec
+- New whitepaper content: copy refresh only, no new PDFs


### PR DESCRIPTION
## Summary
- Add stack breadcrumb navigation (Agent → Render → Chat) to all three product page heroes with current page highlighted
- Upgrade all three footer CTAs from weak glass-card design to the strong dark gradient design with pilot program as primary CTA
- Refresh WhitePaperGate copy per page (updated eyebrows, subtitles, framework attribution)
- Add new Stack Siblings section to each page showing the other two libraries as compact cards
- Fix internal routes from `<a>` to Next.js `<Link>` across all heroes and CTAs
- Add `@media (max-width: 767px)` mobile breakpoints to all product page components (previously had zero)

## Test plan
- [ ] Verify `/angular`, `/render`, `/chat` pages render correctly
- [ ] Check stack breadcrumb links navigate to sibling pages
- [ ] Check "Start Your Pilot" buttons link to `/pilot-to-prod`
- [ ] Check "Download the Guide" buttons trigger PDF download
- [ ] Verify mobile layout at 375px viewport width — reduced padding, single-column grids
- [ ] Build passes (`nx build website`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)