### PR TITLE
[codex] Ensure PostHog captures website events

### DIFF
--- a/apps/website/instrumentation-client.ts
+++ b/apps/website/instrumentation-client.ts
@@ -12,5 +12,6 @@ if (shouldCaptureAnalytics({ token, captureLocal, host: browserHost })) {
   posthog.init(token!, {
     api_host: normalizePostHogHost(process.env.NEXT_PUBLIC_POSTHOG_HOST),
     defaults: '2026-01-30',
+    capture_pageview: true,
   });
 }

--- a/apps/website/src/lib/analytics/client.ts
+++ b/apps/website/src/lib/analytics/client.ts
@@ -11,12 +11,15 @@ function currentSourcePage(): string {
 
 export function track(event: AnalyticsEventName, properties: AnalyticsProperties = {}) {
   if (typeof window === 'undefined') return;
-  if (!posthog.__loaded) return;
 
-  posthog.capture(event, {
-    source_page: currentSourcePage(),
-    ...properties,
-  });
+  try {
+    posthog.capture(event, {
+      source_page: currentSourcePage(),
+      ...properties,
+    });
+  } catch (err) {
+    console.error('[posthog] client capture failed:', err);
+  }
 }
 
 export function trackCtaClick(properties: AnalyticsProperties) {


### PR DESCRIPTION
## Summary
- Remove the client analytics dependency on PostHog internal `__loaded` state.
- Explicitly enable PostHog pageview capture during browser initialization.

## Validation
- npx vitest apps/website/src/lib/analytics/properties.spec.ts --run
- npx nx build website
- npx nx e2e website
- git diff --check