### PR TITLE
fix(minting-service): rename leftover @cacheplane/* imports to @ngaf/*

### DIFF
--- a/apps/minting-service/handlers/stripe-webhook.ts
+++ b/apps/minting-service/handlers/stripe-webhook.ts
@@ -8,7 +8,7 @@ import {
   upsertLicense,
   getLicense,
   revokeLicense,
-} from '@cacheplane/db';
+} from '@ngaf/db';
 import { loadEnv } from '../src/lib/env.js';
 import { getStripe } from '../src/lib/stripe.js';
 import { mintToken } from '../src/lib/sign.js';

--- a/apps/minting-service/package.json
+++ b/apps/minting-service/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@cacheplane/minting-service",
+  "name": "@ngaf/minting-service",
   "version": "0.0.1",
   "type": "module",
   "license": "SEE LICENSE IN LICENSE",

--- a/apps/minting-service/scripts/build.mjs
+++ b/apps/minting-service/scripts/build.mjs
@@ -3,7 +3,7 @@
  * Builds the minting-service API functions using Vercel Build Output API v3.
  *
  * - Bundles each `handlers/*.ts` into a self-contained CommonJS module via
- *   esbuild, inlining workspace deps (@cacheplane/*) and npm deps alike so no
+ *   esbuild, inlining workspace deps (@ngaf/*) and npm deps alike so no
  *   install step is required inside each function directory.
  * - Writes to `.vercel/output/functions/api/<name>.func/` with the companion
  *   `.vc-config.json` Vercel's Node runtime expects.
@@ -44,7 +44,7 @@ async function buildEntry(entry) {
     platform: 'node',
     target: 'node20',
     format: 'cjs',
-    // Lets esbuild resolve `@cacheplane/*` via tsconfig paths and
+    // Lets esbuild resolve `@ngaf/*` via tsconfig paths and
     // follows `extends` up to the workspace tsconfig.base.json.
     tsconfig: join(appRoot, 'tsconfig.app.json'),
     // @vercel/node provides these as ambient in the runtime environment.

--- a/apps/minting-service/scripts/remint.spec.ts
+++ b/apps/minting-service/scripts/remint.spec.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 import { parseArgs, runRemint, type RemintDeps } from './remint.js';
-import type { License } from '@cacheplane/db';
+import type { License } from '@ngaf/db';
 
 function makeLicense(overrides: Partial<License> = {}): License {
   return {

--- a/apps/minting-service/scripts/remint.ts
+++ b/apps/minting-service/scripts/remint.ts
@@ -5,7 +5,7 @@ import {
   updateLicenseToken,
   type Db,
   type License,
-} from '@cacheplane/db';
+} from '@ngaf/db';
 import { loadEnv } from '../src/lib/env.js';
 import { mintToken } from '../src/lib/sign.js';
 import { sendLicenseEmail, renderLicenseEmail, type RenderedEmail } from '../src/lib/email.js';

--- a/apps/minting-service/src/lib/handlers.spec.ts
+++ b/apps/minting-service/src/lib/handlers.spec.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 import type Stripe from 'stripe';
-import type { License } from '@cacheplane/db';
+import type { License } from '@ngaf/db';
 import { handleEvent, type HandlerDeps } from './handlers.js';
 
 function makeDeps(overrides: Partial<HandlerDeps> = {}): HandlerDeps {

--- a/apps/minting-service/src/lib/handlers.ts
+++ b/apps/minting-service/src/lib/handlers.ts
@@ -4,7 +4,7 @@ import type {
   Db,
   License,
   UpsertLicenseInput,
-} from '@cacheplane/db';
+} from '@ngaf/db';
 import type { MintInput } from './sign.js';
 import type { LicenseEmailVars } from './email.js';
 import { extractTier, computeSeats } from './tier.js';

--- a/apps/minting-service/src/lib/sign.spec.ts
+++ b/apps/minting-service/src/lib/sign.spec.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 import * as ed from '@noble/ed25519';
-import { verifyLicense } from '@cacheplane/licensing';
+import { verifyLicense } from '@ngaf/licensing';
 import { mintToken } from './sign.js';
 
 async function makeKeypair() {

--- a/apps/minting-service/src/lib/sign.ts
+++ b/apps/minting-service/src/lib/sign.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
-import { signLicense, type LicenseClaims } from '@cacheplane/licensing';
+import { signLicense, type LicenseClaims } from '@ngaf/licensing';
 import type { MintableTier } from './tier.js';
 
 export interface MintInput {

--- a/apps/minting-service/src/lib/tier.ts
+++ b/apps/minting-service/src/lib/tier.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
-import type { LicenseTier } from '@cacheplane/licensing';
+import type { LicenseTier } from '@ngaf/licensing';
 
 export type MintableTier = Extract<LicenseTier, 'developer-seat' | 'app-deployment'>;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -117,7 +117,7 @@
       "version": "0.0.1"
     },
     "apps/minting-service": {
-      "name": "@cacheplane/minting-service",
+      "name": "@ngaf/minting-service",
       "version": "0.0.1",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
@@ -6907,7 +6907,7 @@
       "dev": true,
       "license": "(Apache-2.0 WITH LLVM-exception)"
     },
-    "node_modules/@cacheplane/minting-service": {
+    "node_modules/@ngaf/minting-service": {
       "resolved": "apps/minting-service",
       "link": true
     },


### PR DESCRIPTION
## Summary

- PR #145 (the `@cacheplane/*` → `@ngaf/*` scope rename) missed `apps/minting-service`. Imports of `@cacheplane/db` and `@cacheplane/licensing` no longer resolve because the tsconfig path aliases were renamed to `@ngaf/*`. Every Vercel preview deploy of `cacheplane-minting-service` since #145 has been failing with `Could not resolve "@cacheplane/db"` / `"@cacheplane/licensing"` esbuild errors.
- Renames the package itself (`@cacheplane/minting-service` → `@ngaf/minting-service`) plus all 8 import sites in `handlers/`, `src/lib/`, and `scripts/`. `package-lock.json` is edited surgically (2 hunks) — not regenerated, to avoid platform-specific `@next/swc-*` binding drift.
- The Vercel project settings (`buildCommand`, `installCommand`, custom domain `mint.cacheplane.ai`, env vars) are untouched and remain correct.

## Test Plan

- [x] `npx nx build minting-service` produces `.vercel/output/functions/api/health.func` and `stripe-webhook.func`
- [x] `npx vitest run` in `apps/minting-service` — 42/42 passing
- [ ] Vercel preview deploy goes green (the whole point of this PR)
- [ ] After merge, prod `https://mint.cacheplane.ai/api/health` still returns `200 {"ok":true}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)