### PR TITLE
fix(chat): suggestions slot projection via ngProjectAs (0.0.16)

### DIFF
--- a/libs/chat/package.json
+++ b/libs/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/chat",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "exports": {
     ".": {
       "types": "./index.d.ts",

--- a/libs/chat/src/lib/compositions/chat/chat.component.ts
+++ b/libs/chat/src/lib/compositions/chat/chat.component.ts
@@ -96,6 +96,9 @@ import type { ChatRenderEvent } from './chat-render-event';
     @if (showWelcome()) {
       <chat-welcome>
         <chat-input chatWelcomeInput [agent]="agent()" [submitOnEnter]="true" placeholder="Type a message..." />
+        <ng-container ngProjectAs="[chatWelcomeSuggestions]">
+          <ng-content select="[chatWelcomeSuggestions]" />
+        </ng-container>
       </chat-welcome>
     } @else {
     <div class="chat-shell">


### PR DESCRIPTION
## What
Hotfix from live smoke testing 0.0.15. Suggestions projected via `[chatWelcomeSuggestions]` from a consumer's `<chat>` content slot weren't reaching the inner `<chat-welcome>`'s matching slot.

## Root cause
Re-projecting `<ng-content select="[chatWelcomeSuggestions]" />` inside the `<chat-welcome>` instance doesn't preserve the selector for the inner component's slot match — Angular's content projection looks at the projected element's own attributes, not at the wrapping `ng-content`'s select.

## Fix
Wrap the inner `<ng-content>` in `<ng-container ngProjectAs="[chatWelcomeSuggestions]">` so chat-welcome's `<ng-content select="[chatWelcomeSuggestions]" />` sees a matching projection target.

## Live smoke verification (all features)
- ✅ Embedded mode: welcome screen renders beacon, title ("How can I help?"), subtitle ("Ask anything to get started."), input, and 3 vertical suggestion rows
- ✅ Suggestion click → submits message, welcome unmounts, conversation appears
- ✅ Action buttons under assistant: regenerate, copy (with ✓ feedback), thumbs up (active state), thumbs down
- ✅ Theme toggle: light → dark, all tokens flip
- ✅ Popup mode: launcher visible bottom-right, Cmd+K toggles, custom header projected, conversation persists across mode switches
- ✅ Sidebar mode: pushContent works, toggle button works
- ✅ Custom Slots mode: renders existing conversation
- ✅ Stop button: visible mid-stream, halts generation, reverts to send
- ✅ Long output: 4266-char ocean-conservation prose with markdown headings + bullets + bold renders end-to-end

## Versions
- `@ngaf/chat`: 0.0.15 → 0.0.16

## Open follow-up (not in this PR)
The optimistic user message can drop after the user clicks Stop mid-stream. Visible only on certain streams; conversation continues fine but the user pill disappears from history. Worth a separate hunt — orthogonal to welcome-screen work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)