### PR TITLE
[codex] Align submit docs with message input

### DIFF
--- a/apps/website/content/AGENTS.md.template
+++ b/apps/website/content/AGENTS.md.template
@@ -26,7 +26,7 @@ import type { BaseMessage } from '@langchain/core/messages';
 `})
 export class ChatComponent {
   chat = agent<{ messages: BaseMessage[] }>({ assistantId: 'chat_agent' });
-  send() { this.chat.submit({ messages: [{ role: 'human', content: 'Hello' }] }); }
+  send() { this.chat.submit({ message: 'Hello' }); }
 }
 ```
 

--- a/apps/website/content/CLAUDE.md.template
+++ b/apps/website/content/CLAUDE.md.template
@@ -26,7 +26,7 @@ import type { BaseMessage } from '@langchain/core/messages';
 `})
 export class ChatComponent {
   chat = agent<{ messages: BaseMessage[] }>({ assistantId: 'chat_agent' });
-  send() { this.chat.submit({ messages: [{ role: 'human', content: 'Hello' }] }); }
+  send() { this.chat.submit({ message: 'Hello' }); }
 }
 ```
 

--- a/apps/website/content/docs/agent/concepts/agent-architecture.mdx
+++ b/apps/website/content/docs/agent/concepts/agent-architecture.mdx
@@ -186,9 +186,7 @@ export class ReactAgentComponent {
   completedTools = computed(() => this.agent.toolCalls());
 
   send(text: string) {
-    this.agent.submit({
-      messages: [{ role: 'human', content: text }],
-    });
+    this.agent.submit({ message: text });
   }
 }
 ```
@@ -450,9 +448,7 @@ export class MultiAgentComponent {
   completedTools = computed(() => this.orchestrator.toolCalls());
 
   send(text: string) {
-    this.orchestrator.submit({
-      messages: [{ role: 'human', content: text }],
-    });
+    this.orchestrator.submit({ message: text });
   }
 }
 ```

--- a/apps/website/content/docs/agent/concepts/angular-signals.mdx
+++ b/apps/website/content/docs/agent/concepts/angular-signals.mdx
@@ -105,7 +105,7 @@ console.log(chat.isLoading());  // false
 After calling `submit()`, the status transitions to `'loading'`. The SSE connection is open and the agent is processing.
 
 ```typescript
-chat.submit({ messages: [{ role: 'user', content: 'Explain quantum computing' }] });
+chat.submit({ message: 'Explain quantum computing' });
 
 console.log(chat.status());     // 'loading'
 console.log(chat.isLoading());  // true
@@ -361,16 +361,12 @@ export class ChatComponent {
     const content = input.value.trim();
     if (!content) return;
 
-    this.chat.submit({
-      messages: [{ role: 'user', content }],
-    });
+    this.chat.submit({ message: content });
     input.value = '';
   }
 
   retry() {
-    this.chat.submit({
-      messages: [{ role: 'user', content: 'Please try again.' }],
-    });
+    this.chat.submit({ message: 'Please try again.' });
   }
 }
 ```
@@ -502,9 +498,7 @@ export class ChatComponent {
   hasError = computed(() => this.chat.status() === 'error');
 
   sendMessage(content: string) {
-    this.chat.submit({
-      messages: [{ role: 'user', content }],
-    });
+    this.chat.submit({ message: content });
   }
 }
 ```

--- a/apps/website/content/docs/agent/concepts/langgraph-basics.mdx
+++ b/apps/website/content/docs/agent/concepts/langgraph-basics.mdx
@@ -277,7 +277,7 @@ Here's why agent() is the natural Angular companion for LangGraph:
 
 <Steps>
 <Step title="Your Angular App">
-Calls `submit({ messages: [userMsg] })` to send user input
+Calls `submit({ message: text })` to send user input
 </Step>
 <Step title="agent()">
 Passes input to the transport layer

--- a/apps/website/content/docs/agent/concepts/state-management.mdx
+++ b/apps/website/content/docs/agent/concepts/state-management.mdx
@@ -14,7 +14,7 @@ This inversion is intentional. Agent state can span multiple LLM calls, tool exe
 
 <Steps>
 <Step title="User submits input">
-Your Angular component calls `agent.submit({ messages: [userMsg] })`. No state is stored in the component.
+Your Angular component calls `agent.submit({ message: text })`. No state is stored in the component.
 </Step>
 <Step title="agent() sends the request">
 `@ngaf/langgraph` forwards the input to `FetchStreamTransport`, which opens an HTTP POST and SSE connection to LangGraph Platform.
@@ -308,7 +308,7 @@ export class ChatComponent {
   send() {
     const text = this.inputText();
     if (!text.trim()) return;
-    this.agent.submit({ messages: [{ role: 'user', content: text }] });
+    this.agent.submit({ message: text });
     this.inputText.set('');                          // UI state — clear the input
   }
 
@@ -492,9 +492,7 @@ export class ResearchComponent {
   });
 
   startResearch(query: string) {
-    this.agent.submit({
-      messages: [{ role: 'user', content: query }],
-    });
+    this.agent.submit({ message: query });
   }
 }
 ```

