### PR TITLE
fix(chat): tighten assistant message typography (0.0.7)

### DIFF
--- a/libs/chat/package.json
+++ b/libs/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/chat",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "exports": {
     ".": {
       "types": "./index.d.ts",

--- a/libs/chat/src/lib/styles/chat-message.styles.ts
+++ b/libs/chat/src/lib/styles/chat-message.styles.ts
@@ -13,7 +13,7 @@ export const CHAT_MESSAGE_STYLES = `
     position: relative;
     margin-top: 1.5rem;
     color: var(--ngaf-chat-text);
-    line-height: var(--ngaf-chat-line-height);
+    line-height: 1.55;
     font-size: var(--ngaf-chat-font-size);
     max-width: 100%;
   }
@@ -32,6 +32,7 @@ export const CHAT_MESSAGE_STYLES = `
   }
 
   .chat-message__assistant-body {
+    padding: 0 12px 0 4px;
     overflow-wrap: break-word;
   }
 


### PR DESCRIPTION
## Summary

Two micro-polish tweaks to the assistant message body, picked up during a careful visual review.

### Changes

1. **Add horizontal padding to `.chat-message__assistant-body`**: previously zero, so plain assistant text touched container edges in narrow containers (popup window, sidebar panel). Adds \`padding: 0 12px 0 4px\` — 12px right for breathing room, 4px left as a slight inset.

2. **Tighten assistant line-height from 1.6 → 1.55**: 1.6 felt a touch airy. 1.55 reads more compactly while still comfortably above WCAG's 1.5 minimum. Markdown paragraphs keep their own line-height (1.75) via \`chat-markdown.styles\`, so this only affects plain (non-markdown) assistant text.

Net change: +1 line, 1 modified line.

## Verification

- \`nx build chat\` clean
- \`nx test chat\` clean
- \`nx lint chat\` clean
- Pure CSS, no API change.

## Test plan

- [x] Build / test / lint pass
- [ ] CI green
- [ ] Tag v0.0.7 to publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)