### PR TITLE
[codex] Add LangGraph queue surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ That's it. `chat.messages()` is an Angular Signal. Bind it directly in your temp
 | Tool call progress | `toolProgress()` | `toolProgress` |
 | Tool calls with results | `toolCalls()` | `toolCalls` |
 | Branch / history | `branch()` / `history()` | `branch` / `history` |
+| Pending run queue | `queue()` | `queue` |
 | Subagent streaming | `subagents()` / `activeSubagents()` | `subagents` / `activeSubagents` |
 | Reactive thread switching | `Signal<string \| null>` input | prop |
 | Submit | `submit(values, opts?)` | `submit(values, opts?)` |
@@ -116,7 +117,7 @@ That's it. `chat.messages()` is an Angular Signal. Bind it directly in your temp
   />
 </p>
 
-`agent()` creates 12 `BehaviorSubject`s at injection-context time — once, at component construction. The `StreamManager` bridge (the only file that touches `@langchain/langgraph-sdk` internals) pushes stream events into those subjects. `toSignal()` converts each subject to an Angular Signal, also at construction time. Dynamic actions (`submit`, `stop`, `switchThread`) push into the existing subjects — no new subjects are ever created after construction. This architecture is required because `toSignal()` must be called in an injection context and cannot be called again later.
+`agent()` creates its internal `BehaviorSubject`s at injection-context time — once, at component construction. The `StreamManager` bridge (the only file that touches `@langchain/langgraph-sdk` internals) pushes stream events into those subjects. `toSignal()` converts each subject to an Angular Signal, also at construction time. Dynamic actions (`submit`, `stop`, `switchThread`) push into the existing subjects — no new subjects are ever created after construction. This architecture is required because `toSignal()` must be called in an injection context and cannot be called again later.
 
 ---
 

