### PR TITLE
feat(a2ui,chat): honor beginRendering.styles per A2UI v1 spec (Pass 2a)

### DIFF
--- a/apps/website/content/docs/chat/api/api-docs.json
+++ b/apps/website/content/docs/chat/api/api-docs.json
@@ -1010,6 +1010,12 @@
         "optional": false
       },
       {
+        "name": "fontFamily",
+        "type": "Signal<string | null>",
+        "description": "Agent-set font family from `beginRendering.styles.font`. Returns\nnull when unset so the host doesn't override consumer fonts.",
+        "optional": false
+      },
+      {
         "name": "handlers",
         "type": "InputSignal<Record<string, object>>",
         "description": "",
@@ -1019,6 +1025,12 @@
         "name": "internalHandlers",
         "type": "Signal<object>",
         "description": "Merge built-in A2UI handlers with consumer-provided handlers.",
+        "optional": false
+      },
+      {
+        "name": "primaryColor",
+        "type": "Signal<string | null>",
+        "description": "Agent-set primary color from `beginRendering.styles.primaryColor`.\nReturns null when unset so the host binding doesn't override the\nconsumer's `:root`-level `--a2ui-primary` default.",
         "optional": false
       },
       {
@@ -3759,6 +3771,12 @@
         "name": "sendDataModel",
         "type": "boolean",
         "description": "",
+        "optional": true
+      },
+      {
+        "name": "styles",
+        "type": "object",
+        "description": "Styles set by the agent via `beginRendering.styles`. The\ncanonical v1 spec defines exactly two fields: `font` (primary\nfont for the UI) and `primaryColor` (hex `#RRGGBB`). The renderer\napplies these as CSS custom properties on the surface root,\noverriding any consumer-set defaults for the duration of the\nsurface's life. Anything richer (typography scale, spacing,\nelevation, etc.) is the renderer's private vocabulary and not\ncommunicated through this field.",
         "optional": true
       },
       {

--- a/libs/a2ui/src/lib/types.ts
+++ b/libs/a2ui/src/lib/types.ts
@@ -231,6 +231,15 @@ export interface A2uiSurface {
   sendDataModel?: boolean;
   components: Map<string, A2uiComponent>;
   dataModel: Record<string, unknown>;
+  /** Styles set by the agent via `beginRendering.styles`. The
+   * canonical v1 spec defines exactly two fields: `font` (primary
+   * font for the UI) and `primaryColor` (hex `#RRGGBB`). The renderer
+   * applies these as CSS custom properties on the surface root,
+   * overriding any consumer-set defaults for the duration of the
+   * surface's life. Anything richer (typography scale, spacing,
+   * elevation, etc.) is the renderer's private vocabulary and not
+   * communicated through this field. */
+  styles?: { font?: string; primaryColor?: string };
 }
 
 // --- Outbound shapes ---

--- a/libs/chat/src/lib/a2ui/surface-store.spec.ts
+++ b/libs/chat/src/lib/a2ui/surface-store.spec.ts
@@ -123,4 +123,47 @@ describe('A2uiSurfaceStore (v1, deferred-apply)', () => {
     expect(s()).toBeDefined();
     expect(s()!.surfaceId).toBe('s1');
   });
+
+  test('captures styles from beginRendering (v1 spec)', () => {
+    const store = setup();
+    store.apply({ surfaceUpdate: { surfaceId: 's1', components: [
+      { id: 'root', component: { Text: { text: { literalString: 'hi' } } } },
+    ] } });
+    store.apply({ beginRendering: {
+      surfaceId: 's1',
+      root: 'root',
+      styles: { font: 'Roboto', primaryColor: '#FF6633' },
+    } });
+    const s = store.surfaces().get('s1')!;
+    expect(s.styles).toEqual({ font: 'Roboto', primaryColor: '#FF6633' });
+  });
+
+  test('omits styles field when beginRendering does not include it', () => {
+    const store = setup();
+    store.apply({ surfaceUpdate: { surfaceId: 's1', components: [
+      { id: 'root', component: { Text: { text: { literalString: 'hi' } } } },
+    ] } });
+    store.apply({ beginRendering: { surfaceId: 's1', root: 'root' } });
+    const s = store.surfaces().get('s1')!;
+    expect(s.styles).toBeUndefined();
+  });
+
+  test('preserves existing styles on re-render when new beginRendering omits them', () => {
+    const store = setup();
+    store.apply({ surfaceUpdate: { surfaceId: 's1', components: [
+      { id: 'root', component: { Text: { text: { literalString: 'hi' } } } },
+    ] } });
+    store.apply({ beginRendering: {
+      surfaceId: 's1',
+      root: 'root',
+      styles: { primaryColor: '#0A84FF' },
+    } });
+    // Second beginRendering without styles — keep prior.
+    store.apply({ surfaceUpdate: { surfaceId: 's1', components: [
+      { id: 'root', component: { Text: { text: { literalString: 'hi' } } } },
+    ] } });
+    store.apply({ beginRendering: { surfaceId: 's1', root: 'root' } });
+    const s = store.surfaces().get('s1')!;
+    expect(s.styles).toEqual({ primaryColor: '#0A84FF' });
+  });
 });

