### PR TITLE
fix(langgraph): regenerate via as_node='__start__' (0.0.29)

### DIFF
--- a/apps/website/content/docs/agent/api/api-docs.json
+++ b/apps/website/content/docs/agent/api/api-docs.json
@@ -173,7 +173,7 @@
       },
       {
         "name": "updateState",
-        "signature": "updateState(threadId: string, values: Record<string, unknown>, _signal: AbortSignal)",
+        "signature": "updateState(threadId: string, values: Record<string, unknown>, _signal: AbortSignal, options: object)",
         "description": "Update server-side thread state, e.g. to remove messages for regenerate rollback.",
         "params": [
           {
@@ -193,6 +193,12 @@
             "type": "AbortSignal",
             "description": "",
             "optional": false
+          },
+          {
+            "name": "options",
+            "type": "object",
+            "description": "",
+            "optional": true
           }
         ]
       }
@@ -937,7 +943,7 @@
       {
         "name": "regenerate",
         "type": "object",
-        "description": "Discards the assistant message at the given index AND all messages after\nit, then re-runs the agent against the trimmed conversation tail. The\npreceding user message (at index - 1) is preserved and re-submitted as\nthe agent's input. No new user message is added to the history.\n\nThrows if the message at `index` is not 'assistant' role, or if the\nagent is currently loading another response.",
+        "description": "Truncate the thread at the given assistant-message index and re-submit the\npreceding user message. Used by `<ngaf-chat>`'s regenerate action and any\ncustom UI that wants the same semantics. Rejects if the agent is currently\nloading, if the index does not point at an assistant message, or if no\npreceding user message exists.",
         "optional": false
       },
       {
@@ -1301,7 +1307,7 @@
       {
         "name": "regenerate",
         "type": "object",
-        "description": "Discards the assistant message at the given index AND all messages after\nit, then re-runs the agent against the trimmed conversation tail. The\npreceding user message (at index - 1) is preserved and re-submitted as\nthe agent's input. No new user message is added to the history.\n\nThrows if the message at `index` is not 'assistant' role, or if the\nagent is currently loading another response.",
+        "description": "Truncate the thread at the given assistant-message index and re-submit the\npreceding user message. Used by `<ngaf-chat>`'s regenerate action and any\ncustom UI that wants the same semantics. Rejects if the agent is currently\nloading, if the index does not point at an assistant message, or if no\npreceding user message exists.",
         "optional": false
       },
       {

--- a/apps/website/content/docs/agent/api/api-docs.json
+++ b/apps/website/content/docs/agent/api/api-docs.json
@@ -943,7 +943,7 @@
       {
         "name": "regenerate",
         "type": "object",
-        "description": "Truncate the thread at the given assistant-message index and re-submit the\npreceding user message. Used by `<ngaf-chat>`'s regenerate action and any\ncustom UI that wants the same semantics. Rejects if the agent is currently\nloading, if the index does not point at an assistant message, or if no\npreceding user message exists.",
+        "description": "Discards the assistant message at the given index AND all messages after\nit, then re-runs the agent against the trimmed conversation tail. The\npreceding user message (at index - 1) is preserved and re-submitted as\nthe agent's input. No new user message is added to the history.\n\nThrows if the message at `index` is not 'assistant' role, or if the\nagent is currently loading another response.",
         "optional": false
       },
       {
@@ -1307,7 +1307,7 @@
       {
         "name": "regenerate",
         "type": "object",
-        "description": "Truncate the thread at the given assistant-message index and re-submit the\npreceding user message. Used by `<ngaf-chat>`'s regenerate action and any\ncustom UI that wants the same semantics. Rejects if the agent is currently\nloading, if the index does not point at an assistant message, or if no\npreceding user message exists.",
+        "description": "Discards the assistant message at the given index AND all messages after\nit, then re-runs the agent against the trimmed conversation tail. The\npreceding user message (at index - 1) is preserved and re-submitted as\nthe agent's input. No new user message is added to the history.\n\nThrows if the message at `index` is not 'assistant' role, or if the\nagent is currently loading another response.",
         "optional": false
       },
       {

--- a/libs/a2ui/package.json
+++ b/libs/a2ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/a2ui",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/ag-ui/package.json
+++ b/libs/ag-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/ag-ui",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "peerDependencies": {
     "@ngaf/chat": "*",
     "@ngaf/licensing": "*",

--- a/libs/chat/package.json
+++ b/libs/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/chat",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "exports": {
     ".": {
       "types": "./index.d.ts",
@@ -13,7 +13,7 @@
     "./chat.css": "./chat.css"
   },
   "dependencies": {
-    "@cacheplane/partial-json": "^0.1.1",
+    "@cacheplane/partial-json": ">=0.1.1 <0.3.0",
     "@cacheplane/partial-markdown": "^0.3.0"
   },
   "peerDependencies": {

--- a/libs/cockpit-docs/package.json
+++ b/libs/cockpit-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/cockpit-docs",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/cockpit-registry/package.json
+++ b/libs/cockpit-registry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/cockpit-registry",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/cockpit-shell/package.json
+++ b/libs/cockpit-shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/cockpit-shell",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/cockpit-testing/package.json
+++ b/libs/cockpit-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/cockpit-testing",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/cockpit-ui/package.json
+++ b/libs/cockpit-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/cockpit-ui",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/db/package.json
+++ b/libs/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/db",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/design-tokens/package.json
+++ b/libs/design-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/design-tokens",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/example-layouts/package.json
+++ b/libs/example-layouts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/example-layouts",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "peerDependencies": {
     "@angular/core": "^20.0.0 || ^21.0.0",
     "@angular/common": "^20.0.0 || ^21.0.0"

--- a/libs/langgraph/package.json
+++ b/libs/langgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/langgraph",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "peerDependencies": {
     "@ngaf/chat": "*",
     "@ngaf/licensing": "*",

--- a/libs/langgraph/src/lib/agent.fn.spec.ts
+++ b/libs/langgraph/src/lib/agent.fn.spec.ts
@@ -747,6 +747,60 @@ describe('agent', () => {
       expect(seen[1]?.payload).toBeNull();
     });
 
+    it("forwards asNode: '__start__' to transport.updateState so the next submit(null) can resume", async () => {
+      // After the original run the LangGraph thread sits at __end__ with
+      // `next: []`. submit(null) is a no-op in that position. The regenerate
+      // flow has to reposition the thread via `as_node='__start__'` before
+      // re-running, so the transport must receive that option.
+      const updateCalls: Array<{
+        threadId: string;
+        values: Record<string, unknown>;
+        options?: { asNode?: string };
+      }> = [];
+      const transport = new MockAgentTransport();
+      // Augment the mock with an updateState capture.
+      (transport as unknown as {
+        updateState: (
+          threadId: string,
+          values: Record<string, unknown>,
+          signal: AbortSignal,
+          options?: { asNode?: string },
+        ) => Promise<void>;
+      }).updateState = async (threadId, values, _signal, options) => {
+        updateCalls.push({ threadId, values, options });
+      };
+
+      const ref = withInjectionContext(() =>
+        agent({ apiUrl: '', assistantId: 'a', threadId: 't-1', transport, throttle: false })
+      );
+
+      ref.submit({ message: 'hello' });
+      transport.emit([{
+        type: 'messages',
+        messages: [
+          { id: 'u-1', type: 'human', content: 'hello' },
+          { id: 'a-1', type: 'ai', content: 'hi there' },
+        ],
+      }]);
+      transport.close();
+      await new Promise(r => setTimeout(r, 30));
+
+      const regeneratePromise = ref.regenerate(1);
+      transport.close();
+      await regeneratePromise;
+
+      // updateState invoked exactly once — with the RemoveMessage payload
+      // AND asNode set to '__start__'. Without asNode, regenerate would
+      // submit(null) against a terminal thread and produce no new assistant.
+      expect(updateCalls).toHaveLength(1);
+      expect(updateCalls[0]?.threadId).toBe('t-1');
+      expect(updateCalls[0]?.options?.asNode).toBe('__start__');
+      const removeMessages = (updateCalls[0]?.values?.['messages'] as Array<Record<string, unknown>>) ?? [];
+      expect(removeMessages).toHaveLength(1);
+      expect(removeMessages[0]?.['type']).toBe('remove');
+      expect(removeMessages[0]?.['id']).toBe('a-1');
+    });
+
     it('throws when target index is not an assistant message', async () => {
       const transport = new MockAgentTransport();
       const ref = withInjectionContext(() =>

--- a/libs/langgraph/src/lib/agent.fn.ts
+++ b/libs/langgraph/src/lib/agent.fn.ts
@@ -310,15 +310,26 @@ export function agent<
         })
         .filter((rm): rm is RemoveMessageInstruction => rm !== null);
 
-      if (removeList.length > 0) {
-        // updateState is a no-op when the transport doesn't support it
-        // (e.g. mock transport in unit tests) — safe to call unconditionally.
-        await manager.updateState({ messages: removeList });
-      }
+      // RemoveMessage rollback + reposition the graph to the entry node
+      // via `as_node: '__start__'`. After the original run, the thread is
+      // at `__end__` with `next: []` — submitting `null` would be a no-op
+      // because there is nothing pending to execute. Setting `asNode` to
+      // the start node tells LangGraph to treat the update as if `__start__`
+      // had just produced the values, so the next pull resumes at the entry
+      // node and runs `generate` against the rolled-back state.
+      //
+      // We always pass `asNode` even when removeList is empty (rare, but
+      // possible if the assistant message had no id) so the regenerate
+      // submit below still runs the graph.
+      await manager.updateState(
+        { messages: removeList },
+        { asNode: '__start__' },
+      );
 
-      // Re-run the graph with no new input so LangGraph executes from the
-      // current (trimmed) thread state. The trailing user message becomes the
-      // active prompt without being re-appended.
+      // Re-run the graph with no new input. With the thread now repositioned
+      // at `__start__`, this resumes at the entry node and produces a fresh
+      // assistant message — the trailing user message becomes the active
+      // prompt without being re-appended.
       await manager.submit(null, undefined);
     },
 

--- a/libs/langgraph/src/lib/agent.types.ts
+++ b/libs/langgraph/src/lib/agent.types.ts
@@ -212,11 +212,18 @@ export interface AgentTransport {
    * Optional: update server-side thread state (e.g. to emit RemoveMessage
    * entries for regenerate rollback). Forwards to the LangGraph
    * `threads.updateState` API.
+   *
+   * `options.asNode` corresponds to LangGraph's `as_node` parameter — the
+   * server treats the update as if that node had just produced the values,
+   * which determines what the next pull resumes. `regenerate()` passes
+   * `asNode: '__start__'` so the next `submit(null)` resumes at the entry
+   * node and re-runs `generate` against the rolled-back state.
    */
   updateState?(
     threadId: string,
     values: Record<string, unknown>,
     signal: AbortSignal,
+    options?: { asNode?: string },
   ): Promise<void>;
 }
 

--- a/libs/langgraph/src/lib/agent.types.ts
+++ b/libs/langgraph/src/lib/agent.types.ts
@@ -319,11 +319,13 @@ export interface LangGraphAgent<T = unknown, ResolvedBag extends BagTemplate = B
   reload: () => void;
 
   /**
-   * Truncate the thread at the given assistant-message index and re-submit the
-   * preceding user message. Used by `<ngaf-chat>`'s regenerate action and any
-   * custom UI that wants the same semantics. Rejects if the agent is currently
-   * loading, if the index does not point at an assistant message, or if no
-   * preceding user message exists.
+   * Discards the assistant message at the given index AND all messages after
+   * it, then re-runs the agent against the trimmed conversation tail. The
+   * preceding user message (at index - 1) is preserved and re-submitted as
+   * the agent's input. No new user message is added to the history.
+   *
+   * Throws if the message at `index` is not 'assistant' role, or if the
+   * agent is currently loading another response.
    */
   regenerate: (assistantMessageIndex: number) => Promise<void>;
 

--- a/libs/langgraph/src/lib/internals/stream-manager.bridge.ts
+++ b/libs/langgraph/src/lib/internals/stream-manager.bridge.ts
@@ -55,7 +55,7 @@ export interface StreamManagerBridge {
   resubmitLast:          () => Promise<void>;
   getReasoningDurationMs:(id: string) => number | undefined;
   /** Update server-side thread state (e.g. RemoveMessage for regenerate rollback). */
-  updateState:           (values: Record<string, unknown>) => Promise<void>;
+  updateState:           (values: Record<string, unknown>, opts?: { asNode?: string }) => Promise<void>;
   /** The current thread ID tracked by the bridge (null if not yet known). */
   readonly currentThreadId: string | null;
 }
@@ -665,13 +665,21 @@ export function createStreamManagerBridge<T, ResolvedBag extends BagTemplate = B
       return entry.endedAt - entry.startedAt;
     },
 
-    updateState: async (values: Record<string, unknown>): Promise<void> => {
+    updateState: async (
+      values: Record<string, unknown>,
+      opts?: { asNode?: string },
+    ): Promise<void> => {
       // No-op when there is no thread yet or the transport doesn't support
       // updateState (e.g. MockAgentTransport in unit tests without a threadId).
       if (!currentThreadId || !transport.updateState) {
         return;
       }
-      await transport.updateState(currentThreadId, values, new AbortController().signal);
+      await transport.updateState(
+        currentThreadId,
+        values,
+        new AbortController().signal,
+        opts,
+      );
     },
 
     get currentThreadId(): string | null {

--- a/libs/langgraph/src/lib/transport/fetch-stream.transport.ts
+++ b/libs/langgraph/src/lib/transport/fetch-stream.transport.ts
@@ -115,8 +115,17 @@ export class FetchStreamTransport implements AgentTransport {
   }
 
   /** Update server-side thread state, e.g. to remove messages for regenerate rollback. */
-  async updateState(threadId: string, values: Record<string, unknown>, _signal: AbortSignal): Promise<void> {
-    await this.client.threads.updateState(threadId, { values });
+  async updateState(
+    threadId: string,
+    values: Record<string, unknown>,
+    _signal: AbortSignal,
+    options?: { asNode?: string },
+  ): Promise<void> {
+    const body: { values: Record<string, unknown>; asNode?: string } = { values };
+    if (options?.asNode !== undefined) {
+      body.asNode = options.asNode;
+    }
+    await this.client.threads.updateState(threadId, body);
   }
 }
 

--- a/libs/licensing/package.json
+++ b/libs/licensing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/licensing",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/partial-json/package.json
+++ b/libs/partial-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/partial-json",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "deprecated": "Replaced by @cacheplane/partial-json. No further versions will be published from this package.",
   "license": "MIT",
   "repository": {

--- a/libs/render/package.json
+++ b/libs/render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/render",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "peerDependencies": {
     "@angular/core": "^20.0.0 || ^21.0.0",
     "@angular/common": "^20.0.0 || ^21.0.0",

--- a/libs/ui-react/package.json
+++ b/libs/ui-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/ui-react",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Live `~/tmp/ngaf` smoke against the freshly-published 0.0.28 reproduced the 1u/1a → 1u/0a regression: regenerate truncated the assistant message but a new one never streamed in.

Root cause confirmed via direct LangGraph API probe:

- After the original run, the thread is at `__end__` with `next: []`
- 0.0.28's `updateState({messages: [removeInstr]})` correctly applied the rollback (server state → just the user message)
- But `submit(null)` is a no-op against a terminal thread — there's nothing pending to execute, so `generate` never re-ran
- Manual `POST /threads/$ID/state` with `as_node: '__start__'` flipped `next` to `['generate']`; subsequent `runs/wait` with `input: null` produced a fresh assistant — confirming the fix

Code change:
- Extend `transport.updateState` + `StreamManagerBridge.updateState` with an optional `asNode` parameter
- `agent.fn.ts` `regenerate()` passes `asNode: '__start__'` so the next pull resumes at the entry node
- New unit test verifies the wire-shape: mock transport captures `updateCalls[0].options.asNode === '__start__'`

Also broadens `@ngaf/chat`'s `@cacheplane/partial-json` dep range to `>=0.1.1 <0.3.0` so consumers can pull the recently-published 0.2.x (StreamStatus rename — non-breaking for the surface @ngaf/chat actually uses).

Bumped all 16 @ngaf packages 0.0.28 → 0.0.29.

## Test plan

- [x] `nx run langgraph:test` green (new asNode spec covers the wire-shape)
- [x] `nx run-many -t test --projects=langgraph,chat,ag-ui,a2ui,render,licensing` green
- [x] `nx run-many -t lint --projects=langgraph,chat,ag-ui` green
- [ ] CI green
- [ ] After publish: bump `~/tmp/ngaf` to 0.0.29, live smoke regenerate produces 1u/1a (NOT 1u/0a)