### PR TITLE
fix(chat,langgraph): jank — stable @for tracking + empty-array guard

### DIFF
--- a/libs/chat/package.json
+++ b/libs/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/chat",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "exports": {
     ".": {
       "types": "./index.d.ts",

--- a/libs/chat/src/lib/primitives/chat-message-list/chat-message-list.component.ts
+++ b/libs/chat/src/lib/primitives/chat-message-list/chat-message-list.component.ts
@@ -39,7 +39,7 @@ export function getMessageType(message: Message): MessageTemplateType {
   changeDetection: ChangeDetectionStrategy.OnPush,
   styles: [CHAT_HOST_TOKENS, CHAT_MESSAGE_LIST_STYLES],
   template: `
-    @for (message of messages(); track $index) {
+    @for (message of messages(); track message.id) {
       @let template = findTemplate(getMessageType(message));
       @if (template) {
         <ng-container

--- a/libs/langgraph/package.json
+++ b/libs/langgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/langgraph",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "peerDependencies": {
     "@ngaf/chat": "*",
     "@ngaf/licensing": "*",

--- a/libs/langgraph/src/lib/internals/stream-manager.bridge.ts
+++ b/libs/langgraph/src/lib/internals/stream-manager.bridge.ts
@@ -322,6 +322,10 @@ export function createStreamManagerBridge<T, ResolvedBag extends BagTemplate = B
       // so optimistic human messages and earlier tool messages are preserved.
       if (event.type === 'messages/partial' || event.messageMetadata) {
         subjects.messages$.next(mergeMessages(subjects.messages$.value, normalized));
+      } else if (normalized.length === 0) {
+        // Defensive: skip empty replacements during streaming. An empty
+        // batch shouldn't tear down the entire UI (causes message DOM
+        // teardown + streaming renderer reset = visible jank).
       } else {
         subjects.messages$.next(normalized);
       }
@@ -346,7 +350,9 @@ export function createStreamManagerBridge<T, ResolvedBag extends BagTemplate = B
           // Also sync messages$ from the values state so the full message
           // history (including human messages) is available to consumers.
           const stateMessages = (vals as Record<string, unknown>)['messages'];
-          if (Array.isArray(stateMessages)) {
+          if (Array.isArray(stateMessages) && stateMessages.length > 0) {
+            // Defensive: only sync when state carries messages. An empty
+            // values payload shouldn't wipe the UI mid-stream.
             if (options.toMessage) {
               subjects.messages$.next(stateMessages.map(options.toMessage));
             } else {


### PR DESCRIPTION
## Summary
- **chat**: `chat-message-list` switches `@for` from `track \$index` to `track message.id`. During streaming the messages array can transiently shrink (and previously even briefly empty) — index-based tracking tore down every chat-message DOM element on each emission, resetting the streaming-md renderer state and causing visible flash/missed tokens.
- **langgraph**: `stream-manager.bridge` skips publishing an empty `messages` array mid-stream (both messages-event and values-event paths). MutationObserver instrumentation showed an empty-array transient between user→assistant emissions; that empty replacement was the upstream cause of the teardown.

## Versions
- `@ngaf/chat`: 0.0.8 → 0.0.9
- `@ngaf/langgraph`: 0.0.2 → 0.0.3

## Test plan
- [x] `nx test chat` — passes (95 tests)
- [x] `nx test langgraph` — passes (95 tests)
- [x] `nx build chat`, `nx build langgraph` — both clean
- [ ] Manual smoke against ngaf-smoke-05 with real OpenAI streaming — verify no chat-message tear-down via MutationObserver

🤖 Generated with [Claude Code](https://claude.com/claude-code)