### PR TITLE
fix(langgraph): extract __interrupt__ from values/updates events

### DIFF
--- a/libs/langgraph/src/lib/internals/stream-manager.bridge.ts
+++ b/libs/langgraph/src/lib/internals/stream-manager.bridge.ts
@@ -420,6 +420,7 @@ export function createStreamManagerBridge<T, ResolvedBag extends BagTemplate = B
           break;
         }
         if (vals != null) {
+          extractInterrupts(vals, subjects);
           subjects.values$.next(vals as T);
           // Also sync messages$ from the values state so the full message
           // history (including human messages) is available to consumers.
@@ -480,6 +481,7 @@ export function createStreamManagerBridge<T, ResolvedBag extends BagTemplate = B
           break;
         }
         if (upd != null) {
+          extractInterrupts(upd, subjects);
           subjects.values$.next({
             ...subjects.values$.value,
             ...(upd as object),
@@ -721,6 +723,36 @@ export function createStreamManagerBridge<T, ResolvedBag extends BagTemplate = B
  * 1. SDK events (via normalizeSdkEvent): data at event['data'] (record) + spread into event
  * 2. Mock/test events: data at event[event.type] (e.g., event['values'], event['updates'])
  */
+/**
+ * LangGraph emits interrupts as part of `updates`/`values` events under the
+ * special `__interrupt__` key, not as standalone events. When such a payload
+ * appears, mirror it onto `interrupt$` (latest) and `interrupts$` (full list)
+ * so consumers can react via `agent.interrupt()` / `agent.interrupts()`.
+ */
+function extractInterrupts<T, B extends BagTemplate>(
+  payload: unknown,
+  subjects: StreamSubjects<T, B>,
+): void {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return;
+  const raw = (payload as Record<string, unknown>)['__interrupt__'];
+  // Cast through unknown — Interrupt$ is parameterized over Bag's InterruptType,
+  // and the SDK delivers raw Interrupt payloads here.
+  if (Array.isArray(raw) && raw.length > 0) {
+    const list = raw as Interrupt[];
+    subjects.interrupts$.next(list as unknown as Parameters<typeof subjects.interrupts$.next>[0]);
+    subjects.interrupt$.next(list[list.length - 1] as unknown as Parameters<typeof subjects.interrupt$.next>[0]);
+    return;
+  }
+  // Payload has no `__interrupt__` key. Clear any stale interrupt so the UI
+  // dismisses the panel after a resume completes (LangGraph does not emit a
+  // separate "cleared" event — the absence of `__interrupt__` in subsequent
+  // values/updates is the signal). No-op if interrupt$ was already empty.
+  if (subjects.interrupt$.value !== undefined) {
+    subjects.interrupt$.next(undefined);
+    subjects.interrupts$.next([]);
+  }
+}
+
 function extractEventData(event: StreamEvent): unknown {
   // Try event['data'] first (SDK format from normalizeSdkEvent)
   const d = event['data'];


### PR DESCRIPTION
## Summary

LangGraph emits interrupts as part of \`values\` and \`updates\` events under the special \`__interrupt__\` key, not as standalone \`interrupt\` events. The \`@ngaf/langgraph\` bridge was only handling the latter, so \`agent.interrupt()\` / \`agent.interrupts()\` never populated for real graphs — any UI gated on those signals (e.g. \`<chat-interrupt-panel>\`) stayed hidden.

Adds an \`extractInterrupts\` helper called from the values/updates branches that:

- Mirrors \`__interrupt__\` payloads onto \`interrupt\$\` (latest) and \`interrupts\$\` (full list)
- Clears both subjects when a values/updates event arrives without an \`__interrupt__\` key — LangGraph does not emit a separate \"cleared\" event, so the absence is the dismissal signal once a resume completes

## Verification

Live smoke against the canonical \`examples/chat\` demo (issue surfaced as Finding H during the Phase 3A re-smoke):

- Trigger the approval welcome suggestion → \`<chat-interrupt-panel>\` renders with the AI's reason ✅
- Accept → graph resumes, panel dismisses, AI continues with deletion plan ✅
- Edit (custom resume value) → graph resumes, panel dismisses ✅
- Respond → graph resumes with the typed text, panel dismisses ✅
- Ignore → graph resumes with denial, panel dismisses ✅

## Test plan

- [ ] CI passes (langgraph unit tests, build, e2e)
- [ ] No regressions to existing \`agent.interrupt\` / \`agent.interrupts\` consumers

🤖 Generated with [Claude Code](https://claude.com/claude-code)