### PR TITLE
[codex] Allow anonymous PostHog website analytics

### DIFF
--- a/apps/website/instrumentation-client.ts
+++ b/apps/website/instrumentation-client.ts
@@ -13,5 +13,6 @@ if (shouldCaptureAnalytics({ token, captureLocal, host: browserHost })) {
     api_host: normalizePostHogHost(process.env.NEXT_PUBLIC_POSTHOG_HOST),
     defaults: '2026-01-30',
     capture_pageview: true,
+    person_profiles: 'always',
   });
 }


### PR DESCRIPTION
## Summary
- enable PostHog person profiles for anonymous website analytics capture
- keeps the website tracking config aligned with the project setting requiring identified profiles

## Verification
- npx vitest apps/website/src/lib/analytics/properties.spec.ts --run
- npx nx build website
- NX_DAEMON=false npx nx e2e website
- git diff --check