--- a/libs/chat/src/lib/a2ui/surface-store.ts
+++ b/libs/chat/src/lib/a2ui/surface-store.ts
@@ -95,11 +95,18 @@ export function createA2uiSurfaceStore(): A2uiSurfaceStore {
       if (existing) {
         dataModel = { ...existing.dataModel, ...dataModel };
       }
+      // Capture v1 styles (font, primaryColor) from beginRendering. A
+      // re-render keeps any prior styles unless the new beginRendering
+      // explicitly overrides them — this matches the agent's likely
+      // intent ("change the data, keep the look").
+      const nextStyles = begin.styles
+        ?? existing?.styles;
       const surface: A2uiSurface = {
         surfaceId: begin.surfaceId,
         catalogId: 'basic',
         components: b.components,
         dataModel,
+        ...(nextStyles ? { styles: nextStyles } : {}),
       };
       const next = new Map(surfacesSignal());
       next.set(begin.surfaceId, surface);

--- a/libs/chat/src/lib/a2ui/surface.component.ts
+++ b/libs/chat/src/lib/a2ui/surface.component.ts
@@ -13,6 +13,14 @@ import { buildA2uiActionMessage } from './build-action-message';
   standalone: true,
   imports: [RenderSpecComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
+  // The host applies the agent-set v1 styles (`beginRendering.styles`)
+  // as inline CSS custom properties + font-family. Catalog components
+  // consume `--a2ui-primary` for accents (buttons, sliders, focus,
+  // etc.); `font-family` cascades naturally from the host.
+  host: {
+    '[style.--a2ui-primary]': 'primaryColor()',
+    '[style.font-family]': 'fontFamily()',
+  },
   template: `
     @if (spec(); as s) {
       <render-spec
@@ -30,6 +38,19 @@ export class A2uiSurfaceComponent {
   readonly handlers = input<Record<string, (params: Record<string, unknown>) => unknown | Promise<unknown>>>({});
   readonly events = output<RenderEvent>();
   readonly action = output<A2uiActionMessage>();
+
+  /** Agent-set primary color from `beginRendering.styles.primaryColor`.
+   * Returns null when unset so the host binding doesn't override the
+   * consumer's `:root`-level `--a2ui-primary` default. */
+  readonly primaryColor = computed<string | null>(() =>
+    this.surface().styles?.primaryColor ?? null
+  );
+
+  /** Agent-set font family from `beginRendering.styles.font`. Returns
+   * null when unset so the host doesn't override consumer fonts. */
+  readonly fontFamily = computed<string | null>(() =>
+    this.surface().styles?.font ?? null
+  );
 
   /** Convert the A2UI surface to a json-render Spec for rendering. */
   readonly spec = computed(() => surfaceToSpec(this.surface()));


### PR DESCRIPTION
## Summary

Closes a v1-spec compliance gap: the canonical A2UI v1 wire format defines exactly two theming knobs on \`beginRendering.styles\` — \`font\` (primary font family) and \`primaryColor\` (hex \`#RRGGBB\`). The type system declared the field but **no consumer read it** — agents could emit \`styles: { primaryColor: \"#FF0000\" }\` and the renderer silently dropped it.

This PR is **Pass 2a** of the A2UI theming track: ship spec compliance first, then layer on the richer internal token system (Pass 2b) that's the renderer's private vocabulary.

### Changes

1. **\`libs/a2ui\` types** — \`A2uiSurface\` gains an optional \`styles?: { font?, primaryColor? }\` field mirroring the wire shape, the renderer's single source of truth for v1-spec-defined theming on a given surface.
2. **\`libs/chat\` surface-store** — \`beginRendering.styles\` is captured onto the new field at commit time. Re-renders preserve existing styles when the new \`beginRendering\` omits them (matches the agent's likely \"change the data, keep the look\" intent).
3. **\`<a2ui-surface>\` host** — applies \`surface.styles.primaryColor\` as \`--a2ui-primary\` and \`surface.styles.font\` as \`font-family\` via host bindings. \`null\` when unset so consumer-set \`:root\` defaults aren't overridden. Catalog components already consume \`var(--a2ui-primary)\` for accents (buttons, sliders, focus, etc.); font cascades naturally.

### Why split from Pass 2b

The richer token surface (spacing/typography/shape/focus/motion/elevation/derived-colors) is the renderer's **private vocabulary** — explicitly NOT communicated through the wire format. The agent shouldn't know about it. Pass 2a is small, high-value (closes the spec gap), and unblocks live testing of agent-driven theming. Pass 2b refactors the catalog to consume an expanded internal token set; Pass 3 ships preset CSS files (Material flavor) consumers \`@import\`.

## Test plan

- [x] \`nx run-many -t test,lint,build -p a2ui,chat\` — all green
- [x] 3 new unit tests cover capture, omission, and preservation across re-renders

### Pending live verification
- [ ] After merge: agent-emitted \`primaryColor\` propagates to the rendered surface — try a prompt like \"render a feedback form with a green primary color\" and verify the Submit button picks up the green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)