### PR TITLE
feat(examples-chat): A2UI Pass 1 — full-catalog surface coverage

### DIFF
--- a/examples/chat/angular/src/app/modes/welcome-suggestions.ts
+++ b/examples/chat/angular/src/app/modes/welcome-suggestions.ts
@@ -64,4 +64,14 @@ export const WELCOME_SUGGESTIONS: readonly WelcomeSuggestion[] = [
     value:
       'Show me a contact form with fields for name, email address, subject, and a multi-line message, plus a Send button.',
   },
+  {
+    label: 'Demo: render a media-rich product card',
+    value:
+      'Render a product card with: a header image at the top, a tab strip with two tabs ("Overview" and "Specs"). Under Overview show a Row containing an icon and a short description Text. Under Specs show a List of feature bullets each prefixed with a small icon. Below the tabs add a primary "Add to cart" Button.',
+  },
+  {
+    label: 'Demo: render a booking surface with modal',
+    value:
+      'Render a booking surface: a heading "Book your trip", a DateTimeInput for travel date, a horizontal divider, then a Row containing two Cards (one for departure city, one for return city) each with a TextField. Below the Row add a primary "Continue" Button whose action opens a Modal containing a confirmation Column with a summary Text and Confirm / Cancel Buttons.',
+  },
 ];

--- a/examples/chat/smoke/CHECKLIST.md
+++ b/examples/chat/smoke/CHECKLIST.md
@@ -266,6 +266,19 @@ renders correctly both during streaming and after completion.
 - [ ] In json-render mode: final AI message content is a bare JSON object starting with `{`
 - [ ] `curl localhost:2024/threads/<id>/state` confirms the above for both modes
 
+### A2UI catalog coverage
+
+The 18 catalog components must render correctly when the LLM-generated surface includes them. After clicking each demo suggestion below, verify the rendered surface contains the listed component types and that each looks visually correct (no overflow, alignment intact, text legible, interactive controls functional).
+
+- [ ] "Demo: render a feedback form" — `Card` + `Column` + `Text` + `TextField` + (`MultipleChoice` or `Slider`) + `Button`
+- [ ] "Demo: render a settings card" — `Card` + `Column` + `Text` + `MultipleChoice` + `CheckBox` + `Button`
+- [ ] "Demo: render a poll" — `Card` + `Column` + `Text` + `MultipleChoice` + `Button`
+- [ ] "Demo: render a contact form" — `Card` + `Column` + `Text` + `TextField` + `Button`
+- [ ] "Demo: render a media-rich product card" — `Image` + `Tabs` + `Row` + `Icon` + `List` + `Button`
+- [ ] "Demo: render a booking surface with modal" — `DateTimeInput` + `Divider` + `Row` + `Card` + `TextField` + `Modal`
+
+Components NOT yet exercised by the demo (deferred to future media-focused suggestions): `Video`, `AudioPlayer`.
+
 ## Subagents
 
 - [ ] Click "Demo: dispatch a research subagent" welcome suggestion


### PR DESCRIPTION
## Summary

First pass of the A2UI theming track: ensure all 18 catalog components are reliably exercised by the demo's welcome suggestions before we audit the theming token surface (Pass 2).

**Audit:** The existing 4 GenUI suggestions ("feedback form", "settings card", "poll", "contact form") only reliably render 8 of 18 catalog components (Card, Column, Text, TextField, MultipleChoice, CheckBox, Slider, Button). The other 10 — Row, List, Tabs, Modal, Divider, DateTimeInput, Icon, Image, Video, AudioPlayer — never see daylight.

**Fix:** Add 2 new welcome suggestions designed to elicit surfaces that collectively render 8 of the 10 gap components:

- "Demo: render a media-rich product card" — `Image` + `Tabs` + `Row` + `Icon` + `List` + `Button`
- "Demo: render a booking surface with modal" — `DateTimeInput` + `Divider` + `Row` + `Card` + `TextField` + `Modal`

Remaining gaps (Video, AudioPlayer) are deferred to a future media-focused demo suggestion when needed.

**CHECKLIST update:** new "A2UI catalog coverage" sub-section under Generative UI / A2UI surfaces mapping each demo prompt to its expected catalog components, so smoke runs can systematically verify rendering across the full 18-component set.

## Why this matters

This sets up the visual baseline for the rest of the theming track:
- **Pass 2** — audit theming knobs (color tokens, typography scale, density, spacing scale, shape radius, focus ring, motion) against the fully-exercised catalog. Ship an expanded \`--a2ui-*\` (or M3 \`--mat-sys-*\`) token surface that all 18 components consume.
- **Pass 3** — ship a Material preset as a token-value CSS file (no \`@angular/material\` runtime dep).

## Test plan

- [x] \`nx run examples-chat-angular:build\` — succeeds
- [ ] After merge: live smoke against the workspace demo confirming the 2 new suggestions reliably elicit surfaces containing the listed catalog components

🤖 Generated with [Claude Code](https://claude.com/claude-code)