### PR TITLE
fix(chat): a2ui catalog layout polish (component-scoped CSS)

### DIFF
--- a/apps/website/content/docs/chat/api/api-docs.json
+++ b/apps/website/content/docs/chat/api/api-docs.json
@@ -236,6 +236,12 @@
     "examples": [],
     "properties": [
       {
+        "name": "alignItems",
+        "type": "Signal<string>",
+        "description": "",
+        "optional": false
+      },
+      {
         "name": "alignment",
         "type": "InputSignal<ColumnAlignment>",
         "description": "",
@@ -250,12 +256,6 @@
       {
         "name": "childKeys",
         "type": "InputSignal<string[]>",
-        "description": "",
-        "optional": false
-      },
-      {
-        "name": "colClass",
-        "type": "Signal<string>",
         "description": "",
         "optional": false
       },
@@ -275,6 +275,12 @@
         "name": "gap",
         "type": "InputSignal<number>",
         "description": "",
+        "optional": false
+      },
+      {
+        "name": "gapPx",
+        "type": "Signal<number>",
+        "description": "Convert the Tailwind gap unit (multiples of 4px) to pixels.",
         "optional": false
       },
       {
@@ -595,7 +601,7 @@
       },
       {
         "name": "listClass",
-        "type": "Signal<\"flex flex-row gap-1 overflow-x-auto\" | \"flex flex-col gap-1 overflow-y-auto max-h-96\">",
+        "type": "Signal<\"a2ui-list--horizontal\" | \"a2ui-list--vertical\">",
         "description": "",
         "optional": false
       },
@@ -814,6 +820,12 @@
     "examples": [],
     "properties": [
       {
+        "name": "alignItems",
+        "type": "Signal<string>",
+        "description": "",
+        "optional": false
+      },
+      {
         "name": "alignment",
         "type": "InputSignal<RowAlignment>",
         "description": "",
@@ -850,14 +862,20 @@
         "optional": false
       },
       {
-        "name": "loading",
-        "type": "InputSignal<boolean>",
+        "name": "gapPx",
+        "type": "Signal<number>",
+        "description": "Convert the gap unit (multiples of 4px) to pixels.",
+        "optional": false
+      },
+      {
+        "name": "justifyContent",
+        "type": "Signal<string>",
         "description": "",
         "optional": false
       },
       {
-        "name": "rowClass",
-        "type": "Signal<string>",
+        "name": "loading",
+        "type": "InputSignal<boolean>",
         "description": "",
         "optional": false
       },

--- a/libs/chat/src/lib/a2ui/catalog/audio-player.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/audio-player.component.ts
@@ -7,12 +7,18 @@ import type { Spec } from '@json-render/core';
   standalone: true,
   template: `
     <audio
-      class="w-full"
+      class="a2ui-audio"
       [src]="url()"
       [autoplay]="autoPlay()"
       [controls]="controls()"
     ></audio>
   `,
+  styles: [`
+    .a2ui-audio {
+      display: block;
+      width: 100%;
+    }
+  `],
 })
 export class A2uiAudioPlayerComponent {
   readonly url = input<string>('');

--- a/libs/chat/src/lib/a2ui/catalog/button.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/button.component.ts
@@ -10,10 +10,7 @@ import { RenderElementComponent } from '@ngaf/render';
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <button
-      class="px-4 py-2 rounded-lg text-sm font-medium transition-colors inline-flex items-center justify-center"
-      [class]="primary()
-        ? 'bg-blue-600 hover:bg-blue-700 text-white'
-        : 'bg-transparent border border-white/20 hover:bg-white/10 text-white/80'"
+      [class]="primary() ? 'a2ui-btn a2ui-btn--primary' : 'a2ui-btn a2ui-btn--secondary'"
       [disabled]="disabled()"
       (click)="handleClick()"
     >
@@ -22,6 +19,32 @@ import { RenderElementComponent } from '@ngaf/render';
       }
     </button>
   `,
+  styles: [`
+    .a2ui-btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 8px 16px;
+      border-radius: 8px;
+      font-size: 14px;
+      font-weight: 500;
+      cursor: pointer;
+      transition: background 120ms, opacity 120ms;
+      border: none;
+    }
+    .a2ui-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+    .a2ui-btn--primary {
+      background: var(--a2ui-primary, #2563eb);
+      color: #fff;
+    }
+    .a2ui-btn--primary:hover:not(:disabled) { background: var(--a2ui-primary-hover, #1d4ed8); }
+    .a2ui-btn--secondary {
+      background: transparent;
+      color: var(--a2ui-input-text, rgba(255,255,255,0.8));
+      border: 1px solid var(--a2ui-border, rgba(255,255,255,0.2));
+    }
+    .a2ui-btn--secondary:hover:not(:disabled) { background: rgba(255,255,255,0.08); }
+  `],
 })
 export class A2uiButtonComponent {
   /** v1: child Text component is rendered inside the button via childKeys. */

--- a/libs/chat/src/lib/a2ui/catalog/card.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/card.component.ts
@@ -8,12 +8,23 @@ import { RenderElementComponent } from '@ngaf/render';
   standalone: true,
   imports: [RenderElementComponent],
   template: `
-    <div class="rounded-xl border border-white/10 bg-white/5 p-4 backdrop-blur-sm">
+    <div class="a2ui-card">
       @for (key of childKeys(); track key) {
         <render-element [elementKey]="key" [spec]="spec()" />
       }
     </div>
   `,
+  styles: [`
+    .a2ui-card {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      border-radius: 12px;
+      border: 1px solid var(--a2ui-border, rgba(255,255,255,0.1));
+      background: var(--a2ui-card-bg, rgba(255,255,255,0.05));
+      padding: 16px;
+    }
+  `],
 })
 export class A2uiCardComponent {
   /** v1: a single child key, delivered via childKeys[0] from the render framework. */

--- a/libs/chat/src/lib/a2ui/catalog/check-box.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/check-box.component.ts
@@ -8,11 +8,27 @@ import { emitBinding } from './emit-binding';
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <label class="flex items-center gap-2 text-sm cursor-pointer">
-      <input type="checkbox" [checked]="checked()" (change)="onChange($event)" class="rounded" />
+    <label class="a2ui-cb">
+      <input type="checkbox" [checked]="checked()" (change)="onChange($event)" class="a2ui-cb__input" />
       {{ label() }}
     </label>
   `,
+  styles: [`
+    .a2ui-cb {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 14px;
+      cursor: pointer;
+    }
+    .a2ui-cb__input {
+      width: 16px;
+      height: 16px;
+      border-radius: 4px;
+      cursor: pointer;
+      accent-color: var(--a2ui-primary, #2563eb);
+    }
+  `],
 })
 export class A2uiCheckBoxComponent {
   readonly label = input<string>('');

--- a/libs/chat/src/lib/a2ui/catalog/column.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/column.component.ts
@@ -5,17 +5,27 @@ import { RenderElementComponent } from '@ngaf/render';
 
 type ColumnAlignment = 'start' | 'center' | 'end' | 'stretch';
 
+const ALIGN_MAP: Record<ColumnAlignment, string> = {
+  start: 'flex-start', center: 'center', end: 'flex-end', stretch: 'stretch',
+};
+
 @Component({
   selector: 'a2ui-column',
   standalone: true,
   imports: [RenderElementComponent],
   template: `
-    <div [class]="colClass()">
+    <div class="a2ui-col" [style.align-items]="alignItems()" [style.gap.px]="gapPx()">
       @for (key of childKeys(); track key) {
         <render-element [elementKey]="key" [spec]="spec()" />
       }
     </div>
   `,
+  styles: [`
+    .a2ui-col {
+      display: flex;
+      flex-direction: column;
+    }
+  `],
 })
 export class A2uiColumnComponent {
   readonly childKeys = input<string[]>([]);
@@ -28,10 +38,7 @@ export class A2uiColumnComponent {
   readonly emit = input<(event: string) => void>(() => { /* noop */ });
   readonly loading = input<boolean>(false);
 
-  protected readonly colClass = computed(() => {
-    const alignMap: Record<ColumnAlignment, string> = {
-      start: 'items-start', center: 'items-center', end: 'items-end', stretch: 'items-stretch',
-    };
-    return `flex flex-col gap-${this.gap()} ${alignMap[this.alignment()]}`;
-  });
+  protected readonly alignItems = computed(() => ALIGN_MAP[this.alignment()] ?? 'flex-start');
+  /** Convert the Tailwind gap unit (multiples of 4px) to pixels. */
+  protected readonly gapPx = computed(() => this.gap() * 4);
 }

--- a/libs/chat/src/lib/a2ui/catalog/date-time-input.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/date-time-input.component.ts
@@ -8,22 +8,37 @@ import { emitBinding } from './emit-binding';
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <div class="flex flex-col gap-1">
+    <div class="a2ui-dti">
       @if (label()) {
-        <label [htmlFor]="_inputId" class="text-xs" style="color: var(--a2ui-label, rgba(255,255,255,0.6));">{{ label() }}</label>
+        <label [htmlFor]="_inputId" class="a2ui-dti__label">{{ label() }}</label>
       }
       <input
         [id]="_inputId"
         [type]="htmlInputType()"
         [value]="value()"
-        class="rounded-lg px-3 py-2 text-sm"
-        [style.background]="'var(--a2ui-input-bg, rgba(255,255,255,0.05))'"
-        [style.color]="'var(--a2ui-input-text, white)'"
-        [style.border]="'1px solid var(--a2ui-border, rgba(255,255,255,0.1))'"
+        class="a2ui-dti__input"
         (change)="onChange($event)"
       />
     </div>
   `,
+  styles: [`
+    .a2ui-dti { display: flex; flex-direction: column; gap: 4px; }
+    .a2ui-dti__label {
+      font-size: 12px;
+      color: var(--a2ui-label, rgba(255,255,255,0.6));
+    }
+    .a2ui-dti__input {
+      padding: 8px 12px;
+      font-size: 14px;
+      border-radius: 8px;
+      background: var(--a2ui-input-bg, rgba(255,255,255,0.05));
+      color: var(--a2ui-input-text, white);
+      border: 1px solid var(--a2ui-border, rgba(255,255,255,0.1));
+      outline: none;
+      transition: border-color 120ms;
+    }
+    .a2ui-dti__input:focus { border-color: var(--a2ui-primary, #4f8df5); }
+  `],
 })
 export class A2uiDateTimeInputComponent {
   private static _idCounter = 0;

--- a/libs/chat/src/lib/a2ui/catalog/divider.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/divider.component.ts
@@ -7,11 +7,27 @@ import type { Spec } from '@json-render/core';
   standalone: true,
   template: `
     @if (orientation() === 'vertical') {
-      <div class="inline-block self-stretch border-l border-white/10 mx-2"></div>
+      <div class="a2ui-divider a2ui-divider--vertical"></div>
     } @else {
-      <hr class="border-white/10 my-2" />
+      <hr class="a2ui-divider a2ui-divider--horizontal" />
     }
   `,
+  styles: [`
+    .a2ui-divider--horizontal {
+      display: block;
+      width: 100%;
+      border: none;
+      border-top: 1px solid var(--a2ui-border, rgba(255,255,255,0.1));
+      margin: 8px 0;
+    }
+    .a2ui-divider--vertical {
+      display: inline-block;
+      align-self: stretch;
+      width: 1px;
+      background: var(--a2ui-border, rgba(255,255,255,0.1));
+      margin: 0 8px;
+    }
+  `],
 })
 export class A2uiDividerComponent {
   /** Canonical v1 spec name. The LLM emits this. */

--- a/libs/chat/src/lib/a2ui/catalog/icon.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/icon.component.ts
@@ -7,10 +7,18 @@ import type { Spec } from '@json-render/core';
   standalone: true,
   template: `
     <span
-      class="inline-flex items-center justify-center select-none"
+      class="a2ui-icon"
       [style.font-size]="size() ? size() + 'px' : '1.125rem'"
     >{{ icon() }}</span>
   `,
+  styles: [`
+    .a2ui-icon {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      user-select: none;
+    }
+  `],
 })
 export class A2uiIconComponent {
   /** v1 prop name: icon (resolved string, e.g. a Unicode symbol or ligature name). */

--- a/libs/chat/src/lib/a2ui/catalog/image.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/image.component.ts
@@ -7,13 +7,20 @@ import type { Spec } from '@json-render/core';
   standalone: true,
   template: `
     <img
+      class="a2ui-img"
       [src]="url()"
       [alt]="alt()"
       [style.width]="width() ? width() + 'px' : null"
       [style.height]="height() ? height() + 'px' : null"
-      class="max-w-full rounded"
     />
   `,
+  styles: [`
+    .a2ui-img {
+      display: block;
+      max-width: 100%;
+      border-radius: 4px;
+    }
+  `],
 })
 export class A2uiImageComponent {
   readonly url = input<string>('');

--- a/libs/chat/src/lib/a2ui/catalog/list.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/list.component.ts
@@ -14,6 +14,21 @@ import { RenderElementComponent } from '@ngaf/render';
       }
     </div>
   `,
+  styles: [`
+    .a2ui-list--vertical {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      overflow-y: auto;
+      max-height: 384px;
+    }
+    .a2ui-list--horizontal {
+      display: flex;
+      flex-direction: row;
+      gap: 4px;
+      overflow-x: auto;
+    }
+  `],
 })
 export class A2uiListComponent {
   readonly childKeys = input<string[]>([]);
@@ -26,7 +41,7 @@ export class A2uiListComponent {
 
   protected readonly listClass = computed(() => {
     return this.direction() === 'horizontal'
-      ? 'flex flex-row gap-1 overflow-x-auto'
-      : 'flex flex-col gap-1 overflow-y-auto max-h-96';
+      ? 'a2ui-list--horizontal'
+      : 'a2ui-list--vertical';
   });
 }

--- a/libs/chat/src/lib/a2ui/catalog/modal.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/modal.component.ts
@@ -19,12 +19,12 @@ import { RenderElementComponent } from '@ngaf/render';
     <!-- Modal overlay: shown when open. -->
     @if (open()) {
       <div
-        class="fixed inset-0 z-50 flex items-center justify-center"
+        class="a2ui-modal__overlay"
         role="dialog"
         aria-modal="true"
       >
         <div
-          class="absolute inset-0 bg-black/60 backdrop-blur-sm"
+          class="a2ui-modal__backdrop"
           role="button"
           tabindex="0"
           aria-label="Dismiss dialog"
@@ -32,9 +32,9 @@ import { RenderElementComponent } from '@ngaf/render';
           (keydown.enter)="open.set(false)"
           (keydown.space)="open.set(false)"
         ></div>
-        <div class="relative bg-gray-900 border border-white/10 rounded-xl p-6 max-w-lg w-full mx-4 shadow-2xl">
+        <div class="a2ui-modal__panel">
           @if (title()) {
-            <h2 class="text-lg font-semibold mb-4">{{ title() }}</h2>
+            <h2 class="a2ui-modal__title">{{ title() }}</h2>
           }
           @if (contentKey(); as cKey) {
             <render-element [elementKey]="cKey" [spec]="spec()" />
@@ -43,6 +43,38 @@ import { RenderElementComponent } from '@ngaf/render';
       </div>
     }
   `,
+  styles: [`
+    .a2ui-modal__overlay {
+      position: fixed;
+      inset: 0;
+      z-index: 50;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .a2ui-modal__backdrop {
+      position: absolute;
+      inset: 0;
+      background: rgba(0,0,0,0.6);
+      backdrop-filter: blur(4px);
+    }
+    .a2ui-modal__panel {
+      position: relative;
+      background: var(--a2ui-card-bg, #111827);
+      border: 1px solid var(--a2ui-border, rgba(255,255,255,0.1));
+      border-radius: 12px;
+      padding: 24px;
+      max-width: 512px;
+      width: 100%;
+      margin: 0 16px;
+      box-shadow: 0 25px 50px rgba(0,0,0,0.5);
+    }
+    .a2ui-modal__title {
+      font-size: 18px;
+      font-weight: 600;
+      margin: 0 0 16px;
+    }
+  `],
 })
 export class A2uiModalComponent {
   /**

--- a/libs/chat/src/lib/a2ui/catalog/multiple-choice.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/multiple-choice.component.ts
@@ -14,34 +14,28 @@ interface ResolvedOption {
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <div class="flex flex-col gap-1">
+    <div class="a2ui-mc">
       @if (label()) {
-        <span class="text-xs" style="color: var(--a2ui-label, rgba(255,255,255,0.6));">{{ label() }}</span>
+        <span class="a2ui-mc__label">{{ label() }}</span>
       }
 
       @if (isSingleSelect()) {
         <!-- Single-select: HTML <select> -->
-        <select
-          class="rounded-lg px-3 py-2 text-sm"
-          [style.background]="'var(--a2ui-input-bg, rgba(255,255,255,0.05))'"
-          [style.color]="'var(--a2ui-input-text, white)'"
-          [style.border]="'1px solid var(--a2ui-border, rgba(255,255,255,0.1))'"
-          (change)="onSelectChange($event)"
-        >
+        <select class="a2ui-mc__select" (change)="onSelectChange($event)">
           @for (opt of options(); track opt.value) {
             <option [value]="opt.value" [selected]="isSelected(opt.value)">{{ opt.label }}</option>
           }
         </select>
       } @else {
         <!-- Multi-select: checkbox list -->
-        <div class="flex flex-col gap-2">
+        <div class="a2ui-mc__checks">
           @for (opt of options(); track opt.value) {
-            <label class="flex items-center gap-2 text-sm cursor-pointer">
+            <label class="a2ui-mc__check-row">
               <input
                 type="checkbox"
+                class="a2ui-mc__checkbox"
                 [checked]="isSelected(opt.value)"
                 (change)="onCheckChange(opt.value, $event)"
-                class="rounded"
               />
               {{ opt.label }}
             </label>
@@ -50,6 +44,36 @@ interface ResolvedOption {
       }
     </div>
   `,
+  styles: [`
+    .a2ui-mc { display: flex; flex-direction: column; gap: 4px; }
+    .a2ui-mc__label { font-size: 12px; color: var(--a2ui-label, rgba(255,255,255,0.6)); }
+    .a2ui-mc__select {
+      padding: 8px 12px;
+      font-size: 14px;
+      border-radius: 8px;
+      background: var(--a2ui-input-bg, rgba(255,255,255,0.05));
+      color: var(--a2ui-input-text, white);
+      border: 1px solid var(--a2ui-border, rgba(255,255,255,0.1));
+      outline: none;
+      transition: border-color 120ms;
+    }
+    .a2ui-mc__select:focus { border-color: var(--a2ui-primary, #4f8df5); }
+    .a2ui-mc__checks { display: flex; flex-direction: column; gap: 8px; }
+    .a2ui-mc__check-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 14px;
+      cursor: pointer;
+    }
+    .a2ui-mc__checkbox {
+      width: 16px;
+      height: 16px;
+      border-radius: 4px;
+      cursor: pointer;
+      accent-color: var(--a2ui-primary, #2563eb);
+    }
+  `],
 })
 export class A2uiMultipleChoiceComponent {
   readonly label = input<string>('');

--- a/libs/chat/src/lib/a2ui/catalog/row.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/row.component.ts
@@ -6,17 +6,38 @@ import { RenderElementComponent } from '@ngaf/render';
 type RowAlignment = 'start' | 'center' | 'end' | 'stretch';
 type RowDistribution = 'start' | 'center' | 'end' | 'space-between' | 'space-around';
 
+const ROW_ALIGN_MAP: Record<RowAlignment, string> = {
+  start: 'flex-start', center: 'center', end: 'flex-end', stretch: 'stretch',
+};
+
+const ROW_JUSTIFY_MAP: Record<RowDistribution, string> = {
+  start: 'flex-start', center: 'center', end: 'flex-end',
+  'space-between': 'space-between', 'space-around': 'space-around',
+};
+
 @Component({
   selector: 'a2ui-row',
   standalone: true,
   imports: [RenderElementComponent],
   template: `
-    <div [class]="rowClass()">
+    <div
+      class="a2ui-row"
+      [style.align-items]="alignItems()"
+      [style.justify-content]="justifyContent()"
+      [style.gap.px]="gapPx()"
+    >
       @for (key of childKeys(); track key) {
         <render-element [elementKey]="key" [spec]="spec()" />
       }
     </div>
   `,
+  styles: [`
+    .a2ui-row {
+      display: flex;
+      flex-direction: row;
+      flex-wrap: wrap;
+    }
+  `],
 })
 export class A2uiRowComponent {
   readonly childKeys = input<string[]>([]);
@@ -29,14 +50,8 @@ export class A2uiRowComponent {
   readonly emit = input<(event: string) => void>(() => { /* noop */ });
   readonly loading = input<boolean>(false);
 
-  protected readonly rowClass = computed(() => {
-    const alignMap: Record<RowAlignment, string> = {
-      start: 'items-start', center: 'items-center', end: 'items-end', stretch: 'items-stretch',
-    };
-    const justifyMap: Record<RowDistribution, string> = {
-      start: 'justify-start', center: 'justify-center', end: 'justify-end',
-      'space-between': 'justify-between', 'space-around': 'justify-around',
-    };
-    return `flex flex-row gap-${this.gap()} ${alignMap[this.alignment()]} ${justifyMap[this.distribution()]}`;
-  });
+  protected readonly alignItems = computed(() => ROW_ALIGN_MAP[this.alignment()] ?? 'flex-start');
+  protected readonly justifyContent = computed(() => ROW_JUSTIFY_MAP[this.distribution()] ?? 'flex-start');
+  /** Convert the gap unit (multiples of 4px) to pixels. */
+  protected readonly gapPx = computed(() => this.gap() * 4);
 }

--- a/libs/chat/src/lib/a2ui/catalog/slider.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/slider.component.ts
@@ -8,22 +8,34 @@ import { emitBinding } from './emit-binding';
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <div class="flex flex-col gap-1">
+    <div class="a2ui-slider">
       @if (label()) {
-        <label [htmlFor]="_inputId" class="text-xs" style="color: var(--a2ui-label, rgba(255,255,255,0.6));">{{ label() }}: {{ value() }}</label>
+        <label [htmlFor]="_inputId" class="a2ui-slider__label">{{ label() }}: {{ value() }}</label>
       }
       <input
         [id]="_inputId"
         type="range"
+        class="a2ui-slider__input"
         [min]="minValue()"
         [max]="maxValue()"
         [step]="step()"
         [value]="value()"
-        class="w-full"
         (input)="onInput($event)"
       />
     </div>
   `,
+  styles: [`
+    .a2ui-slider { display: flex; flex-direction: column; gap: 4px; }
+    .a2ui-slider__label {
+      font-size: 12px;
+      color: var(--a2ui-label, rgba(255,255,255,0.6));
+    }
+    .a2ui-slider__input {
+      width: 100%;
+      cursor: pointer;
+      accent-color: var(--a2ui-primary, #2563eb);
+    }
+  `],
 })
 export class A2uiSliderComponent {
   private static _idCounter = 0;

--- a/libs/chat/src/lib/a2ui/catalog/tabs.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/tabs.component.ts
@@ -8,25 +8,49 @@ import { RenderElementComponent } from '@ngaf/render';
   standalone: true,
   imports: [RenderElementComponent],
   template: `
-    <div class="flex flex-col gap-0">
-      <div class="flex border-b border-white/10" role="tablist">
+    <div class="a2ui-tabs">
+      <div class="a2ui-tabs__tablist" role="tablist">
         @for (title of tabTitles(); track $index) {
           <button
             role="tab"
-            class="px-4 py-2 text-sm font-medium transition-colors border-b-2"
-            [class]="$index === activeIndex() ? 'border-blue-500 text-white' : 'border-transparent text-white/50 hover:text-white/80'"
+            [class]="$index === activeIndex() ? 'a2ui-tabs__tab a2ui-tabs__tab--active' : 'a2ui-tabs__tab'"
             [attr.aria-selected]="$index === activeIndex()"
             (click)="selectTab($index)"
           >{{ title }}</button>
         }
       </div>
-      <div class="pt-3" role="tabpanel">
+      <div class="a2ui-tabs__panel" role="tabpanel">
         @if (activeChildKey(); as key) {
           <render-element [elementKey]="key" [spec]="spec()" />
         }
       </div>
     </div>
   `,
+  styles: [`
+    .a2ui-tabs { display: flex; flex-direction: column; }
+    .a2ui-tabs__tablist {
+      display: flex;
+      border-bottom: 1px solid var(--a2ui-border, rgba(255,255,255,0.1));
+    }
+    .a2ui-tabs__tab {
+      padding: 8px 16px;
+      font-size: 14px;
+      font-weight: 500;
+      cursor: pointer;
+      background: transparent;
+      border: none;
+      border-bottom: 2px solid transparent;
+      color: var(--a2ui-label, rgba(255,255,255,0.5));
+      transition: color 120ms, border-color 120ms;
+      margin-bottom: -1px;
+    }
+    .a2ui-tabs__tab:hover { color: var(--a2ui-input-text, rgba(255,255,255,0.8)); }
+    .a2ui-tabs__tab--active {
+      border-bottom-color: var(--a2ui-primary, #3b82f6);
+      color: var(--a2ui-input-text, white);
+    }
+    .a2ui-tabs__panel { padding-top: 12px; }
+  `],
 })
 export class A2uiTabsComponent {
   /** Resolved tab titles from tabItems[*].title — produced by surface-to-spec. */

--- a/libs/chat/src/lib/a2ui/catalog/text-field.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/text-field.component.ts
@@ -20,9 +20,9 @@ const TYPE_MAP: Record<TextFieldType, string> = {
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <div class="flex flex-col gap-1">
+    <div class="a2ui-tf">
       @if (label()) {
-        <label [htmlFor]="_inputId" class="text-xs" style="color: var(--a2ui-label, rgba(255,255,255,0.6));">{{ label() }}</label>
+        <label [htmlFor]="_inputId" class="a2ui-tf__label">{{ label() }}</label>
       }
       @if (textFieldType() === 'longText') {
         <textarea
@@ -30,10 +30,7 @@ const TYPE_MAP: Record<TextFieldType, string> = {
           [value]="value()"
           [placeholder]="placeholder()"
           rows="4"
-          class="rounded-lg px-3 py-2 text-sm resize-y"
-          [style.background]="'var(--a2ui-input-bg, rgba(255,255,255,0.05))'"
-          [style.color]="'var(--a2ui-input-text, white)'"
-          [style.border]="'1px solid var(--a2ui-border, rgba(255,255,255,0.1))'"
+          class="a2ui-tf__input"
           (input)="onInput($event)"
         ></textarea>
       } @else {
@@ -43,15 +40,31 @@ const TYPE_MAP: Record<TextFieldType, string> = {
           [value]="value()"
           [placeholder]="placeholder()"
           [pattern]="validationRegexp() || ''"
-          class="rounded-lg px-3 py-2 text-sm"
-          [style.background]="'var(--a2ui-input-bg, rgba(255,255,255,0.05))'"
-          [style.color]="'var(--a2ui-input-text, white)'"
-          [style.border]="'1px solid var(--a2ui-border, rgba(255,255,255,0.1))'"
+          class="a2ui-tf__input"
           (input)="onInput($event)"
         />
       }
     </div>
   `,
+  styles: [`
+    .a2ui-tf { display: flex; flex-direction: column; gap: 4px; }
+    .a2ui-tf__label {
+      font-size: 12px;
+      color: var(--a2ui-label, rgba(255,255,255,0.6));
+    }
+    .a2ui-tf__input {
+      padding: 8px 12px;
+      font-size: 14px;
+      border-radius: 8px;
+      background: var(--a2ui-input-bg, rgba(255,255,255,0.05));
+      color: var(--a2ui-input-text, white);
+      border: 1px solid var(--a2ui-border, rgba(255,255,255,0.1));
+      outline: none;
+      transition: border-color 120ms;
+      resize: vertical;
+    }
+    .a2ui-tf__input:focus { border-color: var(--a2ui-primary, #4f8df5); }
+  `],
 })
 export class A2uiTextFieldComponent {
   private static _idCounter = 0;

--- a/libs/chat/src/lib/a2ui/catalog/text-field.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/text-field.component.ts
@@ -74,7 +74,7 @@ export class A2uiTextFieldComponent {
   /** v1 prop: text (resolved string value). */
   readonly text = input<string>('');
   /** Back-compat alias: value. surface-to-spec resolves DynamicString → plain string. */
-  readonly value = computed(() => this.text());
+  readonly value = computed(() => this.text() ?? '');
   readonly placeholder = input<string>('');
   readonly textFieldType = input<TextFieldType>('shortText');
   readonly validationRegexp = input<string>('');

--- a/libs/chat/src/lib/a2ui/catalog/text.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/text.component.ts
@@ -4,20 +4,58 @@ import type { Spec } from '@json-render/core';
 
 type UsageHint = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'caption' | 'body';
 
-const HINT_CLASS: Record<UsageHint, string> = {
-  h1: 'text-3xl font-bold',
-  h2: 'text-2xl font-semibold',
-  h3: 'text-xl font-semibold',
-  h4: 'text-lg font-medium',
-  h5: 'text-base font-medium',
-  caption: 'text-xs text-white/50',
-  body: 'text-sm text-current',
-};
-
 @Component({
   selector: 'a2ui-text',
   standalone: true,
   template: `<span [class]="cssClass()">{{ text() }}</span>`,
+  styles: [`
+    .a2ui-text-h1 {
+      display: block;
+      font-size: 2rem;
+      font-weight: 700;
+      line-height: 1.2;
+      margin: 0;
+    }
+    .a2ui-text-h2 {
+      display: block;
+      font-size: 1.5rem;
+      font-weight: 600;
+      line-height: 1.3;
+      margin: 0;
+    }
+    .a2ui-text-h3 {
+      display: block;
+      font-size: 1.25rem;
+      font-weight: 600;
+      line-height: 1.4;
+      margin: 0;
+    }
+    .a2ui-text-h4 {
+      display: block;
+      font-size: 1.125rem;
+      font-weight: 500;
+      line-height: 1.4;
+      margin: 0;
+    }
+    .a2ui-text-h5 {
+      display: block;
+      font-size: 1rem;
+      font-weight: 500;
+      line-height: 1.5;
+      margin: 0;
+    }
+    .a2ui-text-caption {
+      display: block;
+      font-size: 0.75rem;
+      color: var(--a2ui-caption, rgba(255,255,255,0.5));
+      line-height: 1.4;
+    }
+    .a2ui-text-body {
+      display: block;
+      font-size: 0.875rem;
+      line-height: 1.6;
+    }
+  `],
 })
 export class A2uiTextComponent {
   readonly text = input<string>('');
@@ -30,6 +68,6 @@ export class A2uiTextComponent {
   readonly spec = input<Spec | undefined>(undefined);
 
   protected cssClass(): string {
-    return HINT_CLASS[this.usageHint()] ?? HINT_CLASS.body;
+    return `a2ui-text-${this.usageHint()}`;
   }
 }

--- a/libs/chat/src/lib/a2ui/catalog/video.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/video.component.ts
@@ -7,12 +7,19 @@ import type { Spec } from '@json-render/core';
   standalone: true,
   template: `
     <video
-      class="w-full rounded-lg"
+      class="a2ui-video"
       [src]="url()"
       [autoplay]="autoPlay()"
       [controls]="controls()"
     ></video>
   `,
+  styles: [`
+    .a2ui-video {
+      display: block;
+      width: 100%;
+      border-radius: 8px;
+    }
+  `],
 })
 export class A2uiVideoComponent {
   readonly url = input<string>('');


### PR DESCRIPTION
## Problem

All 18 `@ngaf/chat` a2ui catalog components used Tailwind utility class strings (`flex flex-col gap-1`, `text-3xl font-bold`, `rounded-lg px-3 py-2`, `bg-blue-600`, etc.) in their templates. This workspace has no Tailwind compiler configured — no `tailwind.config.*`, no `@tailwind` directives — so every one of those class names was silently inert. The result was visible layout breakage in every rendered surface:

- **TextField / Slider / DateTimeInput / MultipleChoice**: label and input rendered on the same line (no flex-column wrapper), no padding or border-radius on the input
- **Text**: `h1`–`h5` headings rendered as inline `<span>` at body font size; no block display, no size, no weight
- **Column / Row / List**: flex layout + gap never applied
- **Card**: no border, no padding, no background
- **Button**: no padding, no background, invisible
- **Tabs**: tab strip lost all padding, border, and active-state indicator
- **Modal**: overlay/panel positioning and backdrop lost

## Solution

Added an Angular `styles: [...]` block to each `@Component` decorator — no new dependencies, no toolchain changes. Each component now carries its own BEM-style component-scoped CSS that reproduces the intended layout:

- `TextField`, `Slider`, `DateTimeInput`, `MultipleChoice`: `display:flex; flex-direction:column; gap:4px` wrapper; full padding/border/border-radius/focus state on inputs
- `Text`: block display per `usageHint` with correct `font-size` + `font-weight` for `h1`–`h5`, muted color for `caption`, readable `line-height` for `body`
- `Column` / `Row`: convert the numeric `gap` and `alignment` inputs to real CSS via `[style.gap.px]` / `[style.align-items]` / `[style.justify-content]` bindings (Tailwind's `gap-N` shorthand was not resolvable at runtime)
- `List`: two named classes (`a2ui-list--vertical` / `a2ui-list--horizontal`) replacing the computed Tailwind string
- `Card`: rounded border + padding + background via `--a2ui-card-bg` CSS variable
- `Button`: visible primary/secondary states with hover, padding, border-radius, disabled opacity
- `Tabs`: tab strip with bottom-border indicator, active colour, hover state, panel padding
- `Modal`: fixed overlay + backdrop blur + panel sizing via real CSS classes
- `CheckBox`, `Icon`, `Image`, `Audio`, `Video`, `Divider`: simpler layout fixes (block/inline-flex, `width:100%`, border rules)

All `--a2ui-*` CSS variables from the existing palette (`--a2ui-primary`, `--a2ui-border`, `--a2ui-label`, `--a2ui-input-bg`, `--a2ui-input-text`) are reused as fallback defaults throughout.

## Verification

```
npx nx run-many -t test,lint,build -p chat --skip-nx-cache
# NX   Successfully ran targets test, lint, build for project chat and 4 tasks it depends on
```

## Components touched

| Component | Change |
|---|---|
| `audio-player` | `w-full` → `.a2ui-audio { display:block; width:100% }` |
| `button` | Full primary/secondary styles with padding, border-radius, hover, disabled |
| `card` | flex-column wrapper with border, background, padding, border-radius |
| `check-box` | flex-row label+checkbox with gap and accent-color |
| `column` | Replaced computed Tailwind string with `[style.align-items]` + `[style.gap.px]` |
| `date-time-input` | flex-column + styled label + full input padding/border/focus |
| `divider` | `border-white/10` → real `border-top` / background CSS |
| `icon` | `inline-flex items-center justify-center select-none` → component CSS |
| `image` | `max-w-full rounded` → component CSS |
| `list` | Replaced computed Tailwind string with two named CSS classes |
| `modal` | Fixed overlay, backdrop, panel, title with real position/layout CSS |
| `multiple-choice` | flex-column + label + styled select + checkbox list with gap |
| `row` | Replaced computed Tailwind string with `[style.justify-content]` + `[style.align-items]` + `[style.gap.px]` |
| `slider` | flex-column + label + `width:100%` range with accent-color |
| `tabs` | Tab strip with border, active indicator, hover state, panel padding |
| `text-field` | flex-column + label + input/textarea with full padding/border/focus |
| `text` | Block display per usageHint; font-size/weight/line-height for h1–h5, caption, body |
| `video` | `w-full rounded-lg` → component CSS |

🤖 Generated with [Claude Code](https://claude.com/claude-code)