--- a/apps/website/content/docs/agent/getting-started/introduction.mdx
+++ b/apps/website/content/docs/agent/getting-started/introduction.mdx
@@ -181,9 +181,7 @@ export class ChatComponent {
   send() {
     const msg = this.input();
     if (!msg.trim()) return;
-    this.chat.submit({
-      messages: [{ role: 'user', content: msg }],
-    });
+    this.chat.submit({ message: msg });
     this.input.set('');
   }
 }

--- a/apps/website/content/docs/agent/getting-started/quickstart.mdx
+++ b/apps/website/content/docs/agent/getting-started/quickstart.mdx
@@ -65,7 +65,7 @@ export class ChatComponent {
   send() {
     const msg = this.input();
     if (!msg.trim()) return;
-    this.chat.submit({ messages: [{ role: 'user', content: msg }] });
+    this.chat.submit({ message: msg });
     this.input.set('');
   }
 }

--- a/apps/website/content/docs/agent/guides/interrupts.mdx
+++ b/apps/website/content/docs/agent/guides/interrupts.mdx
@@ -182,9 +182,7 @@ export class ApprovalComponent {
   });
 
   send(input: string) {
-    this.agent.submit({
-      messages: [{ role: 'user', content: input }],
-    });
+    this.agent.submit({ message: input });
   }
 
   approve() {

--- a/apps/website/content/docs/agent/guides/memory.mdx
+++ b/apps/website/content/docs/agent/guides/memory.mdx
@@ -103,9 +103,7 @@ export class MemoryChatComponent {
   messages = computed(() => this.agent.messages());
 
   send(input: string) {
-    this.agent.submit({
-      messages: [{ role: 'user', content: input }],
-    });
+    this.agent.submit({ message: input });
   }
 }
 ```
@@ -285,9 +283,7 @@ export class LongTermChatComponent {
   messages = computed(() => this.agent.messages());
 
   send(input: string) {
-    this.agent.submit({
-      messages: [{ role: 'user', content: input }],
-    });
+    this.agent.submit({ message: input });
   }
 }
 ```

--- a/apps/website/content/docs/agent/guides/persistence.mdx
+++ b/apps/website/content/docs/agent/guides/persistence.mdx
@@ -128,7 +128,7 @@ export class ChatComponent {
   });
 
   send(text: string) {
-    this.chat.submit({ messages: [{ role: 'user', content: text }] });
+    this.chat.submit({ message: text });
   }
 }
 ```

--- a/apps/website/content/docs/agent/guides/streaming.mdx
+++ b/apps/website/content/docs/agent/guides/streaming.mdx
@@ -75,7 +75,7 @@ export class ChatComponent {
   readonly isStreaming = computed(() => this.chat.status() === 'loading');
 
   send(text: string) {
-    this.chat.submit({ messages: [{ role: 'user', content: text }] });
+    this.chat.submit({ message: text });
   }
 }
 ```

