### PR TITLE
fix(chat): make theming actually work (0.0.5)

### DIFF
--- a/libs/chat/package.json
+++ b/libs/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/chat",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "exports": {
     ".": {
       "types": "./index.d.ts",

--- a/libs/chat/src/lib/styles/chat-tokens.ts
+++ b/libs/chat/src/lib/styles/chat-tokens.ts
@@ -89,24 +89,73 @@ const KEYFRAMES = `
 `;
 
 /**
- * Component-host design tokens. Import into every chat component's `styles`
- * array so CSS custom properties resolve on `:host` without consumer setup.
- * Light tokens are default; dark applies via prefers-color-scheme OR via the
- * `[data-ngaf-chat-theme="dark"]` attribute on the host. Consumers can force
- * light by setting `[data-ngaf-chat-theme="light"]`.
+ * Component-scoped styles. Imported into every chat component's `styles`
+ * array. Carries only:
+ *   - `:host` font-family + color (so the component inherits text styling)
+ *   - keyframes the components use
+ *
+ * Token *defaults* are NOT set on `:host` — they're set on `:root` via the
+ * shared style element below (`ensureChatRootStyles()`). That shift is what
+ * makes the documented `:root { --ngaf-chat-*: ... }` consumer override
+ * actually work, because direct-on-host token settings would shadow
+ * inheritance regardless of CSS specificity.
  */
 export const CHAT_HOST_TOKENS = `
   :host {
+    font-family: var(--ngaf-chat-font-family);
+    color: var(--ngaf-chat-text);
+  }
+  ${KEYFRAMES}
+`;
+
+/**
+ * Token defaults written to `<head>` once on first chat-component
+ * construction. Wrapped in `@layer ngaf-chat` so the consumer's unlayered
+ * `:root { --ngaf-chat-*: ... }` rule beats the lib's defaults regardless
+ * of source order — the standard CSS pattern for framework defaults.
+ *
+ * Theme switching:
+ *   - `prefers-color-scheme: dark` → dark by default.
+ *   - `[data-ngaf-chat-theme="dark"]` on `<html>` / `<body>` / any wrapper
+ *     forces dark.
+ *   - `[data-ngaf-chat-theme="light"]` forces light.
+ */
+const ROOT_TOKEN_STYLES = `
+@layer ngaf-chat {
+  :root {
     ${LIGHT_TOKENS}
     ${GEOMETRY_TOKENS}
     ${TYPOGRAPHY_TOKENS}
     ${SPACING_TOKENS}
-    font-family: var(--ngaf-chat-font-family);
-    color: var(--ngaf-chat-text);
   }
   @media (prefers-color-scheme: dark) {
-    :host:not([data-ngaf-chat-theme="light"]) { ${DARK_TOKENS} }
+    :root { ${DARK_TOKENS} }
   }
-  :host([data-ngaf-chat-theme="dark"]) { ${DARK_TOKENS} }
-  ${KEYFRAMES}
+  :root[data-ngaf-chat-theme="light"],
+  [data-ngaf-chat-theme="light"] { ${LIGHT_TOKENS} }
+  :root[data-ngaf-chat-theme="dark"],
+  [data-ngaf-chat-theme="dark"] { ${DARK_TOKENS} }
+}
 `;
+
+const STYLE_ELEMENT_ID = 'ngaf-chat-root-tokens';
+
+/**
+ * Idempotent: appends a `<style id="ngaf-chat-root-tokens">` to `<head>`
+ * the first time it's called. Subsequent calls are no-ops.
+ *
+ * No-op outside the browser (server-side rendering).
+ */
+export function ensureChatRootStyles(): void {
+  if (typeof document === 'undefined') return;
+  if (document.getElementById(STYLE_ELEMENT_ID)) return;
+  const style = document.createElement('style');
+  style.id = STYLE_ELEMENT_ID;
+  style.textContent = ROOT_TOKEN_STYLES;
+  document.head.appendChild(style);
+}
+
+// Auto-inject on module evaluation. Every chat component imports
+// `CHAT_HOST_TOKENS` from this file, so the first chat component to load
+// triggers this once. Safe to evaluate eagerly: idempotent + SSR-guarded.
+ensureChatRootStyles();


### PR DESCRIPTION
## Summary

Theming was advertised but didn't work. Smoke-test investigation against the published @ngaf/chat@0.0.4 surfaced two related bugs:

1. **Consumer's `:root { --ngaf-chat-primary: ...; }` override was ignored.** The 0.0.4 architecture set tokens on every chat component's `:host`. Direct-on-element token settings shadow CSS inheritance from ancestor `:root` regardless of specificity. \`[_nghost-c123] { --ngaf-chat-primary: dark; }\` (set on the chat element) always won over \`:root { --ngaf-chat-primary: blue; }\` (inherited).

2. **`[data-ngaf-chat-theme=\"dark\"]` attribute didn't switch dark mode.** \`:host([data-ngaf-chat-theme=\"dark\"])\` only matched the component's own host. Setting the attribute on \`<body>\`/\`<html>\`/any wrapper had no effect. Even setting it on \`<chat>\` directly, child chat components (chat-input, chat-message, chat-window, ...) re-set light tokens on their own :host and shadowed it anyway.

## Fix

Stop setting tokens on \`:host\`. Inject the defaults onto \`:root\` once via a shared \`<style id=\"ngaf-chat-root-tokens\">\` element, appended to \`<head>\` on first chat-tokens module evaluation (idempotent, SSR-guarded).

Wrap the default rules in \`@layer ngaf-chat\` so consumer's unlayered \`:root { --ngaf-chat-*: ... }\` wins regardless of source order — the standard CSS pattern for framework defaults.

\`\`\`ts
// libs/chat/src/lib/styles/chat-tokens.ts
const ROOT_TOKEN_STYLES = \`
@layer ngaf-chat {
  :root { --ngaf-chat-primary: rgb(28, 28, 28); /* ...defaults... */ }
  @media (prefers-color-scheme: dark) {
    :root { --ngaf-chat-primary: rgb(255, 255, 255); /* ... */ }
  }
  :root[data-ngaf-chat-theme=\"dark\"],
  [data-ngaf-chat-theme=\"dark\"] { /* dark tokens */ }
  /* ...etc... */
}
\`;

export function ensureChatRootStyles(): void {
  if (typeof document === 'undefined') return;
  if (document.getElementById('ngaf-chat-root-tokens')) return;
  const style = document.createElement('style');
  style.id = 'ngaf-chat-root-tokens';
  style.textContent = ROOT_TOKEN_STYLES;
  document.head.appendChild(style);
}

ensureChatRootStyles(); // auto-invoke on module evaluation
\`\`\`

## Validation

End-to-end against the smoke app:

| Scenario | Before | After |
|---|---|---|
| Default load | light theme renders | light theme renders ✓ |
| \`:root { --ngaf-chat-primary: rgb(80, 0, 200); }\` | chatPrimary = rgb(28, 28, 28) (default, override ignored) | chatPrimary = rgb(80, 0, 200) ✓ |
| \`document.body.setAttribute('data-ngaf-chat-theme', 'dark')\` | still light | full dark theme propagates ✓ |
| \`document.documentElement.setAttribute('data-ngaf-chat-theme', 'dark')\` | still light | full dark theme propagates ✓ |
| \`prefers-color-scheme: dark\` | (untested previously) | dark theme by default |

## Test plan

- [x] All chat unit tests pass
- [x] \`nx build chat\` clean
- [x] \`nx lint chat\` clean
- [x] Theme override + dark mode validated manually against the smoke app
- [ ] CI green
- [ ] Tag v0.0.5 to publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)