### PR TITLE
chore(licensing): drop publishConfig.provenance for local first publish

### DIFF
--- a/libs/licensing/package.json
+++ b/libs/licensing/package.json
@@ -12,10 +12,6 @@
     "url": "https://github.com/cacheplane/angular-agent-framework/issues"
   },
   "sideEffects": false,
-  "publishConfig": {
-    "access": "public",
-    "provenance": true
-  },
   "peerDependencies": {
     "@noble/ed25519": "^2.2.3"
   }


### PR DESCRIPTION
Provenance generation needs GitHub OIDC and only works from CI. `NPM_CONFIG_PROVENANCE: 'true'` is already set in `.github/workflows/publish.yml` so future CI publishes still get provenance. This drops the `publishConfig` block from `libs/licensing/package.json` so the user's local first publish doesn't fail.