### PR TITLE
feat: export extractCitations + bridgeCitationsState (0.0.23)

### DIFF
--- a/libs/a2ui/package.json
+++ b/libs/a2ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/a2ui",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/a2ui/src/index.ts
+++ b/libs/a2ui/src/index.ts
@@ -8,13 +8,13 @@ export type {
   A2uiCreateSurface, A2uiUpdateComponents, A2uiUpdateDataModel, A2uiDeleteSurface,
   A2uiMessage, A2uiSurface,
   A2uiClientDataModel, A2uiActionMessage,
-} from './lib/types';
-export { getByPointer, setByPointer, deleteByPointer } from './lib/pointer';
-export { createA2uiMessageParser } from './lib/parser';
-export type { A2uiMessageParser } from './lib/parser';
-export { resolveDynamic } from './lib/resolve';
-export type { A2uiScope } from './lib/resolve';
-export { executeFunction } from './lib/functions';
-export { evaluateCheckRules } from './lib/validate';
-export type { A2uiValidationResult } from './lib/validate';
-export { isPathRef, isFunctionCall } from './lib/guards';
+} from './lib/types.js';
+export { getByPointer, setByPointer, deleteByPointer } from './lib/pointer.js';
+export { createA2uiMessageParser } from './lib/parser.js';
+export type { A2uiMessageParser } from './lib/parser.js';
+export { resolveDynamic } from './lib/resolve.js';
+export type { A2uiScope } from './lib/resolve.js';
+export { executeFunction } from './lib/functions.js';
+export { evaluateCheckRules } from './lib/validate.js';
+export type { A2uiValidationResult } from './lib/validate.js';
+export { isPathRef, isFunctionCall } from './lib/guards.js';

--- a/libs/a2ui/src/lib/guards.ts
+++ b/libs/a2ui/src/lib/guards.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-import type { A2uiPathRef, A2uiFunctionCall } from './types';
+import type { A2uiPathRef, A2uiFunctionCall } from './types.js';
 
 /** Narrows an unknown value to A2uiPathRef — has `path` but not `call`. */
 export function isPathRef(value: unknown): value is A2uiPathRef {

--- a/libs/a2ui/src/lib/parser.ts
+++ b/libs/a2ui/src/lib/parser.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-import type { A2uiMessage } from './types';
+import type { A2uiMessage } from './types.js';
 
 const ENVELOPE_KEYS = ['createSurface', 'updateComponents', 'updateDataModel', 'deleteSurface'] as const;
 

--- a/libs/a2ui/src/lib/resolve.ts
+++ b/libs/a2ui/src/lib/resolve.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
-import type { A2uiPathRef, A2uiFunctionCall } from './types';
-import { getByPointer } from './pointer';
-import { executeFunction } from './functions';
+import type { A2uiPathRef, A2uiFunctionCall } from './types.js';
+import { getByPointer } from './pointer.js';
+import { executeFunction } from './functions.js';
 
 export interface A2uiScope {
   basePath: string;

--- a/libs/a2ui/src/lib/validate.ts
+++ b/libs/a2ui/src/lib/validate.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
-import type { A2uiCheckRule } from './types';
-import { resolveDynamic } from './resolve';
+import type { A2uiCheckRule } from './types.js';
+import { resolveDynamic } from './resolve.js';
 
 export interface A2uiValidationResult {
   valid: boolean;

--- a/libs/ag-ui/package.json
+++ b/libs/ag-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/ag-ui",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "peerDependencies": {
     "@ngaf/chat": "*",
     "@ngaf/licensing": "*",

--- a/libs/ag-ui/src/public-api.ts
+++ b/libs/ag-ui/src/public-api.ts
@@ -5,3 +5,7 @@ export type { AgUiAgentConfig } from './lib/provide-ag-ui-agent';
 export { FakeAgent } from './lib/testing/fake-agent';
 export { provideFakeAgUiAgent } from './lib/testing/provide-fake-ag-ui-agent';
 export type { FakeAgUiAgentConfig } from './lib/testing/provide-fake-ag-ui-agent';
+
+// Citation state bridge — useful for advanced consumers building custom
+// reducers or merging citations from non-standard state paths.
+export { bridgeCitationsState } from './lib/bridge-citations-state';

--- a/libs/chat/package.json
+++ b/libs/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/chat",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "exports": {
     ".": {
       "types": "./index.d.ts",

--- a/libs/cockpit-docs/package.json
+++ b/libs/cockpit-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/cockpit-docs",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/cockpit-registry/package.json
+++ b/libs/cockpit-registry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/cockpit-registry",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/cockpit-shell/package.json
+++ b/libs/cockpit-shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/cockpit-shell",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/cockpit-testing/package.json
+++ b/libs/cockpit-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/cockpit-testing",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/cockpit-ui/package.json
+++ b/libs/cockpit-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/cockpit-ui",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/db/package.json
+++ b/libs/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/db",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/design-tokens/package.json
+++ b/libs/design-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/design-tokens",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/example-layouts/package.json
+++ b/libs/example-layouts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/example-layouts",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "peerDependencies": {
     "@angular/core": "^20.0.0 || ^21.0.0",
     "@angular/common": "^20.0.0 || ^21.0.0"

--- a/libs/langgraph/package.json
+++ b/libs/langgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/langgraph",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "peerDependencies": {
     "@ngaf/chat": "*",
     "@ngaf/licensing": "*",

--- a/libs/langgraph/src/public-api.ts
+++ b/libs/langgraph/src/public-api.ts
@@ -37,3 +37,7 @@ export { FetchStreamTransport } from './lib/transport/fetch-stream.transport';
 // Mock test utility for LangGraph agent
 export { mockLangGraphAgent } from './lib/testing/mock-langgraph-agent';
 export type { MockLangGraphAgent } from './lib/testing/mock-langgraph-agent';
+
+// Citation normalizer — useful for advanced consumers building custom adapters
+// or bridging non-LangGraph message shapes into ngaf Citation[].
+export { extractCitations } from './lib/internals/extract-citations';

--- a/libs/licensing/package.json
+++ b/libs/licensing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/licensing",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/partial-json/package.json
+++ b/libs/partial-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/partial-json",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "deprecated": "Replaced by @cacheplane/partial-json. No further versions will be published from this package.",
   "license": "MIT",
   "repository": {

--- a/libs/render/package.json
+++ b/libs/render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/render",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "peerDependencies": {
     "@angular/core": "^20.0.0 || ^21.0.0",
     "@angular/common": "^20.0.0 || ^21.0.0",

--- a/libs/ui-react/package.json
+++ b/libs/ui-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/ui-react",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

A fresh-install smoke test against published `@ngaf/langgraph@0.0.22` and `@ngaf/ag-ui@0.0.22` (in `~/tmp/ngaf`) caught that the two citation normalizers shipped in 0.0.21 were wired internally but never exported from the public API. Both should be public — advanced consumers building custom adapters or non-standard reducers want to reuse the same normalizer logic.

### Changes

- `@ngaf/langgraph` public API: export `extractCitations`
- `@ngaf/ag-ui` public API: export `bridgeCitationsState`

### Synchronized version bump
All 16 `@ngaf/*` libraries → `0.0.23`. Tag `v0.0.23` will trigger the publish workflow.

## Test plan

- [x] `npx nx run langgraph:lint && npx nx run ag-ui:lint` green
- [x] `npx nx run-many -t test --projects=langgraph,ag-ui` green
- [x] Existing 0.0.21 unit tests on both normalizers continue to pass