--- a/apps/website/content/docs/agent/guides/subgraphs.mdx
+++ b/apps/website/content/docs/agent/guides/subgraphs.mdx
@@ -92,9 +92,7 @@ export class OrchestratorComponent {
   readonly runningCount = computed(() => this.running().length);
 
   send(text: string) {
-    this.orchestrator.submit({
-      messages: [{ role: 'user', content: text }],
-    });
+    this.orchestrator.submit({ message: text });
   }
 }
 ```

--- a/apps/website/content/docs/agent/guides/testing.mdx
+++ b/apps/website/content/docs/agent/guides/testing.mdx
@@ -94,7 +94,7 @@ export class ChatComponent {
   });
 
   send(text: string) {
-    this.chat.submit({ messages: [{ role: 'user', content: text }] });
+    this.chat.submit({ message: text });
   }
 }
 ```
@@ -120,7 +120,7 @@ TestBed.runInInjectionContext(() => {
     transport,
   });
 
-  chat.submit({ messages: [{ role: 'user', content: 'Explain signals' }] });
+  chat.submit({ message: 'Explain signals' });
 
   // Step through each batch
   transport.nextBatch();
@@ -160,7 +160,7 @@ describe('streaming lifecycle', () => {
       expect(chat.messages()).toEqual([]);
 
       // Submit triggers loading
-      chat.submit({ messages: [{ role: 'user', content: 'Hello' }] });
+      chat.submit({ message: 'Hello' });
       expect(chat.status()).toBe('loading');
       expect(chat.isLoading()).toBe(true);
 
@@ -207,7 +207,7 @@ export class ChatComponent {
   });
 
   send(text: string) {
-    this.chat.submit({ messages: [{ role: 'user', content: text }] });
+    this.chat.submit({ message: text });
   }
 }
 ```
@@ -327,7 +327,7 @@ describe('error handling', () => {
         transport,
       });
 
-      chat.submit({ messages: [{ role: 'user', content: 'Hello' }] });
+      chat.submit({ message: 'Hello' });
 
       // Simulate a connection failure
       transport.emitError(new Error('Connection lost'));
@@ -349,12 +349,12 @@ describe('error handling', () => {
       });
 
       // First attempt fails
-      chat.submit({ messages: [{ role: 'user', content: 'Hello' }] });
+      chat.submit({ message: 'Hello' });
       transport.emitError(new Error('Timeout'));
       expect(chat.status()).toBe('error');
 
       // Retry succeeds
-      chat.submit({ messages: [{ role: 'user', content: 'Hello' }] });
+      chat.submit({ message: 'Hello' });
       transport.emit([
         {
           type: 'values',
@@ -396,7 +396,7 @@ export class ChatComponent {
 
   send(text: string) {
     this.lastMessage = text;
-    this.chat.submit({ messages: [{ role: 'user', content: text }] });
+    this.chat.submit({ message: text });
   }
 
   retry() {

--- a/apps/website/content/docs/agent/guides/time-travel.mdx
+++ b/apps/website/content/docs/agent/guides/time-travel.mdx
@@ -85,7 +85,7 @@ export class HistoryViewerComponent {
     const checkpoint = this.rawCheckpoints()[index]?.checkpoint;
     if (!checkpoint) return;
     this.agent.submit(
-      { messages: [{ role: 'user', content: 'Try a different approach' }] },
+      { message: 'Try a different approach' },
       { checkpoint }
     );
   }
@@ -134,7 +134,7 @@ forkFromCheckpoint(index: number) {
   const checkpoint = this.agent.langGraphHistory()[index]?.checkpoint;
   if (!checkpoint) return;
   this.agent.submit(
-    { messages: [{ role: 'user', content: 'Try a different approach' }] },
+    { message: 'Try a different approach' },
     { checkpoint }
   );
 }
@@ -144,7 +144,7 @@ retryWithAlternative(index: number, newInput: string) {
   const checkpoint = this.agent.langGraphHistory()[index]?.checkpoint;
   if (!checkpoint) return;
   this.agent.submit(
-    { messages: [{ role: 'user', content: newInput }] },
+    { message: newInput },
     { checkpoint }
   );
 }
@@ -197,7 +197,7 @@ export class HistoryViewerComponent {
     const checkpoint = this.rawCheckpoints()[index]?.checkpoint;
     if (!checkpoint) return;
     this.agent.submit(
-      { messages: [{ role: 'user', content: 'Try a different approach' }] },
+      { message: 'Try a different approach' },
       { checkpoint }
     );
   }
@@ -283,7 +283,7 @@ export class ReplayComponent {
     const checkpoint = this.rawHistory()[index]?.checkpoint;
     if (!checkpoint) return;
     this.agent.submit(
-      { messages: [{ role: 'user', content: newMessage }] },
+      { message: newMessage },
       { checkpoint }
     );
   }

--- a/apps/website/content/docs/chat/api/mock-langgraph-agent.mdx
+++ b/apps/website/content/docs/chat/api/mock-langgraph-agent.mdx
@@ -233,6 +233,6 @@ agent.submit = submitSpy;
 
 // After triggering a submit in the component:
 expect(submitSpy).toHaveBeenCalledWith({
-  messages: [{ role: 'human', content: 'Hello' }],
+  message: 'Hello',
 });
 ```

