### PR TITLE
ci: harden website e2e and examples deploy gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,7 +281,7 @@ jobs:
           if printf '%s\n' "$changed_files" | grep -E '^(vercel\.examples\.json|scripts/assemble-examples\.ts)$' >/dev/null; then
             examples_changed=true
           fi
-          if printf '%s\n' "$changed_files" | grep -E '^libs/(angular|chat|render)/' >/dev/null; then
+          if printf '%s\n' "$changed_files" | grep -E '^libs/(chat|langgraph|ag-ui|render|a2ui|partial-json|example-layouts)/' >/dev/null; then
             examples_changed=true
           fi
           echo "changed=$examples_changed" >> "$GITHUB_OUTPUT"

--- a/apps/website/playwright.config.ts
+++ b/apps/website/playwright.config.ts
@@ -1,7 +1,11 @@
 import { defineConfig } from '@playwright/test';
 
-const baseURL = process.env['BASE_URL'] ?? 'http://localhost:3000';
+const localHost = '127.0.0.1';
+const localPort = process.env['WEBSITE_E2E_PORT'] ?? '4308';
+const localURL = `http://${localHost}:${localPort}`;
+const baseURL = process.env['BASE_URL'] ?? localURL;
 const shouldStartLocalServer = !process.env['BASE_URL'];
+const reuseExistingServer = process.env['PLAYWRIGHT_REUSE_EXISTING_SERVER'] === 'true';
 
 export default defineConfig({
   testDir: './e2e',
@@ -11,9 +15,9 @@ export default defineConfig({
   },
   webServer: shouldStartLocalServer
     ? {
-        command: 'npx next dev . --port 3000',
-        url: 'http://localhost:3000',
-        reuseExistingServer: !process.env['CI'],
+        command: `npx next dev . --hostname ${localHost} --port ${localPort}`,
+        url: localURL,
+        reuseExistingServer,
       }
     : undefined,
 });


### PR DESCRIPTION
## Summary

Harden the website e2e and examples deploy gates without changing the overall CI topology.

- Move website Playwright's local server default from shared `localhost:3000` to an isolated `127.0.0.1:4308`.
- Disable implicit local server reuse unless `PLAYWRIGHT_REUSE_EXISTING_SERVER=true` is set explicitly.
- Fix the examples production deploy change detector to watch real example-impacting libraries instead of stale `libs/angular`, including `langgraph`, `ag-ui`, `a2ui`, `partial-json`, and `example-layouts`.

## Root Cause

The website e2e config could attach to whatever happened to be running on local port 3000, which can make local verification test the wrong app. The examples deploy gate also still referenced a removed `libs/angular` path and missed libraries that are now part of the example apps' runtime surface.

## Verification

- `npx nx e2e website --skip-nx-cache` — 11 passed
- `npx nx lint website --skip-nx-cache` — passed with existing `apps/website/instrumentation-client.ts` non-null assertion warning
- `npx nx build website --skip-nx-cache`
- `python3` parsed `.github/workflows/ci.yml` with PyYAML
- shell predicate check for examples deploy paths
- `git diff --check`
