### PR TITLE
fix(examples-chat): research tool passes subagent_type so SubagentTracker registers

### DIFF
--- a/examples/chat/python/src/graph.py
+++ b/examples/chat/python/src/graph.py
@@ -58,10 +58,11 @@ SYSTEM_PROMPT = (
     "When the user asks for in-depth research on a focused topic (history, "
     "motivation, comparison, deep-dive on something they want explained), "
     "call the `research` tool to dispatch a subagent that focuses on that "
-    "topic. Pass the topic verbatim or as a concise rephrasing. Use the "
-    "subagent's returned summary to compose your final answer. Do not "
-    "call `research` for trivial chit-chat or simple lookups — those are "
-    "handled by `search_documents`."
+    "topic. Pass the topic verbatim or as a concise rephrasing, and pass "
+    "`subagent_type=\"research\"` so the UI surfaces a subagent card while "
+    "the child runs. Use the subagent's returned summary to compose your "
+    "final answer. Do not call `research` for trivial chit-chat or simple "
+    "lookups — those are handled by `search_documents`."
 )
 
 # Reasoning-capable model prefixes. We only attach the ``reasoning``
@@ -178,11 +179,20 @@ research_subgraph = _research_builder.compile()
 
 
 @tool
-async def research(topic: str) -> str:
+async def research(topic: str, subagent_type: str = "research") -> str:
     """Dispatch a research subagent to gather facts on a focused topic.
     The subagent returns a concise summary; pass that summary back to
     the user, citing it with the inline citation syntax if appropriate.
+
+    `subagent_type` is a free-form label the parent uses to identify the
+    subagent in the UI (the @ngaf/langgraph SubagentTracker keys on it
+    to populate `agent.subagents()` for the chat-subagents primitive).
+    Always pass a stable identifier like "research".
     """
+    # subagent_type is intentionally accepted but unused server-side —
+    # it travels in the tool call args so the SubagentTracker can
+    # register the dispatch and surface a card while the child graph runs.
+    del subagent_type
     result = await research_subgraph.ainvoke({"topic": topic, "messages": []})
     msgs = result.get("messages") if isinstance(result, dict) else None
     if not msgs:


### PR DESCRIPTION
## Summary

Phase 3B (PR #224) merged with a working python graph and Angular shell wiring, but live smoke against the demo revealed `<chat-subagents>` never surfaced a card during the research run. Root cause: \`@ngaf/langgraph\` SubagentTracker silently skips tool calls whose args don't include a valid \`subagent_type\` string — the demo's research tool only carried \`topic\`, so the tracker rejected the registration and \`agent.subagents()\` stayed empty.

Adds \`subagent_type: str = \"research\"\` to the research tool signature (consumed only as a UI hint — body deletes it before invoking the subgraph) and instructs the parent in \`SYSTEM_PROMPT\` to pass it.

## Verification

Live smoke against the workspace examples/chat demo after the fix:

- \`agent.subagents().size === 1\` after the parent dispatches the research tool ✅
- Map entry: \`{ id: \"call_<x>\", status: \"complete\" }\` after the subagent returns ✅
- \`<chat-subagents>\` panel wrapper renders (the @if gate is satisfied by tracker map size) ✅
- Card flashes briefly during the active window; \`activeSubagents()\` filter hides it post-complete (spec-acknowledged behavior — persistent post-complete display is a Phase 4+ concern) ✅
- Final AI message returns the research summary; pytest still 8 passed ✅

## Test plan

- [ ] CI green (8 pytest, lint, build, e2e)
- [ ] No regressions to Phase 3B's existing demo flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)