### PR TITLE
chore: fix stale publish workflow + configure Nx Release groups

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,10 +4,21 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Dry run (no actual publish)'
+        type: boolean
+        default: true
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write  # for npm provenance
+    env:
+      NPM_PUBLISHABLE_PROJECTS: chat,langgraph,ag-ui,render,a2ui,partial-json,licensing,mcp
     steps:
       - uses: actions/checkout@v6.0.2
       - uses: actions/setup-node@v6.3.0
@@ -15,11 +26,21 @@ jobs:
           node-version: 22
           cache: npm
           registry-url: https://registry.npmjs.org
+
       - run: npm ci
-      - run: npx nx test mcp --skip-nx-cache
-      - run: npx nx test langgraph
-      - run: npx nx build langgraph --configuration=production
+
+      - name: Lint, test, build publishable projects
+        run: npx nx run-many -t lint,test,build --projects=$NPM_PUBLISHABLE_PROJECTS --skip-nx-cache
+
       - name: Publish to npm
-        run: npx nx-release-publish agent
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry-run == false)
+        run: npx nx release publish --groups=publishable
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: 'true'
+
+      - name: Publish to npm (dry run)
+        if: github.event_name == 'workflow_dispatch' && inputs.dry-run == true
+        run: npx nx release publish --groups=publishable --dry-run
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/libs/cockpit-docs/package.json
+++ b/libs/cockpit-docs/package.json
@@ -11,5 +11,6 @@
   "bugs": {
     "url": "https://github.com/cacheplane/angular-agent-framework/issues"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "private": true
 }

--- a/libs/cockpit-registry/package.json
+++ b/libs/cockpit-registry/package.json
@@ -11,5 +11,6 @@
   "bugs": {
     "url": "https://github.com/cacheplane/angular-agent-framework/issues"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "private": true
 }

--- a/libs/cockpit-shell/package.json
+++ b/libs/cockpit-shell/package.json
@@ -11,5 +11,6 @@
   "bugs": {
     "url": "https://github.com/cacheplane/angular-agent-framework/issues"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "private": true
 }

--- a/libs/cockpit-testing/package.json
+++ b/libs/cockpit-testing/package.json
@@ -11,5 +11,6 @@
   "bugs": {
     "url": "https://github.com/cacheplane/angular-agent-framework/issues"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "private": true
 }

--- a/libs/cockpit-ui/package.json
+++ b/libs/cockpit-ui/package.json
@@ -11,5 +11,6 @@
   "bugs": {
     "url": "https://github.com/cacheplane/angular-agent-framework/issues"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "private": true
 }

--- a/libs/db/package.json
+++ b/libs/db/package.json
@@ -19,5 +19,6 @@
   "peerDependencies": {
     "drizzle-orm": "^0.45.0",
     "postgres": "^3.4.0"
-  }
+  },
+  "private": true
 }

--- a/libs/design-tokens/package.json
+++ b/libs/design-tokens/package.json
@@ -11,5 +11,6 @@
   "bugs": {
     "url": "https://github.com/cacheplane/angular-agent-framework/issues"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "private": true
 }

--- a/libs/example-layouts/package.json
+++ b/libs/example-layouts/package.json
@@ -15,5 +15,6 @@
   "bugs": {
     "url": "https://github.com/cacheplane/angular-agent-framework/issues"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "private": true
 }

--- a/libs/ui-react/package.json
+++ b/libs/ui-react/package.json
@@ -15,5 +15,6 @@
   "peerDependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
-  }
+  },
+  "private": true
 }

--- a/nx.json
+++ b/nx.json
@@ -42,8 +42,23 @@
     }
   },
   "release": {
+    "groups": {
+      "publishable": {
+        "projects": [
+          "chat",
+          "langgraph",
+          "ag-ui",
+          "render",
+          "a2ui",
+          "partial-json",
+          "licensing",
+          "mcp"
+        ],
+        "projectsRelationship": "independent"
+      }
+    },
     "version": {
-      "preVersionCommand": "npx nx run-many -t build"
+      "preVersionCommand": "npx nx run-many -t build --projects=chat,langgraph,ag-ui,render,a2ui,partial-json,licensing,mcp"
     }
   },
   "generators": {


### PR DESCRIPTION
## Summary
- **\`.github/workflows/publish.yml\`** — rewrite. The previous version referenced a nonexistent \`agent\` project and used the deprecated \`nx-release-publish\` CLI. New workflow uses \`nx release publish --groups=publishable\` and adds a \`workflow_dispatch\` trigger with a \`dry-run\` input for manual verification. Includes npm provenance.
- **\`nx.json\`** — define a \`publishable\` release group containing the 8 user-facing libs (\`chat\`, \`langgraph\`, \`ag-ui\`, \`render\`, \`a2ui\`, \`partial-json\`, \`licensing\`, \`mcp\`). Group uses \`independent\` \`projectsRelationship\` so each lib can version independently.
- **9 internal libs marked \`private: true\`** (\`cockpit-registry\`, \`cockpit-shell\`, \`cockpit-testing\`, \`cockpit-ui\`, \`cockpit-docs\`, \`db\`, \`design-tokens\`, \`example-layouts\`, \`ui-react\`) to prevent accidental publish.

## Verified locally
\`\`\`
npx nx release publish --groups=publishable --dry-run
\`\`\`
Produces exactly 8 tarballs: \`@cacheplane/chat\`, \`@cacheplane/ag-ui\`, \`@cacheplane/render\`, \`@cacheplane/a2ui\`, \`@cacheplane/partial-json\`, \`@cacheplane/licensing\`, \`@cacheplane/langgraph\`, \`@cacheplane/langgraph-mcp\`.

Cockpit demos and internal libs are correctly excluded.

## Note
\`packages/mcp\` publishes as \`@cacheplane/langgraph-mcp\` (its existing package name). Whether to rename to \`@cacheplane/mcp\` is a separate decision out of scope here.

## Test Plan
- [x] Local dry-run produces exactly 8 expected tarballs
- [x] Internal libs excluded
- [ ] Manual workflow_dispatch with dry-run=true after merge to confirm CI runner picks up the same dry-run output
- [ ] First real publish (\`v0.1.0\` tag push) — separate work item; not in this PR

## What this does NOT do
- Bump versions (still \`0.0.1\` everywhere)
- Actually publish anything to npm
- Add CHANGELOG infrastructure (\`nx release\` supports it; can be added when versioning starts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)