### PR TITLE
chore(release): CHANGELOG entry for v0.0.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 0.0.29 — 2026-05-08
+
+### Fixed
+
+- **`@ngaf/langgraph`** — `regenerate(index)` now repositions the LangGraph thread via `as_node: '__start__'` before re-submitting, so the next pull resumes at the entry node and re-runs `generate` against the rolled-back state. Previously the run could resume mid-graph and skip generation. (#209)
+
+### Added
+
+- **`@ngaf/langgraph`** — `regenerate(assistantMessageIndex)` is now declared on the public `LangGraphAgent` surface (previously implemented + tested but missing from `agent.types.ts`). JSDoc matches the canonical `Agent.regenerate` contract in `@ngaf/chat`. (#207, #208)
+- **`AgentTransport.updateState`** — optional `options.asNode` parameter mirrors LangGraph's `as_node`, used by `regenerate()` to anchor the rolled-back state at the entry node.
+
+### Changed
+
+- All 7 publishable @ngaf libraries synchronized to `0.0.29` per project policy (single version across the suite).
+
+---
+
 ## 0.0.28 — 2026-05-07
 
 ### Breaking


### PR DESCRIPTION
## Summary

CHANGELOG entry for the upcoming **v0.0.29** patch release. Covers everything landed since `v0.0.28`.

### What's in 0.0.29

- **Fix (#209)** — `regenerate()` now repositions the LangGraph thread via `as_node: '__start__'` before re-submitting, so the next pull resumes at the entry node. Previously the run could resume mid-graph and skip generation.
- **Added (#207, #208)** — `regenerate(assistantMessageIndex)` declared on the public `LangGraphAgent` type with canonical JSDoc.
- **Added** — optional `options.asNode` on `AgentTransport.updateState` mirroring LangGraph's `as_node`.

After merge, will tag `v0.0.29` on the merge commit to trigger `publish.yml`.

## Test plan

- [x] CHANGELOG renders correctly (Markdown lint clean)
- [ ] CI passes (no code changes, should be a no-op for tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)