--- a/apps/website/content/docs/agent/api/api-docs.json
+++ b/apps/website/content/docs/agent/api/api-docs.json
@@ -23,6 +23,62 @@
     "properties": [],
     "methods": [
       {
+        "name": "cancelRun",
+        "signature": "cancelRun(threadId: string, runId: string, signal: AbortSignal)",
+        "description": "Cancel a server-side run.",
+        "params": [
+          {
+            "name": "threadId",
+            "type": "string",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "runId",
+            "type": "string",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "signal",
+            "type": "AbortSignal",
+            "description": "",
+            "optional": false
+          }
+        ]
+      },
+      {
+        "name": "createQueuedRun",
+        "signature": "createQueuedRun(assistantId: string, threadId: string, payload: unknown, signal: AbortSignal)",
+        "description": "Create a pending server-side run using LangGraph's enqueue strategy.",
+        "params": [
+          {
+            "name": "assistantId",
+            "type": "string",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "threadId",
+            "type": "string",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "payload",
+            "type": "unknown",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "signal",
+            "type": "AbortSignal",
+            "description": "",
+            "optional": false
+          }
+        ]
+      },
+      {
         "name": "joinStream",
         "signature": "joinStream(threadId: string, runId: string, lastEventId: string | undefined, signal: AbortSignal)",
         "description": "Join an already-started run without creating a new thread.",
@@ -101,13 +157,88 @@
     "examples": [
       "```typescript\nconst transport = new MockAgentTransport([\n  [{ type: 'values', data: { messages: [aiMsg('Hello')] } }],\n  [{ type: 'values', data: { status: 'done' } }],\n]);\n```"
     ],
-    "properties": [],
+    "properties": [
+      {
+        "name": "cancelledRuns",
+        "type": "object[]",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "createdQueuedRuns",
+        "type": "AgentQueueEntry<unknown>[]",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "joinedRuns",
+        "type": "object[]",
+        "description": "",
+        "optional": false
+      }
+    ],
     "methods": [
+      {
+        "name": "cancelRun",
+        "signature": "cancelRun(threadId: string, runId: string, signal: AbortSignal)",
+        "description": "Optional: cancel a server-side run.",
+        "params": [
+          {
+            "name": "threadId",
+            "type": "string",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "runId",
+            "type": "string",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "signal",
+            "type": "AbortSignal",
+            "description": "",
+            "optional": false
+          }
+        ]
+      },
       {
         "name": "close",
         "signature": "close()",
         "description": "Close the stream. Remaining queued events are drained before completion.",
         "params": []
+      },
+      {
+        "name": "createQueuedRun",
+        "signature": "createQueuedRun(_assistantId: string, threadId: string, payload: unknown, signal: AbortSignal)",
+        "description": "Optional: create a server-side queued run without joining it immediately.",
+        "params": [
+          {
+            "name": "_assistantId",
+            "type": "string",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "threadId",
+            "type": "string",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "payload",
+            "type": "unknown",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "signal",
+            "type": "AbortSignal",
+            "description": "",
+            "optional": false
+          }
+        ]
       },
       {
         "name": "emit",
@@ -140,6 +271,37 @@
         "signature": "isStreaming()",
         "description": "Returns true if a stream is currently active.",
         "params": []
+      },
+      {
+        "name": "joinStream",
+        "signature": "joinStream(threadId: string, runId: string, lastEventId: string | undefined, signal: AbortSignal)",
+        "description": "Optional: join an already-started run without creating a new one.",
+        "params": [
+          {
+            "name": "threadId",
+            "type": "string",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "runId",
+            "type": "string",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "lastEventId",
+            "type": "string | undefined",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "signal",
+            "type": "AbortSignal",
+            "description": "",
+            "optional": false
+          }
+        ]
       },
       {
         "name": "nextBatch",
@@ -293,10 +455,92 @@
     "examples": []
   },
   {
+    "name": "AgentQueue",
+    "kind": "interface",
+    "description": "Public queue surface for pending server-side LangGraph runs.",
+    "properties": [
+      {
+        "name": "cancel",
+        "type": "object",
+        "description": "Cancel a specific pending run by server run ID.",
+        "optional": false
+      },
+      {
+        "name": "clear",
+        "type": "object",
+        "description": "Cancel all pending runs and clear the queue.",
+        "optional": false
+      },
+      {
+        "name": "entries",
+        "type": "readonly AgentQueueEntry<T>[]",
+        "description": "Read-only pending queue entries.",
+        "optional": false
+      },
+      {
+        "name": "size",
+        "type": "number",
+        "description": "Number of pending queue entries.",
+        "optional": false
+      }
+    ],
+    "examples": []
+  },
+  {
+    "name": "AgentQueueEntry",
+    "kind": "interface",
+    "description": "A queued server-side LangGraph run.",
+    "properties": [
+      {
+        "name": "createdAt",
+        "type": "Date",
+        "description": "Timestamp when the queued run was registered locally.",
+        "optional": false
+      },
+      {
+        "name": "id",
+        "type": "string",
+        "description": "Server-side run ID.",
+        "optional": false
+      },
+      {
+        "name": "options",
+        "type": "LangGraphSubmitOptions",
+        "description": "Submit options used when the queued run was created.",
+        "optional": true
+      },
+      {
+        "name": "threadId",
+        "type": "string",
+        "description": "Thread that owns the queued run.",
+        "optional": false
+      },
+      {
+        "name": "values",
+        "type": "T | null | undefined",
+        "description": "Values submitted for the queued run.",
+        "optional": false
+      }
+    ],
+    "examples": []
+  },
+  {
     "name": "AgentTransport",
     "kind": "interface",
     "description": "Transport interface for connecting to a LangGraph agent.",
     "properties": [
+      {
+        "name": "cancelRun",
+        "type": "unknown",
+        "description": "",
+        "optional": true
+      },
+      {
+        "name": "createQueuedRun",
+        "type": "unknown",
+        "description": "",
+        "optional": true
+      },
       {
         "name": "joinStream",
         "type": "unknown",
@@ -484,6 +728,12 @@
         "optional": false
       },
       {
+        "name": "queue",
+        "type": "Signal<AgentQueue<unknown>>",
+        "description": "Pending server-side runs created via `multitaskStrategy: 'enqueue'`.",
+        "optional": false
+      },
+      {
         "name": "reload",
         "type": "object",
         "description": "Re-submit the last input to restart the stream.",
@@ -548,6 +798,26 @@
         "type": "Signal<T>",
         "description": "Current agent state values (raw, typed per the type parameter T).",
         "optional": false
+      }
+    ],
+    "examples": []
+  },
+  {
+    "name": "LangGraphSubmitOptions",
+    "kind": "interface",
+    "description": "Options accepted by LangGraph-backed submit calls.",
+    "properties": [
+      {
+        "name": "multitaskStrategy",
+        "type": "LangGraphMultitaskStrategy",
+        "description": "Strategy for handling concurrent runs on the same thread.",
+        "optional": true
+      },
+      {
+        "name": "signal",
+        "type": "AbortSignal",
+        "description": "",
+        "optional": true
       }
     ],
     "examples": []
@@ -666,6 +936,12 @@
         "optional": false
       },
       {
+        "name": "queue",
+        "type": "WritableSignal<AgentQueue<unknown>>",
+        "description": "Pending server-side runs created via `multitaskStrategy: 'enqueue'`.",
+        "optional": false
+      },
+      {
         "name": "reload",
         "type": "object",
         "description": "Re-submit the last input to restart the stream.",
@@ -759,7 +1035,7 @@
       },
       {
         "name": "type",
-        "type": "\"error\" | \"values\" | `values|${string}` | \"messages\" | `messages|${string}` | `messages/${string}` | `messages/${string}|${string}` | \"updates\" | `updates|${string}` | \"tools\" | `tools|${string}` | \"custom\" | `custom|${string}` | `error|${string}` | \"metadata\" | \"checkpoints\" | `checkpoints|${string}` | \"tasks\" | `tasks|${string}` | \"debug\" | `debug|${string}` | \"events\" | `events|${string}` | \"interrupt\" | \"interrupts\"",
+        "type": "\"error\" | \"interrupt\" | \"values\" | `values|${string}` | \"messages\" | `messages|${string}` | `messages/${string}` | `messages/${string}|${string}` | \"updates\" | `updates|${string}` | \"tools\" | `tools|${string}` | \"custom\" | `custom|${string}` | `error|${string}` | \"metadata\" | \"checkpoints\" | `checkpoints|${string}` | \"tasks\" | `tasks|${string}` | \"debug\" | `debug|${string}` | \"events\" | `events|${string}` | \"interrupts\"",
         "description": "Event type identifier (e.g., 'values', 'messages', 'error', 'interrupt').",
         "optional": false
       }
@@ -988,6 +1264,13 @@
     "kind": "type",
     "description": "Infer the Bag type from an agent, defaulting to the provided Bag.\n\nCurrently returns the provided Bag for all types.\nCan be extended in the future to extract Bag from agent types.",
     "signature": "T extends { ~agentTypes: unknown } ? BagTemplate : B",
+    "examples": []
+  },
+  {
+    "name": "LangGraphMultitaskStrategy",
+    "kind": "type",
+    "description": "Strategy for handling concurrent LangGraph runs on the same thread.",
+    "signature": "\"reject\" | \"interrupt\" | \"rollback\" | \"enqueue\"",
     "examples": []
   },
   {

--- a/apps/website/content/docs/agent/concepts/langgraph-basics.mdx
+++ b/apps/website/content/docs/agent/concepts/langgraph-basics.mdx
@@ -324,6 +324,7 @@ agent.branch()         // Signal<string> — time-travel branch
 
 agent.toolCalls()      // Signal<ToolCallWithResult[]> — tool results
 agent.toolProgress()   // Signal<ToolProgress[]> — active tool execution
+agent.queue()          // Signal<AgentQueue> — pending enqueue runs
 agent.subagents()      // Signal<Map<string, Subagent>> — delegated agents
 agent.activeSubagents() // Signal<SubagentStreamRef[]> — running workers
 ```

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -66,20 +66,7 @@ SDK and depends on internal tree-diffing utilities not exported from
 
 ---
 
-## 5. `queue` (QueueInterface)
-
-**React behavior:** `useStream()` exposes a `queue` property
-(`QueueInterface`) for inspecting and managing the pending submission queue.
-
-**Angular behavior:** Queue management is handled internally in the
-bridge but not exposed as a public signal in v1. The queue drains
-automatically on `submit()` calls.
-
-**Workaround:** None in v1. Use `isLoading()` to gate UI interactions.
-
----
-
-### Limitation: subagent helper methods are not exposed
+## 5. Subagent Helper Methods
 
 **Feature:** `getSubagent()` / `getSubagentsByType()` /
 `getSubagentsByMessage()`

--- a/libs/langgraph/src/lib/agent.fn.spec.ts
+++ b/libs/langgraph/src/lib/agent.fn.spec.ts
@@ -48,6 +48,24 @@ describe('agent', () => {
     expect(ref.isLoading()).toBe(true);
   });
 
+  it('queue() exposes server-side enqueue submissions', async () => {
+    const transport = new MockAgentTransport();
+    const ref = withInjectionContext(() =>
+      agent({ apiUrl: '', assistantId: 'a', transport, threadId: 'thread-1' })
+    );
+
+    ref.submit({ message: 'active' });
+    await ref.submit({ message: 'queued' }, { multitaskStrategy: 'enqueue' });
+
+    expect(ref.queue().size).toBe(1);
+    expect(ref.queue().entries[0]).toMatchObject({
+      values: { messages: [{ role: 'human', content: 'queued' }] },
+    });
+
+    await ref.queue().clear();
+    expect(ref.queue().size).toBe(0);
+  });
+
   it('hasValue becomes true after values event', async () => {
     const transport = new MockAgentTransport();
     const ref = withInjectionContext(() =>

--- a/libs/langgraph/src/lib/agent.fn.ts
+++ b/libs/langgraph/src/lib/agent.fn.ts
@@ -36,6 +36,8 @@ import {
   StreamSubjects,
   SubagentStreamRef,
   ResourceStatus,
+  AgentQueue,
+  LangGraphSubmitOptions,
 } from './agent.types';
 import type { ThreadState, ToolProgress } from '@langchain/langgraph-sdk';
 import type { MessageMetadata } from '@langchain/langgraph-sdk/ui';
@@ -100,6 +102,12 @@ export function agent<
   const toolCalls$       = new BehaviorSubject<ToolCallWithResult[]>([]);
   const messageMetadata$ = new BehaviorSubject<Map<string, MessageMetadata<Record<string, unknown>>>>(new Map());
   const subagents$       = new BehaviorSubject<Map<string, SubagentStreamRef>>(new Map());
+  const queue$           = new BehaviorSubject<AgentQueue>({
+    entries: [],
+    size: 0,
+    cancel: async () => false,
+    clear: async () => undefined,
+  });
   const custom$          = new BehaviorSubject<CustomStreamEvent[]>([]);
   const hasValue$        = new BehaviorSubject<boolean>(false);
 
@@ -118,7 +126,7 @@ export function agent<
   const subjects: StreamSubjects<T, InferBag<T, Bag>> = {
     status$, values$, messages$, error$,
     interrupt$, interrupts$, branch$, history$,
-    isThreadLoading$, toolProgress$, toolCalls$, messageMetadata$, subagents$, custom$,
+    isThreadLoading$, toolProgress$, toolCalls$, messageMetadata$, subagents$, queue$, custom$,
   };
 
   // threadId$ — resolved before bridge creation (injection context required for toObservable)
@@ -165,6 +173,7 @@ export function agent<
   const toolProgSig  = toSignal(toolProgress$,    { initialValue: [] });
   const rawToolCalls = toSignal(toolCalls$,       { initialValue: [] });
   const subagentsSig = toSignal(subagents$,       { initialValue: new Map<string, SubagentStreamRef>() });
+  const queueSig     = toSignal(queue$,           { initialValue: queue$.value });
   const customSig    = toSignal(custom$,           { initialValue: [] as CustomStreamEvent[] });
 
   const isLoading    = computed(() => statusSig() === ResourceStatus.Loading);
@@ -214,8 +223,8 @@ export function agent<
     subagents: subagentsNeutral,
     events$,
     history:   historyNeutral,
-    submit: (input: AgentSubmitInput, opts?: AgentSubmitOptions) => {
-      manager.submit(buildSubmitPayload(input), opts ? { signal: opts.signal } as never : undefined);
+    submit: (input: AgentSubmitInput, opts?: AgentSubmitOptions & LangGraphSubmitOptions) => {
+      manager.submit(buildSubmitPayload(input), opts);
       return Promise.resolve();
     },
     stop: () => manager.stop(),
@@ -231,6 +240,7 @@ export function agent<
     hasValue:        hasValueSig,
     reload:          () => manager.resubmitLast(),
     toolProgress:    toolProgSig,
+    queue:           queueSig,
     activeSubagents,
     customEvents:    customSig,
     branch:          branchSig,

--- a/libs/langgraph/src/lib/agent.types.ts
+++ b/libs/langgraph/src/lib/agent.types.ts
@@ -73,6 +73,42 @@ export interface StreamEvent {
   [key: string]: unknown;
 }
 
+/** Strategy for handling concurrent LangGraph runs on the same thread. */
+export type LangGraphMultitaskStrategy = 'reject' | 'interrupt' | 'rollback' | 'enqueue';
+
+/** Options accepted by LangGraph-backed submit calls. */
+export interface LangGraphSubmitOptions {
+  signal?: AbortSignal;
+  /** Strategy for handling concurrent runs on the same thread. */
+  multitaskStrategy?: LangGraphMultitaskStrategy;
+}
+
+/** A queued server-side LangGraph run. */
+export interface AgentQueueEntry<T = unknown> {
+  /** Server-side run ID. */
+  id: string;
+  /** Thread that owns the queued run. */
+  threadId: string;
+  /** Values submitted for the queued run. */
+  values: T | null | undefined;
+  /** Submit options used when the queued run was created. */
+  options?: LangGraphSubmitOptions;
+  /** Timestamp when the queued run was registered locally. */
+  createdAt: Date;
+}
+
+/** Public queue surface for pending server-side LangGraph runs. */
+export interface AgentQueue<T = unknown> {
+  /** Read-only pending queue entries. */
+  readonly entries: ReadonlyArray<AgentQueueEntry<T>>;
+  /** Number of pending queue entries. */
+  readonly size: number;
+  /** Cancel a specific pending run by server run ID. */
+  cancel: (id: string) => Promise<boolean>;
+  /** Cancel all pending runs and clear the queue. */
+  clear: () => Promise<void>;
+}
+
 /** A custom event emitted by the LangGraph backend via adispatch_custom_event(). */
 export interface CustomStreamEvent {
   /** Event name set by the backend (e.g., 'state_update'). */
@@ -98,6 +134,21 @@ export interface AgentTransport {
     lastEventId: string | undefined,
     signal: AbortSignal,
   ): AsyncIterable<StreamEvent>;
+
+  /** Optional: create a server-side queued run without joining it immediately. */
+  createQueuedRun?(
+    assistantId: string,
+    threadId: string,
+    payload: unknown,
+    signal: AbortSignal,
+  ): Promise<AgentQueueEntry>;
+
+  /** Optional: cancel a server-side run. */
+  cancelRun?(
+    threadId: string,
+    runId: string,
+    signal: AbortSignal,
+  ): Promise<void>;
 }
 
 // ── Options ──────────────────────────────────────────────────────────────────
@@ -184,6 +235,9 @@ export interface LangGraphAgent<T = unknown, ResolvedBag extends BagTemplate = B
   /** Progress updates for currently executing tools. */
   toolProgress: Signal<ToolProgress[]>;
 
+  /** Pending server-side runs created via `multitaskStrategy: 'enqueue'`. */
+  queue: Signal<AgentQueue>;
+
   /** Filtered list of subagents with status 'running'. */
   activeSubagents: Signal<SubagentStreamRef[]>;
 
@@ -230,5 +284,6 @@ export interface StreamSubjects<T, ResolvedBag extends BagTemplate = BagTemplate
   toolCalls$:       BehaviorSubject<ToolCallWithResult[]>;
   messageMetadata$: BehaviorSubject<Map<string, MessageMetadata<Record<string, unknown>>>>;
   subagents$:       BehaviorSubject<Map<string, SubagentStreamRef>>;
+  queue$:           BehaviorSubject<AgentQueue>;
   custom$:          BehaviorSubject<CustomStreamEvent[]>;
 }

--- a/libs/langgraph/src/lib/internals/stream-manager.bridge.spec.ts
+++ b/libs/langgraph/src/lib/internals/stream-manager.bridge.spec.ts
@@ -20,6 +20,12 @@ function makeSubjects(): StreamSubjects<Record<string, unknown>> {
     toolCalls$:       new BehaviorSubject([]),
     messageMetadata$: new BehaviorSubject(new Map()),
     subagents$:       new BehaviorSubject(new Map()),
+    queue$:           new BehaviorSubject({
+      entries: [],
+      size: 0,
+      cancel: async () => false,
+      clear: async () => undefined,
+    }),
     custom$:          new BehaviorSubject<CustomStreamEvent[]>([]),
   };
 }
@@ -52,6 +58,132 @@ describe('createStreamManagerBridge', () => {
     });
     bridge.submit({ messages: [] });
     expect(subjects.status$.value).toBe(ResourceStatus.Loading);
+    destroy$.next();
+  });
+
+  it('exposes enqueue submissions through queue$ without starting a second stream immediately', async () => {
+    const transport = new MockAgentTransport();
+    const subjects = makeSubjects();
+    const destroy$ = new Subject<void>();
+    const bridge = createStreamManagerBridge({
+      options: { apiUrl: '', assistantId: 'test', transport },
+      subjects,
+      threadId$: of('thread-1'),
+      destroy$: destroy$.asObservable(),
+    });
+
+    bridge.submit({ messages: [{ type: 'human', content: 'active' }] });
+    await bridge.submit(
+      { messages: [{ type: 'human', content: 'queued' }] },
+      { multitaskStrategy: 'enqueue' },
+    );
+
+    expect(subjects.queue$.value.size).toBe(1);
+    expect(subjects.queue$.value.entries[0]).toMatchObject({
+      values: { messages: [{ type: 'human', content: 'queued' }] },
+    });
+    expect(transport.createdQueuedRuns).toHaveLength(1);
+    expect(transport.isStreaming()).toBe(true);
+    destroy$.next();
+  });
+
+  it('can cancel a queued run through queue$', async () => {
+    const transport = new MockAgentTransport();
+    const subjects = makeSubjects();
+    const destroy$ = new Subject<void>();
+    const bridge = createStreamManagerBridge({
+      options: { apiUrl: '', assistantId: 'test', transport },
+      subjects,
+      threadId$: of('thread-1'),
+      destroy$: destroy$.asObservable(),
+    });
+
+    bridge.submit({ messages: [{ type: 'human', content: 'active' }] });
+    await bridge.submit(
+      { messages: [{ type: 'human', content: 'queued' }] },
+      { multitaskStrategy: 'enqueue' },
+    );
+
+    const queued = subjects.queue$.value.entries[0];
+    await subjects.queue$.value.cancel(queued.id);
+
+    expect(subjects.queue$.value.size).toBe(0);
+    expect(transport.cancelledRuns).toEqual([{ threadId: 'thread-1', runId: queued.id }]);
+    destroy$.next();
+  });
+
+  it('cancels queued runs when switching threads', async () => {
+    const transport = new MockAgentTransport();
+    const subjects = makeSubjects();
+    const destroy$ = new Subject<void>();
+    const bridge = createStreamManagerBridge({
+      options: { apiUrl: '', assistantId: 'test', transport },
+      subjects,
+      threadId$: of('thread-1'),
+      destroy$: destroy$.asObservable(),
+    });
+
+    bridge.submit({ messages: [{ type: 'human', content: 'active' }] });
+    await bridge.submit(
+      { messages: [{ type: 'human', content: 'queued' }] },
+      { multitaskStrategy: 'enqueue' },
+    );
+
+    bridge.switchThread('thread-2');
+    await Promise.resolve();
+
+    expect(subjects.queue$.value.size).toBe(0);
+    expect(transport.cancelledRuns).toEqual([{ threadId: 'thread-1', runId: 'queued-run-1' }]);
+    destroy$.next();
+  });
+
+  it('cancels queued runs when stopping the active stream', async () => {
+    const transport = new MockAgentTransport();
+    const subjects = makeSubjects();
+    const destroy$ = new Subject<void>();
+    const bridge = createStreamManagerBridge({
+      options: { apiUrl: '', assistantId: 'test', transport },
+      subjects,
+      threadId$: of('thread-1'),
+      destroy$: destroy$.asObservable(),
+    });
+
+    bridge.submit({ messages: [{ type: 'human', content: 'active' }] });
+    await bridge.submit(
+      { messages: [{ type: 'human', content: 'queued' }] },
+      { multitaskStrategy: 'enqueue' },
+    );
+
+    await bridge.stop();
+
+    expect(subjects.queue$.value.size).toBe(0);
+    expect(transport.cancelledRuns).toEqual([{ threadId: 'thread-1', runId: 'queued-run-1' }]);
+    destroy$.next();
+  });
+
+  it('joins queued runs in FIFO order after the active stream completes', async () => {
+    const transport = new MockAgentTransport();
+    const subjects = makeSubjects();
+    const destroy$ = new Subject<void>();
+    const bridge = createStreamManagerBridge({
+      options: { apiUrl: '', assistantId: 'test', transport },
+      subjects,
+      threadId$: of('thread-1'),
+      destroy$: destroy$.asObservable(),
+    });
+
+    bridge.submit({ messages: [{ type: 'human', content: 'active' }] });
+    await bridge.submit(
+      { messages: [{ type: 'human', content: 'queued' }] },
+      { multitaskStrategy: 'enqueue' },
+    );
+
+    transport.close();
+    await new Promise(r => setTimeout(r, 20));
+
+    expect(transport.joinedRuns).toEqual([{ threadId: 'thread-1', runId: 'queued-run-1' }]);
+    expect(subjects.queue$.value.size).toBe(0);
+    expect(subjects.values$.value).toMatchObject({ queued: true });
     destroy$.next();
   });
 

--- a/libs/langgraph/src/lib/internals/stream-manager.bridge.ts
+++ b/libs/langgraph/src/lib/internals/stream-manager.bridge.ts
@@ -8,6 +8,9 @@ import {
   StreamEvent,
   AgentTransport,
   SubagentStreamRef,
+  AgentQueue,
+  AgentQueueEntry,
+  LangGraphSubmitOptions,
 } from '../agent.types';
 import { FetchStreamTransport } from '../transport/fetch-stream.transport';
 import { BagTemplate } from '@langchain/langgraph-sdk';
@@ -29,7 +32,7 @@ export interface StreamManagerBridgeOptions<T, ResolvedBag extends BagTemplate =
 }
 
 export interface StreamManagerBridge {
-  submit:       (values: unknown, opts?: unknown) => Promise<void>;
+  submit:       (values: unknown, opts?: LangGraphSubmitOptions) => Promise<void>;
   stop:         () => Promise<void>;
   switchThread: (id: string | null) => void;
   joinStream:   (runId: string, lastEventId?: string) => Promise<void>;
@@ -55,6 +58,8 @@ export function createStreamManagerBridge<T, ResolvedBag extends BagTemplate = B
   let abortController: AbortController | null = null;
   let hasSeenThreadId = false;
   const toolProgressMap = new Map<string, ToolProgress>();
+  const queuedRuns: AgentQueueEntry[] = [];
+  let drainingQueue = false;
   const subagentManager = new SubagentTracker({
     subagentToolNames: options.subagentToolNames,
     onSubagentChange: publishSubagents,
@@ -70,6 +75,8 @@ export function createStreamManagerBridge<T, ResolvedBag extends BagTemplate = B
     subjects.toolCalls$.next([]);
     subjects.messageMetadata$.next(new Map());
     subjects.subagents$.next(new Map());
+    void cancelQueueEntries(takeQueuedRuns()).catch(err => subjects.error$.next(err));
+    publishQueue();
     subjects.custom$.next([]);
     subjects.isThreadLoading$.next(false);
     toolProgressMap.clear();
@@ -92,6 +99,111 @@ export function createStreamManagerBridge<T, ResolvedBag extends BagTemplate = B
     hasSeenThreadId = true;
     setThreadId(id, shouldReset);
   });
+
+  function publishQueue(): void {
+    subjects.queue$.next(createQueueSnapshot());
+  }
+
+  function createQueueSnapshot(): AgentQueue {
+    return {
+      entries: [...queuedRuns],
+      size: queuedRuns.length,
+      cancel: cancelQueuedRun,
+      clear: clearQueue,
+    };
+  }
+
+  async function enqueueRun(payload: unknown, opts?: LangGraphSubmitOptions): Promise<void> {
+    if (!currentThreadId) {
+      throw new Error('Cannot enqueue a run before a LangGraph thread exists.');
+    }
+    if (!transport.createQueuedRun) {
+      throw new Error('The configured LangGraph transport does not support server-side queueing.');
+    }
+
+    const controller = new AbortController();
+    const entry = await transport.createQueuedRun(
+      options.assistantId,
+      currentThreadId,
+      payload,
+      opts?.signal ?? controller.signal,
+    );
+    queuedRuns.push({
+      ...entry,
+      values: payload,
+      options: { ...opts, multitaskStrategy: 'enqueue' },
+      createdAt: entry.createdAt ?? new Date(),
+    });
+    publishQueue();
+  }
+
+  async function cancelQueuedRun(id: string): Promise<boolean> {
+    const index = queuedRuns.findIndex(entry => entry.id === id);
+    if (index === -1) return false;
+
+    const [entry] = queuedRuns.splice(index, 1);
+    publishQueue();
+    if (!entry || !transport.cancelRun) return false;
+    await cancelQueueEntries([entry]);
+    return true;
+  }
+
+  async function clearQueue(): Promise<void> {
+    const entries = takeQueuedRuns();
+    publishQueue();
+    await cancelQueueEntries(entries);
+  }
+
+  function takeQueuedRuns(): AgentQueueEntry[] {
+    return queuedRuns.splice(0, queuedRuns.length);
+  }
+
+  async function cancelQueueEntries(entries: AgentQueueEntry[]): Promise<void> {
+    const cancelRun = transport.cancelRun?.bind(transport);
+    if (!cancelRun) return;
+    await Promise.all(entries.map(entry =>
+      cancelRun(entry.threadId, entry.id, new AbortController().signal)
+    ));
+  }
+
+  async function drainQueue(): Promise<void> {
+    if (drainingQueue || queuedRuns.length === 0) return;
+    drainingQueue = true;
+    try {
+      while (queuedRuns.length > 0) {
+        const entry = queuedRuns.shift();
+        publishQueue();
+        if (!entry || !transport.joinStream) continue;
+        await joinQueuedRun(entry);
+      }
+    } finally {
+      drainingQueue = false;
+    }
+  }
+
+  async function joinQueuedRun(entry: AgentQueueEntry): Promise<void> {
+    abortController = new AbortController();
+    subjects.custom$.next([]);
+    subjects.toolProgress$.next([]);
+    toolProgressMap.clear();
+    subjects.status$.next(ResourceStatus.Loading);
+
+    try {
+      const iter = transport.joinStream
+        ? transport.joinStream(entry.threadId, entry.id, undefined, abortController.signal)
+        : [];
+      for await (const event of iter) {
+        if (abortController.signal.aborted) break;
+        processEvent(event);
+      }
+      if (!abortController.signal.aborted) {
+        subjects.status$.next(ResourceStatus.Resolved);
+      }
+    } catch (err) {
+      subjects.error$.next(err);
+      subjects.status$.next(ResourceStatus.Error);
+    }
+  }
 
   async function runStream(payload: unknown): Promise<void> {
     abortController?.abort();
@@ -127,6 +239,7 @@ export function createStreamManagerBridge<T, ResolvedBag extends BagTemplate = B
 
       if (!abortController.signal.aborted) {
         subjects.status$.next(ResourceStatus.Resolved);
+        await drainQueue();
       }
     } catch (err) {
       if ((err as Error)?.name === 'AbortError') {
@@ -373,10 +486,17 @@ export function createStreamManagerBridge<T, ResolvedBag extends BagTemplate = B
   }
 
   return {
-    submit: (payload) => runStream(payload),
+    submit: async (payload, opts) => {
+      if (opts?.multitaskStrategy === 'enqueue' && subjects.status$.value === ResourceStatus.Loading) {
+        await enqueueRun(payload, opts);
+        return;
+      }
+      await runStream(payload);
+    },
 
     stop: async () => {
       abortController?.abort();
+      await clearQueue();
       subjects.status$.next(ResourceStatus.Resolved);
     },
 

--- a/libs/langgraph/src/lib/testing/mock-langgraph-agent.ts
+++ b/libs/langgraph/src/lib/testing/mock-langgraph-agent.ts
@@ -4,6 +4,7 @@ import { Subject } from 'rxjs';
 import type {
   LangGraphAgent,
   SubagentStreamRef,
+  AgentQueue,
   Interrupt,
   ThreadState,
   CustomStreamEvent,
@@ -41,6 +42,7 @@ export interface MockLangGraphAgent extends LangGraphAgent<any, any> {
   toolCalls: WritableSignal<ToolCall[]>;
   langGraphToolCalls: WritableSignal<ToolCallWithResult[]>;
   toolProgress: WritableSignal<ToolProgress[]>;
+  queue: WritableSignal<AgentQueue>;
   branch: WritableSignal<string>;
   history: WritableSignal<AgentCheckpoint[]>;
   langGraphHistory: WritableSignal<ThreadState<any>[]>;
@@ -77,6 +79,12 @@ export function mockLangGraphAgent(
   const toolCalls$ = signal<ToolCall[]>([]);
   const langGraphToolCalls$ = signal<ToolCallWithResult[]>([]);
   const toolProgress$ = signal<ToolProgress[]>([]);
+  const queue$ = signal<AgentQueue>({
+    entries: [],
+    size: 0,
+    cancel: async () => false,
+    clear: async () => undefined,
+  });
   const branch$ = signal<string>('');
   const history$ = signal<AgentCheckpoint[]>([]);
   const langGraphHistory$ = signal<ThreadState<any>[]>([]);
@@ -119,6 +127,7 @@ export function mockLangGraphAgent(
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     reload: () => {},
     toolProgress: toolProgress$,
+    queue: queue$,
     activeSubagents: activeSubagents$,
     customEvents: customEvents$,
     branch: branch$,

--- a/libs/langgraph/src/lib/transport/fetch-stream.transport.spec.ts
+++ b/libs/langgraph/src/lib/transport/fetch-stream.transport.spec.ts
@@ -4,6 +4,8 @@ import { FetchStreamTransport } from './fetch-stream.transport';
 const mocks = vi.hoisted(() => ({
   threadsCreate: vi.fn(),
   runsStream: vi.fn(),
+  runsCreate: vi.fn(),
+  runsCancel: vi.fn(),
   runsJoinStream: vi.fn(),
   clientCtor: vi.fn(function (_config: { apiUrl: string }) {
     return {
@@ -12,6 +14,8 @@ const mocks = vi.hoisted(() => ({
       },
       runs: {
         stream: mocks.runsStream,
+        create: mocks.runsCreate,
+        cancel: mocks.runsCancel,
         joinStream: mocks.runsJoinStream,
       },
     };
@@ -34,6 +38,8 @@ describe('FetchStreamTransport', () => {
   beforeEach(() => {
     mocks.threadsCreate.mockReset();
     mocks.runsStream.mockReset();
+    mocks.runsCreate.mockReset();
+    mocks.runsCancel.mockReset();
     mocks.runsJoinStream.mockReset();
     mocks.clientCtor.mockClear();
   });
@@ -198,5 +204,51 @@ describe('FetchStreamTransport', () => {
     expect(events).toEqual([
       { type: 'values', status: 'resumed', data: { status: 'resumed' } },
     ]);
+  });
+
+  it('creates a server-side queued run with enqueue multitask strategy', async () => {
+    mocks.runsCreate.mockResolvedValue({
+      run_id: 'run-queued',
+      thread_id: 'thread-1',
+      created_at: '2026-05-02T00:00:00.000Z',
+    });
+
+    const transport = new FetchStreamTransport('http://example.test');
+    const entry = await transport.createQueuedRun(
+      'assistant-1',
+      'thread-1',
+      { messages: [{ type: 'human', content: 'queued' }] },
+      new AbortController().signal,
+    );
+
+    expect(mocks.runsCreate).toHaveBeenCalledWith(
+      'thread-1',
+      'assistant-1',
+      expect.objectContaining({
+        input: { messages: [{ type: 'human', content: 'queued' }] },
+        multitaskStrategy: 'enqueue',
+        streamSubgraphs: true,
+      }),
+    );
+    expect(entry).toMatchObject({
+      id: 'run-queued',
+      threadId: 'thread-1',
+      values: { messages: [{ type: 'human', content: 'queued' }] },
+    });
+    expect(entry.createdAt).toBeInstanceOf(Date);
+  });
+
+  it('cancels a queued run by thread and run id', async () => {
+    const transport = new FetchStreamTransport('http://example.test');
+
+    await transport.cancelRun('thread-1', 'run-queued', new AbortController().signal);
+
+    expect(mocks.runsCancel).toHaveBeenCalledWith(
+      'thread-1',
+      'run-queued',
+      false,
+      'interrupt',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
   });
 });

--- a/libs/langgraph/src/lib/transport/fetch-stream.transport.ts
+++ b/libs/langgraph/src/lib/transport/fetch-stream.transport.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 import { Client } from '@langchain/langgraph-sdk';
 import type { StreamMode } from '@langchain/langgraph-sdk';
-import { AgentTransport, StreamEvent } from '../agent.types';
+import { AgentQueueEntry, AgentTransport, StreamEvent } from '../agent.types';
 
 /**
  * Production transport that connects to a LangGraph Platform API via HTTP and SSE.
@@ -83,6 +83,36 @@ export class FetchStreamTransport implements AgentTransport {
     for await (const event of run) {
       yield normalizeSdkEvent(event.event as StreamEvent['type'], event.data);
     }
+  }
+
+  /** Create a pending server-side run using LangGraph's enqueue strategy. */
+  async createQueuedRun(
+    assistantId: string,
+    threadId: string,
+    payload: unknown,
+    signal: AbortSignal,
+  ): Promise<AgentQueueEntry> {
+    const streamMode = ['values', 'messages-tuple', 'updates', 'tools', 'custom'] satisfies StreamMode[];
+    const run = await this.client.runs.create(threadId, assistantId, {
+      input: payload as Record<string, unknown>,
+      streamMode: streamMode as unknown as 'values',
+      streamSubgraphs: true,
+      multitaskStrategy: 'enqueue',
+      signal,
+    });
+
+    return {
+      id: run.run_id,
+      threadId: run.thread_id ?? threadId,
+      values: payload,
+      options: { multitaskStrategy: 'enqueue', signal },
+      createdAt: run.created_at ? new Date(run.created_at) : new Date(),
+    };
+  }
+
+  /** Cancel a server-side run. */
+  async cancelRun(threadId: string, runId: string, signal: AbortSignal): Promise<void> {
+    await this.client.runs.cancel(threadId, runId, false, 'interrupt', { signal });
   }
 }
 

--- a/libs/langgraph/src/lib/transport/mock-stream.transport.ts
+++ b/libs/langgraph/src/lib/transport/mock-stream.transport.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-import { AgentTransport, StreamEvent } from '../agent.types';
+import { AgentQueueEntry, AgentTransport, StreamEvent } from '../agent.types';
 
 /**
  * Test transport for deterministic agent testing without a real LangGraph server.
@@ -16,6 +16,9 @@ import { AgentTransport, StreamEvent } from '../agent.types';
  * ```
  */
 export class MockAgentTransport implements AgentTransport {
+  readonly createdQueuedRuns: AgentQueueEntry[] = [];
+  readonly cancelledRuns: Array<{ threadId: string; runId: string }> = [];
+  readonly joinedRuns: Array<{ threadId: string; runId: string }> = [];
   private script: StreamEvent[][];
   private scriptIndex = 0;
   private streaming = false;
@@ -70,7 +73,8 @@ export class MockAgentTransport implements AgentTransport {
       while (!this.closed && !signal.aborted) {
         if (this.pendingError) throw this.pendingError;
         if (this.eventQueue.length > 0) {
-          yield this.eventQueue.shift()!;
+          const event = this.eventQueue.shift();
+          if (event) yield event;
         } else {
           // Wait until flush() wakes us, then loop again to check state.
           await new Promise<void>((resolve) => {
@@ -81,10 +85,48 @@ export class MockAgentTransport implements AgentTransport {
       }
       if (signal.aborted) return;
       // Drain remaining events after close()
-      while (this.eventQueue.length > 0) yield this.eventQueue.shift()!;
+      while (this.eventQueue.length > 0) {
+        const event = this.eventQueue.shift();
+        if (event) yield event;
+      }
     } finally {
       this.streaming = false;
     }
+  }
+
+  async createQueuedRun(
+    _assistantId: string,
+    threadId: string,
+    payload: unknown,
+    signal: AbortSignal,
+  ): Promise<AgentQueueEntry> {
+    void signal;
+    const entry: AgentQueueEntry = {
+      id: `queued-run-${this.createdQueuedRuns.length + 1}`,
+      threadId,
+      values: payload,
+      options: { multitaskStrategy: 'enqueue' },
+      createdAt: new Date(),
+    };
+    this.createdQueuedRuns.push(entry);
+    return entry;
+  }
+
+  async cancelRun(threadId: string, runId: string, signal: AbortSignal): Promise<void> {
+    void signal;
+    this.cancelledRuns.push({ threadId, runId });
+  }
+
+  async *joinStream(
+    threadId: string,
+    runId: string,
+    lastEventId: string | undefined,
+    signal: AbortSignal,
+  ): AsyncIterable<StreamEvent> {
+    void lastEventId;
+    void signal;
+    this.joinedRuns.push({ threadId, runId });
+    yield { type: 'values', values: { queued: true } };
   }
 
   private flush(): void {

--- a/libs/langgraph/src/public-api.ts
+++ b/libs/langgraph/src/public-api.ts
@@ -9,7 +9,11 @@ export type { AgentConfig } from './lib/agent.provider';
 // Public types
 export type {
   AgentOptions,
+  AgentQueue,
+  AgentQueueEntry,
   LangGraphAgent,
+  LangGraphMultitaskStrategy,
+  LangGraphSubmitOptions,
   AgentTransport,
   CustomStreamEvent,
   StreamEvent,


### PR DESCRIPTION
## Summary

Adds the first public LangGraph queue parity surface for server-side enqueue runs. The Angular `agent()` now exposes `queue()` with pending entries plus cancel and clear helpers, backed by transport methods for `runs.create(... multitaskStrategy: 'enqueue')` and `runs.cancel()`.

The stream bridge now tracks queued runs while an active stream is loading, joins queued runs FIFO after the active stream completes, and cancels pending server runs when users cancel, clear, stop, or switch threads so local queue state does not orphan server-side work.

Docs and generated agent API docs were updated to remove the old queue limitation and list the new queue mapping.

## Validation

- `npx vitest run --config vite.config.mts src/lib/internals/stream-manager.bridge.spec.ts -t "cancels queued runs" --reporter=verbose`
- `npx nx test langgraph`
- `npx nx lint langgraph` (passes with existing warnings)
- `npx nx build langgraph`
- `npm run generate-api-docs`
- `npx nx lint website`
- `npx nx build website`
- `git diff --check`