### PR TITLE
ci: expand Library job to cover all 7 publishable libs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
   library:
     name: Library — lint / test / build
     runs-on: ubuntu-latest
+    env:
+      LIBS: chat,langgraph,ag-ui,render,a2ui,partial-json,licensing
     steps:
       - uses: actions/checkout@v6.0.2
       - uses: actions/setup-node@v6.3.0
@@ -17,9 +19,9 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
-      - run: npx nx lint langgraph
-      - run: npx nx test langgraph --coverage
-      - run: npx nx build langgraph --configuration=production
+      - run: npx nx run-many -t lint --projects=$LIBS
+      - run: npx nx run-many -t test --projects=$LIBS --coverage
+      - run: npx nx run-many -t build --projects=$LIBS --configuration=production
 
   website:
     name: Website — lint / build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,12 @@ jobs:
 
       - run: npm ci
 
+      # Trusted publishing requires npm CLI 11.5.1+. Node 22's bundled npm
+      # is 10.x which has partial OIDC support but doesn't fully implement
+      # the trusted-publishing flow against npm registry's OIDC endpoint.
+      - name: Upgrade npm to support trusted publishing
+        run: npm install -g npm@latest
+
       - name: Lint, test, build publishable projects
         run: npx nx run-many -t lint,test,build --projects=$NPM_PUBLISHABLE_PROJECTS --skip-nx-cache
 


### PR DESCRIPTION
Previously the Library job only ran lint/test/build for @ngaf/langgraph. A regression in chat, ag-ui, render, a2ui, partial-json, or licensing could land unnoticed. Switches to `nx run-many` over the publishable group.

Plan: `docs/superpowers/plans/2026-05-01-ci-library-job-coverage.md`