--- a/apps/website/content/docs/chat/components/chat-input.mdx
+++ b/apps/website/content/docs/chat/components/chat-input.mdx
@@ -45,7 +45,7 @@ When the user submits (via Enter key or clicking the send button):
 
 1. The message text is trimmed
 2. If empty after trimming, nothing happens
-3. `ref.submit()` is called with `{ messages: [{ role: 'human', content: trimmed }] }`
+3. `ref.submit()` is called with `{ message: trimmed }`
 4. The `submitted` output emits the trimmed text
 5. The input is cleared
 6. Focus is returned to the textarea
@@ -94,7 +94,7 @@ function submitMessage(
 
 **Returns:** The trimmed message string if submitted, or `null` if the trimmed text was empty.
 
-The function calls `ref.submit({ messages: [{ role: 'human', content: trimmed }] })` under the hood.
+The function calls `ref.submit({ message: trimmed })` under the hood.
 
 ## Styling
 

--- a/apps/website/content/docs/getting-started.mdx
+++ b/apps/website/content/docs/getting-started.mdx
@@ -32,7 +32,7 @@ import { agent } from 'angular';
     @for (msg of chat.messages(); track $index) {
       <p>{{ msg.content }}</p>
     }
-    <button (click)="chat.submit({ messages: [{ role: 'human', content: 'Hello' }] })">
+    <button (click)="chat.submit({ message: 'Hello' })">
       Send
     </button>
   `,

--- a/apps/website/content/prompts/getting-started.md
+++ b/apps/website/content/prompts/getting-started.md
@@ -6,7 +6,7 @@ Install: npm install @ngaf/langgraph@latest
 
 2. Create a ChatComponent that calls agent<{ messages: BaseMessage[] }>({ assistantId: 'chat_agent' }) in the constructor or as a field initializer. agent() MUST be called inside an Angular injection context — constructor or field initializer is correct; ngOnInit is not.
 
-3. The component template should loop over chat.messages() using @for and render each message's content. Add an input field and a button that calls chat.submit({ messages: [{ role: 'human', content: inputValue }] }).
+3. The component template should loop over chat.messages() using @for and render each message's content. Add an input field and a button that calls chat.submit({ message: inputValue }).
 
 4. In app.config.ts provideAgent call, the apiUrl should point to the LangGraph server. For local dev this is http://localhost:2024. For production use the LangGraph Platform URL from environment.ts.
 

--- a/apps/website/public/AGENTS.md
+++ b/apps/website/public/AGENTS.md
@@ -1,9 +1,9 @@
-# Angular Agent Framework v0.0.1
+# Angular Agent Framework v0.1.0
 
-Angular streaming library for LangChain/LangGraph. Provides `agent()` — full parity with React's `useStream()`.
+Angular agent framework for LangChain/LangGraph. Provides `agent()` — Signal-native streaming for Angular agents, built for LangGraph.
 
 ## Install
-npm install angular
+npm install @ngaf/langgraph
 
 ## Key requirement
 `agent()` MUST be called within an Angular injection context (component constructor or field initializer). Calling it in ngOnInit or any async context throws "NG0203: inject() must be called from an injection context".
@@ -11,13 +11,13 @@ npm install angular
 ## Basic usage
 ```typescript
 // app.config.ts
-import { provideAgent } from 'angular';
+import { provideAgent } from '@ngaf/langgraph';
 export const appConfig: ApplicationConfig = {
   providers: [provideAgent({ apiUrl: 'http://localhost:2024' })]
 };
 
 // chat.component.ts
-import { agent } from 'angular';
+import { agent } from '@ngaf/langgraph';
 import type { BaseMessage } from '@langchain/core/messages';
 
 @Component({ template: `
@@ -26,7 +26,7 @@ import type { BaseMessage } from '@langchain/core/messages';
 `})
 export class ChatComponent {
   chat = agent<{ messages: BaseMessage[] }>({ assistantId: 'chat_agent' });
-  send() { this.chat.submit({ messages: [{ role: 'human', content: 'Hello' }] }); }
+  send() { this.chat.submit({ message: 'Hello' }); }
 }
 ```
 
@@ -38,7 +38,7 @@ export class ChatComponent {
 
 ## MCP server (for tool access)
 Add to ~/.claude/settings.json:
-{"mcpServers":{"angular":{"command":"npx","args":["@angular/mcp"]}}}
+{"mcpServers":{"angular-agent":{"command":"npx","args":["@ngaf/langgraph-mcp"]}}}
 
 ## Version check
 If this file is stale, fetch the latest: https://cacheplane.ai/llms-full.txt

--- a/apps/website/public/CLAUDE.md
+++ b/apps/website/public/CLAUDE.md
@@ -1,9 +1,9 @@
-# Angular Agent Framework v0.0.1
+# Angular Agent Framework v0.1.0
 
-Angular streaming library for LangChain/LangGraph. Provides `agent()` — full parity with React's `useStream()`.
+Angular agent framework for LangChain/LangGraph. Provides `agent()` — Signal-native streaming for Angular agents, built for LangGraph.
 
 ## Install
-npm install angular
+npm install @ngaf/langgraph
 
 ## Key requirement
 `agent()` MUST be called within an Angular injection context (component constructor or field initializer). Calling it in ngOnInit or any async context throws "NG0203: inject() must be called from an injection context".
@@ -11,13 +11,13 @@ npm install angular
 ## Basic usage
 ```typescript
 // app.config.ts
-import { provideAgent } from 'angular';
+import { provideAgent } from '@ngaf/langgraph';
 export const appConfig: ApplicationConfig = {
   providers: [provideAgent({ apiUrl: 'http://localhost:2024' })]
 };
 
 // chat.component.ts
-import { agent } from 'angular';
+import { agent } from '@ngaf/langgraph';
 import type { BaseMessage } from '@langchain/core/messages';
 
 @Component({ template: `
@@ -26,7 +26,7 @@ import type { BaseMessage } from '@langchain/core/messages';
 `})
 export class ChatComponent {
   chat = agent<{ messages: BaseMessage[] }>({ assistantId: 'chat_agent' });
-  send() { this.chat.submit({ messages: [{ role: 'human', content: 'Hello' }] }); }
+  send() { this.chat.submit({ message: 'Hello' }); }
 }
 ```
 
@@ -38,7 +38,7 @@ export class ChatComponent {
 
 ## MCP server (for tool access)
 Add to ~/.claude/settings.json:
-{"mcpServers":{"angular":{"command":"npx","args":["@angular/mcp"]}}}
+{"mcpServers":{"angular-agent":{"command":"npx","args":["@ngaf/langgraph-mcp"]}}}
 
 ## Version check
 If this file is stale, fetch the latest: https://cacheplane.ai/llms-full.txt

--- a/apps/website/src/components/docs/ArchFlowDiagram.tsx
+++ b/apps/website/src/components/docs/ArchFlowDiagram.tsx
@@ -9,7 +9,7 @@ interface LogEntry {
 }
 
 const SCENARIO: { delay: number; chatBubble?: { role: 'user' | 'assistant'; text: string; streaming?: boolean }; log: LogEntry }[] = [
-  { delay: 0, chatBubble: { role: 'user', text: 'How do Angular Signals work with streaming?' }, log: { time: '0.00s', source: 'angular', message: 'chat.submit({ messages: [userMsg] })' } },
+  { delay: 0, chatBubble: { role: 'user', text: 'How do Angular Signals work with streaming?' }, log: { time: '0.00s', source: 'angular', message: 'chat.submit({ message: userText })' } },
   { delay: 800, log: { time: '0.02s', source: 'transport', message: 'POST /threads/t_8f3a/runs/stream → 200' } },
   { delay: 1200, log: { time: '0.04s', source: 'langgraph', message: 'Executing node: call_model (gpt-5-mini)' } },
   { delay: 2200, log: { time: '0.82s', source: 'langgraph', message: 'SSE event: { type: "values", messages: [...] }' } },

--- a/apps/website/src/components/landing/CodeBlock.tsx
+++ b/apps/website/src/components/landing/CodeBlock.tsx
@@ -15,7 +15,7 @@ const TEMPLATE_EXAMPLE = `<!-- chat.component.html -->
 @for (msg of chat.messages(); track $index) {
   <p>{{ msg.content }}</p>
 }
-<button (click)="chat.submit({ messages: [input] })">Send</button>`;
+<button (click)="chat.submit({ message: input })">Send</button>`;
 
 export async function CodeBlock() {
   const tsHtml = await codeToHtml(EXAMPLE, {

--- a/apps/website/src/components/landing/DeepAgentsShowcase.tsx
+++ b/apps/website/src/components/landing/DeepAgentsShowcase.tsx
@@ -68,9 +68,7 @@ const agent = agent<MemoryState>({
 // Memory persists across conversations
 // Agent recalls user preferences,
 // past decisions, and project context
-agent.submit({
-  messages: [{ role: 'user', content: query }],
-});`,
+agent.submit({ message: query });`,
     lang: 'typescript' as const,
   },
 ];

--- a/apps/website/src/components/landing/LangGraphShowcase.tsx
+++ b/apps/website/src/components/landing/LangGraphShowcase.tsx
@@ -58,10 +58,10 @@ agent.submit({ resume: { approved: true } });`,
 const history = agent.history();
 
 // Fork from a previous state
-agent.submit({
-  checkpoint: history[2].checkpoint,
-  messages: [{ role: 'user', content: 'Try again' }],
-});`,
+agent.submit(
+  { message: 'Try again' },
+  { checkpoint: history[2].checkpoint },
+);`,
     lang: 'typescript' as const,
   },
 ];

--- a/packages/mcp/src/tools/get-example.ts
+++ b/packages/mcp/src/tools/get-example.ts
@@ -20,7 +20,7 @@ export class ChatComponent {
   chat = agent<{ messages: BaseMessage[] }>({ assistantId: 'chat_agent' });
   send(content: string) {
     if (!content.trim()) return;
-    this.chat.submit({ messages: [{ role: 'human', content }] } as any);
+    this.chat.submit({ message: content });
   }
 }`,
 

--- a/packages/mcp/src/tools/scaffold-chat-component.ts
+++ b/packages/mcp/src/tools/scaffold-chat-component.ts
@@ -65,7 +65,7 @@ export class ${componentName} {${persistenceFields}
     const content = input.value.trim();
     if (!content) return;
     input.value = '';
-    this.chat.submit({ messages: [{ role: 'human', content }] } as any);
+    this.chat.submit({ message: content });
   }
 }`;
 


### PR DESCRIPTION
## Summary

- Replace stale `submit({ messages: [...] })` examples with the public `submit({ message })` API.
- Update time-travel examples to pass checkpoint data as submit options while using `message` for user input.
- Regenerate public agent context (`apps/website/public/AGENTS.md`, `CLAUDE.md`) and update MCP-generated examples.

## Why

The LangGraph runtime accepts runtime-neutral `AgentSubmitInput` (`message`, `state`, `resume`) and converts `message` into LangGraph `messages` internally. Docs and MCP snippets were still teaching callers to pass raw LangGraph `messages`, which no longer matches the public API.

## Validation

- `npm install` to refresh node_modules from the latest main lockfile dependencies
- `npm run generate-agent-context`
- `rg -n "submit\\(\\{\\s*messages|messages: \\[\\{ role: '(user|human)'|chat\\.submit\\(\\{ messages|submit\\(\\{ messages|as any\\)" apps/website/content apps/website/public apps/website/src packages/mcp -g '!**/api-docs.json'` (no matches)
- `npx nx lint website` (0 errors; existing warning remains)
- `npx nx build website`
- `npx nx build mcp && npx nx test mcp`
- `git diff --check`
