### PR TITLE
fix(langgraph): include role+content in RemoveMessage wire-shape (0.0.28)

### DIFF
--- a/libs/a2ui/package.json
+++ b/libs/a2ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/a2ui",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/ag-ui/package.json
+++ b/libs/ag-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/ag-ui",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "peerDependencies": {
     "@ngaf/chat": "*",
     "@ngaf/licensing": "*",

--- a/libs/chat/package.json
+++ b/libs/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/chat",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "exports": {
     ".": {
       "types": "./index.d.ts",

--- a/libs/cockpit-docs/package.json
+++ b/libs/cockpit-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/cockpit-docs",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/cockpit-registry/package.json
+++ b/libs/cockpit-registry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/cockpit-registry",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/cockpit-shell/package.json
+++ b/libs/cockpit-shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/cockpit-shell",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/cockpit-testing/package.json
+++ b/libs/cockpit-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/cockpit-testing",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/cockpit-ui/package.json
+++ b/libs/cockpit-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/cockpit-ui",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/db/package.json
+++ b/libs/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/db",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/design-tokens/package.json
+++ b/libs/design-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/design-tokens",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/example-layouts/package.json
+++ b/libs/example-layouts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/example-layouts",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "peerDependencies": {
     "@angular/core": "^20.0.0 || ^21.0.0",
     "@angular/common": "^20.0.0 || ^21.0.0"

--- a/libs/langgraph/package.json
+++ b/libs/langgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/langgraph",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "peerDependencies": {
     "@ngaf/chat": "*",
     "@ngaf/licensing": "*",

--- a/libs/langgraph/src/lib/agent.fn.ts
+++ b/libs/langgraph/src/lib/agent.fn.ts
@@ -14,14 +14,21 @@ import type { Observable } from 'rxjs';
 import type { BaseMessage, AIMessage as CoreAIMessage } from '@langchain/core/messages';
 
 /**
- * Wire-shape of a `RemoveMessage` instruction — LangGraph's `add_messages`
- * reducer recognises this plain-object shape and removes the matching
- * message id from server state. Used by `regenerate()`. We construct the
- * shape directly instead of importing the `RemoveMessage` class from
- * `@langchain/core/messages` because that pulls in the full BaseMessage
- * class hierarchy (~30-50 kB) which Cockpit's bundle-size budget rejects.
+ * Wire-shape of a `RemoveMessage` instruction. LangGraph's `add_messages`
+ * reducer (Python side) coerces incoming dicts via a strict check that
+ * expects `role` + `content` keys; without them, the dict-to-Message
+ * conversion throws and the whole `updateState` request 400s. Construct
+ * the shape directly with the required keys so we get correct semantics
+ * without importing the `RemoveMessage` class from `@langchain/core/messages`
+ * (the class import pulls in the full BaseMessage hierarchy, ~30-50 kB,
+ * which Cockpit's example-app bundle budget rejects).
  */
-type RemoveMessageInstruction = { type: 'remove'; id: string };
+type RemoveMessageInstruction = {
+  type: 'remove';
+  role: 'remove';
+  id: string;
+  content: '';
+};
 import type { Command, Interrupt, ToolCallWithResult } from '@langchain/langgraph-sdk';
 import type { BagTemplate, InferBag } from '@langchain/langgraph-sdk';
 import type {
@@ -296,7 +303,9 @@ export function agent<
         .map(m => {
           const raw = m as unknown as Record<string, unknown>;
           const id = typeof raw['id'] === 'string' ? raw['id'] : undefined;
-          return id ? { type: 'remove' as const, id } : null;
+          return id
+            ? { type: 'remove' as const, role: 'remove' as const, id, content: '' as const }
+            : null;
         })
         .filter((rm): rm is RemoveMessageInstruction => rm !== null);
 

--- a/libs/licensing/package.json
+++ b/libs/licensing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/licensing",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/partial-json/package.json
+++ b/libs/partial-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/partial-json",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "deprecated": "Replaced by @cacheplane/partial-json. No further versions will be published from this package.",
   "license": "MIT",
   "repository": {

--- a/libs/render/package.json
+++ b/libs/render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/render",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "peerDependencies": {
     "@angular/core": "^20.0.0 || ^21.0.0",
     "@angular/common": "^20.0.0 || ^21.0.0",

--- a/libs/ui-react/package.json
+++ b/libs/ui-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/ui-react",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- Live cockpit smoke (0.0.27) showed regenerate going **1u/1a → 1u/0a**: the assistant disappears but a new one never streams in.
- Backend log: `ValueError: Message dict must contain 'role' and 'content' keys, got {'type': 'remove', 'id': 'resp_…'}` — the bare `{type:'remove', id}` wire-shape fails Python LangGraph's dict-to-Message coercion before the reducer ever sees the remove discriminator, so `updateState` 400s and rollback never lands.
- Fix: include the required `role: 'remove'` + `content: ''` keys in both the type and the construction site in `agent.fn.ts`. We still avoid importing `RemoveMessage` from `@langchain/core/messages` so Cockpit's example-app bundle budget stays satisfied.
- Bumped all 16 @ngaf packages 0.0.27 → 0.0.28.

## Test plan

- [x] `nx run langgraph:test` green locally
- [x] `nx run langgraph:lint` green locally
- [ ] CI green
- [ ] After publish: bump `~/tmp/ngaf` example to 0.0.28, live Chrome smoke regenerate stays at 1u/1a