### PR TITLE
chore(workflow): switch to npm trusted publishing; drop NPM_TOKEN env

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write  # for npm provenance
+      id-token: write  # required for npm trusted publishing + provenance
     env:
       NPM_PUBLISHABLE_PROJECTS: chat,langgraph,ag-ui,render,a2ui,partial-json,licensing
     steps:
@@ -32,15 +32,17 @@ jobs:
       - name: Lint, test, build publishable projects
         run: npx nx run-many -t lint,test,build --projects=$NPM_PUBLISHABLE_PROJECTS --skip-nx-cache
 
+      # Trusted publishing is configured per-package on npm; no NPM_TOKEN needed.
+      # The OIDC token from id-token: write authenticates this workflow as a
+      # trusted publisher for each @ngaf/* package. Provenance attestations are
+      # generated automatically.
+
       - name: Publish to npm
         if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry-run == false)
         run: npx nx release publish --groups=publishable
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: 'true'
 
       - name: Publish to npm (dry run)
         if: github.event_name == 'workflow_dispatch' && inputs.dry-run == true
         run: npx nx release publish --groups=publishable --dry-run
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Trusted publishing has been configured per-package on npm for all 7 \`@ngaf/*\` packages. The workflow can now authenticate via OIDC instead of a long-lived token.

## Changes
- Drop \`NODE_AUTH_TOKEN: \${{ secrets.NPM_TOKEN }}\` from both publish steps in \`.github/workflows/publish.yml\` (real publish + dry-run).
- Update the \`id-token: write\` comment to reflect its new dual purpose (trusted publishing + provenance).
- Add a brief comment block explaining the trusted-publishing handoff.

## Verification path
After merge, the next workflow trigger will exercise OIDC end-to-end:

- \`workflow_dispatch\` with \`dry-run=true\` from the Actions UI is the safest first run.
- Or just wait for the next \`v0.0.2\` tag push from \`nx release patch\`.

If OIDC fails (e.g., trusted publisher not found), the workflow will error at the publish step. Re-add the token env block as a quick rollback if needed.

## After two clean releases via trusted publishing
\`\`\`
gh secret delete NPM_TOKEN
\`\`\`

Then revoke the local \`.env\` token at https://www.npmjs.com/settings/blove/tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)