### PR TITLE
feat(examples-chat): Phase 5 — GenUI dropdown + dynamic schema generation

### DIFF
--- a/apps/website/content/docs/chat/api/api-docs.json
+++ b/apps/website/content/docs/chat/api/api-docs.json
@@ -13,8 +13,38 @@
         "optional": false
       },
       {
+        "name": "bindings",
+        "type": "InputSignal<Record<string, string>>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "childKeys",
+        "type": "InputSignal<string[]>",
+        "description": "",
+        "optional": false
+      },
+      {
         "name": "controls",
         "type": "InputSignal<boolean>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "emit",
+        "type": "InputSignal<object>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "loading",
+        "type": "InputSignal<boolean>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "spec",
+        "type": "InputSignal<Spec | undefined>",
         "description": "",
         "optional": false
       },
@@ -35,6 +65,12 @@
     "examples": [],
     "properties": [
       {
+        "name": "bindings",
+        "type": "InputSignal<Record<string, string>>",
+        "description": "",
+        "optional": false
+      },
+      {
         "name": "childKeys",
         "type": "InputSignal<string[]>",
         "description": "v1: child Text component is rendered inside the button via childKeys.",
@@ -49,6 +85,12 @@
       {
         "name": "emit",
         "type": "InputSignal<object>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "loading",
+        "type": "InputSignal<boolean>",
         "description": "",
         "optional": false
       },
@@ -82,9 +124,27 @@
     "examples": [],
     "properties": [
       {
+        "name": "bindings",
+        "type": "InputSignal<Record<string, string>>",
+        "description": "",
+        "optional": false
+      },
+      {
         "name": "childKeys",
         "type": "InputSignal<string[]>",
         "description": "v1: a single child key, delivered via childKeys[0] from the render framework.",
+        "optional": false
+      },
+      {
+        "name": "emit",
+        "type": "InputSignal<object>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "loading",
+        "type": "InputSignal<boolean>",
+        "description": "",
         "optional": false
       },
       {
@@ -110,8 +170,20 @@
         "optional": false
       },
       {
+        "name": "bindings",
+        "type": "InputSignal<Record<string, string>>",
+        "description": "",
+        "optional": false
+      },
+      {
         "name": "checked",
         "type": "InputSignal<boolean>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "childKeys",
+        "type": "InputSignal<string[]>",
         "description": "",
         "optional": false
       },
@@ -124,6 +196,18 @@
       {
         "name": "label",
         "type": "InputSignal<string>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "loading",
+        "type": "InputSignal<boolean>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "spec",
+        "type": "InputSignal<Spec | undefined>",
         "description": "",
         "optional": false
       }
@@ -158,6 +242,12 @@
         "optional": false
       },
       {
+        "name": "bindings",
+        "type": "InputSignal<Record<string, string>>",
+        "description": "",
+        "optional": false
+      },
+      {
         "name": "childKeys",
         "type": "InputSignal<string[]>",
         "description": "",
@@ -170,8 +260,26 @@
         "optional": false
       },
       {
+        "name": "distribution",
+        "type": "InputSignal<\"center\" | \"start\" | \"end\" | \"spaceBetween\" | \"spaceAround\" | \"spaceEvenly\">",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "emit",
+        "type": "InputSignal<object>",
+        "description": "",
+        "optional": false
+      },
+      {
         "name": "gap",
         "type": "InputSignal<number>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "loading",
+        "type": "InputSignal<boolean>",
         "description": "",
         "optional": false
       },
@@ -200,6 +308,18 @@
       {
         "name": "_inputId",
         "type": "string",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "bindings",
+        "type": "InputSignal<Record<string, string>>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "childKeys",
+        "type": "InputSignal<string[]>",
         "description": "",
         "optional": false
       },
@@ -234,6 +354,18 @@
         "optional": false
       },
       {
+        "name": "loading",
+        "type": "InputSignal<boolean>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "spec",
+        "type": "InputSignal<Spec | undefined>",
+        "description": "",
+        "optional": false
+      },
+      {
         "name": "value",
         "type": "InputSignal<string>",
         "description": "v1 prop: value (resolved DynamicString).",
@@ -264,8 +396,50 @@
     "examples": [],
     "properties": [
       {
+        "name": "axis",
+        "type": "InputSignal<\"horizontal\" | \"vertical\" | undefined>",
+        "description": "Canonical v1 spec name. The LLM emits this.",
+        "optional": false
+      },
+      {
+        "name": "bindings",
+        "type": "InputSignal<Record<string, string>>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "childKeys",
+        "type": "InputSignal<string[]>",
+        "description": "",
+        "optional": false
+      },
+      {
         "name": "direction",
         "type": "InputSignal<\"horizontal\" | \"vertical\">",
+        "description": "Older alias retained for json-render usage and back-compat.",
+        "optional": false
+      },
+      {
+        "name": "emit",
+        "type": "InputSignal<object>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "loading",
+        "type": "InputSignal<boolean>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "orientation",
+        "type": "Signal<\"horizontal\" | \"vertical\">",
+        "description": "Effective axis — `axis` wins if provided, otherwise fall back to `direction`.",
+        "optional": false
+      },
+      {
+        "name": "spec",
+        "type": "InputSignal<Spec | undefined>",
         "description": "",
         "optional": false
       }
@@ -280,14 +454,44 @@
     "examples": [],
     "properties": [
       {
+        "name": "bindings",
+        "type": "InputSignal<Record<string, string>>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "childKeys",
+        "type": "InputSignal<string[]>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "emit",
+        "type": "InputSignal<object>",
+        "description": "",
+        "optional": false
+      },
+      {
         "name": "icon",
         "type": "InputSignal<string>",
         "description": "v1 prop name: icon (resolved string, e.g. a Unicode symbol or ligature name).",
         "optional": false
       },
       {
+        "name": "loading",
+        "type": "InputSignal<boolean>",
+        "description": "",
+        "optional": false
+      },
+      {
         "name": "size",
         "type": "InputSignal<number | null>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "spec",
+        "type": "InputSignal<Spec | undefined>",
         "description": "",
         "optional": false
       }
@@ -308,8 +512,38 @@
         "optional": false
       },
       {
+        "name": "bindings",
+        "type": "InputSignal<Record<string, string>>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "childKeys",
+        "type": "InputSignal<string[]>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "emit",
+        "type": "InputSignal<object>",
+        "description": "",
+        "optional": false
+      },
+      {
         "name": "height",
         "type": "InputSignal<number | null>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "loading",
+        "type": "InputSignal<boolean>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "spec",
+        "type": "InputSignal<Spec | undefined>",
         "description": "",
         "optional": false
       },
@@ -336,6 +570,12 @@
     "examples": [],
     "properties": [
       {
+        "name": "bindings",
+        "type": "InputSignal<Record<string, string>>",
+        "description": "",
+        "optional": false
+      },
+      {
         "name": "childKeys",
         "type": "InputSignal<string[]>",
         "description": "",
@@ -348,8 +588,20 @@
         "optional": false
       },
       {
+        "name": "emit",
+        "type": "InputSignal<object>",
+        "description": "",
+        "optional": false
+      },
+      {
         "name": "listClass",
         "type": "Signal<\"flex flex-row gap-1 overflow-x-auto\" | \"flex flex-col gap-1 overflow-y-auto max-h-96\">",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "loading",
+        "type": "InputSignal<boolean>",
         "description": "",
         "optional": false
       },
@@ -370,6 +622,12 @@
     "examples": [],
     "properties": [
       {
+        "name": "bindings",
+        "type": "InputSignal<Record<string, string>>",
+        "description": "",
+        "optional": false
+      },
+      {
         "name": "childKeys",
         "type": "InputSignal<string[]>",
         "description": "v1: childKeys[0] = entryPointChild (inline trigger),\n    childKeys[1] = contentChild (modal body).",
@@ -382,8 +640,20 @@
         "optional": false
       },
       {
+        "name": "emit",
+        "type": "InputSignal<object>",
+        "description": "",
+        "optional": false
+      },
+      {
         "name": "entryPointKey",
         "type": "Signal<string>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "loading",
+        "type": "InputSignal<boolean>",
         "description": "",
         "optional": false
       },
@@ -422,6 +692,18 @@
         "optional": false
       },
       {
+        "name": "bindings",
+        "type": "InputSignal<Record<string, string>>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "childKeys",
+        "type": "InputSignal<string[]>",
+        "description": "",
+        "optional": false
+      },
+      {
         "name": "emit",
         "type": "InputSignal<object>",
         "description": "",
@@ -440,6 +722,12 @@
         "optional": false
       },
       {
+        "name": "loading",
+        "type": "InputSignal<boolean>",
+        "description": "",
+        "optional": false
+      },
+      {
         "name": "maxAllowedSelections",
         "type": "InputSignal<number>",
         "description": "When ≤ 1 — render as single-select <select>; otherwise multi-select checkboxes.",
@@ -453,8 +741,20 @@
       },
       {
         "name": "selections",
-        "type": "InputSignal<string[]>",
-        "description": "Resolved current selections (plain string array from surface-to-spec).",
+        "type": "InputSignal<string | string[] | undefined>",
+        "description": "Resolved current selections from surface-to-spec. Normalized in\n`selectionsArray` because LLMs sometimes seed the data model with a\nscalar (e.g. `\"5\"`) instead of an array (`[\"5\"]`); we coerce so\n.includes() works either way.",
+        "optional": false
+      },
+      {
+        "name": "selectionsArray",
+        "type": "Signal<string[]>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "spec",
+        "type": "InputSignal<Spec | undefined>",
+        "description": "",
         "optional": false
       }
     ],
@@ -520,6 +820,12 @@
         "optional": false
       },
       {
+        "name": "bindings",
+        "type": "InputSignal<Record<string, string>>",
+        "description": "",
+        "optional": false
+      },
+      {
         "name": "childKeys",
         "type": "InputSignal<string[]>",
         "description": "",
@@ -532,8 +838,20 @@
         "optional": false
       },
       {
+        "name": "emit",
+        "type": "InputSignal<object>",
+        "description": "",
+        "optional": false
+      },
+      {
         "name": "gap",
         "type": "InputSignal<number>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "loading",
+        "type": "InputSignal<boolean>",
         "description": "",
         "optional": false
       },
@@ -572,6 +890,18 @@
         "optional": false
       },
       {
+        "name": "bindings",
+        "type": "InputSignal<Record<string, string>>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "childKeys",
+        "type": "InputSignal<string[]>",
+        "description": "",
+        "optional": false
+      },
+      {
         "name": "emit",
         "type": "InputSignal<object>",
         "description": "",
@@ -580,6 +910,12 @@
       {
         "name": "label",
         "type": "InputSignal<string>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "loading",
+        "type": "InputSignal<boolean>",
         "description": "",
         "optional": false
       },
@@ -593,6 +929,12 @@
         "name": "minValue",
         "type": "InputSignal<number>",
         "description": "v1 prop: minValue.",
+        "optional": false
+      },
+      {
+        "name": "spec",
+        "type": "InputSignal<Spec | undefined>",
+        "description": "",
         "optional": false
       },
       {
@@ -716,9 +1058,27 @@
         "optional": false
       },
       {
+        "name": "bindings",
+        "type": "InputSignal<Record<string, string>>",
+        "description": "",
+        "optional": false
+      },
+      {
         "name": "childKeys",
         "type": "InputSignal<string[]>",
         "description": "v1: each child key corresponds to a tab's contentChild (childKeys[i] ↔ tabTitles[i]).",
+        "optional": false
+      },
+      {
+        "name": "emit",
+        "type": "InputSignal<object>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "loading",
+        "type": "InputSignal<boolean>",
+        "description": "",
         "optional": false
       },
       {
@@ -757,6 +1117,36 @@
     "params": [],
     "examples": [],
     "properties": [
+      {
+        "name": "bindings",
+        "type": "InputSignal<Record<string, string>>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "childKeys",
+        "type": "InputSignal<string[]>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "emit",
+        "type": "InputSignal<object>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "loading",
+        "type": "InputSignal<boolean>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "spec",
+        "type": "InputSignal<Spec | undefined>",
+        "description": "",
+        "optional": false
+      },
       {
         "name": "text",
         "type": "InputSignal<string>",
@@ -799,6 +1189,18 @@
         "optional": false
       },
       {
+        "name": "bindings",
+        "type": "InputSignal<Record<string, string>>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "childKeys",
+        "type": "InputSignal<string[]>",
+        "description": "",
+        "optional": false
+      },
+      {
         "name": "emit",
         "type": "InputSignal<object>",
         "description": "",
@@ -817,8 +1219,20 @@
         "optional": false
       },
       {
+        "name": "loading",
+        "type": "InputSignal<boolean>",
+        "description": "",
+        "optional": false
+      },
+      {
         "name": "placeholder",
         "type": "InputSignal<string>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "spec",
+        "type": "InputSignal<Spec | undefined>",
         "description": "",
         "optional": false
       },
@@ -877,8 +1291,38 @@
         "optional": false
       },
       {
+        "name": "bindings",
+        "type": "InputSignal<Record<string, string>>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "childKeys",
+        "type": "InputSignal<string[]>",
+        "description": "",
+        "optional": false
+      },
+      {
         "name": "controls",
         "type": "InputSignal<boolean>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "emit",
+        "type": "InputSignal<object>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "loading",
+        "type": "InputSignal<boolean>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "spec",
+        "type": "InputSignal<Spec | undefined>",
         "description": "",
         "optional": false
       },

--- a/docs/superpowers/plans/2026-05-10-canonical-chat-demo-phase-5-genui-dropdown.md
+++ b/docs/superpowers/plans/2026-05-10-canonical-chat-demo-phase-5-genui-dropdown.md
@@ -1,0 +1,1401 @@
+# Canonical `examples/chat` Demo — Phase 5: GenUI Dropdown + Dynamic Schema Generation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace Phase 4's hardcoded `FEEDBACK_FORM_JSONL` path with dynamic schema generation. Add a palette `GenUI` dropdown (`a2ui` / `json-render`); welcome suggestions are now generic intents that work against either rendering protocol via a sub-LLM that has the protocol's full canonical schema in its system prompt.
+
+**Architecture:** Two new sub-LLM tools (`generate_a2ui_schema`, `generate_json_render_spec`) each invoke a nested `ChatOpenAI(temperature=0)` with the protocol's full JSON schema in its system prompt. The parent LLM dispatches the tool matching `state.gen_ui_mode`. Routing diverts these tool calls to a new `emit_generated_surface` post-process node that wraps the sub-LLM output with the chat composition's content-classifier sentinels (`---a2ui_JSON---\n` for a2ui; raw `{` for json-render). Existing Phase 2B/3A/3B paths (search, approval, research) continue unchanged.
+
+**Tech Stack:** Python 3.12 (uv, langgraph.graph.StateGraph, langchain-openai, langchain-core), pytest. Angular 21 (signals, OnPush, standalone components).
+
+**Spec:** `docs/superpowers/specs/2026-05-10-canonical-chat-demo-phase-5-genui-dropdown-design.md` (committed at c474fe43)
+
+**Branch:** `claude/examples-chat-phase-5-genui`, branched from `origin/main` (currently `57a0d721` — tip after PR #228 a2ui v1 migration).
+
+**Hard constraint:** Never reference hashbrown / copilotkit / chatgpt / chatbot-kit / claude in code, comments, commit messages, or PR titles/bodies. Mentions in markdown spec/plan docs are OK as third-party library names; do not propagate.
+
+---
+
+## File Structure
+
+```
+examples/chat/python/
+├── src/
+│   ├── graph.py                                      # Heavy edits: remove Phase 4 + add Phase 5 paths (~120 LOC delta)
+│   └── schemas/
+│       ├── __init__.py                               # NEW — empty package init
+│       ├── a2ui_v1.py                                # NEW — A2UI_V1_SCHEMA_PROMPT constant (~770 LOC, copied from L4 reference)
+│       └── json_render.py                            # NEW — JSON_RENDER_SCHEMA_PROMPT constant (~80 LOC, hand-written)
+└── tests/
+    └── test_graph_smoke.py                           # Drop 3 Phase 4 tests, add 4 Phase 5 tests
+
+examples/chat/angular/src/app/
+├── shell/
+│   ├── demo-shell.component.ts                       # +genUiMode signal, +genUiOptions, +handler, +state injection (~15 LOC)
+│   ├── demo-shell.component.html                     # Wire palette inputs/output (~3 LOC)
+│   ├── control-palette.component.ts                  # +genUiMode input, +genUiOptions input, +genUiModeChange output, +pickGenUi handler (~10 LOC)
+│   └── control-palette.component.html                # +<select> dropdown next to Effort (~8 LOC)
+└── modes/welcome-suggestions.ts                      # Remove Phase 4 entry; +4 generic intents
+
+examples/chat/smoke/CHECKLIST.md                      # Update Generative UI / A2UI surfaces section
+```
+
+Total ≈ 200 LOC of code + 850 LOC of pasted schema-doc constants.
+
+---
+
+## Phase 0 — Branch creation
+
+### Task 0.1: Create implementation branch
+
+- [ ] **Step 1: Branch from origin/main**
+
+```bash
+cd /Users/blove/repos/angular-agent-framework
+git fetch origin main
+git checkout -b claude/examples-chat-phase-5-genui origin/main
+git rev-parse --abbrev-ref HEAD   # must echo claude/examples-chat-phase-5-genui
+git log --oneline -1              # must be 57a0d721 or later (PR #228 a2ui v1 migration)
+```
+
+---
+
+## Phase 1 — Schema-prompt modules
+
+### Task 1.1: Create `schemas/__init__.py`
+
+**File:** `examples/chat/python/src/schemas/__init__.py`
+
+- [ ] **Step 1: Create empty package init**
+
+```python
+# SPDX-License-Identifier: MIT
+"""Schema-prompt modules for the GenUI sub-LLM tools."""
+```
+
+### Task 1.2: Create `schemas/a2ui_v1.py` — A2UI v1 schema prompt
+
+**File:** `examples/chat/python/src/schemas/a2ui_v1.py`
+
+The A2UI v1 schema documentation is ~770 lines of structured prompt + JSON schema. Copy it verbatim from the L4 reference at `/Users/blove/repos/SC-CopilotKit-C1/L4/backend-dynamic/schema.py` (the `SCHEMA_PROMPT` triple-quoted string spanning lines 9-887). The reference's text already targets the canonical Google A2UI v1 protocol, which matches our v1 parser exactly after PR #228.
+
+- [ ] **Step 1: Read the source**
+
+```bash
+sed -n '9,887p' /Users/blove/repos/SC-CopilotKit-C1/L4/backend-dynamic/schema.py | head -40
+```
+
+This shows the start of the `SCHEMA_PROMPT = """..."""` block. The full constant ends at line 887 (the `""".strip()` closure).
+
+- [ ] **Step 2: Create the module**
+
+Create `examples/chat/python/src/schemas/a2ui_v1.py` with the following structure. The triple-quoted string body is the exact content of the L4 reference's `SCHEMA_PROMPT` with NO modifications — the protocol description and JSON schema match our v1 parser as-shipped in PR #228.
+
+```python
+# SPDX-License-Identifier: MIT
+"""A2UI v1 protocol schema documentation, used as the system prompt for
+the `generate_a2ui_schema` sub-LLM tool. Sourced verbatim from the
+L4 production reference (canonical Google A2UI v1 schema)."""
+
+A2UI_V1_SCHEMA_PROMPT = """
+Generate A2UI JSON.
+
+## A2UI Protocol Instructions
+
+A2UI (Agent to UI) is a protocol for rendering rich UI surfaces from agent responses.
+
+To render a surface, you MUST send ALL messages in a SINGLE tool call, in this order:
+1. **surfaceUpdate** - Define all UI components (REQUIRED)
+2. **dataModelUpdate** - Set any data values (OPTIONAL)
+3. **beginRendering** - Signal the client to start rendering (REQUIRED)
+
+### Minimal Working Example
+
+Here is the simplest possible A2UI surface - a button:
+
+```json
+[
+  {
+    "surfaceUpdate": {
+      "surfaceId": "my-surface",
+      "components": [
+        {
+          "id": "root",
+          "component": {
+            "Button": {
+              "child": "btn-text",
+              "action": { "name": "button_clicked" }
+            }
+          }
+        },
+        {
+          "id": "btn-text",
+          "component": {
+            "Text": { "text": { "literalString": "Click Me" } }
+          }
+        }
+      ]
+    }
+  },
+  {
+    "beginRendering": {
+      "surfaceId": "my-surface",
+      "root": "root"
+    }
+  }
+]
+```
+
+## JSON Schema Reference
+[... copy the full JSON schema body from L4 reference lines 58-829 here verbatim ...]
+""".strip()
+```
+
+The `[... copy the full JSON schema body ...]` placeholder must be replaced with the literal content from L4 reference lines 58-829. The simplest mechanical path:
+
+```bash
+# After creating the module file with everything BEFORE the JSON schema section:
+sed -n '58,829p' /Users/blove/repos/SC-CopilotKit-C1/L4/backend-dynamic/schema.py >> /tmp/a2ui_schema_body.txt
+# Then manually paste the contents into the module file inside the triple-quoted string,
+# replacing the placeholder line.
+```
+
+Or simpler — just use Bash + Python to copy the entire SCHEMA_PROMPT constant from line 9 to line 887:
+
+```bash
+python3 -c "
+import re
+src = open('/Users/blove/repos/SC-CopilotKit-C1/L4/backend-dynamic/schema.py').read()
+m = re.search(r'SCHEMA_PROMPT = \"\"\"(.+?)\"\"\"\\.strip\\(\\)', src, re.DOTALL)
+prompt_body = m.group(1)
+out = '''# SPDX-License-Identifier: MIT
+\"\"\"A2UI v1 protocol schema documentation, used as the system prompt for
+the \`generate_a2ui_schema\` sub-LLM tool. Sourced verbatim from the
+L4 production reference (canonical Google A2UI v1 schema).\"\"\"
+
+A2UI_V1_SCHEMA_PROMPT = \"\"\"''' + prompt_body + '''\"\"\".strip()
+'
+open('/Users/blove/repos/angular-agent-framework/examples/chat/python/src/schemas/a2ui_v1.py', 'w').write(out)
+"
+```
+
+After running, verify:
+
+```bash
+wc -l /Users/blove/repos/angular-agent-framework/examples/chat/python/src/schemas/a2ui_v1.py
+grep -c "surfaceUpdate\|dataModelUpdate\|beginRendering\|literalString\|literalNumber" /Users/blove/repos/angular-agent-framework/examples/chat/python/src/schemas/a2ui_v1.py
+```
+
+Expected: ~880 lines; multi-digit count for v1 envelope keys (confirms the schema is fully present).
+
+- [ ] **Step 3: Smoke test the import**
+
+```bash
+cd /Users/blove/repos/angular-agent-framework/examples/chat/python
+uv run python -c "from src.schemas.a2ui_v1 import A2UI_V1_SCHEMA_PROMPT; print(len(A2UI_V1_SCHEMA_PROMPT), 'chars')"
+```
+
+Expected: prints the character count (should be ~30000+ for the full v1 schema doc).
+
+### Task 1.3: Create `schemas/json_render.py` — json-render schema prompt
+
+**File:** `examples/chat/python/src/schemas/json_render.py`
+
+- [ ] **Step 1: Create the module**
+
+```python
+# SPDX-License-Identifier: MIT
+"""json-render protocol schema documentation, used as the system prompt
+for the `generate_json_render_spec` sub-LLM tool. Targets the
+@json-render/core Spec shape: { root, elements, state }."""
+
+JSON_RENDER_SCHEMA_PROMPT = """
+Generate a json-render Spec.
+
+## json-render Protocol Instructions
+
+json-render renders a UI from a single JSON object describing a flat
+component tree. Output ONE JSON object, no array, no prefix, no
+markdown fences. The chat client detects the leading `{` and routes
+the message to `<chat-generative-ui>`.
+
+The Spec shape is:
+
+```json
+{
+  "root": "<id of the root element>",
+  "elements": {
+    "<id1>": { "type": "<ComponentName>", "props": { ... }, "children": ["<childId>", ...], "on": { "click": { "action": "<name>", "params": {...} } } },
+    "<id2>": { ... }
+  },
+  "state": {
+    "<key>": "<initial value>"
+  }
+}
+```
+
+Rules:
+- `root` is the id of the entry-point element. The renderer mounts it first.
+- `elements` is a flat map of element id → element definition. Children are referenced by id, not nested.
+- `props` carries plain literal values (strings, numbers, booleans, arrays, objects). Components whose props bind to state use a special `statePath` field: `props: { value: { statePath: "/name" } }`.
+- `children` is an array of element ids (in render order).
+- `on` maps DOM event names to action descriptors. Most components only emit `click`. The `action` string is a free-form intent name; `params` is a flat object passed to the handler.
+- `state` is the initial state model. Keys are paths (e.g. `name`, `email`); values are initial values.
+
+## Component Catalog (matches @ngaf/chat's a2uiBasicCatalog)
+
+The renderer consumes the same component catalog as A2UI, so component
+names match: `Card`, `Column`, `Row`, `List`, `Tabs`, `Modal`,
+`Divider`, `Button`, `CheckBox`, `TextField`, `DateTimeInput`,
+`MultipleChoice`, `Slider`, `Text`, `Image`, `Icon`, `Video`,
+`AudioPlayer`.
+
+Common props per component:
+- `Card`: no props (children is single id wrapped in array)
+- `Column` / `Row`: `{ gap?: 'small'|'medium'|'large', alignment?: 'start'|'center'|'end'|'stretch' }`
+- `Text`: `{ text: string, usageHint?: 'h1'|'h2'|'h3'|'h4'|'h5'|'caption'|'body' }`
+- `TextField`: `{ label: string, text: string | { statePath: '/path' }, placeholder?: string, textFieldType?: 'shortText'|'longText'|'number'|'date'|'obscured', validationRegexp?: string }`
+- `MultipleChoice`: `{ label: string, options: [{ label: string, value: string }, ...], selections: string[] | { statePath: '/path' }, maxAllowedSelections?: number }`
+- `CheckBox`: `{ label: string, value: boolean | { statePath: '/path' } }`
+- `Slider`: `{ label: string, value: number | { statePath: '/path' }, minValue: number, maxValue: number }`
+- `Button`: `{ label: string, primary?: boolean }` plus `on.click.action` for the action name
+- `DateTimeInput`: `{ label: string, value: string | { statePath: '/path' }, enableDate?: boolean, enableTime?: boolean }`
+- `Image` / `Video` / `AudioPlayer`: `{ url: string }` plus `Image.fit?: 'contain'|'cover'|'fill'|'none'|'scale-down'`, `Image.usageHint?: 'icon'|'avatar'|'smallFeature'|'mediumFeature'|'largeFeature'|'header'`
+- `Icon`: `{ icon: string, size?: number }`
+- `Divider`: `{ direction?: 'horizontal'|'vertical' }`
+- `Tabs`: special — uses `tabTitles: string[]` and one child id per tab in `children`
+- `Modal`: special — `children: [triggerId, contentId]` (entry point + content)
+
+## Minimal Working Example
+
+A "Quick feedback" form:
+
+```json
+{
+  "root": "card",
+  "elements": {
+    "card": { "type": "Card", "children": ["body"] },
+    "body": { "type": "Column", "props": { "gap": "medium" }, "children": ["title", "name", "rating", "submit"] },
+    "title": { "type": "Text", "props": { "text": "Quick feedback", "usageHint": "h3" } },
+    "name": { "type": "TextField", "props": { "label": "Your name", "text": { "statePath": "/name" }, "textFieldType": "shortText" } },
+    "rating": { "type": "MultipleChoice", "props": { "label": "Rating", "options": [
+      { "label": "1", "value": "1" }, { "label": "2", "value": "2" }, { "label": "3", "value": "3" }, { "label": "4", "value": "4" }, { "label": "5", "value": "5" }
+    ], "selections": { "statePath": "/rating" }, "maxAllowedSelections": 1 } },
+    "submit": { "type": "Button", "props": { "label": "Submit feedback", "primary": true }, "on": { "click": { "action": "feedbackSubmit", "params": { "surface": "feedback" } } } }
+  },
+  "state": { "name": "", "rating": "5" }
+}
+```
+
+## Output Requirements
+
+Return ONLY the JSON object. No prose. No markdown code fence. The first
+character of your response MUST be `{`. The chat client's content
+classifier detects this and routes the message to render.
+""".strip()
+```
+
+- [ ] **Step 2: Smoke test**
+
+```bash
+cd /Users/blove/repos/angular-agent-framework/examples/chat/python
+uv run python -c "from src.schemas.json_render import JSON_RENDER_SCHEMA_PROMPT; print(len(JSON_RENDER_SCHEMA_PROMPT), 'chars')"
+```
+
+Expected: prints character count (~3500-4000).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/blove/repos/angular-agent-framework
+git add examples/chat/python/src/schemas/
+git commit -m "feat(examples-chat-python): schema-prompt modules for GenUI sub-LLM tools"
+```
+
+---
+
+## Phase 2 — Python graph: remove Phase 4 artifacts + add Phase 5 paths (TDD)
+
+### Task 2.1: Failing tests for Phase 5 + removed Phase 4
+
+**File:** `examples/chat/python/tests/test_graph_smoke.py`
+
+Phase 4 added 3 tests (`test_render_demo_form_tool_exists`, `test_state_graph_includes_emit_a2ui_surface_node`, `test_a2ui_jsonl_starts_with_prefix_and_parses`); the v1 migration kept them. Phase 5 removes those + adds 4 new tests.
+
+- [ ] **Step 1: Edit the test file**
+
+Open `examples/chat/python/tests/test_graph_smoke.py`. Locate and **delete** these three test functions:
+- `test_render_demo_form_tool_exists`
+- `test_state_graph_includes_emit_a2ui_surface_node`
+- `test_a2ui_jsonl_starts_with_prefix_and_parses`
+
+Then append at the END of the file:
+
+```python
+
+
+@pytest.mark.smoke
+def test_genui_tools_exist():
+    from src.graph import generate_a2ui_schema, generate_json_render_spec
+    assert generate_a2ui_schema.name == "generate_a2ui_schema"
+    assert generate_json_render_spec.name == "generate_json_render_spec"
+
+
+@pytest.mark.smoke
+def test_state_graph_has_emit_generated_surface_node():
+    from src.graph import graph
+    nodes = set(graph.get_graph().nodes.keys())
+    assert "emit_generated_surface" in nodes
+    assert "tools" in nodes
+    assert "attach_citations" in nodes
+
+
+@pytest.mark.smoke
+def test_state_includes_gen_ui_mode_channel():
+    from src.graph import State
+    annotations = State.__annotations__
+    assert "gen_ui_mode" in annotations, \
+        "State must have a gen_ui_mode channel (Phase 5)"
+
+
+@pytest.mark.smoke
+def test_phase4_artifacts_removed():
+    """Phase 5 removes Phase 4's hardcoded path entirely."""
+    import importlib
+    mod = importlib.import_module("src.graph")
+    assert not hasattr(mod, "render_demo_form"), \
+        "render_demo_form tool should be removed in Phase 5"
+    assert not hasattr(mod, "FEEDBACK_FORM_JSONL"), \
+        "FEEDBACK_FORM_JSONL constant should be removed in Phase 5"
+    assert not hasattr(mod, "emit_a2ui_surface"), \
+        "emit_a2ui_surface node should be replaced by emit_generated_surface"
+```
+
+- [ ] **Step 2: Run — must FAIL**
+
+```bash
+cd /Users/blove/repos/angular-agent-framework/examples/chat/python
+uv run pytest -q -m smoke
+```
+
+Expected: 4 new tests fail (the symbols don't exist yet). The 3 deleted tests are gone; remaining 8 (Phase 1+2A+2B+3A+3B) pass. Total expected pass count after Task 2.1 implementation: 8 + 4 = **12 tests**.
+
+Do NOT commit yet — Task 2.2 commits the test changes + implementation together.
+
+### Task 2.2: Edit `examples/chat/python/src/graph.py` — remove Phase 4 artifacts + add Phase 5 paths
+
+**File:** `examples/chat/python/src/graph.py`
+
+This task makes ~10 edits to the existing file. Do NOT replace the whole file — keep `search_documents`, `request_approval`, `research`, `attach_citations`, the existing `State`, `generate`, `should_continue` skeleton, and the builder topology.
+
+- [ ] **Step 1: Add `HumanMessage` to existing langchain_core import (already there from Phase 3B; confirm)**
+
+Locate the existing import block:
+
+```python
+from langchain_core.messages import (
+    AIMessage,
+    HumanMessage,
+    RemoveMessage,
+    SystemMessage,
+    ToolMessage,
+)
+```
+
+Confirm `HumanMessage` is present. If not, add it.
+
+- [ ] **Step 2: REMOVE Phase 4 artifacts**
+
+Delete these blocks from `graph.py`:
+
+1. The `A2UI_PREFIX = "---a2ui_JSON---"` constant declaration block (just before the `# Research subagent` comment).
+2. The entire `FEEDBACK_FORM_JSONL = "\n".join([...]) + "\n"` block (the multi-line constant).
+3. The entire `@tool def render_demo_form(form_type: str = "feedback", subagent_type: str = "feedback")` function.
+4. The entire `async def emit_a2ui_surface(state: State) -> dict:` function.
+5. From `generate`'s `bind_tools([...])` call: REMOVE `render_demo_form`.
+6. From the `_builder.add_node("tools", ToolNode([...]))` call: REMOVE `render_demo_form`.
+7. From the builder: REMOVE the `_builder.add_node("emit_a2ui_surface", emit_a2ui_surface)` line.
+8. From `_builder.add_conditional_edges`'s map: REMOVE the `"emit_a2ui_surface": "emit_a2ui_surface"` entry.
+9. From the builder: REMOVE the `_builder.add_edge("emit_a2ui_surface", "attach_citations")` edge.
+
+- [ ] **Step 3: ADD `gen_ui_mode` to State**
+
+Locate:
+
+```python
+class State(TypedDict):
+    messages: Annotated[list, add_messages]
+    model: Optional[str]
+    reasoning_effort: Optional[str]
+```
+
+Replace with:
+
+```python
+class State(TypedDict):
+    messages: Annotated[list, add_messages]
+    model: Optional[str]
+    reasoning_effort: Optional[str]
+    gen_ui_mode: Optional[str]
+```
+
+- [ ] **Step 4: ADD module-level `A2UI_PREFIX` constant (re-introduce, used only inside the new emit node)**
+
+After the `request_approval` `@tool` block, before the `# Research subagent` comment, insert:
+
+```python
+
+
+# Used by emit_generated_surface to prepend the chat composition's
+# content-classifier sentinel for A2UI mode. The classifier triggers
+# rendering when an AI message content begins with this prefix.
+A2UI_PREFIX = "---a2ui_JSON---"
+```
+
+- [ ] **Step 5: ADD the two GenUI sub-LLM tools**
+
+After the `research` `@tool` block (which ends `return "(no research returned)"`), insert:
+
+```python
+
+
+@tool
+async def generate_a2ui_schema(request: str) -> str:
+    """Dispatch the A2UI schema sub-agent to render a UI surface in A2UI
+    v1 wire format. Use this when the user asks for UI/forms/cards and
+    state.gen_ui_mode is 'a2ui'. Pass the user's request verbatim as the
+    `request` argument. The sub-agent returns a JSON array of v1
+    envelopes (surfaceUpdate, optional dataModelUpdate, beginRendering)
+    that the post-process node wraps for the chat composition."""
+    from src.schemas.a2ui_v1 import A2UI_V1_SCHEMA_PROMPT
+    llm = ChatOpenAI(model="gpt-5-mini", temperature=0)
+    response = await llm.ainvoke([
+        SystemMessage(content=A2UI_V1_SCHEMA_PROMPT),
+        HumanMessage(content=request),
+    ])
+    return _as_text(response.content).strip()
+
+
+@tool
+async def generate_json_render_spec(request: str) -> str:
+    """Dispatch the json-render schema sub-agent to render a UI surface
+    as a json-render Spec ({root, elements, state}). Use this when the
+    user asks for UI/forms/cards and state.gen_ui_mode is 'json-render'.
+    Pass the user's request verbatim as the `request` argument."""
+    from src.schemas.json_render import JSON_RENDER_SCHEMA_PROMPT
+    llm = ChatOpenAI(model="gpt-5-mini", temperature=0)
+    response = await llm.ainvoke([
+        SystemMessage(content=JSON_RENDER_SCHEMA_PROMPT),
+        HumanMessage(content=request),
+    ])
+    return _as_text(response.content).strip()
+
+
+def _as_text(content) -> str:
+    """Normalize a langchain message content to a plain string. ChatOpenAI
+    may return content as either str or a list of typed blocks; this
+    pulls the text out of either."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "\n".join(
+            b.get("text", "")
+            for b in content
+            if isinstance(b, dict) and b.get("type") == "text"
+        )
+    return ""
+```
+
+- [ ] **Step 6: UPDATE `should_continue` routing**
+
+Replace the existing `should_continue` with:
+
+```python
+def should_continue(state: State) -> Literal["tools", "emit_generated_surface", "attach_citations"]:
+    """Conditional edge: route from generate to:
+    - `emit_generated_surface` if any tool_call is generate_a2ui_schema or generate_json_render_spec
+    - `tools` for any other tool_call (search_documents, request_approval, research)
+    - `attach_citations` (terminal) when there are no tool_calls
+    """
+    last = state["messages"][-1]
+    if isinstance(last, AIMessage) and last.tool_calls:
+        for tc in last.tool_calls:
+            if tc["name"] in ("generate_a2ui_schema", "generate_json_render_spec"):
+                return "emit_generated_surface"
+        return "tools"
+    return "attach_citations"
+```
+
+- [ ] **Step 7: ADD `emit_generated_surface` node**
+
+After the new `_as_text` helper, before the existing `attach_citations` async function, insert:
+
+```python
+
+
+async def emit_generated_surface(state: State) -> dict:
+    """Post-process for GenUI tool dispatches. Reads the most recent
+    ToolMessage carrying the sub-LLM's wire-format payload, identifies
+    which protocol the AI dispatched (by tool_call name), wraps the
+    payload with the chat composition's content-classifier sentinel,
+    and emits a fresh AIMessage. The original AI tool-call message and
+    ToolMessage stay in history (visible in chat-debug)."""
+    msgs = state["messages"]
+
+    # Find the most recent ToolMessage and the originating tool_call name
+    tool_msg = None
+    tool_name = None
+    for m in reversed(msgs):
+        if isinstance(m, ToolMessage):
+            tool_msg = m
+            for prior in reversed(msgs):
+                if isinstance(prior, AIMessage) and prior.tool_calls:
+                    for tc in prior.tool_calls:
+                        if tc.get("id") == tool_msg.tool_call_id:
+                            tool_name = tc.get("name")
+                            break
+                    if tool_name:
+                        break
+            break
+
+    if tool_msg is None or tool_name is None:
+        return {}
+
+    payload = tool_msg.content if isinstance(tool_msg.content, str) else ""
+    if not payload:
+        return {}
+
+    if tool_name == "generate_a2ui_schema":
+        # Sub-LLM returns a JSON array of v1 envelopes. Convert to JSONL
+        # (one envelope per line) and prepend the classifier sentinel.
+        try:
+            arr = json.loads(payload)
+            if isinstance(arr, list):
+                jsonl = "\n".join(json.dumps(env) for env in arr)
+            else:
+                jsonl = payload
+        except json.JSONDecodeError:
+            # Sub-LLM may have leading/trailing whitespace or markdown
+            # fencing despite the prompt instructions. Try to strip.
+            stripped = payload.strip()
+            if stripped.startswith("```"):
+                lines = stripped.split("\n")
+                stripped = "\n".join(line for line in lines if not line.startswith("```"))
+            try:
+                arr = json.loads(stripped)
+                jsonl = "\n".join(json.dumps(env) for env in arr) if isinstance(arr, list) else stripped
+            except json.JSONDecodeError:
+                jsonl = payload  # let the parser deal with malformed lines
+        wrapped = A2UI_PREFIX + "\n" + jsonl + "\n"
+    elif tool_name == "generate_json_render_spec":
+        # json-render: classifier detects content starting with `{`, no
+        # prefix needed. Strip whitespace and any markdown fencing the
+        # sub-LLM may have included.
+        stripped = payload.strip()
+        if stripped.startswith("```"):
+            lines = stripped.split("\n")
+            stripped = "\n".join(line for line in lines if not line.startswith("```"))
+            stripped = stripped.strip()
+        wrapped = stripped
+    else:
+        return {}
+
+    return {"messages": [AIMessage(content=wrapped)]}
+```
+
+- [ ] **Step 8: UPDATE `bind_tools` and `ToolNode` lists**
+
+In `generate`, locate:
+
+```python
+    llm = ChatOpenAI(**kwargs).bind_tools([search_documents, request_approval, research])
+```
+
+Replace with (Phase 5 ADDS the two new tools; Phase 4's `render_demo_form` is REMOVED per Step 2.5):
+
+```python
+    llm = ChatOpenAI(**kwargs).bind_tools([
+        search_documents, request_approval, research,
+        generate_a2ui_schema, generate_json_render_spec,
+    ])
+```
+
+In the builder, locate:
+
+```python
+_builder.add_node("tools", ToolNode([search_documents, request_approval, research]))
+```
+
+Replace with:
+
+```python
+_builder.add_node("tools", ToolNode([
+    search_documents, request_approval, research,
+    generate_a2ui_schema, generate_json_render_spec,
+]))
+```
+
+- [ ] **Step 9: UPDATE the builder topology — add `emit_generated_surface` node + edges**
+
+Replace the builder's node-add + edge block (which was modified by Phase 4 with `emit_a2ui_surface` references; Step 2 already removed those) with:
+
+```python
+_builder.add_node("generate", generate)
+_builder.add_node("tools", ToolNode([
+    search_documents, request_approval, research,
+    generate_a2ui_schema, generate_json_render_spec,
+]))
+_builder.add_node("emit_generated_surface", emit_generated_surface)
+_builder.add_node("attach_citations", attach_citations)
+_builder.set_entry_point("generate")
+_builder.add_conditional_edges(
+    "generate",
+    should_continue,
+    {
+        "tools": "tools",
+        "emit_generated_surface": "emit_generated_surface",
+        "attach_citations": "attach_citations",
+    },
+)
+_builder.add_edge("tools", "generate")
+_builder.add_edge("emit_generated_surface", "attach_citations")
+_builder.add_edge("attach_citations", END)
+```
+
+- [ ] **Step 10: UPDATE SYSTEM_PROMPT — replace Phase 4's render_demo_form paragraph**
+
+Locate the existing render_demo_form paragraph in `SYSTEM_PROMPT` (Phase 4 added it; ends `"... — keep the prose short — the user will see the form directly."`). Replace that entire paragraph with:
+
+```python
+    " "
+    "When the user asks to see, build, or render a UI / form / card / "
+    "interactive component, dispatch one of the schema-generation tools "
+    "based on the conversation's `gen_ui_mode` (visible in state if you "
+    "received it; default is 'a2ui'): "
+    "  - 'a2ui'        -> call `generate_a2ui_schema(request)` "
+    "  - 'json-render' -> call `generate_json_render_spec(request)` "
+    "Pass the user's request verbatim as the `request` argument. The "
+    "tool returns a wire-format payload that the chat composition "
+    "renders directly. Do NOT describe the UI in prose — the tool "
+    "dispatches the actual rendering. Briefly acknowledge the dispatch "
+    "in your conversational reply, but keep the prose short — the user "
+    "sees the rendered surface."
+```
+
+- [ ] **Step 11: Run pytest — all 12 tests pass**
+
+```bash
+cd /Users/blove/repos/angular-agent-framework/examples/chat/python
+uv run pytest -q -m smoke
+```
+
+Expected: **12 passed** (8 existing + 4 new).
+
+- [ ] **Step 12: Commit**
+
+```bash
+cd /Users/blove/repos/angular-agent-framework
+git add examples/chat/python/src/graph.py examples/chat/python/tests/test_graph_smoke.py
+git commit -m "feat(examples-chat-python): GenUI dropdown + dynamic schema generation"
+```
+
+---
+
+## Phase 3 — Angular palette: GenUI dropdown
+
+### Task 3.1: Update `control-palette.component.ts` — add `genUiMode` input/output
+
+**File:** `examples/chat/angular/src/app/shell/control-palette.component.ts`
+
+- [ ] **Step 1: Add inputs/outputs**
+
+Locate the existing inputs block:
+
+```typescript
+  readonly mode = input.required<DemoMode>();
+  readonly model = input.required<string>();
+  readonly modelOptions = input.required<readonly { value: string; label: string }[]>();
+  readonly effort = input.required<string>();
+  readonly effortOptions = input.required<readonly { value: string; label: string }[]>();
+  readonly debugOpen = input.required<boolean>();
+```
+
+Add directly after `effortOptions` line:
+
+```typescript
+  readonly genUiMode = input.required<string>();
+  readonly genUiOptions = input.required<readonly { value: string; label: string }[]>();
+```
+
+Locate the existing outputs block:
+
+```typescript
+  readonly modeChange = output<DemoMode>();
+  readonly modelChange = output<string>();
+  readonly effortChange = output<string>();
+  readonly debugOpenChange = output<boolean>();
+  readonly newConversation = output<void>();
+```
+
+Add directly after `effortChange` line:
+
+```typescript
+  readonly genUiModeChange = output<string>();
+```
+
+Locate the existing handlers (after `pickEffort`):
+
+```typescript
+  protected pickEffort(event: Event): void {
+    const value = (event.target as HTMLSelectElement).value;
+    this.effortChange.emit(value);
+  }
+```
+
+Add directly after:
+
+```typescript
+  protected pickGenUi(event: Event): void {
+    const value = (event.target as HTMLSelectElement).value;
+    this.genUiModeChange.emit(value);
+  }
+```
+
+### Task 3.2: Update `control-palette.component.html` — add dropdown
+
+**File:** `examples/chat/angular/src/app/shell/control-palette.component.html`
+
+- [ ] **Step 1: Insert dropdown after the Effort group**
+
+Locate the existing Effort group (around line 45):
+
+```html
+    <label class="palette__group palette__group--model">
+      <span class="palette__label">Effort</span>
+      <select [value]="effort()" (change)="pickEffort($event)">
+        @for (opt of effortOptions(); track opt.value) {
+          <option [value]="opt.value" [selected]="opt.value === effort()">{{ opt.label }}</option>
+        }
+      </select>
+    </label>
+```
+
+Insert directly AFTER the closing `</label>`:
+
+```html
+    <label class="palette__group palette__group--model">
+      <span class="palette__label">GenUI</span>
+      <select [value]="genUiMode()" (change)="pickGenUi($event)">
+        @for (opt of genUiOptions(); track opt.value) {
+          <option [value]="opt.value" [selected]="opt.value === genUiMode()">{{ opt.label }}</option>
+        }
+      </select>
+    </label>
+```
+
+### Task 3.3: Update `demo-shell.component.ts` — add `genUiMode` signal + handler + state injection
+
+**File:** `examples/chat/angular/src/app/shell/demo-shell.component.ts`
+
+- [ ] **Step 1: Add the `genUiMode` signal**
+
+Locate the existing `effort` signal block:
+
+```typescript
+  /** Reasoning effort for the next submit. Persisted across reloads. */
+  readonly effort = signal<string>(this.persistence.read('effort') ?? 'minimal');
+```
+
+Add directly after:
+
+```typescript
+  /** GenUI rendering protocol for the next submit. Persisted across
+   * reloads. 'a2ui' (default) routes form-render dispatches to
+   * generate_a2ui_schema; 'json-render' routes to generate_json_render_spec. */
+  readonly genUiMode = signal<string>(this.persistence.read('genUiMode') ?? 'a2ui');
+```
+
+- [ ] **Step 2: Add `genUiOptions`**
+
+Locate the existing `effortOptions` block:
+
+```typescript
+  protected readonly effortOptions = signal<readonly { value: string; label: string }[]>([
+    { value: 'minimal', label: 'minimal (fast)' },
+    { value: 'low',     label: 'low' },
+    { value: 'medium',  label: 'medium' },
+    { value: 'high',    label: 'high (visible reasoning)' },
+  ]);
+```
+
+Add directly after:
+
+```typescript
+  protected readonly genUiOptions = signal<readonly { value: string; label: string }[]>([
+    { value: 'a2ui',        label: 'A2UI' },
+    { value: 'json-render', label: 'json-render' },
+  ]);
+```
+
+- [ ] **Step 3: Add `onGenUiModeChange` handler**
+
+Locate the existing `onEffortChange` handler (or `onModelChange` — pattern is consistent):
+
+```typescript
+  protected onEffortChange(value: string): void {
+    this.effort.set(value);
+    this.persistence.write('effort', value);
+  }
+```
+
+Add directly after:
+
+```typescript
+  protected onGenUiModeChange(value: string): void {
+    this.genUiMode.set(value);
+    this.persistence.write('genUiMode', value);
+  }
+```
+
+- [ ] **Step 4: Inject `gen_ui_mode` into patched submit**
+
+Locate the patched submit (around line 94, after the `agent({...})` factory call):
+
+```typescript
+    const orig = a.submit.bind(a);
+    (a as { submit: typeof a.submit }).submit = ((
+      input: Parameters<typeof a.submit>[0],
+      opts?: Parameters<typeof a.submit>[1],
+    ) =>
+      orig(
+        {
+          ...(input ?? {}),
+          state: {
+            ...((input as { state?: Record<string, unknown> })?.state ?? {}),
+            model: this.model(),
+            reasoning_effort: this.effort(),
+          },
+        },
+        opts,
+      )) as typeof a.submit;
+```
+
+Add a `gen_ui_mode` line to the state object:
+
+```typescript
+    const orig = a.submit.bind(a);
+    (a as { submit: typeof a.submit }).submit = ((
+      input: Parameters<typeof a.submit>[0],
+      opts?: Parameters<typeof a.submit>[1],
+    ) =>
+      orig(
+        {
+          ...(input ?? {}),
+          state: {
+            ...((input as { state?: Record<string, unknown> })?.state ?? {}),
+            model: this.model(),
+            reasoning_effort: this.effort(),
+            gen_ui_mode: this.genUiMode(),
+          },
+        },
+        opts,
+      )) as typeof a.submit;
+```
+
+### Task 3.4: Update `demo-shell.component.html` — wire palette I/O
+
+**File:** `examples/chat/angular/src/app/shell/demo-shell.component.html`
+
+- [ ] **Step 1: Wire the new inputs/output**
+
+Locate the existing `<app-control-palette>` block:
+
+```html
+  <app-control-palette
+    [mode]="mode()"
+    [model]="model()"
+    [modelOptions]="modelOptions()"
+    [effort]="effort()"
+    [effortOptions]="effortOptions()"
+    [debugOpen]="debugOpen()"
+    (modeChange)="onModeChange($event)"
+    (modelChange)="onModelChange($event)"
+    (effortChange)="onEffortChange($event)"
+    (debugOpenChange)="onDebugChange($event)"
+    (newConversation)="onNewConversation()"
+  />
+```
+
+Replace with:
+
+```html
+  <app-control-palette
+    [mode]="mode()"
+    [model]="model()"
+    [modelOptions]="modelOptions()"
+    [effort]="effort()"
+    [effortOptions]="effortOptions()"
+    [genUiMode]="genUiMode()"
+    [genUiOptions]="genUiOptions()"
+    [debugOpen]="debugOpen()"
+    (modeChange)="onModeChange($event)"
+    (modelChange)="onModelChange($event)"
+    (effortChange)="onEffortChange($event)"
+    (genUiModeChange)="onGenUiModeChange($event)"
+    (debugOpenChange)="onDebugChange($event)"
+    (newConversation)="onNewConversation()"
+  />
+```
+
+### Task 3.5: Build + lint
+
+- [ ] **Step 1: Run**
+
+```bash
+cd /Users/blove/repos/angular-agent-framework
+export PATH=/Users/blove/.nvm/versions/node/v22.14.0/bin:$PATH
+npx nx run examples-chat-angular:lint --skip-nx-cache 2>&1 | tail -3
+npx nx run examples-chat-angular:build --skip-nx-cache --configuration=development 2>&1 | tail -3
+```
+
+Expected: 0 lint errors; build succeeds.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add examples/chat/angular/src/app/shell/
+git commit -m "feat(examples-chat-angular): GenUI palette dropdown + state injection"
+```
+
+---
+
+## Phase 4 — Welcome suggestions
+
+### Task 4.1: Replace Phase 4 entry with 4 generic intents
+
+**File:** `examples/chat/angular/src/app/modes/welcome-suggestions.ts`
+
+The current file has 10 entries (Phase 1–4). Phase 5 removes the 10th entry ("Demo: render an interactive A2UI surface" — references the now-removed `render_demo_form` tool) and adds 4 new generic intents.
+
+- [ ] **Step 1: Edit the array**
+
+Locate the existing 10th entry (Phase 4):
+
+```typescript
+  {
+    label: 'Demo: render an interactive A2UI surface',
+    value:
+      'Use the render_demo_form tool to show me a feedback card with name and rating fields.',
+  },
+];
+```
+
+Replace that entry (remove it; the closing `];` stays) with these 4 new entries — also leaving the closing `];`:
+
+```typescript
+  {
+    label: 'Build a quick feedback form',
+    value:
+      'Build me a quick feedback form with a name field and a 1-5 rating picker.',
+  },
+  {
+    label: 'Render a flight booking card',
+    value:
+      'Render a flight booking card from Seattle to Tokyo with origin, destination, departure date, return date, and a Search Flights button.',
+  },
+  {
+    label: 'Show a settings panel',
+    value:
+      'Show a settings panel with a theme picker (light/dark/auto), a notifications toggle, and a "Reset to defaults" button.',
+  },
+  {
+    label: 'Build a login form',
+    value:
+      'Build a login form with email and password fields and a "Sign in" button.',
+  },
+];
+```
+
+Final entry count: 9 - 1 + 4 = **12 entries**.
+
+- [ ] **Step 2: Confirm build**
+
+```bash
+export PATH=/Users/blove/.nvm/versions/node/v22.14.0/bin:$PATH
+npx nx run examples-chat-angular:build --skip-nx-cache --configuration=development 2>&1 | tail -3
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add examples/chat/angular/src/app/modes/welcome-suggestions.ts
+git commit -m "feat(examples-chat-angular): generic intent welcome suggestions for GenUI dropdown"
+```
+
+---
+
+## Phase 5 — CHECKLIST.md update
+
+### Task 5.1: Update Generative UI / A2UI surfaces section
+
+**File:** `examples/chat/smoke/CHECKLIST.md`
+
+- [ ] **Step 1: Replace the Phase 4 section content**
+
+Locate the populated `## Generative UI / A2UI surfaces` section (Phase 4 + v1 migration). Replace the entire section (everything between this heading and the next `##` heading) with:
+
+```markdown
+## Generative UI / A2UI surfaces
+
+- [ ] Palette has a "GenUI" dropdown with options "A2UI" and "json-render"; default "A2UI"; persists across reload
+- [ ] (GenUI=A2UI) Click "Build a quick feedback form" welcome suggestion
+- [ ] AI emits a tool_call to `generate_a2ui_schema`; the sub-LLM returns v1 JSONL
+- [ ] `<a2ui-surface>` mounts a Card containing TextField + MultipleChoice + Button (LLM-generated, varies per request — not hardcoded)
+- [ ] Final AI message content starts with `---a2ui_JSON---\n` and contains v1 envelopes (`surfaceUpdate` / `dataModelUpdate` / `beginRendering`)
+- [ ] (GenUI=json-render) New conversation, click the same suggestion
+- [ ] AI emits a tool_call to `generate_json_render_spec`; the sub-LLM returns a single JSON Spec object
+- [ ] `<chat-generative-ui>` mounts the spec (different rendering path from A2UI; same logical form)
+- [ ] Verify cross-protocol: same prompt produces different render via dropdown toggle
+- [ ] Other welcome suggestions (search citations, request_approval, research subagent) still work — GenUI dropdown does not affect them
+- [ ] Server-side: `curl localhost:2024/threads/<id>/state` shows the matching tool_call for the chosen mode; no `render_demo_form` or `FEEDBACK_FORM_JSONL` references anywhere
+```
+
+DO NOT touch other Phase 2+ sections.
+
+- [ ] **Step 2: Verify the diff**
+
+```bash
+git diff examples/chat/smoke/CHECKLIST.md | head -50
+```
+
+Expected: only the Generative UI section changes.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add examples/chat/smoke/CHECKLIST.md
+git commit -m "docs(examples-chat-smoke): update Generative UI checklist for Phase 5 dynamic dispatch"
+```
+
+---
+
+## Phase 6 — Verification + PR (controller-driven)
+
+### Task 6.1: Full local sweep
+
+- [ ] **Step 1: Python smoke**
+
+```bash
+cd /Users/blove/repos/angular-agent-framework
+npx nx run examples-chat-python:smoke --skip-nx-cache 2>&1 | tail -3
+```
+
+Expected: 12 passed.
+
+- [ ] **Step 2: Angular tests + lint + build**
+
+```bash
+export PATH=/Users/blove/.nvm/versions/node/v22.14.0/bin:$PATH
+npx nx run-many -t test,lint,build -p examples-chat-angular --skip-nx-cache 2>&1 | tail -10
+```
+
+Expected: all green.
+
+- [ ] **Step 3: Confirm commit count**
+
+```bash
+git rev-list --count origin/main..HEAD
+```
+
+Expected: 5 commits.
+
+### Task 6.2: Server-side end-to-end probes (BOTH modes)
+
+Confirm `OPENAI_API_KEY` in `examples/chat/python/.env`. Start backend:
+
+```bash
+nohup uv run --directory /Users/blove/repos/angular-agent-framework/examples/chat/python langgraph dev --port 2024 --no-browser > /tmp/exchat-py-5.log 2>&1 &
+```
+
+Wait for ready.
+
+- [ ] **Step 1: A2UI mode probe**
+
+```bash
+tid=$(curl -sf -X POST -H 'Content-Type: application/json' http://localhost:2024/threads -d '{}' | python3 -c "import sys,json;print(json.load(sys.stdin)['thread_id'])")
+echo "thread=$tid"
+curl -sf -X POST -H 'Content-Type: application/json' "http://localhost:2024/threads/$tid/runs/wait" \
+  -d '{"assistant_id":"chat","input":{"messages":[{"role":"user","content":"Build me a quick feedback form with a name field and a 1-5 rating picker."}],"model":"gpt-5-mini","gen_ui_mode":"a2ui"}}' \
+  > /tmp/p5-a2ui.json
+python3 << 'EOF'
+import json
+d = json.load(open('/tmp/p5-a2ui.json'))
+msgs = d.get('messages', []) if isinstance(d, dict) else []
+ai_with_tc = [m for m in msgs if m.get('type') == 'ai' and m.get('tool_calls')]
+genui_calls = []
+for ai in ai_with_tc:
+    for tc in ai.get('tool_calls', []):
+        if tc.get('name') in ('generate_a2ui_schema', 'generate_json_render_spec'):
+            genui_calls.append(tc)
+print('total msgs:', len(msgs))
+print('GenUI tool_calls:', len(genui_calls))
+for tc in genui_calls[:1]:
+    print('  name:', tc.get('name'))
+    print('  args:', json.dumps(tc.get('args', {}))[:120])
+final_ai = [m for m in msgs if m.get('type') == 'ai' and not m.get('tool_calls')]
+print('final AI (no tool_calls):', len(final_ai))
+for ai in final_ai[-1:]:
+    c = ai.get('content', '')
+    text = c if isinstance(c, str) else next((b.get('text','') for b in c if isinstance(b, dict) and b.get('type')=='text'), '')
+    print('starts with prefix:', text.startswith('---a2ui_JSON---'))
+    has_v1 = 'surfaceUpdate' in text and 'beginRendering' in text
+    print('contains v1 envelopes:', has_v1)
+    print('first 240 chars:', repr(text[:240]))
+EOF
+```
+
+Expected:
+- `GenUI tool_calls: 1` with `name: generate_a2ui_schema`
+- `final AI (no tool_calls): 1` with `starts with prefix: True` and `contains v1 envelopes: True`
+
+- [ ] **Step 2: json-render mode probe**
+
+```bash
+tid2=$(curl -sf -X POST -H 'Content-Type: application/json' http://localhost:2024/threads -d '{}' | python3 -c "import sys,json;print(json.load(sys.stdin)['thread_id'])")
+echo "thread2=$tid2"
+curl -sf -X POST -H 'Content-Type: application/json' "http://localhost:2024/threads/$tid2/runs/wait" \
+  -d '{"assistant_id":"chat","input":{"messages":[{"role":"user","content":"Build me a quick feedback form with a name field and a 1-5 rating picker."}],"model":"gpt-5-mini","gen_ui_mode":"json-render"}}' \
+  > /tmp/p5-json.json
+python3 << 'EOF'
+import json
+d = json.load(open('/tmp/p5-json.json'))
+msgs = d.get('messages', []) if isinstance(d, dict) else []
+ai_with_tc = [m for m in msgs if m.get('type') == 'ai' and m.get('tool_calls')]
+genui_calls = [tc for ai in ai_with_tc for tc in ai.get('tool_calls', [])
+               if tc.get('name') in ('generate_a2ui_schema', 'generate_json_render_spec')]
+print('total msgs:', len(msgs))
+print('GenUI tool_calls:', len(genui_calls))
+for tc in genui_calls[:1]:
+    print('  name:', tc.get('name'))
+final_ai = [m for m in msgs if m.get('type') == 'ai' and not m.get('tool_calls')]
+print('final AI (no tool_calls):', len(final_ai))
+for ai in final_ai[-1:]:
+    c = ai.get('content', '')
+    text = c if isinstance(c, str) else next((b.get('text','') for b in c if isinstance(b, dict) and b.get('type')=='text'), '')
+    starts_with_brace = text.lstrip().startswith('{')
+    has_root = '"root"' in text and '"elements"' in text
+    print('starts with {:', starts_with_brace)
+    print('contains root + elements:', has_root)
+    print('contains a2ui prefix (must be False):', text.startswith('---a2ui_JSON---'))
+    print('first 240 chars:', repr(text[:240]))
+EOF
+```
+
+Expected:
+- `GenUI tool_calls: 1` with `name: generate_json_render_spec`
+- `starts with {: True`, `contains root + elements: True`, `contains a2ui prefix: False`
+
+- [ ] **Step 3: Stop backend**
+
+```bash
+pkill -f "langgraph dev" 2>/dev/null
+sleep 1
+lsof -nP -iTCP:2024 -sTCP:LISTEN 2>&1 | head -2
+```
+
+Expected: nothing listening on :2024.
+
+### Task 6.3: LIVE Chrome MCP smoke (BOTH modes)
+
+Per the v1 migration's pattern.
+
+- [ ] **Step 1: Restart backend + Angular dev server**
+
+```bash
+nohup uv run --directory /Users/blove/repos/angular-agent-framework/examples/chat/python langgraph dev --port 2024 --no-browser > /tmp/exchat-py-5-smoke.log 2>&1 &
+export PATH=/Users/blove/.nvm/versions/node/v22.14.0/bin:$PATH
+nohup npx nx serve examples-chat-angular > /tmp/exchat-ng-5-smoke.log 2>&1 &
+```
+
+Wait for both ready (`:2024/ok` + `:4200/`).
+
+- [ ] **Step 2: Open `/embed`, verify palette dropdown**
+
+```js
+(()=>{
+  const labels = Array.from(document.querySelectorAll('app-control-palette .palette__label')).map(e=>e.innerText);
+  const selects = Array.from(document.querySelectorAll('app-control-palette select')).map(s=>({
+    label: s.previousElementSibling?.innerText,
+    value: s.value,
+    options: Array.from(s.options).map(o=>o.value),
+  }));
+  return { labels, selects };
+})()
+```
+
+Expected: `labels` includes `'GenUI'`; `selects` contains `{ label: 'GenUI', value: 'a2ui', options: ['a2ui', 'json-render'] }`.
+
+- [ ] **Step 3: A2UI mode — click "Build a quick feedback form"**
+
+Default GenUI is `'a2ui'`. Reset conversation, click the suggestion:
+
+```js
+(async()=>{
+  const reset = Array.from(document.querySelectorAll('button')).find(b=>b.innerText.includes('New conversation'));
+  reset?.click();
+  await new Promise(r=>setTimeout(r,800));
+  const t = Array.from(document.querySelectorAll('button')).find(b=>b.innerText.includes('quick feedback form'));
+  t.click();
+  return 'kicked-a2ui';
+})()
+```
+
+Wait ~25 seconds (the sub-LLM call adds ~3-5s on top of the parent), then verify:
+
+```js
+(()=>{
+  const sf = document.querySelector('a2ui-surface');
+  const subtree = [...new Set(Array.from(document.querySelectorAll('a2ui-surface *')).map(e=>e.tagName.toLowerCase()).filter(t=>t.includes('-')))];
+  const shell = document.querySelector('demo-shell');
+  const agent = ng.getComponent(shell)?.agent;
+  const last = agent?.messages?.()?.at?.(-1);
+  const lastContent = typeof last?.content==='string'?last.content:JSON.stringify(last?.content||'');
+  return {
+    surface: !!sf,
+    subtree,
+    msgs: document.querySelectorAll('chat-message').length,
+    contentStartsWithPrefix: lastContent.startsWith('---a2ui_JSON---'),
+    containsSurfaceUpdate: lastContent.includes('"surfaceUpdate"'),
+    containsBeginRendering: lastContent.includes('"beginRendering"'),
+  };
+})()
+```
+
+Expected: `surface: true`, `subtree` includes `a2ui-card`/`a2ui-text-field`/`a2ui-button`, `contentStartsWithPrefix: true`, `containsSurfaceUpdate: true`, `containsBeginRendering: true`.
+
+- [ ] **Step 4: Switch GenUI to json-render, click same suggestion**
+
+```js
+(async()=>{
+  // Click the GenUI select and choose json-render
+  const select = Array.from(document.querySelectorAll('app-control-palette select')).find(s=>s.previousElementSibling?.innerText==='GenUI');
+  select.value = 'json-render';
+  select.dispatchEvent(new Event('change', { bubbles: true }));
+  await new Promise(r=>setTimeout(r,500));
+  // Reset conversation
+  const reset = Array.from(document.querySelectorAll('button')).find(b=>b.innerText.includes('New conversation'));
+  reset.click();
+  await new Promise(r=>setTimeout(r,800));
+  // Click the same suggestion
+  const t = Array.from(document.querySelectorAll('button')).find(b=>b.innerText.includes('quick feedback form'));
+  t.click();
+  return 'kicked-jsonrender';
+})()
+```
+
+Wait ~25 seconds, then verify:
+
+```js
+(()=>{
+  const genUi = document.querySelector('chat-generative-ui');
+  const a2ui = document.querySelector('a2ui-surface');
+  const shell = document.querySelector('demo-shell');
+  const agent = ng.getComponent(shell)?.agent;
+  const last = agent?.messages?.()?.at?.(-1);
+  const lastContent = typeof last?.content==='string'?last.content:JSON.stringify(last?.content||'');
+  return {
+    genUiMounted: !!genUi,
+    a2uiMounted: !!a2ui,
+    msgs: document.querySelectorAll('chat-message').length,
+    startsWithBrace: lastContent.trimStart().startsWith('{'),
+    containsRoot: lastContent.includes('"root"') && lastContent.includes('"elements"'),
+    containsA2uiPrefix: lastContent.startsWith('---a2ui_JSON---'),
+  };
+})()
+```
+
+Expected: `genUiMounted: true`, `a2uiMounted: false`, `startsWithBrace: true`, `containsRoot: true`, `containsA2uiPrefix: false`.
+
+- [ ] **Step 5: Verify other tools still work**
+
+Switch back to A2UI mode (or any). Click "What are Angular signals? (search + cite sources)" — verify it dispatches `search_documents`, NOT GenUI tools, and renders normal markdown with citations.
+
+Click "Demo: ask for approval before a sensitive action" — verify the interrupt panel appears (Phase 3A still wired).
+
+- [ ] **Step 6: Stop services**
+
+```bash
+pkill -f "langgraph dev" 2>/dev/null
+pkill -f "nx serve" 2>/dev/null
+sleep 1
+```
+
+### Task 6.4: Push + open PR
+
+- [ ] **Step 1: Push**
+
+```bash
+cd /Users/blove/repos/angular-agent-framework
+git push -u origin claude/examples-chat-phase-5-genui 2>&1 | tail -3
+```
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create --title "feat(examples-chat): Phase 5 — GenUI dropdown + dynamic schema generation" --body "$(cat <<'EOF'
+## Summary
+
+Replaces Phase 4's hardcoded \`FEEDBACK_FORM_JSONL\` path with **dynamic schema generation** via a sub-LLM pattern. The palette gains a 5th dropdown (\`GenUI: a2ui | json-render\`); welcome suggestions become generic intents that work against either rendering protocol.
+
+- **Python graph**: Two new sub-LLM tools (\`generate_a2ui_schema\`, \`generate_json_render_spec\`) each invoke a nested \`ChatOpenAI(temperature=0)\` with the protocol's full canonical JSON schema in its system prompt. New routing branch in \`should_continue\` diverts these tool calls to a new \`emit_generated_surface\` post-process node that wraps the sub-LLM output with the chat composition's content-classifier sentinels (\`---a2ui_JSON---\\n\` for a2ui; raw \`{\` for json-render).
+- **Phase 4 artifacts removed**: \`render_demo_form\` tool, \`FEEDBACK_FORM_JSONL\` constant, \`emit_a2ui_surface\` node — all gone.
+- **State channel**: \`gen_ui_mode\` added (default \`'a2ui'\`); patched submit on Angular side propagates via \`state.gen_ui_mode\`.
+- **Schema-prompt modules**: \`src/schemas/a2ui_v1.py\` (full canonical v1 schema, ~770 LOC verbatim from the L4 production reference) + \`src/schemas/json_render.py\` (~80 LOC describing \`@json-render/core\`'s \`{root, elements, state}\` Spec shape).
+- **Angular palette**: New \`GenUI\` dropdown with options A2UI / json-render, default A2UI, persisted across reload via the existing palette-persistence service.
+- **Welcome suggestions**: 4 generic intents replace Phase 4's single hardcoded entry — "Build a quick feedback form", "Render a flight booking card", "Show a settings panel", "Build a login form".
+
+Spec: \`docs/superpowers/specs/2026-05-10-canonical-chat-demo-phase-5-genui-dropdown-design.md\`
+Plan: \`docs/superpowers/plans/2026-05-10-canonical-chat-demo-phase-5-genui-dropdown.md\`
+
+## Test plan
+
+### Verified locally
+- [x] \`nx run examples-chat-python:smoke\` — 12 passed (8 carried + 4 new; Phase 4's 3 a2ui tests removed)
+- [x] \`nx run examples-chat-angular:test/lint/build\` — all green
+- [x] **Server-side A2UI probe**: GenUI tool_call to \`generate_a2ui_schema\`; final AIMessage starts with \`---a2ui_JSON---\\n\` containing v1 envelopes (\`surfaceUpdate\` + \`beginRendering\`).
+- [x] **Server-side json-render probe**: GenUI tool_call to \`generate_json_render_spec\`; final AIMessage starts with \`{\` containing \`root\` + \`elements\` keys; no a2ui prefix.
+- [x] **Live Chrome MCP smoke (A2UI mode)**: Click "Build a quick feedback form" → \`<a2ui-surface>\` mounts dynamic Card with TextField + MultipleChoice + Button (LLM-generated, varies per request).
+- [x] **Live Chrome MCP smoke (json-render mode)**: Same prompt → \`<chat-generative-ui>\` mounts the json-render Spec instead. Different rendering path, same logical form.
+- [x] **Other tools unaffected**: search_documents, request_approval, research still dispatch via normal \`tools\` loop.
+
+### Pending visual verification
+- [ ] After merge: live smoke against \`/embed\`, \`/popup\`, \`/sidebar\` confirming dropdown persists across modes.
+
+### Open follow-ups
+- Finding K (Phase 4): A2UI text-field datamodel back-prop — orthogonal lib gap, separate PR.
+- A2UI Material theming track (3-pass: surface coverage → token contract → Material preset) — independent of Phase 5.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)" 2>&1 | tail -3
+```
+
+- [ ] **Step 3: Note the PR URL**
+
+- [ ] **Step 4: Wait for CI; address failures**
+
+- [ ] **Step 5: Merge once green**
+
+---
+
+## Definition of done
+
+1. PR merged.
+2. CI green: \`nx run examples-chat-python:smoke\` (12 pytest), \`nx run examples-chat-angular:test/lint/build\`.
+3. Server-side probes confirm: A2UI mode dispatches \`generate_a2ui_schema\`, final AIMessage with v1 envelopes; json-render mode dispatches \`generate_json_render_spec\`, final AIMessage as JSON Spec object.
+4. Live Chrome MCP smoke confirms: palette dropdown present + persists; A2UI mode mounts \`<a2ui-surface>\`; json-render mode mounts \`<chat-generative-ui>\`; same prompt, different protocols, both rendering correctly.
+5. Welcome suggestions count = 12 (Phase 4's removed entry replaced by 4 new generic intents).
+6. CHECKLIST `## Generative UI / A2UI surfaces` section updated for dynamic dispatch + dropdown.
+7. Phase 4 artifacts (`render_demo_form`, `FEEDBACK_FORM_JSONL`, `emit_a2ui_surface`) verifiably gone — `test_phase4_artifacts_removed` enforces this.

--- a/docs/superpowers/specs/2026-05-10-canonical-chat-demo-phase-5-genui-dropdown-design.md
+++ b/docs/superpowers/specs/2026-05-10-canonical-chat-demo-phase-5-genui-dropdown-design.md
@@ -1,0 +1,430 @@
+# Canonical `examples/chat` Demo — Phase 5: GenUI Dropdown + Dynamic Schema Generation
+
+**Date:** 2026-05-10
+**Status:** Approved
+**Phase:** 5 of the canonical demo roadmap
+**Builds on:** Phase 1 (#213) + Phase 2A (#216) + Phase 2B (#220) + smoke fixes (#217 #218 #219 #221) + Phase 3A (#222 #223) + Phase 3B (#224 #225) + Phase 4 (#226 #227) + a2ui v1 migration (#228)
+
+## Goal
+
+Replace Phase 4's hardcoded `FEEDBACK_FORM_JSONL` path with **dynamic schema generation**. Add a palette `GenUI` dropdown that toggles between two protocols (`a2ui` / `json-render`); welcome suggestions are now generic intents ("build me a feedback form") that the LLM converts to a concrete schema by dispatching a protocol-specific sub-LLM tool. Each sub-LLM has the full canonical schema in its system prompt and runs at `temperature=0` for schema fidelity.
+
+## Why dynamic now
+
+Phase 4's hardcoded JSONL was a stepping stone: it proved the wire-format prefix routes correctly through the chat composition's content classifier and that the catalog renders. With v1 (#228) merged, the canonical Google A2UI v1 schema is now what `@ngaf/a2ui` actually parses — so a sub-LLM with that schema in its system prompt produces output the parser accepts. The pattern is proven in production at `~/repos/SC-CopilotKit-C1/L4/backend-dynamic/schema.py`. We adopt it here.
+
+## Architecture
+
+```
+User clicks welcome suggestion ("build me a feedback form")
+       ↓
+state.gen_ui_mode = 'a2ui' | 'json-render' (palette-driven)
+       ↓
+generate node — parent LLM sees system prompt instructing it to
+                dispatch generate_<mode>_schema(request) when user
+                wants UI; passes user message verbatim as request
+       ↓
+tools node — runs generate_<mode>_schema, which invokes a NESTED
+              ChatOpenAI(temperature=0) with that protocol's full
+              JSON schema as its system prompt. Returns a JSON
+              string in the protocol's wire format.
+       ↓
+should_continue routes the tool_call to emit_generated_surface
+              (NOT back to generate, like other tools)
+       ↓
+emit_generated_surface — reads the most recent ToolMessage, wraps
+              its content with the protocol's classifier sentinel:
+                a2ui      → `---a2ui_JSON---\n{...JSONL...}\n`
+                json-render → raw `{...Spec JSON...}` (classifier
+                              detects content starting with `{`)
+              Emits the wrapped content as a fresh AIMessage.
+       ↓
+attach_citations (no-op for these messages — no preceding ToolMessage
+                  with citation JSON)
+       ↓
+__end__
+```
+
+Existing Phase 2B/3A/3B paths (`search_documents`, `request_approval`, `research`) continue to work — only the GenUI tool calls divert through `emit_generated_surface`.
+
+## Sub-LLM pattern
+
+Reference: `~/repos/SC-CopilotKit-C1/L4/backend-dynamic/schema.py` lines 1-887. The `generate_schema` tool there uses langchain's newer `@tool()` decorator with `ToolRuntime[Any]`; ours uses langchain-core's `@tool` (matching Phase 2B/3A/3B) and accesses prior messages via the standard state injection.
+
+Each tool body:
+1. Filters preceding messages to drop tool messages and pending tool-call AI turns (the schema sub-LLM should see only conversational context).
+2. Invokes `ChatOpenAI(model='gpt-5-mini', temperature=0)` with `[SystemMessage(SCHEMA_PROMPT), *filtered_messages]`.
+3. Returns the response content as a string. The string IS the wire-format payload (raw JSONL for a2ui; raw JSON object for json-render).
+
+The sub-LLM never sees the parent's other tool descriptions. It's a focused contractor: input = user intent + chat history; output = schema-correct payload.
+
+## Python graph changes
+
+### State additions
+
+```python
+class State(TypedDict):
+    messages: Annotated[list, add_messages]
+    model: Optional[str]
+    reasoning_effort: Optional[str]
+    gen_ui_mode: Optional[str]   # NEW: 'a2ui' | 'json-render', default 'a2ui'
+```
+
+### Removed (was Phase 4)
+
+- `A2UI_PREFIX` constant — moved to inline use inside `emit_generated_surface`
+- `FEEDBACK_FORM_JSONL` constant — removed entirely (schema is now generated, not hardcoded)
+- `render_demo_form` tool — removed
+- `emit_a2ui_surface` node — replaced by `emit_generated_surface`
+- `should_continue` branch for `render_demo_form` — replaced
+
+### Added
+
+Two sub-LLM tools (one per protocol). Schema docs are large (the A2UI one is ~770 lines verbatim from the L4 reference; the json-render one is ~80 lines). Each lives in a dedicated module:
+
+- `examples/chat/python/src/schemas/a2ui_v1.py` — exports `A2UI_V1_SCHEMA_PROMPT: str`
+- `examples/chat/python/src/schemas/json_render.py` — exports `JSON_RENDER_SCHEMA_PROMPT: str`
+
+The A2UI prompt is the L4 reference's `SCHEMA_PROMPT` verbatim (no modifications — its protocol description matches our v1 parser exactly). The json-render prompt describes the `{root, elements, state}` Spec shape per `@json-render/core` types.
+
+```python
+# In graph.py — tool wrappers
+@tool
+async def generate_a2ui_schema(request: str) -> str:
+    """Dispatch the A2UI schema sub-agent. Use this when the user asks for
+    UI/forms/cards and `gen_ui_mode` is 'a2ui'. Pass the user's request
+    verbatim as the `request` arg."""
+    from src.schemas.a2ui_v1 import A2UI_V1_SCHEMA_PROMPT
+    llm = ChatOpenAI(model="gpt-5-mini", temperature=0)
+    response = await llm.ainvoke([
+        SystemMessage(content=A2UI_V1_SCHEMA_PROMPT),
+        HumanMessage(content=request),
+    ])
+    return _as_text(response.content).strip()
+
+
+@tool
+async def generate_json_render_spec(request: str) -> str:
+    """Dispatch the json-render schema sub-agent. Use this when the user
+    asks for UI/forms/cards and `gen_ui_mode` is 'json-render'. Pass the
+    user's request verbatim as the `request` arg."""
+    from src.schemas.json_render import JSON_RENDER_SCHEMA_PROMPT
+    llm = ChatOpenAI(model="gpt-5-mini", temperature=0)
+    response = await llm.ainvoke([
+        SystemMessage(content=JSON_RENDER_SCHEMA_PROMPT),
+        HumanMessage(content=request),
+    ])
+    return _as_text(response.content).strip()
+
+
+def _as_text(content) -> str:
+    if isinstance(content, str): return content
+    if isinstance(content, list):
+        return "\n".join(b.get("text", "") for b in content
+                         if isinstance(b, dict) and b.get("type") == "text")
+    return ""
+```
+
+### `should_continue` routing
+
+```python
+def should_continue(state: State) -> Literal["tools", "emit_generated_surface", "attach_citations"]:
+    last = state["messages"][-1]
+    if isinstance(last, AIMessage) and last.tool_calls:
+        for tc in last.tool_calls:
+            if tc["name"] in ("generate_a2ui_schema", "generate_json_render_spec"):
+                return "emit_generated_surface"
+        return "tools"
+    return "attach_citations"
+```
+
+### `emit_generated_surface` node
+
+```python
+A2UI_PREFIX = "---a2ui_JSON---"
+
+async def emit_generated_surface(state: State) -> dict:
+    """Post-process: read the most recent ToolMessage carrying the
+    sub-LLM's wire-format payload, wrap with the appropriate classifier
+    sentinel, emit as a fresh AIMessage. Existing Tool-call AI message
+    + ToolMessage history is preserved (debug visible in chat-debug)."""
+    msgs = state["messages"]
+    # Find the most recent ToolMessage and its preceding AIMessage's tool_call name
+    tool_msg = None
+    tool_name = None
+    for m in reversed(msgs):
+        if isinstance(m, ToolMessage):
+            tool_msg = m
+            # Find the AI message that originated this tool_call
+            for prior in reversed(msgs):
+                if isinstance(prior, AIMessage) and prior.tool_calls:
+                    for tc in prior.tool_calls:
+                        if tc.get("id") == tool_msg.tool_call_id:
+                            tool_name = tc.get("name")
+                            break
+                if tool_name:
+                    break
+            break
+    if tool_msg is None or tool_name is None:
+        return {}
+
+    payload = tool_msg.content if isinstance(tool_msg.content, str) else ""
+    if not payload:
+        return {}
+
+    if tool_name == "generate_a2ui_schema":
+        # Sub-LLM returns a JSON array per the v1 schema prompt;
+        # convert to JSONL and prepend the classifier sentinel.
+        try:
+            arr = json.loads(payload)
+            jsonl = "\n".join(json.dumps(env) for env in arr) if isinstance(arr, list) else payload
+        except json.JSONDecodeError:
+            jsonl = payload  # let the parser deal with it; classifier still triggers on prefix
+        wrapped = A2UI_PREFIX + "\n" + jsonl + "\n"
+    elif tool_name == "generate_json_render_spec":
+        # json-render content is a single JSON object — classifier detects on '{'
+        wrapped = payload.strip()
+    else:
+        return {}
+
+    return {"messages": [AIMessage(content=wrapped)]}
+```
+
+### `generate` node — pick up `gen_ui_mode`
+
+The patched submit on the Angular side propagates `gen_ui_mode` through `state.gen_ui_mode`. The parent LLM's SYSTEM_PROMPT references it; the tool descriptions also nudge it.
+
+### SYSTEM_PROMPT update
+
+Append one paragraph (replaces Phase 4's render_demo_form paragraph):
+
+```
+"When the user asks to see, build, or render a UI / form / card / "
+"interactive component, dispatch one of the schema-generation tools "
+"based on `state.gen_ui_mode`: "
+"  - 'a2ui'        → call `generate_a2ui_schema(request)` "
+"  - 'json-render' → call `generate_json_render_spec(request)` "
+"Pass the user's request verbatim as the `request` argument. The tool "
+"returns a wire-format payload that the chat composition renders "
+"directly. Do NOT describe the UI in prose — the tool dispatches the "
+"actual rendering. Briefly acknowledge after the tool completes."
+```
+
+### Builder topology
+
+```python
+_builder = StateGraph(State)
+_builder.add_node("generate", generate)
+_builder.add_node("tools", ToolNode([
+    search_documents, request_approval, research,
+    generate_a2ui_schema, generate_json_render_spec,
+]))
+_builder.add_node("emit_generated_surface", emit_generated_surface)
+_builder.add_node("attach_citations", attach_citations)
+_builder.set_entry_point("generate")
+_builder.add_conditional_edges("generate", should_continue, {
+    "tools": "tools",
+    "emit_generated_surface": "emit_generated_surface",
+    "attach_citations": "attach_citations",
+})
+_builder.add_edge("tools", "generate")
+_builder.add_edge("emit_generated_surface", "attach_citations")
+_builder.add_edge("attach_citations", END)
+```
+
+## Angular changes
+
+### Palette: GenUI dropdown
+
+`examples/chat/angular/src/app/shell/control-palette.component.ts` already houses model + effort dropdowns. Add a 5th dropdown `GenUI` with options `[{value: 'a2ui', label: 'A2UI'}, {value: 'json-render', label: 'json-render'}]`. Default `'a2ui'`.
+
+`examples/chat/angular/src/app/shell/demo-shell.component.ts`:
+- New signal: `readonly genUiMode = signal<string>(this.persistence.read('genUiMode') ?? 'a2ui');`
+- Add to `modelOptions`/`effortOptions` block: `genUiOptions` signal listing the two values.
+- Add `onGenUiModeChange(value)` handler — persists via `palette-persistence.service`.
+- Patched submit injects `gen_ui_mode: this.genUiMode()` into state alongside `model` and `reasoning_effort`.
+
+`examples/chat/angular/src/app/shell/demo-shell.component.html`:
+- Pass `[genUiMode]="genUiMode()"`, `[genUiOptions]="genUiOptions()"`, `(genUiModeChange)="onGenUiModeChange($event)"` to `<app-control-palette>`.
+
+`examples/chat/angular/src/app/shell/control-palette.component.ts`:
+- Add `readonly genUiMode = input.required<string>();`, `readonly genUiOptions = input.required<readonly {value, label}[]>();`, `readonly genUiModeChange = output<string>();`
+- Template adds a `<select>` next to the model + effort selects.
+
+`examples/chat/angular/src/app/shell/palette-persistence.service.ts`:
+- The persistence read/write generic already supports arbitrary string keys, so `read('genUiMode')` / `write('genUiMode', value)` works without service changes.
+
+### Welcome suggestions
+
+`examples/chat/angular/src/app/modes/welcome-suggestions.ts`:
+
+Remove the Phase 4 entry "Demo: render an interactive A2UI surface" (it referenced `render_demo_form` which is gone).
+
+Add four generic intents (replacing entry 10 from Phase 4):
+
+```ts
+{
+  label: 'Build a quick feedback form',
+  value:
+    'Build me a quick feedback form with a name field and a 1-5 rating picker.',
+},
+{
+  label: 'Render a flight booking card',
+  value:
+    'Render a flight booking card from Seattle to Tokyo with origin, destination, departure date, return date, and a Search Flights button.',
+},
+{
+  label: 'Show a settings panel',
+  value:
+    'Show a settings panel with a theme picker (light/dark/auto), a notifications toggle, and a "Reset to defaults" button.',
+},
+{
+  label: 'Build a login form',
+  value:
+    'Build a login form with email and password fields and a "Sign in" button.',
+},
+```
+
+Toggle the GenUI dropdown to see the same prompts render via either protocol.
+
+## Python verification probe
+
+Server-side check the round-trip for each protocol:
+
+```bash
+# A2UI mode
+tid=$(curl -sf -X POST http://localhost:2024/threads -d '{}' | jq -r .thread_id)
+curl -sf -X POST "http://localhost:2024/threads/$tid/runs/wait" \
+  -H 'Content-Type: application/json' \
+  -d '{"assistant_id":"chat","input":{"messages":[{"role":"user","content":"Build a quick feedback form."}],"model":"gpt-5-mini","gen_ui_mode":"a2ui"}}'
+# Expect: tool_call to generate_a2ui_schema → ToolMessage with v1 JSONL
+# array → final AIMessage starts with ---a2ui_JSON---\n and contains
+# surfaceUpdate + beginRendering envelopes.
+
+# json-render mode
+tid=$(curl -sf -X POST http://localhost:2024/threads -d '{}' | jq -r .thread_id)
+curl -sf -X POST "http://localhost:2024/threads/$tid/runs/wait" \
+  -H 'Content-Type: application/json' \
+  -d '{"assistant_id":"chat","input":{"messages":[{"role":"user","content":"Build a quick feedback form."}],"model":"gpt-5-mini","gen_ui_mode":"json-render"}}'
+# Expect: tool_call to generate_json_render_spec → ToolMessage with a
+# JSON Spec object → final AIMessage starts with `{` (classifier picks
+# up json-render type).
+```
+
+## Live Chrome MCP smoke
+
+Per established pattern:
+
+1. Reload demo at `/embed`. Confirm 5th palette dropdown "GenUI" with options A2UI / json-render, default A2UI.
+2. Click "Build a quick feedback form" welcome suggestion (default a2ui mode):
+   - AI emits tool_call to `generate_a2ui_schema`
+   - `<a2ui-surface>` mounts the dynamically generated form (Card + TextField + MultipleChoice + Button)
+   - Different from Phase 4's hardcoded form — this varies per LLM response
+3. New conversation. Switch GenUI dropdown to `json-render`. Click same suggestion:
+   - AI emits tool_call to `generate_json_render_spec`
+   - `<chat-generative-ui>` mounts (different rendering path)
+   - Same logical form, different protocol output
+4. Verify other tools still work: click "What are Angular signals?" (search_documents) → no GenUI dispatch, normal markdown answer with citations.
+5. Verify interrupts still work: click "Demo: ask for approval" (request_approval) → interrupt panel appears.
+6. Verify subagents still work: click "Demo: dispatch a research subagent" (research) → subagent flashes briefly.
+
+## TDD
+
+`examples/chat/python/tests/test_graph_smoke.py` updates:
+
+```python
+@pytest.mark.smoke
+def test_genui_tools_exist():
+    from src.graph import generate_a2ui_schema, generate_json_render_spec
+    assert generate_a2ui_schema.name == "generate_a2ui_schema"
+    assert generate_json_render_spec.name == "generate_json_render_spec"
+
+
+@pytest.mark.smoke
+def test_state_graph_has_emit_generated_surface_node():
+    from src.graph import graph
+    nodes = set(graph.get_graph().nodes.keys())
+    assert "emit_generated_surface" in nodes
+    assert "tools" in nodes
+    assert "attach_citations" in nodes
+
+
+@pytest.mark.smoke
+def test_state_includes_gen_ui_mode_channel():
+    from src.graph import State
+    annotations = State.__annotations__
+    assert "gen_ui_mode" in annotations
+
+
+@pytest.mark.smoke
+def test_phase4_artifacts_removed():
+    """Phase 5 removes Phase 4's hardcoded path."""
+    import importlib
+    mod = importlib.import_module("src.graph")
+    assert not hasattr(mod, "render_demo_form"), \
+        "render_demo_form tool should be removed in Phase 5"
+    assert not hasattr(mod, "FEEDBACK_FORM_JSONL"), \
+        "FEEDBACK_FORM_JSONL constant should be removed in Phase 5"
+    assert not hasattr(mod, "emit_a2ui_surface"), \
+        "emit_a2ui_surface node should be replaced by emit_generated_surface"
+```
+
+Drop the three Phase 4 a2ui smoke tests (they target removed symbols):
+- `test_render_demo_form_tool_exists`
+- `test_state_graph_includes_emit_a2ui_surface_node`
+- `test_a2ui_jsonl_starts_with_prefix_and_parses`
+
+Final test count: 11 (Phase 4) - 3 + 4 = **12 tests**.
+
+## CHECKLIST.md update
+
+Generative UI / A2UI surfaces section gets a v1 + dynamic-mode update:
+
+```markdown
+## Generative UI / A2UI surfaces
+
+- [ ] Palette has a "GenUI" dropdown with options A2UI / json-render; default A2UI; persists across reload
+- [ ] (GenUI=A2UI) Click "Build a quick feedback form" welcome suggestion
+- [ ] AI emits tool_call to `generate_a2ui_schema`; sub-LLM returns v1 JSONL
+- [ ] `<a2ui-surface>` mounts a Card with TextField + MultipleChoice + Button (LLM-generated, not hardcoded)
+- [ ] Final AI message content starts with `---a2ui_JSON---\n` and contains v1 envelopes (`surfaceUpdate`/`dataModelUpdate`/`beginRendering`)
+- [ ] (GenUI=json-render) New conversation, click same suggestion
+- [ ] AI emits tool_call to `generate_json_render_spec`; sub-LLM returns a json-render Spec
+- [ ] `<chat-generative-ui>` mounts the spec (different rendering path from A2UI)
+- [ ] Verify cross-protocol: same prompt produces different render via dropdown toggle
+- [ ] Server-side: thread state shows the matching tool_call for the chosen mode; no hardcoded JSONL anywhere in messages
+```
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `examples/chat/python/src/graph.py` | Remove Phase 4 (`render_demo_form`, `FEEDBACK_FORM_JSONL`, `emit_a2ui_surface`); add `gen_ui_mode` State channel, two sub-LLM tools, `emit_generated_surface` node, routing, SYSTEM_PROMPT update. |
+| `examples/chat/python/src/schemas/__init__.py` | NEW — package init |
+| `examples/chat/python/src/schemas/a2ui_v1.py` | NEW — exports `A2UI_V1_SCHEMA_PROMPT` (full v1 schema doc, ~770 LOC verbatim from L4 reference) |
+| `examples/chat/python/src/schemas/json_render.py` | NEW — exports `JSON_RENDER_SCHEMA_PROMPT` (~80 LOC describing `{root, elements, state}`) |
+| `examples/chat/python/tests/test_graph_smoke.py` | Drop 3 Phase 4 tests; add 4 Phase 5 tests. |
+| `examples/chat/angular/src/app/shell/demo-shell.component.ts` | `genUiMode` signal + `genUiOptions` + handler + state injection. |
+| `examples/chat/angular/src/app/shell/demo-shell.component.html` | Wire palette inputs/output. |
+| `examples/chat/angular/src/app/shell/control-palette.component.ts` | New `genUiMode` input + `genUiOptions` input + `genUiModeChange` output + `<select>` in template. |
+| `examples/chat/angular/src/app/modes/welcome-suggestions.ts` | Remove Phase 4 entry; add 4 generic intent entries. |
+| `examples/chat/smoke/CHECKLIST.md` | Update Generative UI section per above. |
+
+Total ≈ 200 LOC + 770 LOC schema-doc constant + 80 LOC json-render-doc constant ≈ **~1050 LOC** (most of which is pasted schema documentation that doesn't get reviewed line-by-line).
+
+## Phasing for the implementation plan
+
+- Phase 0 — Branch creation (`claude/examples-chat-phase-5-genui`)
+- Phase 1 — Schema-prompt modules (`a2ui_v1.py`, `json_render.py`); the A2UI doc is verbatim from L4 reference, the json-render doc is hand-written.
+- Phase 2 — Python graph: TDD (failing tests first) → remove Phase 4 artifacts → add `gen_ui_mode` State channel + two sub-LLM tools + `emit_generated_surface` node + routing + SYSTEM_PROMPT.
+- Phase 3 — Angular palette: `genUiMode` signal + persistence + new dropdown + state injection in patched submit.
+- Phase 4 — Welcome suggestions (remove Phase 4 entry; add 4 new generic intents).
+- Phase 5 — CHECKLIST.md update.
+- Phase 6 — Verification: full lib + python smoke + lint + build sweep + server-side curl probe (both modes) + LIVE Chrome MCP smoke (both modes) + PR open + merge.
+
+## Out of scope (deferred)
+
+- **Pass-through mode hint to non-GenUI tools.** Other tools (`search_documents`, `request_approval`, `research`) ignore `gen_ui_mode`. The dropdown only affects rendering surfaces.
+- **GenUI dropdown propagating to thread checkpoints.** The mode lives on `state` and is persisted client-side via palette-persistence; thread restoration on reload uses last-known palette state, not state-from-history.
+- **A2UI surface generation actually delivering a fully working interactive form.** Finding K (datamodel back-prop) is still open lib-level. The form RENDERS; user input doesn't yet propagate to `dataModel`. Out of Phase 5 scope; tracked separately.
+- **Material theming and full-catalog surface coverage** — those move to a parallel "theming" track (3 passes outlined in the brainstorm; not gated by Phase 5).

--- a/examples/chat/angular/src/app/modes/welcome-suggestions.ts
+++ b/examples/chat/angular/src/app/modes/welcome-suggestions.ts
@@ -45,8 +45,23 @@ export const WELCOME_SUGGESTIONS: readonly WelcomeSuggestion[] = [
       'Use the research subagent to investigate the history and motivation behind Angular standalone components, then report back with a concise summary.',
   },
   {
-    label: 'Demo: render an interactive A2UI surface',
+    label: 'Demo: render a feedback form',
     value:
-      'Use the render_demo_form tool to show me a feedback card with name and rating fields.',
+      'Build me an interactive feedback form with a name field, a 1–5 rating picker, and a Submit button.',
+  },
+  {
+    label: 'Demo: render a settings card',
+    value:
+      'Render a settings card with a toggle for dark mode, a language dropdown (English / Spanish / French), and a Save button.',
+  },
+  {
+    label: 'Demo: render a poll',
+    value:
+      'Create a quick poll asking "Which front-end framework do you prefer?" with options Angular, React, Vue, and Svelte, plus a Vote button.',
+  },
+  {
+    label: 'Demo: render a contact form',
+    value:
+      'Show me a contact form with fields for name, email address, subject, and a multi-line message, plus a Send button.',
   },
 ];

--- a/examples/chat/angular/src/app/shell/control-palette.component.html
+++ b/examples/chat/angular/src/app/shell/control-palette.component.html
@@ -51,6 +51,15 @@
       </select>
     </label>
 
+    <label class="palette__group palette__group--model">
+      <span class="palette__label">Gen UI</span>
+      <select [value]="genUiMode()" (change)="pickGenUiMode($event)">
+        @for (opt of genUiOptions(); track opt.value) {
+          <option [value]="opt.value" [selected]="opt.value === genUiMode()">{{ opt.label }}</option>
+        }
+      </select>
+    </label>
+
     <button
       type="button"
       class="palette__toggle"

--- a/examples/chat/angular/src/app/shell/control-palette.component.ts
+++ b/examples/chat/angular/src/app/shell/control-palette.component.ts
@@ -26,11 +26,14 @@ export class ControlPalette {
   readonly modelOptions = input.required<readonly { value: string; label: string }[]>();
   readonly effort = input.required<string>();
   readonly effortOptions = input.required<readonly { value: string; label: string }[]>();
+  readonly genUiMode = input.required<string>();
+  readonly genUiOptions = input.required<readonly { value: string; label: string }[]>();
   readonly debugOpen = input.required<boolean>();
 
   readonly modeChange = output<DemoMode>();
   readonly modelChange = output<string>();
   readonly effortChange = output<string>();
+  readonly genUiModeChange = output<string>();
   readonly debugOpenChange = output<boolean>();
   readonly newConversation = output<void>();
 
@@ -58,6 +61,11 @@ export class ControlPalette {
   protected pickEffort(event: Event): void {
     const value = (event.target as HTMLSelectElement).value;
     this.effortChange.emit(value);
+  }
+
+  protected pickGenUiMode(event: Event): void {
+    const value = (event.target as HTMLSelectElement).value;
+    this.genUiModeChange.emit(value);
   }
 
   protected toggleDebug(): void {

--- a/examples/chat/angular/src/app/shell/demo-shell.component.html
+++ b/examples/chat/angular/src/app/shell/demo-shell.component.html
@@ -7,10 +7,13 @@
     [modelOptions]="modelOptions()"
     [effort]="effort()"
     [effortOptions]="effortOptions()"
+    [genUiMode]="genUiMode()"
+    [genUiOptions]="genUiOptions()"
     [debugOpen]="debugOpen()"
     (modeChange)="onModeChange($event)"
     (modelChange)="onModelChange($event)"
     (effortChange)="onEffortChange($event)"
+    (genUiModeChange)="onGenUiModeChange($event)"
     (debugOpenChange)="onDebugChange($event)"
     (newConversation)="onNewConversation()"
   />

--- a/examples/chat/angular/src/app/shell/demo-shell.component.ts
+++ b/examples/chat/angular/src/app/shell/demo-shell.component.ts
@@ -57,6 +57,13 @@ export class DemoShell {
   /** Reasoning effort for the next submit. Persisted across reloads. */
   readonly effort = signal<string>(this.persistence.read('effort') ?? 'minimal');
 
+  /**
+   * GenUI dispatch mode for the next UI-render prompt. Controls which
+   * sub-LLM tool the graph calls (generate_a2ui_schema vs
+   * generate_json_render_spec). Persisted across reloads.
+   */
+  readonly genUiMode = signal<string>(this.persistence.read('genUiMode') ?? 'a2ui');
+
   protected readonly debugOpen = signal<boolean>(this.persistence.read('debug') ?? false);
 
   protected readonly modelOptions = signal<readonly { value: string; label: string }[]>([
@@ -70,6 +77,11 @@ export class DemoShell {
     { value: 'low',     label: 'low' },
     { value: 'medium',  label: 'medium' },
     { value: 'high',    label: 'high (visible reasoning)' },
+  ]);
+
+  protected readonly genUiOptions = signal<readonly { value: string; label: string }[]>([
+    { value: 'a2ui',        label: 'A2UI v1' },
+    { value: 'json-render', label: 'json-render' },
   ]);
 
   /** Persisted thread id (null on first run). Reactive so reload reconnects to the same thread. */
@@ -106,6 +118,7 @@ export class DemoShell {
             ...((input as { state?: Record<string, unknown> })?.state ?? {}),
             model: this.model(),
             reasoning_effort: this.effort(),
+            gen_ui_mode: this.genUiMode(),
           },
         },
         opts,
@@ -125,6 +138,11 @@ export class DemoShell {
   protected onEffortChange(next: string): void {
     this.effort.set(next);
     this.persistence.write('effort', next);
+  }
+
+  protected onGenUiModeChange(next: string): void {
+    this.genUiMode.set(next);
+    this.persistence.write('genUiMode', next);
   }
 
   protected onDebugChange(next: boolean): void {

--- a/examples/chat/angular/src/app/shell/palette-persistence.service.ts
+++ b/examples/chat/angular/src/app/shell/palette-persistence.service.ts
@@ -6,6 +6,7 @@ const KEY = 'ngaf-chat-demo:palette';
 interface PaletteState {
   model?: string | null;
   effort?: string | null;
+  genUiMode?: string | null;
   debug?: boolean | null;
   threadId?: string | null;
   collapsed?: boolean | null;

--- a/examples/chat/python/src/graph.py
+++ b/examples/chat/python/src/graph.py
@@ -65,17 +65,16 @@ SYSTEM_PROMPT = (
     "lookups — those are handled by `search_documents`. "
     " "
     "When the user asks to see, build, or render a UI / form / card / "
-    "interactive component, dispatch one of the schema-generation tools "
-    "based on the conversation's `gen_ui_mode` (visible in state if you "
-    "received it; default is 'a2ui'): "
-    "  - 'a2ui'        -> call `generate_a2ui_schema(request)` "
-    "  - 'json-render' -> call `generate_json_render_spec(request)` "
-    "Pass the user's request verbatim as the `request` argument. The "
-    "tool returns a wire-format payload that the chat composition "
-    "renders directly. Do NOT describe the UI in prose — the tool "
-    "dispatches the actual rendering. Briefly acknowledge the dispatch "
-    "in your conversational reply, but keep the prose short — the user "
-    "sees the rendered surface."
+    "interactive component, immediately dispatch the schema-generation "
+    "tool that's bound (one of `generate_a2ui_schema` or "
+    "`generate_json_render_spec`, depending on the user's GenUI palette "
+    "selection). Pass the user's request VERBATIM as the `request` "
+    "argument — do NOT ask clarifying questions, do NOT describe the UI "
+    "in prose, do NOT add fields or design choices the user did not ask "
+    "for. The tool dispatches the actual rendering; your job is just to "
+    "route the request. After the tool returns, briefly acknowledge the "
+    "dispatch in one short sentence — the user sees the rendered "
+    "surface directly."
 )
 
 # Reasoning-capable model prefixes. We only attach the ``reasoning``
@@ -297,28 +296,52 @@ async def generate(state: State) -> dict:
         # to render). The adapter's `extractReasoning` reads either the
         # legacy `block.text` field or the modern `block.summary[].text`.
         kwargs["reasoning"] = {"effort": effort, "summary": "auto"}
+    # Pick the GenUI tool matching the user's palette dropdown. Only ONE
+    # is bound per request so the parent LLM has a single, unambiguous
+    # render tool to choose. ToolNode below is bound to BOTH so either
+    # side of the conditional resolves at execution time.
+    gen_ui_mode = state.get("gen_ui_mode") or "a2ui"
+    gen_ui_tool = (
+        generate_a2ui_schema if gen_ui_mode == "a2ui"
+        else generate_json_render_spec
+    )
     llm = ChatOpenAI(**kwargs).bind_tools([
-        search_documents, request_approval, research,
-        generate_a2ui_schema, generate_json_render_spec,
+        search_documents, request_approval, research, gen_ui_tool,
     ])
     messages = [SystemMessage(content=SYSTEM_PROMPT)] + state["messages"]
     response = await llm.ainvoke(messages)
     return {"messages": [response]}
 
 
-def should_continue(state: State) -> Literal["tools", "emit_generated_surface", "attach_citations"]:
-    """Conditional edge: route from generate to:
-    - `emit_generated_surface` if any tool_call is generate_a2ui_schema or generate_json_render_spec
-    - `tools` for any other tool_call (search_documents, request_approval, research)
-    - `attach_citations` (terminal) when there are no tool_calls
-    """
+def should_continue(state: State) -> Literal["tools", "attach_citations"]:
+    """Conditional edge from generate: route to tools node when any
+    tool_call is present (GenUI tools, search, approval, research),
+    otherwise route to attach_citations terminal post-process."""
     last = state["messages"][-1]
     if isinstance(last, AIMessage) and last.tool_calls:
-        for tc in last.tool_calls:
-            if tc["name"] in ("generate_a2ui_schema", "generate_json_render_spec"):
-                return "emit_generated_surface"
         return "tools"
     return "attach_citations"
+
+
+def after_tools(state: State) -> Literal["emit_generated_surface", "generate"]:
+    """Conditional edge from tools: if the most recent ToolMessage came
+    from a GenUI tool, route to emit_generated_surface (terminal
+    post-process that wraps the sub-LLM payload). Otherwise loop back
+    to generate so the parent LLM can incorporate the tool result."""
+    msgs = state["messages"]
+    # Find the most recent ToolMessage and its originating tool_call name
+    for m in reversed(msgs):
+        if isinstance(m, ToolMessage):
+            for prior in reversed(msgs):
+                if isinstance(prior, AIMessage) and prior.tool_calls:
+                    for tc in prior.tool_calls:
+                        if tc.get("id") == m.tool_call_id and tc.get("name") in (
+                            "generate_a2ui_schema", "generate_json_render_spec",
+                        ):
+                            return "emit_generated_surface"
+                    break
+            break
+    return "generate"
 
 
 async def emit_generated_surface(state: State) -> dict:
@@ -462,11 +485,17 @@ _builder.add_conditional_edges(
     should_continue,
     {
         "tools": "tools",
-        "emit_generated_surface": "emit_generated_surface",
         "attach_citations": "attach_citations",
     },
 )
-_builder.add_edge("tools", "generate")
+_builder.add_conditional_edges(
+    "tools",
+    after_tools,
+    {
+        "emit_generated_surface": "emit_generated_surface",
+        "generate": "generate",
+    },
+)
 _builder.add_edge("emit_generated_surface", "attach_citations")
 _builder.add_edge("attach_citations", END)
 

--- a/examples/chat/python/src/graph.py
+++ b/examples/chat/python/src/graph.py
@@ -63,14 +63,19 @@ SYSTEM_PROMPT = (
     "the child runs. Use the subagent's returned summary to compose your "
     "final answer. Do not call `research` for trivial chit-chat or simple "
     "lookups — those are handled by `search_documents`. "
-    "When the user asks to see a form, render UI, or display an "
-    "interactive card (anything visually interactive — a feedback "
-    "form, a settings card, a poll), call the `render_demo_form` "
-    "tool with `form_type=\"feedback\"`. Do not describe the UI in "
-    "prose; the tool dispatches the actual rendering. Briefly "
-    "acknowledge in your conversational reply that you have rendered "
-    "the form, but keep the prose short — the user will see the form "
-    "directly."
+    " "
+    "When the user asks to see, build, or render a UI / form / card / "
+    "interactive component, dispatch one of the schema-generation tools "
+    "based on the conversation's `gen_ui_mode` (visible in state if you "
+    "received it; default is 'a2ui'): "
+    "  - 'a2ui'        -> call `generate_a2ui_schema(request)` "
+    "  - 'json-render' -> call `generate_json_render_spec(request)` "
+    "Pass the user's request verbatim as the `request` argument. The "
+    "tool returns a wire-format payload that the chat composition "
+    "renders directly. Do NOT describe the UI in prose — the tool "
+    "dispatches the actual rendering. Briefly acknowledge the dispatch "
+    "in your conversational reply, but keep the prose short — the user "
+    "sees the rendered surface."
 )
 
 # Reasoning-capable model prefixes. We only attach the ``reasoning``
@@ -151,84 +156,6 @@ def request_approval(reason: str) -> str:
     return f"Human response: {response}"
 
 
-# A2UI wire-format prefix recognized by the chat composition's content
-# classifier (libs/chat/src/lib/streaming/content-classifier.ts). When an
-# AI message content begins with this exact sentinel, the classifier
-# routes the message to <a2ui-surface> rendering instead of plain markdown.
-A2UI_PREFIX = "---a2ui_JSON---"
-
-# Hardcoded A2UI v1 surface spec for the feedback-card demo. Each line
-# is one envelope ({"<type>": {...}}) consumed by the parser at \n
-# boundaries. Three envelopes in order:
-#   1. surfaceUpdate  — declares all component definitions
-#   2. dataModelUpdate — seeds the initial data-model values
-#   3. beginRendering  — commits the buffer and names the root component
-# The surface defines: a Card (child = inner Column) containing a
-# TextField (Name), a MultipleChoice (Rating 1-5, single selection), and
-# a Button (Submit) whose Text child carries the label. Hardcoded because
-# A2UI's schema-exact format is not a reliable LLM capability today.
-FEEDBACK_FORM_JSONL = "\n".join([
-    json.dumps({"surfaceUpdate": {
-        "surfaceId": "feedback",
-        "components": [
-            {"id": "card", "component": {"Card": {"child": "inner_col"}}},
-            {"id": "inner_col", "component": {"Column": {
-                "children": {"explicitList": ["name_field", "rating_picker", "submit_btn"]},
-            }}},
-            {"id": "name_field", "component": {"TextField": {
-                "label": {"literalString": "Your name"},
-                "text": {"path": "/name"},
-                "textFieldType": "shortText",
-            }}},
-            {"id": "rating_picker", "component": {"MultipleChoice": {
-                "label": {"literalString": "Rating"},
-                "selections": {"path": "/rating"},
-                "options": [
-                    {"label": {"literalString": "1"}, "value": "1"},
-                    {"label": {"literalString": "2"}, "value": "2"},
-                    {"label": {"literalString": "3"}, "value": "3"},
-                    {"label": {"literalString": "4"}, "value": "4"},
-                    {"label": {"literalString": "5"}, "value": "5"},
-                ],
-                "maxAllowedSelections": 1,
-            }}},
-            {"id": "submit_btn", "component": {"Button": {
-                "child": "submit_label",
-                "action": {"name": "feedbackSubmit"},
-            }}},
-            {"id": "submit_label", "component": {"Text": {
-                "text": {"literalString": "Submit feedback"},
-            }}},
-        ],
-    }}),
-    json.dumps({"dataModelUpdate": {
-        "surfaceId": "feedback",
-        "contents": [
-            {"key": "name", "valueString": ""},
-            {"key": "rating", "valueString": "5"},
-        ],
-    }}),
-    json.dumps({"beginRendering": {
-        "surfaceId": "feedback",
-        "root": "card",
-    }}),
-]) + "\n"  # Trailing newline required — parser processes at \n boundaries
-
-
-@tool
-def render_demo_form(form_type: str = "feedback") -> str:
-    """Render an interactive A2UI surface in the chat. Use this when the
-    user asks to see a form, render UI, or display an interactive card.
-    `form_type` is a hint; the demo currently supports "feedback".
-
-    The tool body returns a stable marker; the actual surface rendering
-    happens in the `emit_a2ui_surface` post-process node, which detects
-    the tool_call and synthesizes the AIMessage carrying the A2UI prefix
-    and JSONL.
-    """
-    return f"a2ui:render:{form_type}"
-
-
 # Research subagent — a small compiled child graph the parent dispatches
 # via the `research` @tool. Running it as an actual subgraph (vs. inline
 # logic) is what causes LangGraph to emit stream events under namespace
@@ -297,10 +224,64 @@ async def research(topic: str, subagent_type: str = "research") -> str:
     return "(no research returned)"
 
 
+# Used by emit_generated_surface to prepend the chat composition's
+# content-classifier sentinel for A2UI mode. The classifier triggers
+# rendering when an AI message content begins with this prefix.
+A2UI_PREFIX = "---a2ui_JSON---"
+
+
+@tool
+async def generate_a2ui_schema(request: str) -> str:
+    """Dispatch the A2UI schema sub-agent to render a UI surface in A2UI
+    v1 wire format. Use this when the user asks for UI/forms/cards and
+    state.gen_ui_mode is 'a2ui'. Pass the user's request verbatim as the
+    `request` argument. The sub-agent returns a JSON array of v1
+    envelopes (surfaceUpdate, optional dataModelUpdate, beginRendering)
+    that the post-process node wraps for the chat composition."""
+    from src.schemas.a2ui_v1 import A2UI_V1_SCHEMA_PROMPT
+    llm = ChatOpenAI(model="gpt-5-mini", temperature=0)
+    response = await llm.ainvoke([
+        SystemMessage(content=A2UI_V1_SCHEMA_PROMPT),
+        HumanMessage(content=request),
+    ])
+    return _as_text(response.content).strip()
+
+
+@tool
+async def generate_json_render_spec(request: str) -> str:
+    """Dispatch the json-render schema sub-agent to render a UI surface
+    as a json-render Spec ({root, elements, state}). Use this when the
+    user asks for UI/forms/cards and state.gen_ui_mode is 'json-render'.
+    Pass the user's request verbatim as the `request` argument."""
+    from src.schemas.json_render import JSON_RENDER_SCHEMA_PROMPT
+    llm = ChatOpenAI(model="gpt-5-mini", temperature=0)
+    response = await llm.ainvoke([
+        SystemMessage(content=JSON_RENDER_SCHEMA_PROMPT),
+        HumanMessage(content=request),
+    ])
+    return _as_text(response.content).strip()
+
+
+def _as_text(content) -> str:
+    """Normalize a langchain message content to a plain string. ChatOpenAI
+    may return content as either str or a list of typed blocks; this
+    pulls the text out of either."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "\n".join(
+            b.get("text", "")
+            for b in content
+            if isinstance(b, dict) and b.get("type") == "text"
+        )
+    return ""
+
+
 class State(TypedDict):
     messages: Annotated[list, add_messages]
     model: Optional[str]
     reasoning_effort: Optional[str]
+    gen_ui_mode: Optional[str]
 
 
 async def generate(state: State) -> dict:
@@ -316,54 +297,98 @@ async def generate(state: State) -> dict:
         # to render). The adapter's `extractReasoning` reads either the
         # legacy `block.text` field or the modern `block.summary[].text`.
         kwargs["reasoning"] = {"effort": effort, "summary": "auto"}
-    llm = ChatOpenAI(**kwargs).bind_tools([search_documents, request_approval, research, render_demo_form])
+    llm = ChatOpenAI(**kwargs).bind_tools([
+        search_documents, request_approval, research,
+        generate_a2ui_schema, generate_json_render_spec,
+    ])
     messages = [SystemMessage(content=SYSTEM_PROMPT)] + state["messages"]
     response = await llm.ainvoke(messages)
     return {"messages": [response]}
 
 
-def should_continue(state: State) -> Literal["tools", "emit_a2ui_surface", "attach_citations"]:
+def should_continue(state: State) -> Literal["tools", "emit_generated_surface", "attach_citations"]:
     """Conditional edge: route from generate to:
-    - `emit_a2ui_surface` if any tool_call is `render_demo_form` (A2UI demo)
+    - `emit_generated_surface` if any tool_call is generate_a2ui_schema or generate_json_render_spec
     - `tools` for any other tool_call (search_documents, request_approval, research)
-    - `attach_citations` (terminal post-process) when there are no tool_calls
+    - `attach_citations` (terminal) when there are no tool_calls
     """
     last = state["messages"][-1]
     if isinstance(last, AIMessage) and last.tool_calls:
         for tc in last.tool_calls:
-            if tc["name"] == "render_demo_form":
-                return "emit_a2ui_surface"
+            if tc["name"] in ("generate_a2ui_schema", "generate_json_render_spec"):
+                return "emit_generated_surface"
         return "tools"
     return "attach_citations"
 
 
-async def emit_a2ui_surface(state: State) -> dict:
-    """Deterministic post-process for `render_demo_form` tool calls.
+async def emit_generated_surface(state: State) -> dict:
+    """Post-process for GenUI tool dispatches. Reads the most recent
+    ToolMessage carrying the sub-LLM's wire-format payload, identifies
+    which protocol the AI dispatched (by tool_call name), wraps the
+    payload with the chat composition's content-classifier sentinel,
+    and emits a fresh AIMessage. The original AI tool-call message and
+    ToolMessage stay in history (visible in chat-debug)."""
+    msgs = state["messages"]
 
-    Synthesizes (a) a ToolMessage satisfying the tool_call so the
-    conversation history is well-formed, and (b) a fresh AIMessage whose
-    content begins with `A2UI_PREFIX` followed by the hardcoded JSONL
-    surface spec. The chat composition's content classifier detects the
-    prefix and renders `<a2ui-surface>` instead of plain markdown.
+    # Find the most recent ToolMessage and the originating tool_call name
+    tool_msg = None
+    tool_name = None
+    for m in reversed(msgs):
+        if isinstance(m, ToolMessage):
+            tool_msg = m
+            for prior in reversed(msgs):
+                if isinstance(prior, AIMessage) and prior.tool_calls:
+                    for tc in prior.tool_calls:
+                        if tc.get("id") == tool_msg.tool_call_id:
+                            tool_name = tc.get("name")
+                            break
+                    if tool_name:
+                        break
+            break
 
-    Hardcoded JSONL because A2UI's schema-exact format is not a reliable
-    LLM capability today.
-    """
-    last = state["messages"][-1]
-    tool_calls = getattr(last, "tool_calls", []) or []
-    tc = next(
-        (t for t in tool_calls if t["name"] == "render_demo_form"),
-        None,
-    )
-    if tc is None:
-        # Defensive: should_continue routes here only when render_demo_form
-        # is in tool_calls. Returning {} keeps the graph well-formed if
-        # routing somehow misfires.
+    if tool_msg is None or tool_name is None:
         return {}
-    return {"messages": [
-        ToolMessage(content="rendered", tool_call_id=tc["id"]),
-        AIMessage(content=A2UI_PREFIX + "\n" + FEEDBACK_FORM_JSONL),
-    ]}
+
+    payload = tool_msg.content if isinstance(tool_msg.content, str) else ""
+    if not payload:
+        return {}
+
+    if tool_name == "generate_a2ui_schema":
+        # Sub-LLM returns a JSON array of v1 envelopes. Convert to JSONL
+        # (one envelope per line) and prepend the classifier sentinel.
+        try:
+            arr = json.loads(payload)
+            if isinstance(arr, list):
+                jsonl = "\n".join(json.dumps(env) for env in arr)
+            else:
+                jsonl = payload
+        except json.JSONDecodeError:
+            # Sub-LLM may have leading/trailing whitespace or markdown
+            # fencing despite the prompt instructions. Try to strip.
+            stripped = payload.strip()
+            if stripped.startswith("```"):
+                lines = stripped.split("\n")
+                stripped = "\n".join(line for line in lines if not line.startswith("```"))
+            try:
+                arr = json.loads(stripped)
+                jsonl = "\n".join(json.dumps(env) for env in arr) if isinstance(arr, list) else stripped
+            except json.JSONDecodeError:
+                jsonl = payload  # let the parser deal with malformed lines
+        wrapped = A2UI_PREFIX + "\n" + jsonl + "\n"
+    elif tool_name == "generate_json_render_spec":
+        # json-render: classifier detects content starting with `{`, no
+        # prefix needed. Strip whitespace and any markdown fencing the
+        # sub-LLM may have included.
+        stripped = payload.strip()
+        if stripped.startswith("```"):
+            lines = stripped.split("\n")
+            stripped = "\n".join(line for line in lines if not line.startswith("```"))
+            stripped = stripped.strip()
+        wrapped = stripped
+    else:
+        return {}
+
+    return {"messages": [AIMessage(content=wrapped)]}
 
 
 async def attach_citations(state: State) -> dict:
@@ -425,8 +450,11 @@ async def attach_citations(state: State) -> dict:
 
 _builder = StateGraph(State)
 _builder.add_node("generate", generate)
-_builder.add_node("tools", ToolNode([search_documents, request_approval, research, render_demo_form]))
-_builder.add_node("emit_a2ui_surface", emit_a2ui_surface)
+_builder.add_node("tools", ToolNode([
+    search_documents, request_approval, research,
+    generate_a2ui_schema, generate_json_render_spec,
+]))
+_builder.add_node("emit_generated_surface", emit_generated_surface)
 _builder.add_node("attach_citations", attach_citations)
 _builder.set_entry_point("generate")
 _builder.add_conditional_edges(
@@ -434,12 +462,12 @@ _builder.add_conditional_edges(
     should_continue,
     {
         "tools": "tools",
-        "emit_a2ui_surface": "emit_a2ui_surface",
+        "emit_generated_surface": "emit_generated_surface",
         "attach_citations": "attach_citations",
     },
 )
 _builder.add_edge("tools", "generate")
-_builder.add_edge("emit_a2ui_surface", "attach_citations")
+_builder.add_edge("emit_generated_surface", "attach_citations")
 _builder.add_edge("attach_citations", END)
 
 # LangGraph API manages persistence for the deployed graph; keep the

--- a/examples/chat/python/src/graph.py
+++ b/examples/chat/python/src/graph.py
@@ -64,17 +64,28 @@ SYSTEM_PROMPT = (
     "final answer. Do not call `research` for trivial chit-chat or simple "
     "lookups — those are handled by `search_documents`. "
     " "
-    "When the user asks to see, build, or render a UI / form / card / "
-    "interactive component, immediately dispatch the schema-generation "
-    "tool that's bound (one of `generate_a2ui_schema` or "
-    "`generate_json_render_spec`, depending on the user's GenUI palette "
-    "selection). Pass the user's request VERBATIM as the `request` "
-    "argument — do NOT ask clarifying questions, do NOT describe the UI "
-    "in prose, do NOT add fields or design choices the user did not ask "
-    "for. The tool dispatches the actual rendering; your job is just to "
-    "route the request. After the tool returns, briefly acknowledge the "
-    "dispatch in one short sentence — the user sees the rendered "
-    "surface directly."
+    "If the user asks to see / build / render / show / display a UI, "
+    "form, card, panel, button, picker, slider, table, list, or any "
+    "other interactive surface — INCLUDING phrases like 'build me X', "
+    "'render Y', 'show a Z', 'create a form for', 'make a card with' — "
+    "you MUST IMMEDIATELY dispatch the schema-generation tool bound "
+    "to the conversation. Exactly ONE such tool is bound per request: "
+    "either `generate_a2ui_schema` or `generate_json_render_spec`. "
+    "Do NOT ask clarifying questions about platform, framework, fields, "
+    "validation, styling, or anything else. Do NOT describe the UI in "
+    "prose. Do NOT request more details from the user. The tool ITSELF "
+    "is responsible for filling in reasonable defaults from the user's "
+    "request. Pass the user's request VERBATIM as the `request` "
+    "argument. Your only job for UI-rendering requests is to route "
+    "them to the tool. After the tool returns its payload (a wire-"
+    "format string the chat composition renders directly), respond with "
+    "at most ONE short sentence acknowledging the dispatch — the user "
+    "sees the rendered surface, not your prose. Examples of prompts "
+    "that MUST dispatch the tool: 'build a feedback form', 'render a "
+    "settings card', 'show me a poll', 'make a contact form'. If the "
+    "user is having a casual conversation or asking factual questions, "
+    "do NOT dispatch the UI tool — only dispatch when they explicitly "
+    "ask for a UI / form / card / interactive surface."
 )
 
 # Reasoning-capable model prefixes. We only attach the ``reasoning``
@@ -349,12 +360,14 @@ async def emit_generated_surface(state: State) -> dict:
     ToolMessage carrying the sub-LLM's wire-format payload, identifies
     which protocol the AI dispatched (by tool_call name), wraps the
     payload with the chat composition's content-classifier sentinel,
-    and emits a fresh AIMessage. The original AI tool-call message and
-    ToolMessage stay in history (visible in chat-debug)."""
+    emits a fresh AIMessage carrying the wrapped content, and REMOVES
+    the AI tool-call message + ToolMessage from history so the chat UI
+    doesn't render the raw schema JSON dump alongside the surface."""
     msgs = state["messages"]
 
-    # Find the most recent ToolMessage and the originating tool_call name
+    # Find the most recent ToolMessage + its originating AI tool-call message
     tool_msg = None
+    ai_tool_call_msg = None
     tool_name = None
     for m in reversed(msgs):
         if isinstance(m, ToolMessage):
@@ -364,6 +377,7 @@ async def emit_generated_surface(state: State) -> dict:
                     for tc in prior.tool_calls:
                         if tc.get("id") == tool_msg.tool_call_id:
                             tool_name = tc.get("name")
+                            ai_tool_call_msg = prior
                             break
                     if tool_name:
                         break
@@ -411,7 +425,23 @@ async def emit_generated_surface(state: State) -> dict:
     else:
         return {}
 
-    return {"messages": [AIMessage(content=wrapped)]}
+    # In-place replace the ToolMessage with a tiny "rendered" placeholder
+    # (langgraph add_messages reducer matches by id and replaces). This
+    # collapses the chat-tool-calls result panel from a multi-KB schema
+    # dump to a single word. The AI tool-call message stays — its small
+    # tool-call card chrome is fine. We append the wrapped surface
+    # AIMessage as the final message; the chat composition's content
+    # classifier picks up the prefix and mounts <a2ui-surface> /
+    # <chat-generative-ui>.
+    out = []
+    if getattr(tool_msg, "id", None):
+        out.append(ToolMessage(
+            id=tool_msg.id,
+            content="rendered",
+            tool_call_id=tool_msg.tool_call_id,
+        ))
+    out.append(AIMessage(content=wrapped))
+    return {"messages": out}
 
 
 async def attach_citations(state: State) -> dict:
@@ -438,6 +468,12 @@ async def attach_citations(state: State) -> dict:
             if isinstance(hits, list):
                 for i, h in enumerate(hits):
                     if not isinstance(h, dict):
+                        continue
+                    # Only treat dicts that look like citation hits — must
+                    # carry at least one of title/url/snippet. Skips unrelated
+                    # JSON arrays (e.g. A2UI envelope arrays) that the
+                    # search_documents tool would never produce.
+                    if not any(k in h for k in ("title", "url", "snippet")):
                         continue
                     citations.append(
                         {
@@ -496,7 +532,7 @@ _builder.add_conditional_edges(
         "generate": "generate",
     },
 )
-_builder.add_edge("emit_generated_surface", "attach_citations")
+_builder.add_edge("emit_generated_surface", END)
 _builder.add_edge("attach_citations", END)
 
 # LangGraph API manages persistence for the deployed graph; keep the

--- a/examples/chat/python/src/schemas/__init__.py
+++ b/examples/chat/python/src/schemas/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: MIT
+"""Schema-prompt modules for the GenUI sub-LLM tools."""

--- a/examples/chat/python/src/schemas/a2ui_v1.py
+++ b/examples/chat/python/src/schemas/a2ui_v1.py
@@ -1,0 +1,828 @@
+# SPDX-License-Identifier: MIT
+"""A2UI v1 protocol schema documentation, used as the system prompt for
+the `generate_a2ui_schema` sub-LLM tool. Sourced verbatim from the
+L4 production reference (canonical Google A2UI v1 schema)."""
+
+A2UI_V1_SCHEMA_PROMPT = """
+Generate A2UI JSON.
+
+## A2UI Protocol Instructions
+
+A2UI (Agent to UI) is a protocol for rendering rich UI surfaces from agent responses.
+
+To render a surface, you MUST send ALL messages in a SINGLE tool call, in this order:
+1. **surfaceUpdate** - Define all UI components (REQUIRED)
+2. **dataModelUpdate** - Set any data values (OPTIONAL)
+3. **beginRendering** - Signal the client to start rendering (REQUIRED)
+
+### Minimal Working Example
+
+Here is the simplest possible A2UI surface - a button:
+
+```json
+[
+  {
+    "surfaceUpdate": {
+      "surfaceId": "my-surface",
+      "components": [
+        {
+          "id": "root",
+          "component": {
+            "Button": {
+              "child": "btn-text",
+              "action": { "name": "button_clicked" }
+            }
+          }
+        },
+        {
+          "id": "btn-text",
+          "component": {
+            "Text": { "text": { "literalString": "Click Me" } }
+          }
+        }
+      ]
+    }
+  },
+  {
+    "beginRendering": {
+      "surfaceId": "my-surface",
+      "root": "root"
+    }
+  }
+]
+```
+
+## JSON Schema Reference
+{
+  "type": "array",
+  "items": {
+    "title": "A2UI Message Schema",
+    "description": "Describes a JSON payload for an A2UI (Agent to UI) message, which is used to dynamically construct and update user interfaces. A message MUST contain exactly ONE of the action properties: 'beginRendering', 'surfaceUpdate', 'dataModelUpdate', or 'deleteSurface'.",
+    "type": "object",
+  "properties": {
+    "beginRendering": {
+      "type": "object",
+      "description": "Signals the client to begin rendering a surface with a root component and specific styles.",
+      "properties": {
+        "surfaceId": {
+          "type": "string",
+          "description": "The unique identifier for the UI surface to be rendered."
+        },
+        "root": {
+          "type": "string",
+          "description": "The ID of the root component to render."
+        },
+        "styles": {
+          "type": "object",
+          "description": "Styling information for the UI.",
+          "properties": {
+            "font": {
+              "type": "string",
+              "description": "The primary font for the UI."
+            },
+            "primaryColor": {
+              "type": "string",
+              "description": "The primary UI color as a hexadecimal code (e.g., '#00BFFF').",
+              "pattern": "^#[0-9a-fA-F]{6}$"
+            }
+          }
+        }
+      },
+      "required": ["root", "surfaceId"]
+    },
+    "surfaceUpdate": {
+      "type": "object",
+      "description": "Updates a surface with a new set of components.",
+      "properties": {
+        "surfaceId": {
+          "type": "string",
+          "description": "The unique identifier for the UI surface to be updated. If you are adding a new surface this *must* be a new, unique identified that has never been used for any existing surfaces shown."
+        },
+        "components": {
+          "type": "array",
+          "description": "A list containing all UI components for the surface.",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "description": "Represents a *single* component in a UI widget tree. This component could be one of many supported types.",
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "The unique identifier for this component."
+              },
+              "weight": {
+                "type": "number",
+                "description": "The relative weight of this component within a Row or Column. This corresponds to the CSS 'flex-grow' property. Note: this may ONLY be set when the component is a direct descendant of a Row or Column."
+              },
+              "component": {
+                "type": "object",
+                "description": "A wrapper object that MUST contain exactly one key, which is the name of the component type (e.g., 'Heading'). The value is an object containing the properties for that specific component.",
+                "properties": {
+                  "Text": {
+                    "type": "object",
+                    "properties": {
+                      "text": {
+                        "type": "object",
+                        "description": "The text content to display. This can be a literal string or a reference to a value in the data model ('path', e.g., '/doc/title'). While simple Markdown formatting is supported (i.e. without HTML, images, or links), utilizing dedicated UI components is generally preferred for a richer and more structured presentation.",
+                        "properties": {
+                          "literalString": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "usageHint": {
+                        "type": "string",
+                        "description": "A hint for the base text style. One of:\\n- `h1`: Largest heading.\\n- `h2`: Second largest heading.\\n- `h3`: Third largest heading.\\n- `h4`: Fourth largest heading.\\n- `h5`: Fifth largest heading.\\n- `caption`: Small text for captions.\\n- `body`: Standard body text.",
+                        "enum": [
+                          "h1",
+                          "h2",
+                          "h3",
+                          "h4",
+                          "h5",
+                          "caption",
+                          "body"
+                        ]
+                      }
+                    },
+                    "required": ["text"]
+                  },
+                  "Image": {
+                    "type": "object",
+                    "properties": {
+                      "url": {
+                        "type": "object",
+                        "description": "The URL of the image to display. This can be a literal string ('literal') or a reference to a value in the data model ('path', e.g. '/thumbnail/url').",
+                        "properties": {
+                          "literalString": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "fit": {
+                        "type": "string",
+                        "description": "Specifies how the image should be resized to fit its container. This corresponds to the CSS 'object-fit' property.",
+                        "enum": [
+                          "contain",
+                          "cover",
+                          "fill",
+                          "none",
+                          "scale-down"
+                        ]
+                      },
+                      "usageHint": {
+                        "type": "string",
+                        "description": "A hint for the image size and style. One of:\\n- `icon`: Small square icon.\\n- `avatar`: Circular avatar image.\\n- `smallFeature`: Small feature image.\\n- `mediumFeature`: Medium feature image.\\n- `largeFeature`: Large feature image.\\n- `header`: Full-width, full bleed, header image.",
+                        "enum": [
+                          "icon",
+                          "avatar",
+                          "smallFeature",
+                          "mediumFeature",
+                          "largeFeature",
+                          "header"
+                        ]
+                      }
+                    },
+                    "required": ["url"]
+                  },
+                  "Icon": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "object",
+                        "description": "The name of the icon to display. This can be a literal string or a reference to a value in the data model ('path', e.g. '/form/submit').",
+                        "properties": {
+                          "literalString": {
+                            "type": "string",
+                            "enum": [
+                              "accountCircle",
+                              "add",
+                              "arrowBack",
+                              "arrowForward",
+                              "attachFile",
+                              "calendarToday",
+                              "call",
+                              "camera",
+                              "check",
+                              "close",
+                              "delete",
+                              "download",
+                              "edit",
+                              "event",
+                              "error",
+                              "favorite",
+                              "favoriteOff",
+                              "folder",
+                              "help",
+                              "home",
+                              "info",
+                              "locationOn",
+                              "lock",
+                              "lockOpen",
+                              "mail",
+                              "menu",
+                              "moreVert",
+                              "moreHoriz",
+                              "notificationsOff",
+                              "notifications",
+                              "payment",
+                              "person",
+                              "phone",
+                              "photo",
+                              "print",
+                              "refresh",
+                              "search",
+                              "send",
+                              "settings",
+                              "share",
+                              "shoppingCart",
+                              "star",
+                              "starHalf",
+                              "starOff",
+                              "upload",
+                              "visibility",
+                              "visibilityOff",
+                              "warning"
+                            ]
+                          },
+                          "path": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "required": ["name"]
+                  },
+                  "Video": {
+                    "type": "object",
+                    "properties": {
+                      "url": {
+                        "type": "object",
+                        "description": "The URL of the video to display. This can be a literal string or a reference to a value in the data model ('path', e.g. '/video/url').",
+                        "properties": {
+                          "literalString": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "required": ["url"]
+                  },
+                  "AudioPlayer": {
+                    "type": "object",
+                    "properties": {
+                      "url": {
+                        "type": "object",
+                        "description": "The URL of the audio to be played. This can be a literal string ('literal') or a reference to a value in the data model ('path', e.g. '/song/url').",
+                        "properties": {
+                          "literalString": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "description": {
+                        "type": "object",
+                        "description": "A description of the audio, such as a title or summary. This can be a literal string or a reference to a value in the data model ('path', e.g. '/song/title').",
+                        "properties": {
+                          "literalString": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "required": ["url"]
+                  },
+                  "Row": {
+                    "type": "object",
+                    "properties": {
+                      "children": {
+                        "type": "object",
+                        "description": "Defines the children. Use 'explicitList' for a fixed set of children, or 'template' to generate children from a data list.",
+                        "properties": {
+                          "explicitList": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "template": {
+                            "type": "object",
+                            "description": "A template for generating a dynamic list of children from a data model list. `componentId` is the component to use as a template, and `dataBinding` is the path to the map of components in the data model. Values in the map will define the list of children.",
+                            "properties": {
+                              "componentId": {
+                                "type": "string"
+                              },
+                              "dataBinding": {
+                                "type": "string"
+                              }
+                            },
+                            "required": ["componentId", "dataBinding"]
+                          }
+                        }
+                      },
+                      "distribution": {
+                        "type": "string",
+                        "description": "Defines the arrangement of children along the main axis (horizontally). This corresponds to the CSS 'justify-content' property.",
+                        "enum": [
+                          "center",
+                          "end",
+                          "spaceAround",
+                          "spaceBetween",
+                          "spaceEvenly",
+                          "start"
+                        ]
+                      },
+                      "alignment": {
+                        "type": "string",
+                        "description": "Defines the alignment of children along the cross axis (vertically). This corresponds to the CSS 'align-items' property.",
+                        "enum": ["start", "center", "end", "stretch"]
+                      }
+                    },
+                    "required": ["children"]
+                  },
+                  "Column": {
+                    "type": "object",
+                    "properties": {
+                      "children": {
+                        "type": "object",
+                        "description": "Defines the children. Use 'explicitList' for a fixed set of children, or 'template' to generate children from a data list.",
+                        "properties": {
+                          "explicitList": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "template": {
+                            "type": "object",
+                            "description": "A template for generating a dynamic list of children from a data model list. `componentId` is the component to use as a template, and `dataBinding` is the path to the map of components in the data model. Values in the map will define the list of children.",
+                            "properties": {
+                              "componentId": {
+                                "type": "string"
+                              },
+                              "dataBinding": {
+                                "type": "string"
+                              }
+                            },
+                            "required": ["componentId", "dataBinding"]
+                          }
+                        }
+                      },
+                      "distribution": {
+                        "type": "string",
+                        "description": "Defines the arrangement of children along the main axis (vertically). This corresponds to the CSS 'justify-content' property.",
+                        "enum": [
+                          "start",
+                          "center",
+                          "end",
+                          "spaceBetween",
+                          "spaceAround",
+                          "spaceEvenly"
+                        ]
+                      },
+                      "alignment": {
+                        "type": "string",
+                        "description": "Defines the alignment of children along the cross axis (horizontally). This corresponds to the CSS 'align-items' property.",
+                        "enum": ["center", "end", "start", "stretch"]
+                      }
+                    },
+                    "required": ["children"]
+                  },
+                  "List": {
+                    "type": "object",
+                    "properties": {
+                      "children": {
+                        "type": "object",
+                        "description": "Defines the children. Use 'explicitList' for a fixed set of children, or 'template' to generate children from a data list.",
+                        "properties": {
+                          "explicitList": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "template": {
+                            "type": "object",
+                            "description": "A template for generating a dynamic list of children from a data model list. `componentId` is the component to use as a template, and `dataBinding` is the path to the map of components in the data model. Values in the map will define the list of children.",
+                            "properties": {
+                              "componentId": {
+                                "type": "string"
+                              },
+                              "dataBinding": {
+                                "type": "string"
+                              }
+                            },
+                            "required": ["componentId", "dataBinding"]
+                          }
+                        }
+                      },
+                      "direction": {
+                        "type": "string",
+                        "description": "The direction in which the list items are laid out.",
+                        "enum": ["vertical", "horizontal"]
+                      },
+                      "alignment": {
+                        "type": "string",
+                        "description": "Defines the alignment of children along the cross axis.",
+                        "enum": ["start", "center", "end", "stretch"]
+                      }
+                    },
+                    "required": ["children"]
+                  },
+                  "Card": {
+                    "type": "object",
+                    "properties": {
+                      "child": {
+                        "type": "string",
+                        "description": "The ID of the component to be rendered inside the card."
+                      }
+                    },
+                    "required": ["child"]
+                  },
+                  "Tabs": {
+                    "type": "object",
+                    "properties": {
+                      "tabItems": {
+                        "type": "array",
+                        "description": "An array of objects, where each object defines a tab with a title and a child component.",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "title": {
+                              "type": "object",
+                              "description": "The tab title. Defines the value as either a literal value or a path to data model value (e.g. '/options/title').",
+                              "properties": {
+                                "literalString": {
+                                  "type": "string"
+                                },
+                                "path": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "child": {
+                              "type": "string"
+                            }
+                          },
+                          "required": ["title", "child"]
+                        }
+                      }
+                    },
+                    "required": ["tabItems"]
+                  },
+                  "Divider": {
+                    "type": "object",
+                    "properties": {
+                      "axis": {
+                        "type": "string",
+                        "description": "The orientation of the divider.",
+                        "enum": ["horizontal", "vertical"]
+                      }
+                    }
+                  },
+                  "Modal": {
+                    "type": "object",
+                    "properties": {
+                      "entryPointChild": {
+                        "type": "string",
+                        "description": "The ID of the component that opens the modal when interacted with (e.g., a button)."
+                      },
+                      "contentChild": {
+                        "type": "string",
+                        "description": "The ID of the component to be displayed inside the modal."
+                      }
+                    },
+                    "required": ["entryPointChild", "contentChild"]
+                  },
+                  "Button": {
+                    "type": "object",
+                    "properties": {
+                      "child": {
+                        "type": "string",
+                        "description": "The ID of the component to display in the button, typically a Text component."
+                      },
+                      "primary": {
+                        "type": "boolean",
+                        "description": "Indicates if this button should be styled as the primary action."
+                      },
+                      "action": {
+                        "type": "object",
+                        "description": "The client-side action to be dispatched when the button is clicked. It includes the action's name and an optional context payload.",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "context": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "object",
+                                  "description": "Defines the value to be included in the context as either a literal value or a path to a data model value (e.g. '/user/name').",
+                                  "properties": {
+                                    "path": {
+                                      "type": "string"
+                                    },
+                                    "literalString": {
+                                      "type": "string"
+                                    },
+                                    "literalNumber": {
+                                      "type": "number"
+                                    },
+                                    "literalBoolean": {
+                                      "type": "boolean"
+                                    }
+                                  }
+                                }
+                              },
+                              "required": ["key", "value"]
+                            }
+                          }
+                        },
+                        "required": ["name"]
+                      }
+                    },
+                    "required": ["child", "action"]
+                  },
+                  "CheckBox": {
+                    "type": "object",
+                    "properties": {
+                      "label": {
+                        "type": "object",
+                        "description": "The text to display next to the checkbox. Defines the value as either a literal value or a path to data model ('path', e.g. '/option/label').",
+                        "properties": {
+                          "literalString": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "value": {
+                        "type": "object",
+                        "description": "The current state of the checkbox (true for checked, false for unchecked). This can be a literal boolean ('literalBoolean') or a reference to a value in the data model ('path', e.g. '/filter/open').",
+                        "properties": {
+                          "literalBoolean": {
+                            "type": "boolean"
+                          },
+                          "path": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "required": ["label", "value"]
+                  },
+                  "TextField": {
+                    "type": "object",
+                    "properties": {
+                      "label": {
+                        "type": "object",
+                        "description": "The text label for the input field. This can be a literal string or a reference to a value in the data model ('path, e.g. '/user/name').",
+                        "properties": {
+                          "literalString": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "text": {
+                        "type": "object",
+                        "description": "The value of the text field. This can be a literal string or a reference to a value in the data model ('path', e.g. '/user/name').",
+                        "properties": {
+                          "literalString": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "textFieldType": {
+                        "type": "string",
+                        "description": "The type of input field to display.",
+                        "enum": [
+                          "date",
+                          "longText",
+                          "number",
+                          "shortText",
+                          "obscured"
+                        ]
+                      },
+                      "validationRegexp": {
+                        "type": "string",
+                        "description": "A regular expression used for client-side validation of the input."
+                      }
+                    },
+                    "required": ["label"]
+                  },
+                  "DateTimeInput": {
+                    "type": "object",
+                    "properties": {
+                      "value": {
+                        "type": "object",
+                        "description": "The selected date and/or time value in ISO 8601 format. This can be a literal string ('literalString') or a reference to a value in the data model ('path', e.g. '/user/dob').",
+                        "properties": {
+                          "literalString": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "enableDate": {
+                        "type": "boolean",
+                        "description": "If true, allows the user to select a date."
+                      },
+                      "enableTime": {
+                        "type": "boolean",
+                        "description": "If true, allows the user to select a time."
+                      }
+                    },
+                    "required": ["value"]
+                  },
+                  "MultipleChoice": {
+                    "type": "object",
+                    "properties": {
+                      "selections": {
+                        "type": "object",
+                        "description": "The currently selected values for the component. This can be a literal array of strings or a path to an array in the data model('path', e.g. '/hotel/options').",
+                        "properties": {
+                          "literalArray": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "path": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "options": {
+                        "type": "array",
+                        "description": "An array of available options for the user to choose from.",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "label": {
+                              "type": "object",
+                              "description": "The text to display for this option. This can be a literal string or a reference to a value in the data model (e.g. '/option/label').",
+                              "properties": {
+                                "literalString": {
+                                  "type": "string"
+                                },
+                                "path": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "value": {
+                              "type": "string",
+                              "description": "The value to be associated with this option when selected."
+                            }
+                          },
+                          "required": ["label", "value"]
+                        }
+                      },
+                      "maxAllowedSelections": {
+                        "type": "integer",
+                        "description": "The maximum number of options that the user is allowed to select."
+                      }
+                    },
+                    "required": ["selections", "options"]
+                  },
+                  "Slider": {
+                    "type": "object",
+                    "properties": {
+                      "value": {
+                        "type": "object",
+                        "description": "The current value of the slider. This can be a literal number ('literalNumber') or a reference to a value in the data model ('path', e.g. '/restaurant/cost').",
+                        "properties": {
+                          "literalNumber": {
+                            "type": "number"
+                          },
+                          "path": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "minValue": {
+                        "type": "number",
+                        "description": "The minimum value of the slider."
+                      },
+                      "maxValue": {
+                        "type": "number",
+                        "description": "The maximum value of the slider."
+                      }
+                    },
+                    "required": ["value"]
+                  }
+                }
+              }
+            },
+            "required": ["id", "component"]
+          }
+        }
+      },
+      "required": ["surfaceId", "components"]
+    },
+    "dataModelUpdate": {
+      "type": "object",
+      "description": "Updates the data model for a surface.",
+      "properties": {
+        "surfaceId": {
+          "type": "string",
+          "description": "The unique identifier for the UI surface this data model update applies to."
+        },
+        "path": {
+          "type": "string",
+          "description": "An optional path to a location within the data model (e.g., '/user/name'). If omitted, or set to '/', the entire data model will be replaced."
+        },
+        "contents": {
+          "type": "array",
+          "description": "An array of data entries. Each entry must contain a 'key' and exactly one corresponding typed 'value*' property.",
+          "items": {
+            "type": "object",
+            "description": "A single data entry. Exactly one 'value*' property should be provided alongside the key.",
+            "properties": {
+              "key": {
+                "type": "string",
+                "description": "The key for this data entry."
+              },
+              "valueString": {
+                "type": "string"
+              },
+              "valueNumber": {
+                "type": "number"
+              },
+              "valueBoolean": {
+                "type": "boolean"
+              },
+              "valueMap": {
+                "description": "Represents a map as an adjacency list.",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "description": "One entry in the map. Exactly one 'value*' property should be provided alongside the key.",
+                  "properties": {
+                    "key": {
+                      "type": "string"
+                    },
+                    "valueString": {
+                      "type": "string"
+                    },
+                    "valueNumber": {
+                      "type": "number"
+                    },
+                    "valueBoolean": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": ["key"]
+                }
+              }
+            },
+            "required": ["key"]
+          }
+        }
+      },
+      "required": ["contents", "surfaceId"]
+    },
+    "deleteSurface": {
+      "type": "object",
+      "description": "Signals the client to delete the surface identified by 'surfaceId'.",
+      "properties": {
+        "surfaceId": {
+          "type": "string",
+          "description": "The unique identifier for the UI surface to be deleted."
+        }
+      },
+      "required": ["surfaceId"]
+    }
+  }
+  }
+}
+""".strip()

--- a/examples/chat/python/src/schemas/json_render.py
+++ b/examples/chat/python/src/schemas/json_render.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: MIT
+"""json-render protocol schema documentation, used as the system prompt
+for the `generate_json_render_spec` sub-LLM tool. Targets the
+@json-render/core Spec shape: { root, elements, state }."""
+
+JSON_RENDER_SCHEMA_PROMPT = """
+Generate a json-render Spec.
+
+## json-render Protocol Instructions
+
+json-render renders a UI from a single JSON object describing a flat
+component tree. Output ONE JSON object, no array, no prefix, no
+markdown fences. The chat client detects the leading `{` and routes
+the message to `<chat-generative-ui>`.
+
+The Spec shape is:
+
+```json
+{
+  "root": "<id of the root element>",
+  "elements": {
+    "<id1>": { "type": "<ComponentName>", "props": { ... }, "children": ["<childId>", ...], "on": { "click": { "action": "<name>", "params": {...} } } },
+    "<id2>": { ... }
+  },
+  "state": {
+    "<key>": "<initial value>"
+  }
+}
+```
+
+Rules:
+- `root` is the id of the entry-point element. The renderer mounts it first.
+- `elements` is a flat map of element id → element definition. Children are referenced by id, not nested.
+- `props` carries plain literal values (strings, numbers, booleans, arrays, objects). Components whose props bind to state use a special `statePath` field: `props: { value: { statePath: "/name" } }`.
+- `children` is an array of element ids (in render order).
+- `on` maps DOM event names to action descriptors. Most components only emit `click`. The `action` string is a free-form intent name; `params` is a flat object passed to the handler.
+- `state` is the initial state model. Keys are paths (e.g. `name`, `email`); values are initial values.
+
+## Component Catalog (matches @ngaf/chat's a2uiBasicCatalog)
+
+The renderer consumes the same component catalog as A2UI, so component
+names match: `Card`, `Column`, `Row`, `List`, `Tabs`, `Modal`,
+`Divider`, `Button`, `CheckBox`, `TextField`, `DateTimeInput`,
+`MultipleChoice`, `Slider`, `Text`, `Image`, `Icon`, `Video`,
+`AudioPlayer`.
+
+Common props per component:
+- `Card`: no props (children is single id wrapped in array)
+- `Column` / `Row`: `{ gap?: 'small'|'medium'|'large', alignment?: 'start'|'center'|'end'|'stretch' }`
+- `Text`: `{ text: string, usageHint?: 'h1'|'h2'|'h3'|'h4'|'h5'|'caption'|'body' }`
+- `TextField`: `{ label: string, text: string | { statePath: '/path' }, placeholder?: string, textFieldType?: 'shortText'|'longText'|'number'|'date'|'obscured', validationRegexp?: string }`
+- `MultipleChoice`: `{ label: string, options: [{ label: string, value: string }, ...], selections: string[] | { statePath: '/path' }, maxAllowedSelections?: number }`
+- `CheckBox`: `{ label: string, value: boolean | { statePath: '/path' } }`
+- `Slider`: `{ label: string, value: number | { statePath: '/path' }, minValue: number, maxValue: number }`
+- `Button`: `{ label: string, primary?: boolean }` plus `on.click.action` for the action name
+- `DateTimeInput`: `{ label: string, value: string | { statePath: '/path' }, enableDate?: boolean, enableTime?: boolean }`
+- `Image` / `Video` / `AudioPlayer`: `{ url: string }` plus `Image.fit?: 'contain'|'cover'|'fill'|'none'|'scale-down'`, `Image.usageHint?: 'icon'|'avatar'|'smallFeature'|'mediumFeature'|'largeFeature'|'header'`
+- `Icon`: `{ icon: string, size?: number }`
+- `Divider`: `{ direction?: 'horizontal'|'vertical' }`
+- `Tabs`: special — uses `tabTitles: string[]` and one child id per tab in `children`
+- `Modal`: special — `children: [triggerId, contentId]` (entry point + content)
+
+## Minimal Working Example
+
+A "Quick feedback" form:
+
+```json
+{
+  "root": "card",
+  "elements": {
+    "card": { "type": "Card", "children": ["body"] },
+    "body": { "type": "Column", "props": { "gap": "medium" }, "children": ["title", "name", "rating", "submit"] },
+    "title": { "type": "Text", "props": { "text": "Quick feedback", "usageHint": "h3" } },
+    "name": { "type": "TextField", "props": { "label": "Your name", "text": { "statePath": "/name" }, "textFieldType": "shortText" } },
+    "rating": { "type": "MultipleChoice", "props": { "label": "Rating", "options": [
+      { "label": "1", "value": "1" }, { "label": "2", "value": "2" }, { "label": "3", "value": "3" }, { "label": "4", "value": "4" }, { "label": "5", "value": "5" }
+    ], "selections": { "statePath": "/rating" }, "maxAllowedSelections": 1 } },
+    "submit": { "type": "Button", "props": { "label": "Submit feedback", "primary": true }, "on": { "click": { "action": "feedbackSubmit", "params": { "surface": "feedback" } } } }
+  },
+  "state": { "name": "", "rating": "5" }
+}
+```
+
+## Output Requirements
+
+Return ONLY the JSON object. No prose. No markdown code fence. The first
+character of your response MUST be `{`. The chat client's content
+classifier detects this and routes the message to render.
+""".strip()

--- a/examples/chat/python/tests/test_graph_smoke.py
+++ b/examples/chat/python/tests/test_graph_smoke.py
@@ -89,34 +89,39 @@ def test_state_graph_topology_unchanged_after_research():
     assert "attach_citations" in nodes
 
 
+
 @pytest.mark.smoke
-def test_render_demo_form_tool_exists():
-    from src.graph import render_demo_form
-    assert render_demo_form is not None
-    # @tool decorator gives the resulting object a `.name` attribute
-    assert render_demo_form.name == "render_demo_form"
+def test_genui_tools_exist():
+    from src.graph import generate_a2ui_schema, generate_json_render_spec
+    assert generate_a2ui_schema.name == "generate_a2ui_schema"
+    assert generate_json_render_spec.name == "generate_json_render_spec"
 
 
 @pytest.mark.smoke
-def test_state_graph_includes_emit_a2ui_surface_node():
+def test_state_graph_has_emit_generated_surface_node():
     from src.graph import graph
     nodes = set(graph.get_graph().nodes.keys())
-    assert "emit_a2ui_surface" in nodes
-    assert "attach_citations" in nodes
+    assert "emit_generated_surface" in nodes
     assert "tools" in nodes
-    assert "generate" in nodes
+    assert "attach_citations" in nodes
 
 
 @pytest.mark.smoke
-def test_a2ui_jsonl_starts_with_prefix_and_parses():
-    import json
-    from src.graph import A2UI_PREFIX, FEEDBACK_FORM_JSONL
-    assert A2UI_PREFIX == "---a2ui_JSON---", \
-        "Prefix must match the chat content-classifier sentinel"
-    full = A2UI_PREFIX + "\n" + FEEDBACK_FORM_JSONL
-    lines = [ln for ln in full.split("\n") if ln.strip() and ln != A2UI_PREFIX]
-    parsed = [json.loads(ln) for ln in lines]
-    assert any("surfaceUpdate" in m for m in parsed), \
-        "JSONL must include a surfaceUpdate envelope"
-    assert any("beginRendering" in m for m in parsed), \
-        "JSONL must include a beginRendering envelope"
+def test_state_includes_gen_ui_mode_channel():
+    from src.graph import State
+    annotations = State.__annotations__
+    assert "gen_ui_mode" in annotations, \
+        "State must have a gen_ui_mode channel (Phase 5)"
+
+
+@pytest.mark.smoke
+def test_phase4_artifacts_removed():
+    """Phase 5 removes Phase 4's hardcoded path entirely."""
+    import importlib
+    mod = importlib.import_module("src.graph")
+    assert not hasattr(mod, "render_demo_form"), \
+        "render_demo_form tool should be removed in Phase 5"
+    assert not hasattr(mod, "FEEDBACK_FORM_JSONL"), \
+        "FEEDBACK_FORM_JSONL constant should be removed in Phase 5"
+    assert not hasattr(mod, "emit_a2ui_surface"), \
+        "emit_a2ui_surface node should be replaced by emit_generated_surface"

--- a/examples/chat/smoke/CHECKLIST.md
+++ b/examples/chat/smoke/CHECKLIST.md
@@ -233,17 +233,38 @@ renders correctly both during streaming and after completion.
 
 ## Generative UI / A2UI surfaces
 
-- [ ] Click "Demo: render an interactive A2UI surface" welcome suggestion
-- [ ] Parent AI emits a tool_call to `render_demo_form` (no plain markdown reply yet)
-- [ ] Final assistant bubble renders an `<a2ui-surface>` (a Card titled "Quick feedback") instead of plain markdown
-- [ ] Card contains: TextField labeled "Your name", ChoicePicker labeled "Rating" with options 1-5, Submit button labeled "Submit feedback"
-- [ ] Required-name validation: Submit button shows the inline error "Name is required" / "Enter your name before submitting" while the name field is empty
-- [ ] Type a name → validation error clears
-- [ ] Pick a rating → ChoicePicker updates the data model
-- [ ] Click Submit → `<a2ui-surface>` emits an `A2uiActionMessage` (event name `feedbackSubmit`); chat round-trips it as a new user submit
-- [ ] AI replies conversationally referencing the submitted form (acknowledges receipt; may quote the name/rating)
-- [ ] Server-side: `curl localhost:2024/threads/<id>/state` shows: AI message with `tool_calls=[{ "name": "render_demo_form", ... }]`, ToolMessage with `content="rendered"`, AI message whose `content` starts with `---a2ui_JSON---\n` and contains `surfaceUpdate` + `beginRendering` envelopes (v1 wire format)
+### Gen UI mode dropdown
+
+- [ ] Palette "Gen UI" dropdown lists 2 options: `A2UI v1` and `json-render`
+- [ ] Default value is `A2UI v1` on first load
+- [ ] Selection persists across reload and mode switches
+- [ ] Server-side: `curl localhost:2024/threads/<id>/state` shows `values.gen_ui_mode` matches the palette selection
+
+### Dynamic dispatch — A2UI v1 mode
+
+- [ ] With Gen UI = `A2UI v1`, click any GenUI welcome suggestion (e.g. "Demo: render a feedback form")
+- [ ] Parent AI emits a tool_call to `generate_a2ui_schema` (not `render_demo_form`)
+- [ ] Sub-LLM generates a v1 A2UI envelope array; `emit_generated_surface` node wraps it with `---a2ui_JSON---\n`
+- [ ] Final assistant bubble renders an `<a2ui-surface>` matching the requested form
+- [ ] Surface is interactive: fields accept input, buttons are clickable
+- [ ] Click Submit (or equivalent action button) → chat round-trips the `A2uiActionMessage` as a new user submit
+- [ ] AI replies conversationally referencing the submitted data
 - [ ] No console errors during the surface render or submit cycle
+
+### Dynamic dispatch — json-render mode
+
+- [ ] Switch Gen UI dropdown to `json-render`
+- [ ] Click any GenUI welcome suggestion (e.g. "Demo: render a settings card")
+- [ ] Parent AI emits a tool_call to `generate_json_render_spec`
+- [ ] Sub-LLM generates a json-render Spec (`{root, elements, state}`); `emit_generated_surface` strips markdown fencing and emits a bare JSON AIMessage
+- [ ] Final assistant bubble renders the json-render surface
+- [ ] No console errors during the render cycle
+
+### Server-side wire format
+
+- [ ] In A2UI v1 mode: final AI message content starts with `---a2ui_JSON---\n` followed by JSONL (one envelope per line); must contain `surfaceUpdate` and `beginRendering` envelopes
+- [ ] In json-render mode: final AI message content is a bare JSON object starting with `{`
+- [ ] `curl localhost:2024/threads/<id>/state` confirms the above for both modes
 
 ## Subagents
 

--- a/libs/chat/src/lib/a2ui/catalog/audio-player.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/audio-player.component.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { Component, input } from '@angular/core';
+import type { Spec } from '@json-render/core';
 
 @Component({
   selector: 'a2ui-audio-player',
@@ -18,4 +19,10 @@ export class A2uiAudioPlayerComponent {
   /** v1 prop name: autoPlay (camelCase). */
   readonly autoPlay = input<boolean>(false);
   readonly controls = input<boolean>(true);
+  // Framework inputs required by the render harness.
+  readonly bindings = input<Record<string, string>>({});
+  readonly emit = input<(event: string) => void>(() => { /* noop */ });
+  readonly loading = input<boolean>(false);
+  readonly childKeys = input<string[]>([]);
+  readonly spec = input<Spec | undefined>(undefined);
 }

--- a/libs/chat/src/lib/a2ui/catalog/button.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/button.component.ts
@@ -30,6 +30,9 @@ export class A2uiButtonComponent {
   readonly primary = input<boolean>(true);
   readonly disabled = input<boolean>(false);
   readonly emit = input<(event: string) => void>(() => { /* noop */ });
+  // Framework inputs required by the render harness.
+  readonly bindings = input<Record<string, string>>({});
+  readonly loading = input<boolean>(false);
 
   handleClick(): void {
     this.emit()('click');

--- a/libs/chat/src/lib/a2ui/catalog/card.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/card.component.ts
@@ -19,4 +19,8 @@ export class A2uiCardComponent {
   /** v1: a single child key, delivered via childKeys[0] from the render framework. */
   readonly childKeys = input<string[]>([]);
   readonly spec = input.required<Spec>();
+  // Framework inputs required by the render harness.
+  readonly bindings = input<Record<string, string>>({});
+  readonly emit = input<(event: string) => void>(() => { /* noop */ });
+  readonly loading = input<boolean>(false);
 }

--- a/libs/chat/src/lib/a2ui/catalog/check-box.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/check-box.component.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { Component, input, ChangeDetectionStrategy } from '@angular/core';
+import type { Spec } from '@json-render/core';
 import { emitBinding } from './emit-binding';
 
 @Component({
@@ -18,6 +19,11 @@ export class A2uiCheckBoxComponent {
   readonly checked = input<boolean>(false);
   readonly _bindings = input<Record<string, string>>({});
   readonly emit = input<(event: string) => void>(() => { /* noop */ });
+  // Framework inputs required by the render harness.
+  readonly bindings = input<Record<string, string>>({});
+  readonly loading = input<boolean>(false);
+  readonly childKeys = input<string[]>([]);
+  readonly spec = input<Spec | undefined>(undefined);
 
   onChange(event: Event): void {
     const val = (event.target as HTMLInputElement).checked;

--- a/libs/chat/src/lib/a2ui/catalog/column.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/column.component.ts
@@ -22,6 +22,11 @@ export class A2uiColumnComponent {
   readonly spec = input.required<Spec>();
   readonly gap = input<number>(3);
   readonly alignment = input<ColumnAlignment>('start');
+  readonly distribution = input<'start' | 'center' | 'end' | 'spaceBetween' | 'spaceAround' | 'spaceEvenly'>('start');
+  // Framework inputs required by the render harness.
+  readonly bindings = input<Record<string, string>>({});
+  readonly emit = input<(event: string) => void>(() => { /* noop */ });
+  readonly loading = input<boolean>(false);
 
   protected readonly colClass = computed(() => {
     const alignMap: Record<ColumnAlignment, string> = {

--- a/libs/chat/src/lib/a2ui/catalog/date-time-input.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/date-time-input.component.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { Component, computed, input, ChangeDetectionStrategy } from '@angular/core';
+import type { Spec } from '@json-render/core';
 import { emitBinding } from './emit-binding';
 
 @Component({
@@ -37,6 +38,11 @@ export class A2uiDateTimeInputComponent {
   readonly enableTime = input<boolean>(false);
   readonly _bindings = input<Record<string, string>>({});
   readonly emit = input<(event: string) => void>(() => { /* noop */ });
+  // Framework inputs required by the render harness.
+  readonly bindings = input<Record<string, string>>({});
+  readonly loading = input<boolean>(false);
+  readonly childKeys = input<string[]>([]);
+  readonly spec = input<Spec | undefined>(undefined);
 
   /** Derives HTML input type from enableDate + enableTime. */
   protected readonly htmlInputType = computed<string>(() => {

--- a/libs/chat/src/lib/a2ui/catalog/divider.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/divider.component.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { Component, input } from '@angular/core';
+import type { Spec } from '@json-render/core';
 
 @Component({
   selector: 'a2ui-divider',
@@ -14,4 +15,10 @@ import { Component, input } from '@angular/core';
 })
 export class A2uiDividerComponent {
   readonly direction = input<'horizontal' | 'vertical'>('horizontal');
+  // Framework inputs required by the render harness.
+  readonly bindings = input<Record<string, string>>({});
+  readonly emit = input<(event: string) => void>(() => { /* noop */ });
+  readonly loading = input<boolean>(false);
+  readonly childKeys = input<string[]>([]);
+  readonly spec = input<Spec | undefined>(undefined);
 }

--- a/libs/chat/src/lib/a2ui/catalog/divider.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/divider.component.ts
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
-import { Component, input } from '@angular/core';
+import { Component, computed, input } from '@angular/core';
 import type { Spec } from '@json-render/core';
 
 @Component({
   selector: 'a2ui-divider',
   standalone: true,
   template: `
-    @if (direction() === 'vertical') {
+    @if (orientation() === 'vertical') {
       <div class="inline-block self-stretch border-l border-white/10 mx-2"></div>
     } @else {
       <hr class="border-white/10 my-2" />
@@ -14,7 +14,14 @@ import type { Spec } from '@json-render/core';
   `,
 })
 export class A2uiDividerComponent {
+  /** Canonical v1 spec name. The LLM emits this. */
+  readonly axis = input<'horizontal' | 'vertical' | undefined>(undefined);
+  /** Older alias retained for json-render usage and back-compat. */
   readonly direction = input<'horizontal' | 'vertical'>('horizontal');
+  /** Effective axis — `axis` wins if provided, otherwise fall back to `direction`. */
+  protected readonly orientation = computed<'horizontal' | 'vertical'>(() =>
+    this.axis() ?? this.direction()
+  );
   // Framework inputs required by the render harness.
   readonly bindings = input<Record<string, string>>({});
   readonly emit = input<(event: string) => void>(() => { /* noop */ });

--- a/libs/chat/src/lib/a2ui/catalog/icon.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/icon.component.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { Component, input } from '@angular/core';
+import type { Spec } from '@json-render/core';
 
 @Component({
   selector: 'a2ui-icon',
@@ -15,4 +16,10 @@ export class A2uiIconComponent {
   /** v1 prop name: icon (resolved string, e.g. a Unicode symbol or ligature name). */
   readonly icon = input<string>('');
   readonly size = input<number | null>(null);
+  // Framework inputs required by the render harness.
+  readonly bindings = input<Record<string, string>>({});
+  readonly emit = input<(event: string) => void>(() => { /* noop */ });
+  readonly loading = input<boolean>(false);
+  readonly childKeys = input<string[]>([]);
+  readonly spec = input<Spec | undefined>(undefined);
 }

--- a/libs/chat/src/lib/a2ui/catalog/image.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/image.component.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { Component, input } from '@angular/core';
+import type { Spec } from '@json-render/core';
 
 @Component({
   selector: 'a2ui-image',
@@ -19,4 +20,10 @@ export class A2uiImageComponent {
   readonly alt = input<string>('');
   readonly width = input<number | null>(null);
   readonly height = input<number | null>(null);
+  // Framework inputs required by the render harness.
+  readonly bindings = input<Record<string, string>>({});
+  readonly emit = input<(event: string) => void>(() => { /* noop */ });
+  readonly loading = input<boolean>(false);
+  readonly childKeys = input<string[]>([]);
+  readonly spec = input<Spec | undefined>(undefined);
 }

--- a/libs/chat/src/lib/a2ui/catalog/list.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/list.component.ts
@@ -19,6 +19,10 @@ export class A2uiListComponent {
   readonly childKeys = input<string[]>([]);
   readonly spec = input.required<Spec>();
   readonly direction = input<'vertical' | 'horizontal'>('vertical');
+  // Framework inputs required by the render harness.
+  readonly bindings = input<Record<string, string>>({});
+  readonly emit = input<(event: string) => void>(() => { /* noop */ });
+  readonly loading = input<boolean>(false);
 
   protected readonly listClass = computed(() => {
     return this.direction() === 'horizontal'

--- a/libs/chat/src/lib/a2ui/catalog/modal.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/modal.component.ts
@@ -53,6 +53,10 @@ export class A2uiModalComponent {
   readonly spec = input.required<Spec>();
   /** Resolved title string (from optional title DynamicString). */
   readonly title = input<string>('');
+  // Framework inputs required by the render harness.
+  readonly bindings = input<Record<string, string>>({});
+  readonly emit = input<(event: string) => void>(() => { /* noop */ });
+  readonly loading = input<boolean>(false);
 
   protected readonly open = signal(false);
 

--- a/libs/chat/src/lib/a2ui/catalog/multiple-choice.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/multiple-choice.component.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { Component, computed, input, ChangeDetectionStrategy } from '@angular/core';
+import type { Spec } from '@json-render/core';
 import { emitBinding } from './emit-binding';
 
 /** Resolved option shape — label and value are plain strings after surface-to-spec resolves them. */
@@ -70,6 +71,11 @@ export class A2uiMultipleChoiceComponent {
   readonly maxAllowedSelections = input<number>(1);
   readonly _bindings = input<Record<string, string>>({});
   readonly emit = input<(event: string) => void>(() => { /* noop */ });
+  // Framework inputs required by the render harness.
+  readonly bindings = input<Record<string, string>>({});
+  readonly loading = input<boolean>(false);
+  readonly childKeys = input<string[]>([]);
+  readonly spec = input<Spec | undefined>(undefined);
 
   protected readonly isSingleSelect = computed(() => this.maxAllowedSelections() <= 1);
 

--- a/libs/chat/src/lib/a2ui/catalog/multiple-choice.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/multiple-choice.component.ts
@@ -52,8 +52,18 @@ interface ResolvedOption {
 })
 export class A2uiMultipleChoiceComponent {
   readonly label = input<string>('');
-  /** Resolved current selections (plain string array from surface-to-spec). */
-  readonly selections = input<string[]>([]);
+  /** Resolved current selections from surface-to-spec. Normalized in
+   * `selectionsArray` because LLMs sometimes seed the data model with a
+   * scalar (e.g. `"5"`) instead of an array (`["5"]`); we coerce so
+   * .includes() works either way. */
+  readonly selections = input<string | string[] | undefined>(undefined);
+
+  protected readonly selectionsArray = computed<string[]>(() => {
+    const v = this.selections();
+    if (Array.isArray(v)) return v;
+    if (v == null || v === '') return [];
+    return [String(v)];
+  });
   /** Resolved options with plain string labels (surface-to-spec resolves DynamicString). */
   readonly options = input<ResolvedOption[]>([]);
   /** When ≤ 1 — render as single-select <select>; otherwise multi-select checkboxes. */
@@ -64,7 +74,7 @@ export class A2uiMultipleChoiceComponent {
   protected readonly isSingleSelect = computed(() => this.maxAllowedSelections() <= 1);
 
   protected isSelected(value: string): boolean {
-    return this.selections().includes(value);
+    return this.selectionsArray().includes(value);
   }
 
   onSelectChange(event: Event): void {
@@ -74,7 +84,7 @@ export class A2uiMultipleChoiceComponent {
 
   onCheckChange(value: string, event: Event): void {
     const checked = (event.target as HTMLInputElement).checked;
-    const current = [...this.selections()];
+    const current = [...this.selectionsArray()];
     const idx = current.indexOf(value);
     if (checked && idx === -1) {
       current.push(value);

--- a/libs/chat/src/lib/a2ui/catalog/row.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/row.component.ts
@@ -24,6 +24,10 @@ export class A2uiRowComponent {
   readonly gap = input<number>(3);
   readonly alignment = input<RowAlignment>('start');
   readonly distribution = input<RowDistribution>('start');
+  // Framework inputs required by the render harness.
+  readonly bindings = input<Record<string, string>>({});
+  readonly emit = input<(event: string) => void>(() => { /* noop */ });
+  readonly loading = input<boolean>(false);
 
   protected readonly rowClass = computed(() => {
     const alignMap: Record<RowAlignment, string> = {

--- a/libs/chat/src/lib/a2ui/catalog/slider.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/slider.component.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { Component, input, ChangeDetectionStrategy } from '@angular/core';
+import type { Spec } from '@json-render/core';
 import { emitBinding } from './emit-binding';
 
 @Component({
@@ -38,6 +39,11 @@ export class A2uiSliderComponent {
   readonly step = input<number>(1);
   readonly _bindings = input<Record<string, string>>({});
   readonly emit = input<(event: string) => void>(() => { /* noop */ });
+  // Framework inputs required by the render harness.
+  readonly bindings = input<Record<string, string>>({});
+  readonly loading = input<boolean>(false);
+  readonly childKeys = input<string[]>([]);
+  readonly spec = input<Spec | undefined>(undefined);
 
   onInput(event: Event): void {
     const val = Number((event.target as HTMLInputElement).value);

--- a/libs/chat/src/lib/a2ui/catalog/tabs.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/tabs.component.ts
@@ -34,6 +34,10 @@ export class A2uiTabsComponent {
   /** v1: each child key corresponds to a tab's contentChild (childKeys[i] ↔ tabTitles[i]). */
   readonly childKeys = input<string[]>([]);
   readonly spec = input.required<Spec>();
+  // Framework inputs required by the render harness.
+  readonly bindings = input<Record<string, string>>({});
+  readonly emit = input<(event: string) => void>(() => { /* noop */ });
+  readonly loading = input<boolean>(false);
 
   protected readonly activeIndex = signal(0);
 

--- a/libs/chat/src/lib/a2ui/catalog/text-field.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/text-field.component.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { Component, computed, input, ChangeDetectionStrategy } from '@angular/core';
+import type { Spec } from '@json-render/core';
 import { emitBinding } from './emit-binding';
 
 /** v1 textFieldType values from A2uiTextField. */
@@ -66,6 +67,11 @@ export class A2uiTextFieldComponent {
   readonly validationRegexp = input<string>('');
   readonly _bindings = input<Record<string, string>>({});
   readonly emit = input<(event: string) => void>(() => { /* noop */ });
+  // Framework inputs required by the render harness.
+  readonly bindings = input<Record<string, string>>({});
+  readonly loading = input<boolean>(false);
+  readonly childKeys = input<string[]>([]);
+  readonly spec = input<Spec | undefined>(undefined);
 
   protected readonly htmlInputType = computed(() =>
     TYPE_MAP[this.textFieldType()] ?? 'text',

--- a/libs/chat/src/lib/a2ui/catalog/text.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/text.component.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { Component, input } from '@angular/core';
+import type { Spec } from '@json-render/core';
 
 type UsageHint = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'caption' | 'body';
 
@@ -21,6 +22,12 @@ const HINT_CLASS: Record<UsageHint, string> = {
 export class A2uiTextComponent {
   readonly text = input<string>('');
   readonly usageHint = input<UsageHint>('body');
+  // Framework-mandated inputs the render harness passes to every element.
+  readonly bindings = input<Record<string, string>>({});
+  readonly emit = input<(event: string) => void>(() => { /* noop */ });
+  readonly loading = input<boolean>(false);
+  readonly childKeys = input<string[]>([]);
+  readonly spec = input<Spec | undefined>(undefined);
 
   protected cssClass(): string {
     return HINT_CLASS[this.usageHint()] ?? HINT_CLASS.body;

--- a/libs/chat/src/lib/a2ui/catalog/video.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/video.component.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { Component, input } from '@angular/core';
+import type { Spec } from '@json-render/core';
 
 @Component({
   selector: 'a2ui-video',
@@ -18,4 +19,10 @@ export class A2uiVideoComponent {
   /** v1 prop name: autoPlay (camelCase). */
   readonly autoPlay = input<boolean>(false);
   readonly controls = input<boolean>(true);
+  // Framework inputs required by the render harness.
+  readonly bindings = input<Record<string, string>>({});
+  readonly emit = input<(event: string) => void>(() => { /* noop */ });
+  readonly loading = input<boolean>(false);
+  readonly childKeys = input<string[]>([]);
+  readonly spec = input<Spec | undefined>(undefined);
 }

--- a/libs/chat/src/lib/streaming/content-classifier.ts
+++ b/libs/chat/src/lib/streaming/content-classifier.ts
@@ -98,12 +98,36 @@ export function createContentClassifier(): ContentClassifier {
     return false;
   }
 
+  function resetState(): void {
+    typeSignal.set('undetermined');
+    markdownSignal.set('');
+    specSignal.set(null);
+    elementStatesSignal.set(new Map());
+    streamingSignal.set(false);
+    errorsSignal.set([]);
+    processedLength = 0;
+    store = null;
+    jsonStartIndex = 0;
+    a2uiParser = null;
+    a2uiStore = null;
+    a2uiSurfacesSignal.set(new Map());
+  }
+
   function update(content: string): void {
     // Wrap in untracked() because this is called during template rendering
     // (via classifyMessage in ChatComponent's AI message template). Angular's
     // NG0600 forbids writing signals during change detection; untracked()
     // opts out of the reactive graph for this imperative push-based update.
     untracked(() => {
+      // If content shrunk vs. last seen length, the underlying message was
+      // replaced (e.g. via langgraph RemoveMessage / id-match content
+      // replacement followed by force-refresh-from-server). Reset state so
+      // the new content is classified fresh — otherwise the classifier
+      // keeps the streamed (pre-mutation) markdown/json type and the UI
+      // never updates.
+      if (content.length < processedLength) {
+        resetState();
+      }
       const currentType = typeSignal();
 
       if (currentType === 'undetermined') {

--- a/libs/langgraph/src/lib/internals/stream-manager.bridge.ts
+++ b/libs/langgraph/src/lib/internals/stream-manager.bridge.ts
@@ -140,7 +140,7 @@ export function createStreamManagerBridge<T, ResolvedBag extends BagTemplate = B
     reasoningTimingMap.clear();
   });
 
-  async function refreshHistory(): Promise<void> {
+  async function refreshHistory(force = false): Promise<void> {
     const getHistory = transport.getHistory?.bind(transport);
     if (!currentThreadId || !getHistory) return;
 
@@ -155,23 +155,20 @@ export function createStreamManagerBridge<T, ResolvedBag extends BagTemplate = B
       if (!controller.signal.aborted && currentThreadId === threadId) {
         subjects.history$.next(history as ThreadState<T>[]);
 
-        // Project the latest checkpoint into messages$ + values$ on first
-        // connect. The user expectation (per the canonical examples/chat
-        // demo spec) is that reloading mid-conversation reattaches to the
-        // existing thread and the history reappears in the chat UI. The
-        // chat composition reads messages$ (not history$), so this
-        // projection is the bridge between "we fetched the checkpoint"
-        // and "the user can see the conversation".
-        //
-        // Guard: only populate when messages$ is currently empty, so we
-        // don't overwrite optimistic local state if the user already
-        // submitted a message in the gap between threadId-set and
-        // history-fetched.
+        // Project the latest checkpoint into messages$ + values$:
+        //  - On first connect (`force=false`): only when messages$ is
+        //    empty, so optimistic local state isn't clobbered.
+        //  - At run completion (`force=true`): always — server state is
+        //    authoritative for node-level mutations (e.g. RemoveMessage
+        //    or id-match content replacement performed by post-process
+        //    nodes), and the streaming SDK doesn't always restream those.
         const latest = history[0] as
           | { values?: { messages?: BaseMessage[] } & T }
           | undefined;
-        if (latest?.values && subjects.messages$.value.length === 0) {
-          const restoredMessages = latest.values.messages ?? [];
+        const shouldProject = latest?.values
+          && (force || subjects.messages$.value.length === 0);
+        if (shouldProject) {
+          const restoredMessages = latest.values?.messages ?? [];
           const restoredValues = { ...(latest.values as T) };
           // Strip the `messages` field from values — messages$ is the
           // canonical surface for them; keeping a duplicate in values$
@@ -179,6 +176,11 @@ export function createStreamManagerBridge<T, ResolvedBag extends BagTemplate = B
           delete (restoredValues as { messages?: unknown }).messages;
           subjects.messages$.next(restoredMessages);
           subjects.values$.next(restoredValues);
+          // Rebuild derived subjects from the new authoritative messages$.
+          // Tool-call results displayed by chat-tool-calls come from
+          // toolCalls$, which is built from messages$; without this, the
+          // panel keeps showing the streamed pre-mutation content.
+          syncToolCallsFromMessages();
         }
       }
     } catch (err) {
@@ -292,7 +294,10 @@ export function createStreamManagerBridge<T, ResolvedBag extends BagTemplate = B
       }
       if (!abortController.signal.aborted) {
         subjects.status$.next(ResourceStatus.Resolved);
-        await refreshHistory();
+        // force=true: rehydrate from server-authoritative state so any
+        // post-process node mutations (RemoveMessage, id-match content
+        // replacement) reflected on the server are picked up client-side.
+        await refreshHistory(true);
       }
     } catch (err) {
       subjects.error$.next(err);
@@ -346,7 +351,9 @@ export function createStreamManagerBridge<T, ResolvedBag extends BagTemplate = B
 
       if (!abortController.signal.aborted) {
         subjects.status$.next(ResourceStatus.Resolved);
-        await refreshHistory();
+        // force=true: see refreshHistory comment — server state is
+        // authoritative after run completion.
+        await refreshHistory(true);
         await drainQueue();
       }
     } catch (err) {


### PR DESCRIPTION
## Summary

Replaces Phase 4's hardcoded \`FEEDBACK_FORM_JSONL\` path with **dynamic schema generation** via a sub-LLM pattern. Palette gains a 5th dropdown (\`Gen UI: A2UI v1 | json-render\`); welcome suggestions become generic intents that work against either rendering protocol.

- **Python graph**: Two new sub-LLM tools (\`generate_a2ui_schema\`, \`generate_json_render_spec\`) each invoke a nested \`ChatOpenAI(temperature=0)\` with the protocol's full canonical JSON schema in its system prompt. The parent LLM is bound to ONE GenUI tool per request based on \`state.gen_ui_mode\`. New routing: \`should_continue\` sends all tool_calls to ToolNode; a new \`after_tools\` conditional diverts GenUI tool results to a new \`emit_generated_surface\` post-process node that wraps the sub-LLM output with the chat composition's content-classifier sentinels (\`---a2ui_JSON---\\n\` for a2ui; raw \`{\` for json-render). Other tools (search, approval, research) loop back to \`generate\` as before.
- **Phase 4 artifacts removed**: \`render_demo_form\` tool, \`FEEDBACK_FORM_JSONL\` constant, \`emit_a2ui_surface\` node — all gone.
- **State channel**: \`gen_ui_mode\` added (default \`'a2ui'\`); patched submit on Angular side propagates via \`state.gen_ui_mode\`.
- **Schema-prompt modules**: \`src/schemas/a2ui_v1.py\` (full canonical v1 schema, ~828 LOC verbatim from L4 production reference) + \`src/schemas/json_render.py\` (~80 LOC describing \`@json-render/core\`'s \`{root, elements, state}\` Spec).
- **Angular palette**: New \`Gen UI\` dropdown (default A2UI v1, persisted across reload via the existing palette-persistence service).
- **Welcome suggestions**: Phase 4's hardcoded entry replaced with 4 generic intents (feedback form / settings card / poll / contact form). Same prompts work for both protocols — toggle the dropdown.

Spec: \`docs/superpowers/specs/2026-05-10-canonical-chat-demo-phase-5-genui-dropdown-design.md\`
Plan: \`docs/superpowers/plans/2026-05-10-canonical-chat-demo-phase-5-genui-dropdown.md\`

## Test plan

### Verified locally
- [x] \`nx run examples-chat-python:smoke\` — 12 passed (8 carried + 4 new; Phase 4's 3 a2ui tests removed)
- [x] \`nx run examples-chat-angular:test/lint/build\` — all green
- [x] **Server-side A2UI probe** (\`gen_ui_mode='a2ui'\`): GenUI tool_call to \`generate_a2ui_schema\`; final AIMessage starts with \`---a2ui_JSON---\\n\` containing v1 envelopes (\`surfaceUpdate\` + \`beginRendering\`).
- [x] **Server-side json-render probe** (\`gen_ui_mode='json-render'\`): GenUI tool_call to \`generate_json_render_spec\`; final AIMessage starts with \`{\` containing \`root\` + \`elements\` keys; no a2ui prefix.
- [x] **Live Chrome MCP smoke (A2UI mode)**: Click "Demo: render a feedback form" → \`<a2ui-surface>\` mounts dynamic Card with TextField + MultipleChoice + Button (LLM-generated, varies per request).
- [x] **Live Chrome MCP smoke (json-render mode)**: Switch dropdown, same prompt → \`<chat-generative-ui>\` mounts the json-render Spec instead. Different rendering path, same logical form.
- [x] **Routing fix verified**: tool body actually executes (sub-LLM call happens) before \`emit_generated_surface\` post-process. Initial routing skipped ToolNode entirely; fixed via two-conditional topology (\`generate→tools\`, then \`tools→{emit_generated_surface | generate}\` based on most-recent tool_call name).

### Pending visual verification
- [ ] After merge: live smoke against \`/embed\`, \`/popup\`, \`/sidebar\` confirming dropdown persists across modes.

### Open follow-ups
- Finding K (Phase 4): A2UI text-field datamodel back-prop — orthogonal lib gap, separate PR.
- A2UI Material theming track (3-pass: surface coverage → token contract → Material preset) — independent of Phase 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)