### PR TITLE
chore: post-first-release cleanup (tag pattern + npm badge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 <p align="center">
   <a href="https://www.npmjs.com/package/@ngaf/langgraph">
-    <img alt="npm version" src="https://img.shields.io/npm/v/@cacheplane%2Fangular?color=6C8EFF&labelColor=080B14&style=flat-square" />
+    <img alt="npm version" src="https://img.shields.io/npm/v/@ngaf%2Flanggraph?color=6C8EFF&labelColor=080B14&style=flat-square" />
   </a>
   <a href="./LICENSE">
     <img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-6C8EFF?labelColor=080B14&style=flat-square" />

--- a/nx.json
+++ b/nx.json
@@ -42,6 +42,7 @@
     }
   },
   "release": {
+    "releaseTagPattern": "v{version}",
     "groups": {
       "publishable": {
         "projects": [


### PR DESCRIPTION
Two small fixes after shipping 0.0.1:

1. **Release tag pattern.** First release accidentally tagged \`publishable-v0.0.1\` (Nx's default fixed-group pattern). The publish workflow trigger is \`tags: v*\` so it didn't fire on push. Setting \`release.releaseTagPattern: 'v{version}'\` means future releases produce \`v0.0.2\`, \`v0.0.3\`, etc. — workflow auto-publishes from the next release onward.

2. **README npm badge.** The npm version badge URL still pointed at \`@cacheplane%2Fangular\` (stale before the rename). Fixed to \`@ngaf%2Flanggraph\` matching the link target.

## What this does NOT do
- Drop \`NPM_TOKEN\` from the workflow — that comes after trusted publishing is configured per-package on npm (manual web UI step).
- Backfill a \`v0.0.1\` git tag — not strictly needed; the next release will have a clean \`v{version}\` lineage going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)