### PR TITLE
fix(examples-chat): use Pandoc citation refs so inline markers link

### DIFF
--- a/examples/chat/angular/src/app/modes/welcome-suggestions.ts
+++ b/examples/chat/angular/src/app/modes/welcome-suggestions.ts
@@ -32,6 +32,6 @@ export const WELCOME_SUGGESTIONS: readonly WelcomeSuggestion[] = [
   {
     label: 'What are Angular signals? (search + cite sources)',
     value:
-      'Use the search tool to find authoritative information about Angular signals, then explain what they are and when to use them. Cite your sources inline using [1], [2] etc.',
+      'Use the search tool to find authoritative information about Angular signals, then explain what they are and when to use them. Cite each source inline as [^doc-id] using the document `id` field returned by the tool.',
   },
 ];

--- a/examples/chat/python/src/graph.py
+++ b/examples/chat/python/src/graph.py
@@ -41,8 +41,13 @@ SYSTEM_PROMPT = (
     "You are a helpful, concise assistant. "
     "Format responses with markdown when useful (headings, lists, code blocks, tables). "
     "When the user asks about specific Angular topics or technical questions, "
-    "use the `search_documents` tool to find authoritative information before answering, "
-    "and cite the sources inline using [1], [2], etc."
+    "use the `search_documents` tool to find authoritative information before answering. "
+    "Cite sources inline using Pandoc-style citation references with the "
+    "document `id` field as the refId, e.g. `[^ng-signals-overview]` or "
+    "`[^ng-control-flow]`. Each first-use of a document gets an auto-numbered "
+    "marker; subsequent references to the same document share the number. "
+    "Do not write `[1]` or `[1, 2]` — those are plain text and won't link to "
+    "the sources panel."
 )
 
 # Reasoning-capable model prefixes. We only attach the ``reasoning``


### PR DESCRIPTION
## Summary

Live smoke (post Phase 2B merge in #220) surfaced **Finding G**: chat-streaming-md rendered the assistant's response with plain `[1]`, `[2]` text markers and a fully-populated Sources panel below — but the inline markers were **not** clickable links to the sources. They rendered as raw text.

## Root cause

`@cacheplane/partial-markdown` recognises Pandoc-style `[^refId]` citation syntax, not plain `[N]` numerical markers. The Phase 2B system prompt instructed the model to emit `[1]`, `[2]`, etc., which the parser ignored — so `<chat-md-citation-reference>` elements were never generated despite the citations registry being correctly wired.

## Fix

Update the python graph's system prompt and the Angular welcome suggestion to instruct Pandoc-style `[^doc-id]` syntax, using the document `id` field returned by the `search_documents` tool (e.g. `[^ng-signals-overview]`, `[^ng-control-flow]`). Each first-use of a document gets an auto-numbered marker; subsequent references to the same document share the number.

The `Message.citations` shape produced by `attach_citations` already carries each document's `id` as the citation's id field, which `CitationsResolverService.lookup(refId)` matches against — so the resolver finds the citation by document id and renders the marker as a clickable `<a>` link to the source URL.

## Test plan

### Verified locally
- [x] `nx run examples-chat-python:smoke` — 4 passed
- [x] `nx run examples-chat-angular:build` — succeeds (development)
- [x] **Server-side probe**: submit the welcome suggestion to gpt-5-mini. Raw AI text contains 17 `[^doc-id]` markers (3 unique: `ng-signals-overview`, `ng-signals-rxjs`, `ng-control-flow`); 0 plain `[N]` markers.

### Pending visual verification
- [ ] After merge: live smoke against the workspace `examples/chat` demo. Inline `[N]` superscript markers in the assistant's response link to the Sources panel; hovering shows the citation snippet; clicking opens the source URL.