### PR TITLE
fixup(langgraph): canonical regenerate JSDoc to unblock api-docs gate

### DIFF
--- a/libs/langgraph/src/lib/agent.types.ts
+++ b/libs/langgraph/src/lib/agent.types.ts
@@ -312,11 +312,13 @@ export interface LangGraphAgent<T = unknown, ResolvedBag extends BagTemplate = B
   reload: () => void;
 
   /**
-   * Truncate the thread at the given assistant-message index and re-submit the
-   * preceding user message. Used by `<ngaf-chat>`'s regenerate action and any
-   * custom UI that wants the same semantics. Rejects if the agent is currently
-   * loading, if the index does not point at an assistant message, or if no
-   * preceding user message exists.
+   * Discards the assistant message at the given index AND all messages after
+   * it, then re-runs the agent against the trimmed conversation tail. The
+   * preceding user message (at index - 1) is preserved and re-submitted as
+   * the agent's input. No new user message is added to the history.
+   *
+   * Throws if the message at `index` is not 'assistant' role, or if the
+   * agent is currently loading another response.
    */
   regenerate: (assistantMessageIndex: number) => Promise<void>;
 


### PR DESCRIPTION
## Summary

PR #207 was merged via admin override while the stale-api-docs CI gate was red. The gate is now failing on main.

The shorter JSDoc on `LangGraphAgent.regenerate` (added in #207) causes TypeDoc to emit a description that diverges from the committed `apps/website/content/docs/agent/api/api-docs.json`. CI's `git diff --exit-code` check on the regenerated api-docs blocks any subsequent green build until this is fixed.

This PR matches the canonical JSDoc text from `libs/chat/src/lib/agent/agent.ts:38-46` (where the `regenerate` method is originally declared on the parent `Agent` interface) so the regenerated docs are byte-identical to what's already on main.

Why not regenerate and commit api-docs instead: the implementation's intent is to inherit the parent contract's docstring, not to introduce a new (less-detailed) one. Matching JSDoc keeps a single source of truth.

## Test plan

- [x] `nx run langgraph:test` (29 specs pass)
- [x] `nx run langgraph:lint` (0 errors)
- [ ] CI Website lint/build green (api-docs gate passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)