### PR TITLE
chat input pill + chat-select + streaming/markdown fixes (chat 0.0.18, langgraph 0.0.10)

### DIFF
--- a/apps/website/content/docs/chat/components/chat-input.mdx
+++ b/apps/website/content/docs/chat/components/chat-input.mdx
@@ -96,6 +96,18 @@ function submitMessage(
 
 The function calls `ref.submit({ message: trimmed })` under the hood.
 
+## Slots
+
+### `[chatInputModelSelect]`
+
+Projects content into the controls row of the input pill, between `[chatInputTrailing]` and the send button. Designed for `<chat-select>` (a model picker), but accepts any element.
+
+```html
+<chat-input [agent]="agent">
+  <chat-select chatInputModelSelect [options]="opts" [(value)]="selected" />
+</chat-input>
+```
+
 ## Styling
 
 The component renders a `<form>` containing a `<textarea>` and a `<button>`. It uses the following CSS custom properties from the chat theme:

--- a/apps/website/content/docs/chat/components/chat-select.mdx
+++ b/apps/website/content/docs/chat/components/chat-select.mdx
@@ -1,0 +1,122 @@
+# ChatSelectComponent
+
+`ChatSelectComponent` is a generic single-select dropdown. It renders a ghosted, fully rounded trigger and a popover menu. Designed to slot into the chat input pill (via `[chatInputModelSelect]`) for a model picker, but usable anywhere.
+
+**Selector:** `chat-select`
+
+**Import:**
+
+```typescript
+import { ChatSelectComponent, type ChatSelectOption } from '@ngaf/chat';
+```
+
+## Basic Usage
+
+Project into the chat input pill so the select appears between the trailing slot and the send button:
+
+```html
+<chat [agent]="agent">
+  <chat-select
+    chatInputModelSelect
+    [options]="models()"
+    [(value)]="selectedModel"
+    placeholder="Choose a model"
+  />
+</chat>
+```
+
+Standalone usage (anywhere):
+
+```html
+<chat-select
+  [options]="opts"
+  [(value)]="selected"
+  placeholder="Pick one"
+/>
+```
+
+## API
+
+### Inputs
+
+| Input         | Type                                 | Default      | Description |
+|---------------|--------------------------------------|--------------|-------------|
+| `options`     | `readonly ChatSelectOption[]`        | **Required** | Items to display in the menu. |
+| `value`       | `string` (two-way, `model()`)        | `''`         | The currently selected option's `value`. |
+| `placeholder` | `string`                             | `'Select'`   | Label rendered in the trigger when no option matches `value`. |
+| `disabled`    | `boolean`                            | `false`      | Disables the trigger. |
+| `menuLabel`   | `string \| undefined`                | placeholder  | aria-label for the popover. |
+
+### `ChatSelectOption`
+
+```typescript
+interface ChatSelectOption {
+  value: string;
+  label: string;
+  disabled?: boolean;
+}
+```
+
+### Two-way binding
+
+Use `[(value)]` to bind a writable signal:
+
+```html
+<chat-select [options]="opts" [(value)]="selected" />
+```
+
+Or bind one-way + listen for changes:
+
+```html
+<chat-select
+  [options]="opts"
+  [value]="selected()"
+  (valueChange)="selected.set($event)"
+/>
+```
+
+## Behavior
+
+### Open / Close
+
+- **Open**: click the trigger, or press `Enter`/`Space`/`↓` while it has focus.
+- **Close**: click an option, click outside, or press `Esc`.
+
+### Keyboard
+
+| Key            | Behavior                                        |
+|----------------|-------------------------------------------------|
+| `Enter`/`Space`/`↓` on trigger | Opens the menu, focuses first option |
+| `↑` / `↓` in menu              | Moves focus to prev/next non-disabled option |
+| `Enter` / `Space` on option    | Selects, closes, returns focus to trigger |
+| `Esc`                          | Closes, returns focus to trigger     |
+
+### Disabled options
+
+A `ChatSelectOption` with `disabled: true` is rendered, skipped during keyboard navigation, and not selectable by click.
+
+### Menu position
+
+The menu opens UP (anchored above the trigger) so it lands above the chat input when the select sits inside the input pill. For standalone usage at the top of a page the menu may overflow the viewport upward — wrap in a positioned container if needed.
+
+## Theming
+
+Inherits from chat tokens. Override on `:host` or any ancestor:
+
+```css
+chat-select {
+  --ngaf-chat-text-muted: hsl(0 0% 50%);
+  --ngaf-chat-surface-alt: hsl(0 0% 96%);
+  --ngaf-chat-shadow-lg: 0 8px 24px rgba(0,0,0,.12);
+}
+```
+
+## Public API
+
+```typescript
+import { ChatSelectComponent, type ChatSelectOption } from '@ngaf/chat';
+```
+
+## See also
+
+- `ChatInputComponent` — the chat input pill that hosts the `[chatInputModelSelect]` slot.

--- a/cockpit/chat/generative-ui/python/src/graph.py
+++ b/cockpit/chat/generative-ui/python/src/graph.py
@@ -19,7 +19,7 @@ from src.dashboard_tools import ALL_TOOLS
 
 _PROMPT = (Path(__file__).parent.parent / "prompts" / "dashboard.md").read_text()
 
-_llm = ChatOpenAI(model="gpt-4o-mini", temperature=0, streaming=True)
+_llm = ChatOpenAI(model="gpt-5-mini", temperature=0, streaming=True)
 _llm_with_tools = _llm.bind_tools(ALL_TOOLS)
 
 

--- a/cockpit/deep-agents/filesystem/python/docs/guide.md
+++ b/cockpit/deep-agents/filesystem/python/docs/guide.md
@@ -139,7 +139,7 @@ def write_file(path: str, content: str) -> str:
     return f"Successfully wrote {len(content)} bytes to {path}"
 
 # Bind tools to the LLM
-llm = ChatOpenAI(model="gpt-4o-mini").bind_tools([read_file, write_file])
+llm = ChatOpenAI(model="gpt-5-mini").bind_tools([read_file, write_file])
 ```
 
 The agent node invokes the LLM, which may emit tool calls. A conditional edge routes to the `ToolNode` when tool calls are present, then loops back to the agent. The frontend sees each tool call in `stream.messages()`.

--- a/cockpit/deep-agents/filesystem/python/src/graph.py
+++ b/cockpit/deep-agents/filesystem/python/src/graph.py
@@ -35,7 +35,7 @@ class FilesystemState(TypedDict):
 
 def build_filesystem_graph():
     tools = [read_file, write_file]
-    llm = ChatOpenAI(model="gpt-4o-mini", streaming=True).bind_tools(tools)
+    llm = ChatOpenAI(model="gpt-5-mini", streaming=True).bind_tools(tools)
 
     async def agent(state: FilesystemState) -> dict:
         """Run the agent — may emit tool calls."""

--- a/cockpit/deep-agents/memory/python/src/graph.py
+++ b/cockpit/deep-agents/memory/python/src/graph.py
@@ -24,7 +24,7 @@ class MemoryState(TypedDict):
 
 
 def build_memory_graph():
-    llm = ChatOpenAI(model="gpt-4o-mini", streaming=True)
+    llm = ChatOpenAI(model="gpt-5-mini", streaming=True)
 
     async def generate(state: MemoryState) -> dict:
         """Generate a response using remembered facts in the system prompt."""

--- a/cockpit/deep-agents/planning/python/src/graph.py
+++ b/cockpit/deep-agents/planning/python/src/graph.py
@@ -27,7 +27,7 @@ class PlanningState(TypedDict):
 
 
 def build_planning_graph():
-    llm = ChatOpenAI(model="gpt-4o-mini", streaming=True)
+    llm = ChatOpenAI(model="gpt-5-mini", streaming=True)
 
     async def create_plan(state: PlanningState) -> dict:
         """Decompose the task into ordered steps."""

--- a/cockpit/deep-agents/sandboxes/python/docs/guide.md
+++ b/cockpit/deep-agents/sandboxes/python/docs/guide.md
@@ -153,7 +153,7 @@ def run_code(code: str) -> str:
         "exit_status": 0,
     })
 
-llm = ChatOpenAI(model="gpt-4o-mini").bind_tools([run_code])
+llm = ChatOpenAI(model="gpt-5-mini").bind_tools([run_code])
 tool_node = ToolNode([run_code])
 ```
 

--- a/cockpit/deep-agents/sandboxes/python/src/graph.py
+++ b/cockpit/deep-agents/sandboxes/python/src/graph.py
@@ -71,7 +71,7 @@ def run_code(code: str) -> str:
 
 def build_sandboxes_graph():
     tools = [run_code]
-    llm = ChatOpenAI(model="gpt-4o-mini", streaming=True).bind_tools(tools)
+    llm = ChatOpenAI(model="gpt-5-mini", streaming=True).bind_tools(tools)
     tool_node = ToolNode(tools)
 
     async def agent(state: SandboxesState) -> dict:

--- a/cockpit/deep-agents/skills/python/docs/guide.md
+++ b/cockpit/deep-agents/skills/python/docs/guide.md
@@ -150,7 +150,7 @@ def summarize(text: str) -> str:
     return sentences[0] + "." if sentences else "No content."
 
 # Bind all tools to the LLM
-llm = ChatOpenAI(model="gpt-4o-mini").bind_tools([calculator, word_count, summarize])
+llm = ChatOpenAI(model="gpt-5-mini").bind_tools([calculator, word_count, summarize])
 ```
 
 The agent selects which skill to call based on the user's request. `ToolNode` dispatches the call and returns the result as a `ToolMessage`.

--- a/cockpit/deep-agents/skills/python/src/graph.py
+++ b/cockpit/deep-agents/skills/python/src/graph.py
@@ -65,7 +65,7 @@ def summarize(text: str) -> str:
 
 def build_skills_graph():
     tools = [calculator, word_count, summarize]
-    llm = ChatOpenAI(model="gpt-4o-mini", streaming=True).bind_tools(tools)
+    llm = ChatOpenAI(model="gpt-5-mini", streaming=True).bind_tools(tools)
     tool_node = ToolNode(tools)
 
     async def agent(state: SkillsState) -> dict:

--- a/cockpit/deep-agents/subagents/python/src/graph.py
+++ b/cockpit/deep-agents/subagents/python/src/graph.py
@@ -23,12 +23,12 @@ class SubagentsState(TypedDict):
 
 
 def build_subagents_graph():
-    llm = ChatOpenAI(model="gpt-4o-mini", streaming=True)
+    llm = ChatOpenAI(model="gpt-5-mini", streaming=True)
 
     @tool
     async def research_agent(topic: str) -> str:
         """Spawn a research subagent to gather information on a topic."""
-        research_llm = ChatOpenAI(model="gpt-4o-mini", streaming=True)
+        research_llm = ChatOpenAI(model="gpt-5-mini", streaming=True)
         response = await research_llm.ainvoke([
             SystemMessage(content="You are a research specialist. Provide concise, factual information."),
             {"role": "human", "content": f"Research this topic and provide key facts: {topic}"},
@@ -38,7 +38,7 @@ def build_subagents_graph():
     @tool
     async def analysis_agent(content: str) -> str:
         """Spawn an analysis subagent to analyze and synthesize information."""
-        analysis_llm = ChatOpenAI(model="gpt-4o-mini", streaming=True)
+        analysis_llm = ChatOpenAI(model="gpt-5-mini", streaming=True)
         response = await analysis_llm.ainvoke([
             SystemMessage(content="You are an analysis specialist. Identify patterns, draw insights, and synthesize information clearly."),
             {"role": "human", "content": f"Analyze this content and provide key insights: {content}"},
@@ -48,7 +48,7 @@ def build_subagents_graph():
     @tool
     async def summary_agent(findings: str) -> str:
         """Spawn a summary subagent to produce a final coherent response."""
-        summary_llm = ChatOpenAI(model="gpt-4o-mini", streaming=True)
+        summary_llm = ChatOpenAI(model="gpt-5-mini", streaming=True)
         response = await summary_llm.ainvoke([
             SystemMessage(content="You are a summarization specialist. Produce clear, well-structured summaries."),
             {"role": "human", "content": f"Summarize these findings into a concise final answer: {findings}"},

--- a/cockpit/langgraph/deployment-runtime/python/src/graph.py
+++ b/cockpit/langgraph/deployment-runtime/python/src/graph.py
@@ -28,7 +28,7 @@ def build_deployment_runtime_graph():
     LangGraph Cloud. The assistantId in the Angular component must match
     the graph key in langgraph.json.
     """
-    llm = ChatOpenAI(model="gpt-4o-mini", streaming=True)
+    llm = ChatOpenAI(model="gpt-5-mini", streaming=True)
 
     async def generate(state: MessagesState) -> dict:
         """Generate a response using the full message history."""

--- a/cockpit/langgraph/durable-execution/python/docs/guide.md
+++ b/cockpit/langgraph/durable-execution/python/docs/guide.md
@@ -124,7 +124,7 @@ class DurableState(TypedDict):
 checkpointer = MemorySaver()
 
 def build_durable_execution_graph():
-    llm = ChatOpenAI(model="gpt-4o-mini", streaming=True)
+    llm = ChatOpenAI(model="gpt-5-mini", streaming=True)
 
     async def analyze(state): ...   # Node 1
     async def plan(state):   ...   # Node 2

--- a/cockpit/langgraph/durable-execution/python/src/graph.py
+++ b/cockpit/langgraph/durable-execution/python/src/graph.py
@@ -32,7 +32,7 @@ def build_durable_execution_graph():
     and checkpoints state after each one. This means any node failure
     only requires replaying from the previous checkpoint, not the start.
     """
-    llm = ChatOpenAI(model="gpt-4o-mini", streaming=True)
+    llm = ChatOpenAI(model="gpt-5-mini", streaming=True)
     system_prompt = (PROMPTS_DIR / "durable-execution.md").read_text()
 
     async def analyze(state: DurableState) -> dict:

--- a/cockpit/langgraph/interrupts/python/docs/guide.md
+++ b/cockpit/langgraph/interrupts/python/docs/guide.md
@@ -111,7 +111,7 @@ from langgraph.types import interrupt
 checkpointer = MemorySaver()
 
 def build_interrupts_graph():
-    llm = ChatOpenAI(model="gpt-4o-mini", streaming=True)
+    llm = ChatOpenAI(model="gpt-5-mini", streaming=True)
 
     async def generate(state: MessagesState) -> dict:
         response = await llm.ainvoke(state["messages"])

--- a/cockpit/langgraph/memory/python/docs/guide.md
+++ b/cockpit/langgraph/memory/python/docs/guide.md
@@ -119,7 +119,7 @@ class MemoryState(TypedDict):
 checkpointer = MemorySaver()
 
 def build_memory_graph():
-    llm = ChatOpenAI(model="gpt-4o-mini", streaming=True)
+    llm = ChatOpenAI(model="gpt-5-mini", streaming=True)
 
     async def generate(state: MemoryState) -> dict:
         memory = state.get("memory", {})

--- a/cockpit/langgraph/memory/python/src/graph.py
+++ b/cockpit/langgraph/memory/python/src/graph.py
@@ -37,8 +37,8 @@ def build_memory_graph():
     This ensures every response is followed by a memory extraction pass,
     keeping the agent's knowledge up to date without blocking the reply.
     """
-    llm = ChatOpenAI(model="gpt-4o-mini", streaming=True)
-    extractor_llm = ChatOpenAI(model="gpt-4o-mini", streaming=False)
+    llm = ChatOpenAI(model="gpt-5-mini", streaming=True)
+    extractor_llm = ChatOpenAI(model="gpt-5-mini", streaming=False)
 
     async def generate(state: MemoryState) -> dict:
         """Generate a response using current messages and known memory."""

--- a/cockpit/langgraph/persistence/python/docs/guide.md
+++ b/cockpit/langgraph/persistence/python/docs/guide.md
@@ -121,7 +121,7 @@ from langgraph.checkpoint.memory import MemorySaver
 checkpointer = MemorySaver()
 
 def build_persistence_graph():
-    llm = ChatOpenAI(model="gpt-4o-mini", streaming=True)
+    llm = ChatOpenAI(model="gpt-5-mini", streaming=True)
 
     async def generate(state: MessagesState) -> dict:
         response = await llm.ainvoke(state["messages"])

--- a/cockpit/langgraph/streaming/python/docs/guide.md
+++ b/cockpit/langgraph/streaming/python/docs/guide.md
@@ -95,7 +95,7 @@ from langgraph.graph import StateGraph, END
 from langchain_openai import ChatOpenAI
 
 def build_streaming_graph():
-    llm = ChatOpenAI(model="gpt-4o-mini", streaming=True)
+    llm = ChatOpenAI(model="gpt-5-mini", streaming=True)
 
     async def generate(state):
         response = await llm.ainvoke(state["messages"])

--- a/cockpit/langgraph/streaming/python/src/dashboard_graph.py
+++ b/cockpit/langgraph/streaming/python/src/dashboard_graph.py
@@ -19,7 +19,7 @@ from src.dashboard_tools import ALL_TOOLS
 
 _PROMPT = (Path(__file__).parent.parent / "prompts" / "dashboard.md").read_text()
 
-_llm = ChatOpenAI(model="gpt-4o-mini", temperature=0, streaming=True)
+_llm = ChatOpenAI(model="gpt-5-mini", temperature=0, streaming=True)
 _llm_with_tools = _llm.bind_tools(ALL_TOOLS)
 
 

--- a/cockpit/langgraph/subgraphs/python/docs/guide.md
+++ b/cockpit/langgraph/subgraphs/python/docs/guide.md
@@ -89,7 +89,7 @@ The backend uses a parent orchestrator that delegates to a compiled child subgra
 from langgraph.graph import StateGraph, MessagesState, END
 from langchain_openai import ChatOpenAI
 
-llm = ChatOpenAI(model="gpt-4o-mini", streaming=True)
+llm = ChatOpenAI(model="gpt-5-mini", streaming=True)
 
 # Child: research subgraph
 async def research_node(state: MessagesState) -> dict:

--- a/cockpit/langgraph/subgraphs/python/src/graph.py
+++ b/cockpit/langgraph/subgraphs/python/src/graph.py
@@ -22,7 +22,7 @@ def build_subgraphs_graph():
     The parent orchestrator decides when to delegate to the research subgraph.
     The research subgraph runs independently and returns its results to the parent.
     """
-    llm = ChatOpenAI(model="gpt-4o-mini", streaming=True)
+    llm = ChatOpenAI(model="gpt-5-mini", streaming=True)
 
     # ── Child: research subgraph ──────────────────────────────────────────────
 

--- a/cockpit/langgraph/time-travel/python/docs/guide.md
+++ b/cockpit/langgraph/time-travel/python/docs/guide.md
@@ -112,7 +112,7 @@ from langgraph.checkpoint.memory import MemorySaver
 checkpointer = MemorySaver()
 
 def build_time_travel_graph():
-    llm = ChatOpenAI(model="gpt-4o-mini", streaming=True)
+    llm = ChatOpenAI(model="gpt-5-mini", streaming=True)
 
     async def generate(state: MessagesState) -> dict:
         response = await llm.ainvoke(state["messages"])

--- a/cockpit/langgraph/time-travel/python/src/graph.py
+++ b/cockpit/langgraph/time-travel/python/src/graph.py
@@ -25,7 +25,7 @@ def build_time_travel_graph():
     producing a history of ThreadState objects that the client can replay or
     branch from using checkpoint IDs.
     """
-    llm = ChatOpenAI(model="gpt-4o-mini", streaming=True)
+    llm = ChatOpenAI(model="gpt-5-mini", streaming=True)
 
     async def generate(state: MessagesState) -> dict:
         """Generate a response, checkpointed for time travel."""

--- a/docs/superpowers/plans/2026-03-19-langsmith-deployment.md
+++ b/docs/superpowers/plans/2026-03-19-langsmith-deployment.md
@@ -20,7 +20,7 @@ Website (Vercel)
        └─ NEXT_PUBLIC_LANGGRAPH_URL
             └─ LangGraph Cloud (LangSmith)
                  └─ chat_agent graph (Python)
-                      └─ ChatOpenAI (gpt-4o-mini)
+                      └─ ChatOpenAI (gpt-5-mini)
 ```
 
 ---
@@ -141,7 +141,7 @@ From the LangSmith dashboard → Deployments → your deployment → Environment
 | Variable | Value |
 |---|---|
 | `OPENAI_API_KEY` | Your OpenAI key |
-| `OPENAI_MODEL` | `gpt-4o-mini` (default) or preferred model |
+| `OPENAI_MODEL` | `gpt-5-mini` (default) or preferred model |
 | `LANGSMITH_TRACING` | `true` (optional, for production tracing) |
 | `LANGSMITH_PROJECT` | `angular-example` |
 

--- a/docs/superpowers/plans/2026-04-03-cockpit-example-harness.md
+++ b/docs/superpowers/plans/2026-04-03-cockpit-example-harness.md
@@ -1077,7 +1077,7 @@ def build_streaming_graph() -> StateGraph:
     Returns:
         A compiled StateGraph ready for invocation
     """
-    llm = ChatOpenAI(model="gpt-4o-mini", streaming=True)
+    llm = ChatOpenAI(model="gpt-5-mini", streaming=True)
 
     async def generate(state: StreamingState) -> dict:
         """

--- a/docs/superpowers/plans/2026-04-03-docs-mode-redesign.md
+++ b/docs/superpowers/plans/2026-04-03-docs-mode-redesign.md
@@ -779,7 +779,7 @@ from langgraph.graph import StateGraph, END
 from langchain_openai import ChatOpenAI
 
 def build_streaming_graph():
-    llm = ChatOpenAI(model="gpt-4o-mini", streaming=True)
+    llm = ChatOpenAI(model="gpt-5-mini", streaming=True)
 
     async def generate(state):
         response = await llm.ainvoke(state["messages"])

--- a/docs/superpowers/plans/2026-04-03-narrative-docs.md
+++ b/docs/superpowers/plans/2026-04-03-narrative-docs.md
@@ -514,7 +514,7 @@ from langgraph.graph import StateGraph, END
 from langchain_openai import ChatOpenAI
 
 def build_streaming_graph():
-    llm = ChatOpenAI(model="gpt-4o-mini", streaming=True)
+    llm = ChatOpenAI(model="gpt-5-mini", streaming=True)
 
     async def generate(state):
         response = await llm.ainvoke(state["messages"])

--- a/docs/superpowers/plans/2026-04-08-generative-ui-spike.md
+++ b/docs/superpowers/plans/2026-04-08-generative-ui-spike.md
@@ -176,7 +176,7 @@ PROMPTS_DIR = Path(__file__).parent.parent / "prompts"
 
 
 def build_generative_ui_graph():
-    llm = ChatOpenAI(model="gpt-4o-mini", streaming=True)
+    llm = ChatOpenAI(model="gpt-5-mini", streaming=True)
 
     async def generate(state: MessagesState) -> dict:
         system_prompt = (PROMPTS_DIR / "generative-ui.md").read_text()

--- a/docs/superpowers/specs/2026-03-18-chat-agent-design.md
+++ b/docs/superpowers/specs/2026-03-18-chat-agent-design.md
@@ -121,7 +121,7 @@ const chat = agent<{ messages: BaseMessage[] }>({
 | Variable | Required | Description |
 |---|---|---|
 | `OPENAI_API_KEY` | Yes | OpenAI API key |
-| `OPENAI_MODEL` | No | Model name (default: `gpt-5-mini`). Change to `gpt-4o-mini` if `gpt-5-mini` is unavailable in your account |
+| `OPENAI_MODEL` | No | Model name (default: `gpt-5-mini`). |
 | `LANGSMITH_API_KEY` | Deploy only | Required for `langgraph deploy`. Not needed for local `langgraph dev` |
 | `LANGSMITH_TRACING` | No | Set to `true` to enable LangSmith trace logging during local dev |
 | `LANGSMITH_PROJECT` | No | Project name in LangSmith UI (default: `angular-example`) |

--- a/libs/chat/package.json
+++ b/libs/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/chat",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "exports": {
     ".": {
       "types": "./index.d.ts",

--- a/libs/chat/package.json
+++ b/libs/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/chat",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "exports": {
     ".": {
       "types": "./index.d.ts",

--- a/libs/chat/src/lib/compositions/chat/chat.component.spec.ts
+++ b/libs/chat/src/lib/compositions/chat/chat.component.spec.ts
@@ -206,6 +206,65 @@ describe('ChatComponent welcome branch', () => {
   });
 });
 
+describe('ChatComponent — left-flash regression', () => {
+  // Regression for: optimistic-user injection coalesced with first AI partial
+  // emission, causing the AI bubble (empty assistant) to paint first. The
+  // langgraph rawMessages bridge now bypasses the throttle on length-growth
+  // emissions so the user message renders in its own frame.
+  //
+  // We verify the two surfaces that together produce the user-visible bubble:
+  // (1) ChatMessageList's `getMessageType` routes role:'user' -> 'human',
+  // (2) ChatMessageComponent with role='user' renders host attr
+  //     data-role="user".
+  // If either regresses, a user message would no longer paint as a user
+  // bubble. Full ChatComponent template-level rendering is not feasible
+  // under vitest JIT (NG0303/NG0950 on transitively-required signal inputs).
+
+  it('routes role:"user" through the human template (data-role=user surface)', async () => {
+    const { getMessageType } = await import(
+      '../../primitives/chat-message-list/chat-message-list.component'
+    );
+    expect(getMessageType({ id: 'u1', role: 'user', content: 'hi' } as never))
+      .toBe('human');
+    expect(getMessageType({ id: 'a1', role: 'assistant', content: '' } as never))
+      .toBe('ai');
+  });
+
+  it('the rendered chat-message has data-role="user" when role input is user', async () => {
+    const { ChatMessageComponent } = await import(
+      '../../primitives/chat-message/chat-message.component'
+    );
+    TestBed.configureTestingModule({});
+    const fixture = TestBed.createComponent(ChatMessageComponent);
+    setSignalInput(fixture.componentInstance.role, 'user');
+    fixture.detectChanges();
+    const host = fixture.nativeElement as HTMLElement;
+    expect(host.getAttribute('data-role')).toBe('user');
+  });
+
+  it('messages signal growing from [] -> [user] surfaces the user message first', () => {
+    // This is the core left-flash invariant: when the messages array grows
+    // from empty to a single user message, that message is what the chat
+    // composition sees as the first message. The langgraph fix ensures this
+    // emission is not coalesced with a subsequent AI-partial emission.
+    const agent = mockAgent({ messages: [] });
+    expect(agent.messages().length).toBe(0);
+
+    agent.messages.set([{ id: 'u1', role: 'user', content: 'hi', extra: {} } as never]);
+    expect(agent.messages().length).toBe(1);
+    expect(agent.messages()[0].role).toBe('user');
+
+    // First AI partial arrives — both messages present, in order.
+    agent.messages.set([
+      { id: 'u1', role: 'user', content: 'hi', extra: {} } as never,
+      { id: 'a1', role: 'assistant', content: '', extra: {} } as never,
+    ]);
+    expect(agent.messages().length).toBe(2);
+    expect(agent.messages()[0].role).toBe('user');
+    expect(agent.messages()[1].role).toBe('assistant');
+  });
+});
+
 describe('ChatComponent — events$ routing', () => {
   // Angular 21 zoneless mode (ZONELESS_ENABLED defaults to true) means
   // ComponentFixture.autoDetect cannot be disabled, making createComponent

--- a/libs/chat/src/lib/compositions/chat/chat.component.ts
+++ b/libs/chat/src/lib/compositions/chat/chat.component.ts
@@ -1,7 +1,7 @@
 // libs/chat/src/lib/compositions/chat/chat.component.ts
 // SPDX-License-Identifier: MIT
 import {
-  Component, ChangeDetectionStrategy, input, output, computed, effect, viewChild, ElementRef,
+  Component, ChangeDetectionStrategy, input, model, output, computed, effect, viewChild, ElementRef,
   DestroyRef, inject,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -26,6 +26,7 @@ import { ChatToolCallsComponent } from '../../primitives/chat-tool-calls/chat-to
 import { ChatSubagentsComponent } from '../../primitives/chat-subagents/chat-subagents.component';
 import { ChatMessageActionsComponent } from '../../primitives/chat-message-actions/chat-message-actions.component';
 import { ChatWelcomeComponent } from '../../primitives/chat-welcome/chat-welcome.component';
+import { ChatSelectComponent, type ChatSelectOption } from '../../primitives/chat-select/chat-select.component';
 import { A2uiSurfaceComponent } from '../../a2ui/surface.component';
 import { createContentClassifier, type ContentClassifier } from '../../streaming/content-classifier';
 import { messageContent } from '../shared/message-utils';
@@ -41,7 +42,7 @@ import type { ChatRenderEvent } from './chat-render-event';
     ChatInputComponent, ChatTypingIndicatorComponent, ChatErrorComponent, ChatInterruptComponent,
     ChatThreadListComponent, ChatGenerativeUiComponent,
     ChatStreamingMdComponent, ChatToolCallsComponent, ChatSubagentsComponent, A2uiSurfaceComponent,
-    ChatMessageActionsComponent, ChatWelcomeComponent,
+    ChatMessageActionsComponent, ChatWelcomeComponent, ChatSelectComponent,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   styles: [CHAT_HOST_TOKENS, `
@@ -98,7 +99,16 @@ import type { ChatRenderEvent } from './chat-render-event';
   template: `
     @if (showWelcome()) {
       <chat-welcome>
-        <chat-input chatWelcomeInput [agent]="agent()" [submitOnEnter]="true" placeholder="Type a message..." />
+        <chat-input chatWelcomeInput [agent]="agent()" [submitOnEnter]="true" placeholder="Type a message...">
+          @if (modelOptions().length > 0) {
+            <chat-select
+              chatInputModelSelect
+              [options]="modelOptions()"
+              [(value)]="selectedModel"
+              [placeholder]="modelPickerPlaceholder()"
+            />
+          }
+        </chat-input>
         <ng-container ngProjectAs="[chatWelcomeSuggestions]">
           <ng-content select="[chatWelcomeSuggestions]" />
         </ng-container>
@@ -182,7 +192,20 @@ import type { ChatRenderEvent } from './chat-render-event';
           <div chatFooter>
             <chat-error [agent]="agent()" />
             <chat-interrupt [agent]="agent()" />
-            <chat-input [agent]="agent()" [submitOnEnter]="true" placeholder="Type a message..." />
+            <chat-input [agent]="agent()" [submitOnEnter]="true" placeholder="Type a message...">
+              @if (modelOptions().length > 0) {
+                <chat-select
+                  chatInputModelSelect
+                  [options]="modelOptions()"
+                  [(value)]="selectedModel"
+                  [placeholder]="modelPickerPlaceholder()"
+                />
+              } @else {
+                <ng-container ngProjectAs="[chatInputModelSelect]">
+                  <ng-content select="[chatInputModelSelect]" />
+                </ng-container>
+              }
+            </chat-input>
           </div>
         </chat-window>
       </div>
@@ -198,6 +221,17 @@ export class ChatComponent {
   readonly threads = input<Thread[]>([]);
   readonly activeThreadId = input<string>('');
   readonly welcomeDisabled = input<boolean>(false);
+
+  /**
+   * High-level model-picker API. When `modelOptions` is non-empty, the chat
+   * composition renders a `<chat-select>` inside the input pill (in BOTH
+   * welcome and conversation modes), wired to the two-way `selectedModel`
+   * model. Consumers who want full control should leave `modelOptions`
+   * empty and project a `<chat-select chatInputModelSelect>` themselves.
+   */
+  readonly modelOptions = input<readonly ChatSelectOption[]>([]);
+  readonly selectedModel = model<string>('');
+  readonly modelPickerPlaceholder = input<string>('Choose a model');
 
   readonly showWelcome = computed(() => {
     if (this.welcomeDisabled()) return false;

--- a/libs/chat/src/lib/compositions/chat/chat.component.ts
+++ b/libs/chat/src/lib/compositions/chat/chat.component.ts
@@ -88,9 +88,12 @@ import type { ChatRenderEvent } from './chat-render-event';
     .chat-empty__sub { margin: 0; font-size: var(--ngaf-chat-font-size-sm); }
     .chat-empty__title { font-size: 1.125rem; font-weight: 500; color: var(--ngaf-chat-text); margin: 0; }
     .chat-empty__sub { margin: 0; font-size: var(--ngaf-chat-font-size-sm); }
-    .chat-scroll { flex: 1; min-height: 0; overflow-y: auto; }
+    .chat-scroll { flex: 1; min-height: 0; overflow-y: auto; padding-top: var(--ngaf-chat-edge-pad); }
     .chat-scroll::-webkit-scrollbar { width: 6px; }
     .chat-scroll::-webkit-scrollbar-thumb { background: var(--ngaf-chat-separator); border-radius: 10px; }
+    [chatFooter] {
+      padding-bottom: var(--ngaf-chat-edge-pad);
+    }
   `],
   template: `
     @if (showWelcome()) {

--- a/libs/chat/src/lib/compositions/shared/message-utils.ts
+++ b/libs/chat/src/lib/compositions/shared/message-utils.ts
@@ -3,10 +3,38 @@ import type { BaseMessage } from '@langchain/core/messages';
 
 /**
  * Extracts a human-readable string from a message's content.
- * Handles string content directly; serializes structured (array) content to JSON.
+ *
+ * `BaseMessage.content` is `string | MessageContentComplex[]`. Reasoning-
+ * capable models (OpenAI gpt-5/o-series, Anthropic) emit complex arrays of
+ * typed blocks: `{type:'text',text}`, `{type:'reasoning',...}`, tool-use
+ * blocks, etc. We render only the visible text portions and skip anything
+ * else. Stringifying the whole array would dump raw JSON like
+ * `[{"type":"text",...}]` into the chat bubble.
  */
 export function messageContent(message: BaseMessage): string {
-  const content = message.content;
+  return extractText(message.content);
+}
+
+function extractText(content: unknown): string {
   if (typeof content === 'string') return content;
-  return JSON.stringify(content);
+  if (!Array.isArray(content)) return '';
+  let out = '';
+  for (const block of content) {
+    if (typeof block === 'string') {
+      out += block;
+      continue;
+    }
+    if (!isRecord(block)) continue;
+    const t = block['type'];
+    if (t === 'text' || t === 'output_text' || t === undefined) {
+      const text = block['text'];
+      if (typeof text === 'string') out += text;
+    }
+    // Skip reasoning, tool_use, image, etc. — not chat-bubble content.
+  }
+  return out;
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
 }

--- a/libs/chat/src/lib/primitives/chat-input/chat-input.component.spec.ts
+++ b/libs/chat/src/lib/primitives/chat-input/chat-input.component.spec.ts
@@ -1,8 +1,26 @@
 // SPDX-License-Identifier: MIT
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { signal, computed } from '@angular/core';
-import { submitMessage } from './chat-input.component';
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { ChatInputComponent, submitMessage } from './chat-input.component';
 import { mockAgent } from '../../testing/mock-agent';
+
+function setSignalInput<T>(sig: unknown, value: T): void {
+  const obj = sig as Record<symbol, unknown>;
+  const signalSymbol = Object.getOwnPropertySymbols(obj).find(
+    (s) => s.description === 'SIGNAL',
+  );
+  if (!signalSymbol) throw new Error('Could not find SIGNAL symbol on input');
+  const node = obj[signalSymbol] as {
+    applyValueToInputSignal?: (n: unknown, v: T) => void;
+    value?: T;
+  };
+  if (typeof node.applyValueToInputSignal === 'function') {
+    node.applyValueToInputSignal(node, value);
+  } else {
+    node.value = value;
+  }
+}
 
 describe('submitMessage()', () => {
   it('calls agent.submit with { message: trimmed text }', async () => {
@@ -72,5 +90,35 @@ describe('ChatInputComponent — isDisabled computed', () => {
     expect(isDisabled()).toBe(false);
     agent$.set(loadingAgent);
     expect(isDisabled()).toBe(true);
+  });
+});
+
+describe('ChatInputComponent', () => {
+  let fixture: ComponentFixture<ChatInputComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    fixture = TestBed.createComponent(ChatInputComponent);
+    setSignalInput(fixture.componentInstance.agent, mockAgent({ isLoading: false }));
+    fixture.detectChanges();
+  });
+
+  it('renders the pill with full border-radius', () => {
+    const pill = (fixture.nativeElement as HTMLElement).querySelector('.chat-input__pill') as HTMLElement;
+    expect(pill).not.toBeNull();
+    const cs = getComputedStyle(pill);
+    expect(cs.borderRadius).toBe('9999px');
+  });
+
+  it('renders the send button as a circle', () => {
+    const btn = (fixture.nativeElement as HTMLElement).querySelector('.chat-input__send') as HTMLElement;
+    expect(btn).not.toBeNull();
+    const cs = getComputedStyle(btn);
+    expect(cs.borderRadius).toBe('50%');
+  });
+
+  it('exposes [chatInputModelSelect] slot inside the controls row', () => {
+    const controls = (fixture.nativeElement as HTMLElement).querySelector('.chat-input__controls');
+    expect(controls).not.toBeNull();
   });
 });

--- a/libs/chat/src/lib/primitives/chat-input/chat-input.component.ts
+++ b/libs/chat/src/lib/primitives/chat-input/chat-input.component.ts
@@ -57,6 +57,7 @@ export function submitMessage(
           aria-label="Type a message"
         ></textarea>
         <div class="chat-input__controls">
+          <ng-content select="[chatInputModelSelect]" />
           <ng-content select="[chatInputTrailing]" />
           @if (isLoading() && canStop()) {
             <button

--- a/libs/chat/src/lib/primitives/chat-message/chat-message.component.ts
+++ b/libs/chat/src/lib/primitives/chat-message/chat-message.component.ts
@@ -20,7 +20,7 @@ export type ChatMessageRole = 'user' | 'assistant' | 'system' | 'tool';
   template: `
     <div [class]="bodyClass()">
       <ng-content />
-      <span class="chat-message__caret" aria-hidden="true">▍</span>
+      <span class="chat-message__caret" aria-hidden="true"></span>
     </div>
     <div class="chat-message__controls">
       <ng-content select="[chatMessageControls]" />

--- a/libs/chat/src/lib/primitives/chat-select/chat-select.component.spec.ts
+++ b/libs/chat/src/lib/primitives/chat-select/chat-select.component.spec.ts
@@ -10,13 +10,24 @@ const OPTS: readonly ChatSelectOption[] = [
   { value: 'c', label: 'Charlie', disabled: true },
 ];
 
+// SIGNAL-symbol writer for input signals (canonical pattern; setInput()
+// silently no-ops with NG0303 under vitest JIT).
 function setSignalInput<T>(fixture: ComponentFixture<unknown>, name: string, value: T): void {
-  try {
-    fixture.componentRef.setInput(name, value);
-  } catch {
-    const inputs = fixture.componentInstance as Record<string, unknown>;
-    const sig = inputs[name] as { set?: (v: T) => void };
-    sig?.set?.(value);
+  const inputs = fixture.componentInstance as Record<string, unknown>;
+  const sig = inputs[name];
+  const obj = sig as Record<symbol, unknown>;
+  const signalSymbol = Object.getOwnPropertySymbols(obj).find(
+    (s) => s.description === 'SIGNAL',
+  );
+  if (!signalSymbol) throw new Error(`Could not find SIGNAL symbol on input "${name}"`);
+  const node = obj[signalSymbol] as {
+    applyValueToInputSignal?: (n: unknown, v: T) => void;
+    value?: T;
+  };
+  if (typeof node.applyValueToInputSignal === 'function') {
+    node.applyValueToInputSignal(node, value);
+  } else {
+    node.value = value;
   }
 }
 

--- a/libs/chat/src/lib/primitives/chat-select/chat-select.component.spec.ts
+++ b/libs/chat/src/lib/primitives/chat-select/chat-select.component.spec.ts
@@ -1,0 +1,95 @@
+// libs/chat/src/lib/primitives/chat-select/chat-select.component.spec.ts
+// SPDX-License-Identifier: MIT
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ChatSelectComponent, type ChatSelectOption } from './chat-select.component';
+
+const OPTS: readonly ChatSelectOption[] = [
+  { value: 'a', label: 'Alpha' },
+  { value: 'b', label: 'Bravo' },
+  { value: 'c', label: 'Charlie', disabled: true },
+];
+
+function setSignalInput<T>(fixture: ComponentFixture<unknown>, name: string, value: T): void {
+  try {
+    fixture.componentRef.setInput(name, value);
+  } catch {
+    const inputs = fixture.componentInstance as Record<string, unknown>;
+    const sig = inputs[name] as { set?: (v: T) => void };
+    sig?.set?.(value);
+  }
+}
+
+describe('ChatSelectComponent', () => {
+  let fixture: ComponentFixture<ChatSelectComponent>;
+  let host: HTMLElement;
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ChatSelectComponent);
+    setSignalInput(fixture, 'options', OPTS);
+    setSignalInput(fixture, 'value', 'a');
+    fixture.detectChanges();
+    host = fixture.nativeElement as HTMLElement;
+  });
+
+  it('renders the selected option label', () => {
+    expect(host.querySelector('.chat-select__label')?.textContent).toContain('Alpha');
+  });
+
+  it('falls back to placeholder when value not in options', () => {
+    setSignalInput(fixture, 'value', '');
+    setSignalInput(fixture, 'placeholder', 'Pick one');
+    fixture.detectChanges();
+    expect(host.querySelector('.chat-select__label')?.textContent).toContain('Pick one');
+  });
+
+  it('opens the menu on trigger click', () => {
+    expect(host.querySelector('.chat-select__menu')).toBeNull();
+    host.querySelector<HTMLButtonElement>('.chat-select__trigger')!.click();
+    fixture.detectChanges();
+    expect(host.querySelector('.chat-select__menu')).not.toBeNull();
+    const opts = host.querySelectorAll('.chat-select__option');
+    expect(opts.length).toBe(3);
+  });
+
+  it('emits valueChange and closes the menu on option click', () => {
+    let emitted: string | undefined;
+    fixture.componentInstance.value.subscribe((v) => { emitted = v; });
+    host.querySelector<HTMLButtonElement>('.chat-select__trigger')!.click();
+    fixture.detectChanges();
+    const bravo = host.querySelectorAll<HTMLButtonElement>('.chat-select__option')[1];
+    bravo.click();
+    fixture.detectChanges();
+    expect(emitted).toBe('b');
+    expect(host.querySelector('.chat-select__menu')).toBeNull();
+  });
+
+  it('does not select a disabled option', () => {
+    let emitted: string | undefined;
+    fixture.componentInstance.value.subscribe((v) => { emitted = v; });
+    host.querySelector<HTMLButtonElement>('.chat-select__trigger')!.click();
+    fixture.detectChanges();
+    const charlie = host.querySelectorAll<HTMLButtonElement>('.chat-select__option')[2];
+    expect(charlie.disabled).toBe(true);
+    charlie.click();
+    fixture.detectChanges();
+    expect(emitted).toBeUndefined();
+  });
+
+  it('closes the menu on Escape', () => {
+    host.querySelector<HTMLButtonElement>('.chat-select__trigger')!.click();
+    fixture.detectChanges();
+    expect(host.querySelector('.chat-select__menu')).not.toBeNull();
+    const evt = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true });
+    host.querySelector<HTMLElement>('.chat-select__menu')!.dispatchEvent(evt);
+    fixture.detectChanges();
+    expect(host.querySelector('.chat-select__menu')).toBeNull();
+  });
+
+  it('disables the trigger when [disabled]=true', () => {
+    setSignalInput(fixture, 'disabled', true);
+    fixture.detectChanges();
+    const btn = host.querySelector<HTMLButtonElement>('.chat-select__trigger')!;
+    expect(btn.disabled).toBe(true);
+  });
+});

--- a/libs/chat/src/lib/primitives/chat-select/chat-select.component.ts
+++ b/libs/chat/src/lib/primitives/chat-select/chat-select.component.ts
@@ -1,0 +1,194 @@
+// libs/chat/src/lib/primitives/chat-select/chat-select.component.ts
+// SPDX-License-Identifier: MIT
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  ElementRef,
+  computed,
+  effect,
+  inject,
+  input,
+  model,
+  signal,
+  DOCUMENT,
+} from '@angular/core';
+import { CHAT_HOST_TOKENS } from '../../styles/chat-tokens';
+import { CHAT_SELECT_STYLES } from '../../styles/chat-select.styles';
+
+export interface ChatSelectOption {
+  value: string;
+  label: string;
+  disabled?: boolean;
+}
+
+/**
+ * Generic single-select dropdown. Designed to slot into the chat input pill
+ * (via [chatInputModelSelect]) but usable anywhere.
+ *
+ * Inputs:
+ *   options      — array of { value, label, disabled? }; required
+ *   value        — currently selected value (two-way via model())
+ *   placeholder  — trigger label when no option matches; default 'Select'
+ *   disabled     — disables the trigger; default false
+ *   menuLabel    — aria-label for the popover; defaults to placeholder
+ */
+@Component({
+  selector: 'chat-select',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  styles: [CHAT_HOST_TOKENS, CHAT_SELECT_STYLES],
+  template: `
+    <button
+      type="button"
+      class="chat-select__trigger"
+      [class.is-open]="open()"
+      [disabled]="disabled()"
+      [attr.aria-haspopup]="'listbox'"
+      [attr.aria-expanded]="open()"
+      (click)="toggle()"
+      (keydown)="onTriggerKeydown($event)"
+    >
+      <span class="chat-select__label">{{ currentLabel() }}</span>
+      <svg class="chat-select__chevron" viewBox="0 0 16 16" aria-hidden="true">
+        <path d="M4 6l4 4 4-4" stroke="currentColor" fill="none" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+      </svg>
+    </button>
+    @if (open()) {
+      <div
+        class="chat-select__menu"
+        role="listbox"
+        [attr.aria-label]="menuLabel() ?? placeholder()"
+        (keydown)="onMenuKeydown($event)"
+      >
+        @for (opt of options(); track opt.value) {
+          <button
+            type="button"
+            class="chat-select__option"
+            [class.is-active]="opt.value === value()"
+            [disabled]="opt.disabled === true"
+            role="option"
+            [attr.aria-selected]="opt.value === value()"
+            (click)="selectOption(opt)"
+          >
+            {{ opt.label }}
+          </button>
+        }
+      </div>
+    }
+  `,
+})
+export class ChatSelectComponent {
+  readonly options = input.required<readonly ChatSelectOption[]>();
+  readonly value = model<string>('');
+  readonly placeholder = input<string>('Select');
+  readonly disabled = input<boolean>(false);
+  readonly menuLabel = input<string | undefined>(undefined);
+
+  protected readonly open = signal(false);
+
+  protected readonly currentLabel = computed(() => {
+    const v = this.value();
+    const match = this.options().find((o) => o.value === v);
+    return match?.label ?? this.placeholder();
+  });
+
+  private readonly hostEl = inject(ElementRef).nativeElement as HTMLElement;
+  private readonly document = inject(DOCUMENT);
+  private readonly destroyRef = inject(DestroyRef);
+
+  constructor() {
+    let onDocClick: ((e: Event) => void) | null = null;
+    effect(() => {
+      const isOpen = this.open();
+      const win = this.document.defaultView;
+      if (!win) return;
+      if (isOpen && !onDocClick) {
+        onDocClick = (e) => {
+          const path = (e as Event & { composedPath?: () => EventTarget[] }).composedPath?.() ?? [];
+          if (!path.includes(this.hostEl as EventTarget)) {
+            this.open.set(false);
+          }
+        };
+        win.addEventListener('mousedown', onDocClick, true);
+      } else if (!isOpen && onDocClick) {
+        win.removeEventListener('mousedown', onDocClick, true);
+        onDocClick = null;
+      }
+    });
+    this.destroyRef.onDestroy(() => {
+      if (onDocClick) {
+        const win = this.document.defaultView;
+        win?.removeEventListener('mousedown', onDocClick, true);
+        onDocClick = null;
+      }
+    });
+  }
+
+  protected toggle(): void {
+    if (this.disabled()) return;
+    this.open.update((v) => !v);
+  }
+
+  protected selectOption(opt: ChatSelectOption): void {
+    if (opt.disabled) return;
+    this.value.set(opt.value);
+    this.open.set(false);
+  }
+
+  protected onTriggerKeydown(e: KeyboardEvent): void {
+    if (this.disabled()) return;
+    if (e.key === 'Enter' || e.key === ' ' || e.key === 'ArrowDown') {
+      e.preventDefault();
+      this.open.set(true);
+      requestAnimationFrame(() => this.focusOption(0));
+    }
+  }
+
+  protected onMenuKeydown(e: KeyboardEvent): void {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      this.open.set(false);
+      this.focusTrigger();
+      return;
+    }
+    if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+      e.preventDefault();
+      this.moveFocus(e.key === 'ArrowDown' ? 1 : -1);
+      return;
+    }
+    if (e.key === 'Enter' || e.key === ' ') {
+      const t = e.target as HTMLElement;
+      if (t.classList.contains('chat-select__option')) {
+        e.preventDefault();
+        (t as HTMLButtonElement).click();
+      }
+    }
+  }
+
+  private focusOption(index: number): void {
+    const opts = this.queryOptions();
+    opts[index]?.focus();
+  }
+
+  private focusTrigger(): void {
+    this.queryTrigger()?.focus();
+  }
+
+  private moveFocus(dir: 1 | -1): void {
+    const opts = this.queryOptions().filter((b) => !b.disabled);
+    if (!opts.length) return;
+    const active = this.document.activeElement as HTMLElement | null;
+    const idx = active ? opts.indexOf(active as HTMLButtonElement) : -1;
+    const next = (idx + dir + opts.length) % opts.length;
+    opts[next]?.focus();
+  }
+
+  private queryOptions(): HTMLButtonElement[] {
+    return Array.from(this.hostEl.querySelectorAll<HTMLButtonElement>('.chat-select__option'));
+  }
+
+  private queryTrigger(): HTMLButtonElement | null {
+    return this.hostEl.querySelector<HTMLButtonElement>('.chat-select__trigger');
+  }
+}

--- a/libs/chat/src/lib/primitives/chat-select/chat-select.component.ts
+++ b/libs/chat/src/lib/primitives/chat-select/chat-select.component.ts
@@ -58,6 +58,7 @@ export interface ChatSelectOption {
       <div
         class="chat-select__menu"
         role="listbox"
+        tabindex="-1"
         [attr.aria-label]="menuLabel() ?? placeholder()"
         (keydown)="onMenuKeydown($event)"
       >

--- a/libs/chat/src/lib/primitives/chat-welcome/chat-welcome.component.spec.ts
+++ b/libs/chat/src/lib/primitives/chat-welcome/chat-welcome.component.spec.ts
@@ -1,32 +1,52 @@
 // SPDX-License-Identifier: MIT
-import { describe, it, expect, beforeEach } from 'vitest';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { describe, it, expect } from 'vitest';
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 import { ChatWelcomeComponent } from './chat-welcome.component';
 
+@Component({
+  standalone: true,
+  imports: [ChatWelcomeComponent],
+  template: `
+    <chat-welcome>
+      <input chatWelcomeInput />
+    </chat-welcome>
+  `,
+})
+class Host {}
+
 describe('ChatWelcomeComponent', () => {
-  let fixture: ComponentFixture<ChatWelcomeComponent>;
-
-  beforeEach(() => {
-    TestBed.configureTestingModule({});
-    fixture = TestBed.createComponent(ChatWelcomeComponent);
-    fixture.detectChanges();
-  });
-
   it('renders default greeting', () => {
-    const el = fixture.nativeElement as HTMLElement;
-    expect(el.querySelector('.chat-welcome__title')?.textContent).toContain('How can I help?');
-    expect(el.querySelector('.chat-welcome__subtitle')?.textContent).toContain('Ask anything');
+    TestBed.configureTestingModule({});
+    const fx = TestBed.createComponent(Host);
+    fx.detectChanges();
+    const win = fx.nativeElement.querySelector('chat-welcome') as HTMLElement;
+    expect(win.querySelector('.chat-welcome__title')?.textContent).toContain('How can I help?');
   });
 
   it('renders the beacon dot', () => {
-    const el = fixture.nativeElement as HTMLElement;
-    expect(el.querySelector('.chat-welcome__beacon')).not.toBeNull();
+    TestBed.configureTestingModule({});
+    const fx = TestBed.createComponent(Host);
+    fx.detectChanges();
+    const win = fx.nativeElement.querySelector('chat-welcome') as HTMLElement;
+    expect(win.querySelector('.chat-welcome__beacon')).not.toBeNull();
   });
 
   it('exposes slots for title, subtitle, input, suggestions', () => {
-    const el = fixture.nativeElement as HTMLElement;
-    expect(el.querySelector('.chat-welcome__inner')).not.toBeNull();
-    expect(el.querySelector('.chat-welcome__input')).not.toBeNull();
-    expect(el.querySelector('.chat-welcome__suggestions')).not.toBeNull();
+    TestBed.configureTestingModule({});
+    const fx = TestBed.createComponent(Host);
+    fx.detectChanges();
+    const win = fx.nativeElement.querySelector('chat-welcome') as HTMLElement;
+    expect(win.querySelector('.chat-welcome__inner')).not.toBeNull();
+    expect(win.querySelector('.chat-welcome__input')).not.toBeNull();
+    expect(win.querySelector('.chat-welcome__suggestions')).not.toBeNull();
+  });
+
+  it('does not render a subtitle slot', () => {
+    TestBed.configureTestingModule({});
+    const fx = TestBed.createComponent(Host);
+    fx.detectChanges();
+    const win = fx.nativeElement.querySelector('chat-welcome') as HTMLElement;
+    expect(win.querySelector('.chat-welcome__subtitle')).toBeNull();
   });
 });

--- a/libs/chat/src/lib/primitives/chat-welcome/chat-welcome.component.ts
+++ b/libs/chat/src/lib/primitives/chat-welcome/chat-welcome.component.ts
@@ -10,13 +10,12 @@ import { CHAT_WELCOME_STYLES } from '../../styles/chat-welcome.styles';
  *
  * Slots:
  *   [chatWelcomeTitle]       — replaces the default <h1> "How can I help?"
- *   [chatWelcomeSubtitle]    — replaces the default <p> "Ask anything to get started."
  *   [chatWelcomeInput]       — projects the chat input into the center column
  *   [chatWelcomeSuggestions] — projects suggestion rows below the input
  *
  * Host CSS variables (override on :host or any ancestor):
  *   --ngaf-chat-welcome-max-width  default 36rem
- *   --ngaf-chat-welcome-gap        default 1.5rem
+ *   --ngaf-chat-welcome-gap        default 1.25rem
  *   --ngaf-chat-welcome-padding    default 24px
  */
 @Component({
@@ -29,9 +28,6 @@ import { CHAT_WELCOME_STYLES } from '../../styles/chat-welcome.styles';
       <span class="chat-welcome__beacon" aria-hidden="true"></span>
       <ng-content select="[chatWelcomeTitle]">
         <h1 class="chat-welcome__title">How can I help?</h1>
-      </ng-content>
-      <ng-content select="[chatWelcomeSubtitle]">
-        <p class="chat-welcome__subtitle">Ask anything to get started.</p>
       </ng-content>
       <div class="chat-welcome__input"><ng-content select="[chatWelcomeInput]" /></div>
       <div class="chat-welcome__suggestions">

--- a/libs/chat/src/lib/streaming/markdown-render.ts
+++ b/libs/chat/src/lib/streaming/markdown-render.ts
@@ -10,7 +10,12 @@ function ensureMarkedLoaded(): void {
   // Eagerly kick off the dynamic import so it's ready for subsequent calls
   void import('marked')
     .then((m) => {
-      markedParse = (src: string) => (m as any).marked.parse(src, { async: false }) as string;
+      // GFM: enables tables, strikethrough, autolinks, task lists.
+      // breaks: single \n becomes <br>. LLM chat output frequently uses
+      // soft line breaks for visual structure where stricter markdown
+      // would treat them as continuation. Matching common chat UX.
+      const opts = { async: false, gfm: true, breaks: true } as const;
+      markedParse = (src: string) => (m as any).marked.parse(src, opts) as string;
     })
     .catch(() => {
       markedParse = null;

--- a/libs/chat/src/lib/streaming/streaming-markdown.component.ts
+++ b/libs/chat/src/lib/streaming/streaming-markdown.component.ts
@@ -5,6 +5,7 @@ import {
   ChangeDetectionStrategy,
   DestroyRef,
   ElementRef,
+  ViewEncapsulation,
   effect,
   inject,
   input,
@@ -13,6 +14,7 @@ import {
 import { DomSanitizer } from '@angular/platform-browser';
 import { renderMarkdownToString } from './markdown-render';
 import { isTraceEnabled, trace } from './trace';
+import { CHAT_MARKDOWN_STYLES } from '../styles/chat-markdown.styles';
 
 /**
  * Renders markdown content via marked.parse + sanitized innerHTML, coalesced
@@ -26,8 +28,16 @@ import { isTraceEnabled, trace } from './trace';
   selector: 'chat-streaming-md',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
+  // Disable emulated view encapsulation. The component sets its content via
+  // `innerHTML` (Angular's sanitized markdown render), so the resulting DOM
+  // nodes never carry the `_ngcontent-xxx` attribute that emulated styles
+  // require to match descendants. Without this, `chat-streaming-md ul` and
+  // friends in CHAT_MARKDOWN_STYLES never apply, and bullets/headings/code
+  // blocks render unstyled. We scope every selector to `chat-streaming-md`
+  // in CHAT_MARKDOWN_STYLES so the rules don't leak globally.
+  encapsulation: ViewEncapsulation.None,
   template: '',
-  styles: `:host { display: block; }`,
+  styles: CHAT_MARKDOWN_STYLES,
 })
 export class ChatStreamingMdComponent {
   readonly content = input.required<string>();

--- a/libs/chat/src/lib/styles/chat-input.styles.ts
+++ b/libs/chat/src/lib/styles/chat-input.styles.ts
@@ -1,78 +1,86 @@
 // libs/chat/src/lib/styles/chat-input.styles.ts
 // SPDX-License-Identifier: MIT
 export const CHAT_INPUT_STYLES = `
-  :host { display: block; background: var(--ngaf-chat-bg); }
-  .chat-input__container { padding: 0 0 15px 0; background: var(--ngaf-chat-bg); }
-  .chat-input__pill {
-    cursor: text;
-    position: relative;
-    background: var(--ngaf-chat-surface-alt);
-    border: 1px solid var(--ngaf-chat-separator);
-    border-radius: var(--ngaf-chat-radius-input);
-    padding: 12px 14px;
-    padding-right: 56px;
-    min-height: 75px;
-    margin: 0 auto;
-    width: 95%;
-    box-sizing: border-box;
-    display: flex;
-    align-items: flex-start;
-    transition: border-color 200ms ease;
-  }
-  .chat-input__pill:focus-within { border-color: var(--ngaf-chat-text-muted); }
-  .chat-input__textarea {
-    flex: 1;
-    outline: 0;
-    border: 0;
-    resize: none;
-    background: transparent;
-    color: var(--ngaf-chat-text);
-    font-family: inherit;
-    font-size: var(--ngaf-chat-font-size-sm);
-    line-height: 1.5rem;
-    width: 100%;
-    margin: 0;
-    padding: 0;
-    field-sizing: content;
-    min-height: 1.5rem;
-    max-height: 9rem;
-    overflow-y: auto;
-  }
-  .chat-input__textarea::placeholder { color: var(--ngaf-chat-text-muted); opacity: 1; }
-  .chat-input__textarea::-webkit-scrollbar { width: 6px; }
-  .chat-input__textarea::-webkit-scrollbar-thumb { background: var(--ngaf-chat-separator); border-radius: 10px; }
-  .chat-input__controls {
-    position: absolute;
-    right: 14px;
-    bottom: 12px;
-    display: flex;
-    gap: 3px;
-  }
-  .chat-input__send {
-    width: 32px;
-    height: 32px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border: 0;
-    background: var(--ngaf-chat-primary);
-    color: var(--ngaf-chat-on-primary);
-    border-radius: 9999px;
-    cursor: pointer;
-    transition: transform 200ms ease, background 200ms ease;
-  }
-  .chat-input__send:hover:not(:disabled) { transform: scale(1.05); }
-  .chat-input__send:disabled {
-    background: var(--ngaf-chat-surface-alt);
-    color: var(--ngaf-chat-muted);
-    cursor: not-allowed;
-    opacity: 0.7;
-  }
-  .chat-input__send--stop {
-    /* Slightly subdued vs the active send so the user doesn't fear the button. */
-    background: var(--ngaf-chat-text);
-    color: var(--ngaf-chat-bg);
-  }
-  .chat-input__send--stop:hover { transform: scale(1.05); }
-  .chat-input__send svg { width: 16px; height: 16px; }
+:host {
+  display: block;
+  width: 100%;
+  padding: 0 var(--ngaf-chat-edge-pad);
+  box-sizing: border-box;
+}
+
+.chat-input__container {
+  width: 100%;
+  max-width: var(--ngaf-chat-max-width);
+  margin: 0 auto;
+}
+
+.chat-input__pill {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--ngaf-chat-surface);
+  border: 1px solid var(--ngaf-chat-separator);
+  border-radius: 9999px;
+  padding: 8px 8px 8px 16px;
+  min-height: 56px;
+  box-sizing: border-box;
+}
+
+.chat-input__textarea {
+  flex: 1 1 auto;
+  border: 0;
+  outline: none;
+  resize: none;
+  background: transparent;
+  color: var(--ngaf-chat-text);
+  font: inherit;
+  font-size: 1rem;
+  line-height: 1.5;
+  max-height: 1.5em;
+  padding: 0;
+  field-sizing: content;
+  overflow-y: auto;
+}
+.chat-input__textarea::placeholder { color: var(--ngaf-chat-text-muted); }
+.chat-input__textarea::-webkit-scrollbar { width: 4px; }
+.chat-input__textarea::-webkit-scrollbar-thumb { background: var(--ngaf-chat-separator); border-radius: 4px; }
+
+.chat-input__controls {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex: none;
+}
+
+.chat-input__send,
+.chat-input__send--stop {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: opacity 150ms ease, transform 150ms ease, background 150ms ease;
+  padding: 0;
+}
+.chat-input__send {
+  background: var(--ngaf-chat-text);
+  color: var(--ngaf-chat-bg);
+}
+.chat-input__send:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+  background: var(--ngaf-chat-text-muted);
+}
+.chat-input__send:not(:disabled):hover { transform: scale(1.05); }
+.chat-input__send svg { width: 16px; height: 16px; }
+
+.chat-input__send--stop {
+  background: var(--ngaf-chat-text-muted);
+  color: var(--ngaf-chat-bg);
+}
+.chat-input__send--stop:hover { transform: scale(1.05); }
+.chat-input__send--stop svg { width: 14px; height: 14px; }
 `;

--- a/libs/chat/src/lib/styles/chat-markdown.styles.ts
+++ b/libs/chat/src/lib/styles/chat-markdown.styles.ts
@@ -1,39 +1,116 @@
 // libs/chat/src/lib/styles/chat-markdown.styles.ts
 // SPDX-License-Identifier: MIT
+//
+// Scoped to the `chat-streaming-md` element selector (not `:host`) because
+// the component renders markdown via innerHTML and uses
+// `ViewEncapsulation.None` — emulated encapsulation would skip these rules
+// since innerHTML-injected nodes don't carry `_ngcontent-xxx` attributes.
+// Keeping selectors prefixed with the element name preserves locality so
+// these rules don't leak to other markup on the page.
+//
+// Covers the CommonMark + GFM surface: headings, paragraphs, links, lists
+// (bullet/ordered/task), code (inline + fenced), blockquotes, horizontal
+// rules, tables, images, bold (`strong`), italic (`em`), strikethrough
+// (`del`/`s`).
 export const CHAT_MARKDOWN_STYLES = `
-  :host { display: block; color: var(--ngaf-chat-text); line-height: var(--ngaf-chat-line-height); }
-  :host h1, :host h2, :host h3, :host h4, :host h5, :host h6 { font-weight: bold; line-height: 1.2; margin: 0 0 1rem; }
-  :host h1 { font-size: 1.5em; }
-  :host h2 { font-size: 1.25em; font-weight: 600; }
-  :host h3 { font-size: 1.1em; }
-  :host h4 { font-size: 1em; }
-  :host p { margin: 0 0 1rem; line-height: 1.75; font-size: var(--ngaf-chat-font-size); }
-  :host p:last-child { margin-bottom: 0; }
-  :host a { color: var(--ngaf-chat-primary); text-decoration: underline; }
-  :host ul, :host ol { margin: 0 0 1rem; padding-left: 1.25rem; }
-  :host code {
+  chat-streaming-md { display: block; color: var(--ngaf-chat-text); line-height: var(--ngaf-chat-line-height); }
+
+  /* Headings */
+  chat-streaming-md h1, chat-streaming-md h2, chat-streaming-md h3, chat-streaming-md h4, chat-streaming-md h5, chat-streaming-md h6 {
+    font-weight: 600;
+    line-height: 1.25;
+    margin: 1.25rem 0 0.75rem;
+  }
+  chat-streaming-md h1:first-child, chat-streaming-md h2:first-child, chat-streaming-md h3:first-child,
+  chat-streaming-md h4:first-child, chat-streaming-md h5:first-child, chat-streaming-md h6:first-child { margin-top: 0; }
+  chat-streaming-md h1 { font-size: 1.5em; font-weight: 700; }
+  chat-streaming-md h2 { font-size: 1.25em; }
+  chat-streaming-md h3 { font-size: 1.1em; }
+  chat-streaming-md h4 { font-size: 1em; }
+  chat-streaming-md h5, chat-streaming-md h6 { font-size: 0.95em; color: var(--ngaf-chat-text-muted); }
+
+  /* Paragraphs and inline emphasis */
+  chat-streaming-md p { margin: 0 0 0.75rem; line-height: 1.6; font-size: var(--ngaf-chat-font-size); }
+  chat-streaming-md p:last-child { margin-bottom: 0; }
+  chat-streaming-md strong, chat-streaming-md b { font-weight: 700; }
+  chat-streaming-md em, chat-streaming-md i { font-style: italic; }
+  chat-streaming-md del, chat-streaming-md s { text-decoration: line-through; color: var(--ngaf-chat-text-muted); }
+  chat-streaming-md mark { background: var(--ngaf-chat-surface-alt); padding: 0 2px; border-radius: 2px; }
+  chat-streaming-md sub { font-size: 0.75em; vertical-align: sub; }
+  chat-streaming-md sup { font-size: 0.75em; vertical-align: super; }
+
+  /* Links */
+  chat-streaming-md a { color: var(--ngaf-chat-primary); text-decoration: underline; text-underline-offset: 2px; }
+  chat-streaming-md a:hover { text-decoration-thickness: 2px; }
+
+  /* Lists (CommonMark + GFM task lists) */
+  chat-streaming-md ul, chat-streaming-md ol { margin: 0 0 0.75rem; padding-left: 1.5rem; }
+  chat-streaming-md ul { list-style: disc outside; }
+  chat-streaming-md ol { list-style: decimal outside; }
+  chat-streaming-md ul ul { list-style: circle outside; }
+  chat-streaming-md ul ul ul { list-style: square outside; }
+  chat-streaming-md li { margin: 0.2rem 0; }
+  chat-streaming-md li::marker { color: var(--ngaf-chat-text-muted); }
+  chat-streaming-md li > p { margin: 0 0 0.25rem; }
+  chat-streaming-md li > ul, chat-streaming-md li > ol { margin: 0.25rem 0 0; }
+  /* GFM task lists: marked emits <li><input type="checkbox" disabled> ... */
+  chat-streaming-md li:has(> input[type="checkbox"]) { list-style: none; margin-left: -1.25rem; }
+  chat-streaming-md li > input[type="checkbox"] { margin-right: 0.5rem; vertical-align: middle; }
+
+  /* Code (inline + fenced) */
+  chat-streaming-md code {
     background: var(--ngaf-chat-surface-alt);
     color: var(--ngaf-chat-text);
-    padding: 1px 4px;
+    padding: 1px 5px;
     border-radius: 4px;
     font-family: var(--ngaf-chat-font-mono);
     font-size: 0.9em;
   }
-  :host pre {
+  chat-streaming-md pre {
     background: var(--ngaf-chat-surface-alt);
     color: var(--ngaf-chat-text);
-    padding: 12px;
+    padding: 12px 14px;
     border-radius: var(--ngaf-chat-radius-card);
     overflow-x: auto;
     font-family: var(--ngaf-chat-font-mono);
     font-size: var(--ngaf-chat-font-size-sm);
-    margin: 0 0 1rem;
+    line-height: 1.5;
+    margin: 0 0 0.75rem;
   }
-  :host pre code { background: transparent; padding: 0; border-radius: 0; }
-  :host blockquote {
+  chat-streaming-md pre code { background: transparent; padding: 0; border-radius: 0; font-size: inherit; }
+
+  /* Blockquote */
+  chat-streaming-md blockquote {
     border-left: 3px solid var(--ngaf-chat-separator);
-    padding-left: 12px;
-    margin: 0 0 1rem;
+    padding: 0.25rem 0 0.25rem 12px;
+    margin: 0 0 0.75rem;
     color: var(--ngaf-chat-text-muted);
   }
+  chat-streaming-md blockquote > :last-child { margin-bottom: 0; }
+
+  /* Horizontal rule */
+  chat-streaming-md hr {
+    border: none;
+    border-top: 1px solid var(--ngaf-chat-separator);
+    margin: 1rem 0;
+  }
+
+  /* Tables (GFM) */
+  chat-streaming-md table {
+    border-collapse: collapse;
+    margin: 0 0 0.75rem;
+    width: 100%;
+    font-size: 0.95em;
+  }
+  chat-streaming-md thead { background: var(--ngaf-chat-surface-alt); }
+  chat-streaming-md th, chat-streaming-md td {
+    border: 1px solid var(--ngaf-chat-separator);
+    padding: 6px 10px;
+    text-align: left;
+    vertical-align: top;
+  }
+  chat-streaming-md th { font-weight: 600; }
+
+  /* Media */
+  chat-streaming-md img { max-width: 100%; height: auto; border-radius: 6px; }
 `;

--- a/libs/chat/src/lib/styles/chat-message.styles.ts
+++ b/libs/chat/src/lib/styles/chat-message.styles.ts
@@ -38,22 +38,23 @@ export const CHAT_MESSAGE_STYLES = `
 
   .chat-message__caret {
     display: none;
-    margin-left: 2px;
-    margin-top: 0.25rem;
-    color: var(--ngaf-chat-text-muted);
-    vertical-align: text-bottom;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    vertical-align: middle;
+    margin-left: 4px;
+    margin-bottom: 2px;
+    background: radial-gradient(circle at 30% 30%,
+      var(--ngaf-chat-text) 0%,
+      var(--ngaf-chat-text-muted) 70%,
+      transparent 100%);
+    box-shadow: 0 0 6px var(--ngaf-chat-text-muted);
+    animation: ngaf-chat-caret-fade-in 200ms ease-out 300ms forwards,
+               ngaf-chat-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) 500ms infinite;
+    opacity: 0;
   }
   :host([data-role="assistant"][data-current="true"][data-streaming="true"]) .chat-message__caret {
     display: inline-block;
-    /* The caret is suppressed for the first 300ms of streaming so quick
-       responses (one-or-two-token "hello"-style replies) never flash the
-       cursor. Past 300ms the smooth pulse takes over (copilotkit-style)
-       — easier on the eyes than a hard blink during long streams.
-       Note: animations restart whenever the element is created/inserted,
-       so this delay re-applies on every new streaming message. */
-    opacity: 0;
-    animation: ngaf-chat-caret-fade-in 200ms ease-out 300ms forwards,
-               ngaf-chat-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) 500ms infinite;
   }
 
   .chat-message__plain { /* system / tool fallback */ }

--- a/libs/chat/src/lib/styles/chat-select.styles.ts
+++ b/libs/chat/src/lib/styles/chat-select.styles.ts
@@ -1,0 +1,80 @@
+// libs/chat/src/lib/styles/chat-select.styles.ts
+// SPDX-License-Identifier: MIT
+export const CHAT_SELECT_STYLES = `
+  :host {
+    display: inline-block;
+    position: relative;
+  }
+  .chat-select__trigger {
+    height: 32px;
+    padding: 0 10px;
+    border: 0;
+    border-radius: 9999px;
+    background: transparent;
+    color: var(--ngaf-chat-text-muted);
+    font: inherit;
+    font-size: var(--ngaf-chat-font-size-sm);
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    cursor: pointer;
+    transition: background 120ms ease, color 120ms ease;
+  }
+  .chat-select__trigger:hover:not(:disabled) {
+    background: var(--ngaf-chat-surface-alt);
+    color: var(--ngaf-chat-text);
+  }
+  .chat-select__trigger:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  .chat-select__chevron {
+    width: 12px;
+    height: 12px;
+    transition: transform 120ms ease;
+    flex: none;
+  }
+  .chat-select__trigger.is-open .chat-select__chevron {
+    transform: rotate(180deg);
+  }
+  .chat-select__menu {
+    position: absolute;
+    bottom: calc(100% + 8px);
+    right: 0;
+    min-width: 180px;
+    max-height: 320px;
+    overflow-y: auto;
+    background: var(--ngaf-chat-surface);
+    border: 1px solid var(--ngaf-chat-separator);
+    border-radius: 12px;
+    box-shadow: var(--ngaf-chat-shadow-lg);
+    padding: 4px;
+    z-index: 10;
+  }
+  .chat-select__option {
+    display: block;
+    width: 100%;
+    text-align: left;
+    border: 0;
+    background: transparent;
+    padding: 8px 10px;
+    border-radius: 8px;
+    color: var(--ngaf-chat-text);
+    font: inherit;
+    font-size: var(--ngaf-chat-font-size-sm);
+    cursor: pointer;
+  }
+  .chat-select__option:hover:not(:disabled),
+  .chat-select__option:focus-visible {
+    background: var(--ngaf-chat-surface-alt);
+    outline: none;
+  }
+  .chat-select__option.is-active {
+    background: var(--ngaf-chat-surface-alt);
+    font-weight: 500;
+  }
+  .chat-select__option:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+`;

--- a/libs/chat/src/lib/styles/chat-tokens.ts
+++ b/libs/chat/src/lib/styles/chat-tokens.ts
@@ -67,6 +67,7 @@ const SPACING_TOKENS = `
   --ngaf-chat-space-5: 20px;
   --ngaf-chat-space-6: 24px;
   --ngaf-chat-space-8: 32px;
+  --ngaf-chat-edge-pad: 16px;
 `;
 
 const KEYFRAMES = `

--- a/libs/chat/src/lib/styles/chat-welcome.styles.ts
+++ b/libs/chat/src/lib/styles/chat-welcome.styles.ts
@@ -50,39 +50,40 @@ export const CHAT_WELCOME_STYLES = `
   .chat-welcome__suggestions {
     width: 100%;
     display: flex;
-    flex-direction: column;
-    align-items: stretch;
-    gap: 0;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 8px;
+    margin-top: 4px;
   }
   .chat-welcome__suggestions:empty { display: none; }
 `;
 
 export const CHAT_WELCOME_SUGGESTION_STYLES = `
-  :host { display: block; width: 100%; }
+  :host { display: inline-block; }
   .chat-welcome-suggestion {
-    width: 100%;
-    display: flex;
+    display: inline-flex;
     align-items: center;
-    gap: 0.75rem;
-    padding: 12px 14px;
-    background: transparent;
-    border: 0;
-    border-bottom: 1px solid var(--ngaf-chat-separator);
+    gap: 0.5rem;
+    padding: 10px 16px;
+    background: var(--ngaf-chat-surface);
+    border: 1px solid var(--ngaf-chat-separator);
+    border-radius: 9999px;
     color: var(--ngaf-chat-text);
     font-family: inherit;
     font-size: var(--ngaf-chat-font-size-sm);
-    text-align: left;
+    text-align: center;
     cursor: pointer;
-    transition: background 150ms ease;
+    transition: background 150ms ease, border-color 150ms ease, transform 120ms ease;
   }
-  .chat-welcome-suggestion:hover { background: var(--ngaf-chat-surface-alt); }
+  .chat-welcome-suggestion:hover {
+    background: var(--ngaf-chat-surface-alt);
+    border-color: var(--ngaf-chat-text-muted);
+  }
+  .chat-welcome-suggestion:active { transform: scale(0.98); }
   .chat-welcome-suggestion:focus-visible {
     outline: 2px solid var(--ngaf-chat-text-muted);
-    outline-offset: -2px;
+    outline-offset: 2px;
   }
-  .chat-welcome-suggestion__label { flex: 1 1 auto; }
-  .chat-welcome-suggestion__chevron {
-    color: var(--ngaf-chat-text-muted);
-    font-size: 1.1em;
-  }
+  .chat-welcome-suggestion__label { white-space: nowrap; }
+  .chat-welcome-suggestion__chevron { display: none; }
 `;

--- a/libs/chat/src/lib/styles/chat-welcome.styles.ts
+++ b/libs/chat/src/lib/styles/chat-welcome.styles.ts
@@ -16,7 +16,7 @@ export const CHAT_WELCOME_STYLES = `
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: var(--ngaf-chat-welcome-gap, 1.5rem);
+    gap: var(--ngaf-chat-welcome-gap, 1.25rem);
     width: 100%;
     max-width: var(--ngaf-chat-welcome-max-width, 36rem);
     text-align: center;
@@ -42,12 +42,6 @@ export const CHAT_WELCOME_STYLES = `
   }
   @media (min-width: 768px) {
     .chat-welcome__title { font-size: 1.5rem; }
-  }
-  .chat-welcome__subtitle {
-    margin: 0;
-    font-size: var(--ngaf-chat-font-size-sm);
-    color: var(--ngaf-chat-text-muted);
-    line-height: 1.5;
   }
   .chat-welcome__input {
     width: 100%;

--- a/libs/chat/src/public-api.ts
+++ b/libs/chat/src/public-api.ts
@@ -54,6 +54,8 @@ export { ChatTimelineComponent } from './lib/primitives/chat-timeline/chat-timel
 export { ChatGenerativeUiComponent } from './lib/primitives/chat-generative-ui/chat-generative-ui.component';
 export { ChatWelcomeComponent } from './lib/primitives/chat-welcome/chat-welcome.component';
 export { ChatWelcomeSuggestionComponent } from './lib/primitives/chat-welcome/chat-welcome-suggestion.component';
+export { ChatSelectComponent } from './lib/primitives/chat-select/chat-select.component';
+export type { ChatSelectOption } from './lib/primitives/chat-select/chat-select.component';
 
 // DI provider
 export { provideChat, CHAT_CONFIG } from './lib/provide-chat';

--- a/libs/langgraph/package.json
+++ b/libs/langgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/langgraph",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "peerDependencies": {
     "@ngaf/chat": "*",
     "@ngaf/licensing": "*",

--- a/libs/langgraph/src/lib/agent.fn.ts
+++ b/libs/langgraph/src/lib/agent.fn.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 import {
   inject, DestroyRef, computed, effect,
-  isSignal, Signal,
+  isSignal, Signal, signal,
 } from '@angular/core';
 import { AGENT_CONFIG } from './agent.provider';
 import { toSignal, toObservable } from '@angular/core/rxjs-interop';
@@ -162,7 +162,49 @@ export function agent<
 
   // Convert to Angular Signals (must happen in injection context)
   const value        = toSignal(maybeThrottle(values$),   { initialValue: init });
-  const rawMessages  = toSignal(maybeThrottle(messages$), { initialValue: [] as BaseMessage[] });
+  // rawMessages is hand-rolled instead of `toSignal(maybeThrottle(messages$))`
+  // to avoid the leading/trailing throttle collapsing the optimistic-user
+  // injection into the same emission as the first AI partial. We bypass the
+  // throttle whenever the messages array grows in length (new message added)
+  // so user-visible message additions render in their own frame. Same-length
+  // updates (token-by-token AI streaming) still get throttled to ~60fps.
+  const rawMessagesSig = signal<BaseMessage[]>([]);
+  {
+    let lastLen = 0;
+    let throttleHandle: ReturnType<typeof setTimeout> | null = null;
+    let pending: BaseMessage[] | null = null;
+    const flushPending = () => {
+      throttleHandle = null;
+      if (pending) {
+        rawMessagesSig.set(pending);
+        pending = null;
+      }
+    };
+    messages$
+      .pipe(takeUntil(destroy$))
+      .subscribe((m) => {
+        if (m.length !== lastLen) {
+          // Length changed (add or remove): emit synchronously, cancel pending.
+          lastLen = m.length;
+          if (throttleHandle !== null) {
+            clearTimeout(throttleHandle);
+            throttleHandle = null;
+            pending = null;
+          }
+          rawMessagesSig.set(m);
+        } else if (ms > 0) {
+          // Same-length update (token streaming): coalesce within the throttle window.
+          pending = m;
+          if (throttleHandle === null) {
+            throttleHandle = setTimeout(flushPending, ms);
+          }
+        } else {
+          // No throttle configured: emit immediately.
+          rawMessagesSig.set(m);
+        }
+      });
+  }
+  const rawMessages = rawMessagesSig.asReadonly();
   const statusSig    = toSignal(status$,          { initialValue: ResourceStatus.Idle });
   const errorSig     = toSignal(error$,           { initialValue: undefined as unknown });
   const hasValueSig  = toSignal(hasValue$,        { initialValue: false });

--- a/libs/langgraph/src/lib/agent.fn.ts
+++ b/libs/langgraph/src/lib/agent.fn.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 import {
   inject, DestroyRef, computed, effect,
-  isSignal, Signal, signal,
+  isSignal, Signal,
 } from '@angular/core';
 import { AGENT_CONFIG } from './agent.provider';
 import { toSignal, toObservable } from '@angular/core/rxjs-interop';
@@ -162,49 +162,13 @@ export function agent<
 
   // Convert to Angular Signals (must happen in injection context)
   const value        = toSignal(maybeThrottle(values$),   { initialValue: init });
-  // rawMessages is hand-rolled instead of `toSignal(maybeThrottle(messages$))`
-  // to avoid the leading/trailing throttle collapsing the optimistic-user
-  // injection into the same emission as the first AI partial. We bypass the
-  // throttle whenever the messages array grows in length (new message added)
-  // so user-visible message additions render in their own frame. Same-length
-  // updates (token-by-token AI streaming) still get throttled to ~60fps.
-  const rawMessagesSig = signal<BaseMessage[]>([]);
-  {
-    let lastLen = 0;
-    let throttleHandle: ReturnType<typeof setTimeout> | null = null;
-    let pending: BaseMessage[] | null = null;
-    const flushPending = () => {
-      throttleHandle = null;
-      if (pending) {
-        rawMessagesSig.set(pending);
-        pending = null;
-      }
-    };
-    messages$
-      .pipe(takeUntil(destroy$))
-      .subscribe((m) => {
-        if (m.length !== lastLen) {
-          // Length changed (add or remove): emit synchronously, cancel pending.
-          lastLen = m.length;
-          if (throttleHandle !== null) {
-            clearTimeout(throttleHandle);
-            throttleHandle = null;
-            pending = null;
-          }
-          rawMessagesSig.set(m);
-        } else if (ms > 0) {
-          // Same-length update (token streaming): coalesce within the throttle window.
-          pending = m;
-          if (throttleHandle === null) {
-            throttleHandle = setTimeout(flushPending, ms);
-          }
-        } else {
-          // No throttle configured: emit immediately.
-          rawMessagesSig.set(m);
-        }
-      });
-  }
-  const rawMessages = rawMessagesSig.asReadonly();
+  // No throttle on messages$: we need every token emission to propagate to
+  // Angular so streaming markdown actually streams. The bridge already
+  // batches per-tuple at the SDK level; further throttling at the signal
+  // boundary collapses tokens together and breaks visible token-by-token
+  // rendering. Same-frame multiple emissions are coalesced by Angular's
+  // CD anyway.
+  const rawMessages  = toSignal(messages$, { initialValue: [] as BaseMessage[] });
   const statusSig    = toSignal(status$,          { initialValue: ResourceStatus.Idle });
   const errorSig     = toSignal(error$,           { initialValue: undefined as unknown });
   const hasValueSig  = toSignal(hasValue$,        { initialValue: false });
@@ -226,20 +190,14 @@ export function agent<
 
   // ── Runtime-neutral projections ───────────────────────────────────────────
 
-  // Memoise BaseMessage → Message projections by raw-message identity. This
-  // keeps the projected `id` stable for the same logical message across
-  // recomputes (e.g. token-by-token streaming emits a fresh array but the
-  // BaseMessage reference is the same). Track-by-id in chat-message-list
-  // depends on this identity to avoid DOM teardown + animation restarts.
-  const messageProjections = new WeakMap<BaseMessage, Message>();
-  const projectMessage = (m: BaseMessage): Message => {
-    let cached = messageProjections.get(m);
-    if (cached) return cached;
-    cached = toMessage(m);
-    messageProjections.set(m, cached);
-    return cached;
-  };
-  const messagesNeutral = computed<Message[]>(() => rawMessages().map(projectMessage));
+  // Project BaseMessage → Message on every recompute. We deliberately do
+  // NOT cache: the LangGraph SDK mutates the same AIMessage instance in
+  // place during token streaming (appends content to the same object), so
+  // any identity-based cache returns stale projections and Angular's
+  // `@let content = messageContent(message)` short-circuits — DOM never
+  // updates per token. DOM stability is provided by `track message.id`
+  // in chat-message-list, not by Message identity.
+  const messagesNeutral = computed<Message[]>(() => rawMessages().map(toMessage));
 
   const toolCallsNeutral = computed<ToolCall[]>(() => rawToolCalls().map(toToolCall));
 
@@ -391,11 +349,42 @@ function toMessage(m: BaseMessage): Message {
   return {
     id: (m.id as string | undefined) ?? (raw['id'] as string | undefined) ?? randomId(),
     role,
-    content: typeof m.content === 'string' ? m.content : JSON.stringify(m.content),
+    content: extractTextContent(m.content),
     toolCallId: raw['tool_call_id'] as string | undefined,
     name: raw['name'] as string | undefined,
     extra: raw,
   };
+}
+
+/**
+ * Extract user-visible text from a `BaseMessage.content` value.
+ *
+ * LangChain's `BaseMessage.content` is `string | MessageContentComplex[]`.
+ * Reasoning-capable models (OpenAI gpt-5/o-series, Anthropic) emit complex
+ * arrays of typed blocks: `{type: 'text', text}`, `{type: 'reasoning', ...}`,
+ * tool-use blocks, etc. We render only the visible text portions and skip
+ * anything else. JSON-stringifying the whole array (the previous behaviour)
+ * would dump raw `[{"type":"text",...}]` into the chat bubble.
+ */
+function extractTextContent(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  let out = '';
+  for (const block of content) {
+    if (typeof block === 'string') {
+      out += block;
+      continue;
+    }
+    if (!isRecord(block)) continue;
+    const t = block['type'];
+    // Common text-bearing block shapes across providers.
+    if (t === 'text' || t === 'output_text' || t === undefined) {
+      const text = block['text'];
+      if (typeof text === 'string') out += text;
+    }
+    // Skip reasoning, tool_use, image, etc. — not chat-bubble content.
+  }
+  return out;
 }
 
 function toToolCall(tc: ToolCallWithResult): ToolCall {

--- a/libs/langgraph/src/lib/internals/stream-manager.bridge.ts
+++ b/libs/langgraph/src/lib/internals/stream-manager.bridge.ts
@@ -389,8 +389,24 @@ export function createStreamManagerBridge<T, ResolvedBag extends BagTemplate = B
             const projected = options.toMessage
               ? stateMessages.map(options.toMessage)
               : (stateMessages as BaseMessage[]);
+            // Drop empty-content AI placeholders before merging. LangGraph
+            // emits intermediate `values` events whose `state.messages`
+            // includes an unfilled assistant turn at the tail. Keeping it
+            // would create a phantom slot that competes with the chunk-
+            // streamed AIMessageChunk arriving via messages-tuple — they'd
+            // never merge (different ids; non-overlapping content fragments)
+            // and the user sees two assistant bubbles.
+            const filtered = projected.filter((m, i) => {
+              if (i !== projected.length - 1) return true;
+              const t = normalizeMessageType(
+                typeof m._getType === 'function' ? m._getType() : (m as unknown as Record<string, unknown>)['type'] as string | undefined,
+              );
+              if (t !== 'ai') return true;
+              const text = extractText(m.content);
+              return text.length > 0;
+            });
             // Preserve existing ids by content match (server echo / final-id swap).
-            const remapped = preserveIds(subjects.messages$.value, projected);
+            const remapped = preserveIds(subjects.messages$.value, filtered);
             // ALWAYS merge values-derived messages into existing rather
             // than replacing. LangGraph emits intermediate values events
             // during streaming where state.messages can lag behind what
@@ -703,10 +719,52 @@ function normalizeMessages(event: StreamEvent): unknown[] | null {
   return null;
 }
 
+/**
+ * Collapse adjacent AI messages where one's text is a prefix of the other.
+ *
+ * When complex-content streaming is in play, the same conceptual assistant
+ * message can land in two slots: the canonical AI from values-sync (id
+ * `resp_…` or run id) and the chunk-streamed AIMessageChunk from
+ * messages-tuple (id `lc_run--…`). Both slots fill in parallel; once both
+ * carry the full text we collapse them, keeping the older slot's id so
+ * track-by-id stays stable in the chat list.
+ */
+function collapseAdjacentAi(messages: BaseMessage[]): BaseMessage[] {
+  if (messages.length < 2) return messages;
+  const out: BaseMessage[] = [];
+  for (const msg of messages) {
+    const last = out[out.length - 1];
+    if (!last) { out.push(msg); continue; }
+    const lastType = normalizeMessageType(
+      typeof last._getType === 'function' ? last._getType() : (last as unknown as Record<string, unknown>)['type'] as string | undefined,
+    );
+    const msgType = normalizeMessageType(
+      typeof msg._getType === 'function' ? msg._getType() : (msg as unknown as Record<string, unknown>)['type'] as string | undefined,
+    );
+    if (lastType === 'ai' && msgType === 'ai') {
+      const lastText = extractText(last.content);
+      const msgText = extractText(msg.content);
+      if (lastText.length === 0
+          || msgText.length === 0
+          || lastText === msgText
+          || lastText.startsWith(msgText)
+          || msgText.startsWith(lastText)) {
+        // Keep the longer content; preserve last (older) id and metadata.
+        const longerText = msgText.length >= lastText.length ? msgText : lastText;
+        out[out.length - 1] = { ...(last as object), content: longerText } as BaseMessage;
+        continue;
+      }
+    }
+    out.push(msg);
+  }
+  return out;
+}
+
 function mergeMessages(existing: BaseMessage[], incoming: BaseMessage[]): BaseMessage[] {
   const merged = [...existing];
   for (const msg of incoming) {
-    const id = (msg as unknown as Record<string, unknown>)['id'];
+    const rawIn = msg as unknown as Record<string, unknown>;
+    const id = rawIn['id'];
     let idx = id ? merged.findIndex(m => (m as unknown as Record<string, unknown>)['id'] === id) : -1;
     // Fallback: match by (role, content) when ids differ. This is the path
     // that fires when the server echoes back our optimistic human message
@@ -717,18 +775,100 @@ function mergeMessages(existing: BaseMessage[], incoming: BaseMessage[]): BaseMe
     if (idx < 0) {
       idx = findContentMatch(merged, msg);
     }
+    // When an AIMessageChunk arrives without an id-match or content-prefix
+    // match, treat the trailing AI message as its accumulator. The
+    // OpenAI Responses API emits per-chunk events whose ids identify the
+    // *event*, not the message, so consecutive chunks land here. Without
+    // this we'd append every chunk as a separate bubble.
+    if (idx < 0) {
+      const inType = normalizeMessageType(rawIn['type'] as string | undefined);
+      if (inType === 'ai') {
+        for (let i = merged.length - 1; i >= 0; i--) {
+          const t = normalizeMessageType(
+            typeof (merged[i] as BaseMessage)._getType === 'function'
+              ? (merged[i] as BaseMessage)._getType()
+              : (merged[i] as unknown as Record<string, unknown>)['type'] as string | undefined,
+          );
+          if (t === 'ai') { idx = i; break; }
+          if (t === 'human' || t === 'tool' || t === 'system') break;
+        }
+      }
+    }
     if (idx >= 0) {
-      const existingId = (merged[idx] as unknown as Record<string, unknown>)['id'];
+      const existing = merged[idx];
+      const existingId = (existing as unknown as Record<string, unknown>)['id'];
       // Keep the *existing* id so downstream track-by-id sees stable identity.
-      // The replacement carries the latest content + metadata.
-      merged[idx] = existingId
-        ? ({ ...(msg as object), id: existingId } as BaseMessage)
-        : msg;
+      // For complex-content streaming (OpenAI gpt-5/o-series, Anthropic) the
+      // SDK emits per-chunk *delta* arrays — not accumulated arrays — so a
+      // straight replacement collapses the rendered bubble to just the
+      // latest token. Accumulate text-bearing content across chunks here
+      // and hand a string to consumers; downstream code already handles
+      // string content uniformly.
+      const accumulatedContent = accumulateContent(
+        existing.content as unknown,
+        (msg as unknown as Record<string, unknown>)['content'],
+      );
+      const next = { ...(msg as object), content: accumulatedContent } as BaseMessage;
+      if (existingId) {
+        (next as unknown as Record<string, unknown>)['id'] = existingId;
+      }
+      merged[idx] = next;
     } else {
       merged.push(msg);
     }
   }
-  return merged;
+  return collapseAdjacentAi(merged);
+}
+
+/**
+ * Merge an incoming chunk's content into prior accumulated content for the
+ * same message id.
+ *
+ * - string + string → concat (delta append)
+ * - array + array  → concat extracted text from existing + incoming blocks
+ * - array + string → use the string (server final-id swap)
+ * - empty existing → use incoming as-is
+ *
+ * We deliberately collapse complex content arrays to a string at this layer.
+ * The langgraph-sdk client does not accumulate complex-content arrays the
+ * way it accumulates strings, and per-chunk arrays carry only the latest
+ * delta. Concatenating extracted text gives consumers the same uniform
+ * string they get for non-reasoning models.
+ */
+function accumulateContent(existing: unknown, incoming: unknown): string {
+  const existingText = extractText(existing);
+  const incomingText = extractText(incoming);
+
+  // Always return a string. We never want array content escaping the bridge:
+  // (a) downstream consumers expect string content, and (b) findContentMatch
+  // stringifies arrays, which would prevent the canonical-message id-swap
+  // dedupe from matching the streamed-chunk message after a partial chunk.
+  if (existingText.length === 0) return incomingText;
+  if (incomingText.length === 0) return existingText;
+  // Incoming is a strict-superset of accumulated (final-id swap with full content).
+  if (incomingText.startsWith(existingText)) return incomingText;
+  // Existing already a strict-superset — chunk arrived after the canonical
+  // message merged in via values-sync. Keep what we have.
+  if (existingText.startsWith(incomingText)) return existingText;
+  // Otherwise treat incoming as a delta and append.
+  return existingText + incomingText;
+}
+
+function extractText(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  let out = '';
+  for (const block of content) {
+    if (typeof block === 'string') { out += block; continue; }
+    if (block == null || typeof block !== 'object') continue;
+    const rec = block as Record<string, unknown>;
+    const t = rec['type'];
+    if (t === 'text' || t === 'output_text' || t === undefined) {
+      const text = rec['text'];
+      if (typeof text === 'string') out += text;
+    }
+  }
+  return out;
 }
 
 /**
@@ -737,9 +877,9 @@ function mergeMessages(existing: BaseMessage[], incoming: BaseMessage[]): BaseMe
  * track-by-id stable across server echoes and final-id swaps.
  */
 function preserveIds(existing: BaseMessage[], incoming: BaseMessage[]): BaseMessage[] {
-  if (existing.length === 0) return incoming;
+  if (existing.length === 0) return collapseAdjacentAi(incoming);
   const usedExisting = new Set<number>();
-  return incoming.map((msg, i) => {
+  const remapped = incoming.map((msg, i) => {
     const inRaw = msg as unknown as Record<string, unknown>;
     const inId = inRaw['id'];
     // First try same-position match (the dominant case).
@@ -756,11 +896,16 @@ function preserveIds(existing: BaseMessage[], incoming: BaseMessage[]): BaseMess
     if (!existingId || existingId === inId) return msg;
     return { ...(msg as object), id: existingId } as BaseMessage;
   });
+  return collapseAdjacentAi(remapped);
 }
 
 function sameRoleAndContent(a: BaseMessage, b: BaseMessage): boolean {
-  const aType = typeof a._getType === 'function' ? a._getType() : (a as unknown as Record<string, unknown>)['type'];
-  const bType = typeof b._getType === 'function' ? b._getType() : (b as unknown as Record<string, unknown>)['type'];
+  const aType = normalizeMessageType(
+    typeof a._getType === 'function' ? a._getType() : (a as unknown as Record<string, unknown>)['type'] as string | undefined,
+  );
+  const bType = normalizeMessageType(
+    typeof b._getType === 'function' ? b._getType() : (b as unknown as Record<string, unknown>)['type'] as string | undefined,
+  );
   if (aType !== bType) return false;
   const aContent = typeof a.content === 'string' ? a.content : JSON.stringify(a.content);
   const bContent = typeof b.content === 'string' ? b.content : JSON.stringify(b.content);
@@ -774,24 +919,54 @@ function sameRoleAndContent(a: BaseMessage, b: BaseMessage): boolean {
 
 function findContentMatch(merged: BaseMessage[], incoming: BaseMessage): number {
   const inRaw = incoming as unknown as Record<string, unknown>;
-  const inType = typeof incoming._getType === 'function' ? incoming._getType() : (inRaw['type'] as string | undefined);
+  const inType = normalizeMessageType(
+    typeof incoming._getType === 'function' ? incoming._getType() : (inRaw['type'] as string | undefined),
+  );
   const inContent = typeof incoming.content === 'string' ? incoming.content : JSON.stringify(incoming.content);
   // Only worth matching for human messages (where the optimistic→echo
   // mismatch happens) and for AI messages where content is a strict prefix
   // of the existing (token-streaming + final-id swap pattern).
   for (let i = merged.length - 1; i >= 0; i--) {
     const m = merged[i] as unknown as Record<string, unknown>;
-    const mType = typeof (merged[i] as BaseMessage)._getType === 'function'
-      ? (merged[i] as BaseMessage)._getType()
-      : (m['type'] as string | undefined);
+    const mType = normalizeMessageType(
+      typeof (merged[i] as BaseMessage)._getType === 'function'
+        ? (merged[i] as BaseMessage)._getType()
+        : (m['type'] as string | undefined),
+    );
     if (mType !== inType) continue;
     const mContent = typeof (merged[i] as BaseMessage).content === 'string'
       ? (merged[i] as BaseMessage).content as string
       : JSON.stringify((merged[i] as BaseMessage).content);
     if (inType === 'human' && mContent === inContent) return i;
-    if (inType === 'ai' && (mContent === inContent || (typeof mContent === 'string' && typeof inContent === 'string' && (inContent.startsWith(mContent) || mContent.startsWith(inContent))))) return i;
+    if (inType === 'ai') {
+      // Skip empty placeholders. We don't want a pre-existing empty AI
+      // (created by an early values-sync emission with `state.messages`
+      // including an unfilled assistant turn) to absorb the first chunk
+      // arriving via messages-tuple — that strands subsequent chunks in a
+      // separate slot whose content no longer prefix-matches the canonical.
+      const aSafe = typeof mContent === 'string' ? mContent : '';
+      const bSafe = typeof inContent === 'string' ? inContent : '';
+      if (aSafe.length === 0 || bSafe.length === 0) continue;
+      if (mContent === inContent || aSafe.startsWith(bSafe) || bSafe.startsWith(aSafe)) return i;
+    }
   }
   return -1;
+}
+
+/**
+ * Normalize message type so AIMessage and AIMessageChunk compare equal.
+ * The LangGraph SDK emits type='AIMessageChunk' on the messages-tuple
+ * streaming path and type='ai' on the values-sync path for the same
+ * canonical assistant message — distinguishing them prevents the
+ * content-prefix dedupe from collapsing the duplicate bubbles.
+ */
+function normalizeMessageType(t: string | undefined): string | undefined {
+  if (!t) return t;
+  if (t === 'AIMessageChunk' || t === 'AIMessage' || t === 'assistant') return 'ai';
+  if (t === 'HumanMessage' || t === 'HumanMessageChunk' || t === 'user') return 'human';
+  if (t === 'ToolMessage') return 'tool';
+  if (t === 'SystemMessage') return 'system';
+  return t;
 }
 
 function toSubagentRefs(


### PR DESCRIPTION
## Summary
- **Chat input pill + chat-select primitive** (the original plan): pill-shaped input, circle send/stop, content-width centering, symmetric edge padding, `--ngaf-chat-edge-pad` token, ghosted `<chat-select>` popover with keyboard nav, `[chatInputModelSelect]` slot, welcome subtitle dropped, glowing-dot caret.
- **First-class model picker on `<chat>`**: pass `[modelOptions]` + `[(selectedModel)]` and the chat composition projects a `<chat-select>` into the input pill on both welcome and conversation views — no manual slot wiring required.
- **Welcome suggestions restyle**: floating pills (rounded, surface bg, centered, wraps) instead of stacked rows with dividers.
- **Streaming complex-content fix (langgraph)**: OpenAI gpt-5/o-series Responses API streams typed content blocks (`[{type:'text',text:'…',index}]`) and emits both `AIMessageChunk` (messages-tuple) and canonical `ai` (values-sync) views of the same message. The bridge now extracts visible text from typed blocks, accumulates per-chunk deltas into a single slot, normalizes message types so dedupe matches across paths, drops empty-AI placeholders, and collapses adjacent AI bubbles. Single bubble accumulating cleanly.
- **Markdown rendering fix (chat)**: `chat-streaming-md` now uses `ViewEncapsulation.None` + element-scoped styles so `CHAT_MARKDOWN_STYLES` actually apply to innerHTML-injected DOM. Full CommonMark + GFM coverage: headings (sized hierarchy), `strong`/`em`/`del`, lists with visible markers (incl. nested + task lists), inline + fenced code, blockquote, hr, GFM tables (bordered + header bg), images. `marked` enabled with `gfm: true, breaks: true`.
- **Cockpit demos + superpowers docs**: stale `gpt-4o-mini` references swept to `gpt-5-mini`. Reasoning models stream visibly with `reasoning.effort='minimal'` (langgraph default).

Bumps `@ngaf/chat` 0.0.16 → 0.0.18 and `@ngaf/langgraph` 0.0.9 → 0.0.10.

## Test plan
- [ ] Smoke: `~/tmp/ngaf` against LangGraph backend — pick gpt-5/gpt-5-mini/gpt-5-nano, send a suggestion, verify single assistant bubble streams visibly with markdown bullets/headings/code formatted
- [ ] Markdown sampler renders headings, bold, italic, strikethrough, links, blockquote, hr, bullet/ordered/task lists, GFM tables, fenced code
- [ ] No left-flash on optimistic user message after suggestion click
- [ ] chat-select keyboard nav (↑/↓/Enter/Esc) works in both welcome and conversation modes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)