### PR TITLE
ci(minting-service): only deploy Vercel from main branch

### DIFF
--- a/apps/minting-service/vercel.json
+++ b/apps/minting-service/vercel.json
@@ -1,5 +1,10 @@
 {
   "installCommand": "cd ../.. && npm ci",
   "buildCommand": "cd ../.. && npx nx build minting-service",
-  "framework": null
+  "framework": null,
+  "git": {
+    "deploymentEnabled": {
+      "main": true
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- Add `git.deploymentEnabled` to `apps/minting-service/vercel.json` whitelisting only `main` for deploys.
- Stops the cacheplane-minting-service Vercel project from triggering doomed preview deployments on every PR push.

## Why

Vercel's Git integration auto-deploys preview builds for every commit on every branch unless `vercel.json` opts out. Toggling "Preview Deployments" in the Vercel dashboard alone doesn't catch this when the project's `vercel.json` ships without `git.deploymentEnabled`. Result: every unrelated PR (e.g. website-only changes) shows a red "Vercel – cacheplane-minting-service" check.

After this lands, only commits to `main` will trigger a minting-service deploy. Other branches will see no Vercel attempt for this project at all.

## Test plan

- [ ] Open this PR; confirm the `Vercel – cacheplane-minting-service` check is **absent** (not failed) on this branch
- [ ] After merge, push a tiny commit to a fresh PR branch and verify minting-service still doesn't appear in the checks list
- [ ] Confirm a push to `main` still triggers a production minting-service deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)