### PR TITLE
feat(chat,examples-chat): catalog v1 prop additions + theme cascade fix (smoke pass)

### DIFF
--- a/apps/website/content/docs/chat/api/api-docs.json
+++ b/apps/website/content/docs/chat/api/api-docs.json
@@ -31,6 +31,12 @@
         "optional": false
       },
       {
+        "name": "description",
+        "type": "InputSignal<string>",
+        "description": "v1 canonical prop: short description / title rendered above the player.",
+        "optional": false
+      },
+      {
         "name": "emit",
         "type": "InputSignal<object>",
         "description": "",
@@ -178,12 +184,18 @@
       {
         "name": "checked",
         "type": "InputSignal<boolean>",
-        "description": "",
+        "description": "Pre-v1 alias retained for back-compat.",
         "optional": false
       },
       {
         "name": "childKeys",
         "type": "InputSignal<string[]>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "effectiveValue",
+        "type": "Signal<boolean>",
         "description": "",
         "optional": false
       },
@@ -209,6 +221,12 @@
         "name": "spec",
         "type": "InputSignal<Spec | undefined>",
         "description": "",
+        "optional": false
+      },
+      {
+        "name": "value",
+        "type": "InputSignal<boolean | undefined>",
+        "description": "v1 canonical prop: boolean checked state.",
         "optional": false
       }
     ],
@@ -472,6 +490,12 @@
         "optional": false
       },
       {
+        "name": "effectiveName",
+        "type": "Signal<string>",
+        "description": "",
+        "optional": false
+      },
+      {
         "name": "emit",
         "type": "InputSignal<object>",
         "description": "",
@@ -480,13 +504,19 @@
       {
         "name": "icon",
         "type": "InputSignal<string>",
-        "description": "v1 prop name: icon (resolved string, e.g. a Unicode symbol or ligature name).",
+        "description": "Pre-v1 alias retained for back-compat.",
         "optional": false
       },
       {
         "name": "loading",
         "type": "InputSignal<boolean>",
         "description": "",
+        "optional": false
+      },
+      {
+        "name": "name",
+        "type": "InputSignal<string | undefined>",
+        "description": "v1 canonical prop.",
         "optional": false
       },
       {
@@ -536,6 +566,12 @@
         "optional": false
       },
       {
+        "name": "fit",
+        "type": "InputSignal<ImageFit | undefined>",
+        "description": "v1 prop: CSS object-fit equivalent.",
+        "optional": false
+      },
+      {
         "name": "height",
         "type": "InputSignal<number | null>",
         "description": "",
@@ -560,13 +596,38 @@
         "optional": false
       },
       {
+        "name": "usageHint",
+        "type": "InputSignal<ImageUsageHint | undefined>",
+        "description": "v1 prop: sizing preset.",
+        "optional": false
+      },
+      {
         "name": "width",
         "type": "InputSignal<number | null>",
         "description": "",
         "optional": false
       }
     ],
-    "methods": []
+    "methods": [
+      {
+        "name": "explicitHeight",
+        "signature": "explicitHeight()",
+        "description": "",
+        "params": []
+      },
+      {
+        "name": "explicitWidth",
+        "signature": "explicitWidth()",
+        "description": "",
+        "params": []
+      },
+      {
+        "name": "hintStyle",
+        "signature": "hintStyle()",
+        "description": "",
+        "params": []
+      }
+    ]
   },
   {
     "name": "A2uiListComponent",
@@ -575,6 +636,18 @@
     "params": [],
     "examples": [],
     "properties": [
+      {
+        "name": "alignment",
+        "type": "InputSignal<\"center\" | \"start\" | \"end\" | \"stretch\" | undefined>",
+        "description": "v1 canonical prop: cross-axis alignment.",
+        "optional": false
+      },
+      {
+        "name": "alignmentCss",
+        "type": "Signal<string | null>",
+        "description": "",
+        "optional": false
+      },
       {
         "name": "bindings",
         "type": "InputSignal<Record<string, string>>",

--- a/examples/chat/angular/src/app/modes/welcome-suggestions.ts
+++ b/examples/chat/angular/src/app/modes/welcome-suggestions.ts
@@ -74,4 +74,14 @@ export const WELCOME_SUGGESTIONS: readonly WelcomeSuggestion[] = [
     value:
       'Render a booking surface: a heading "Book your trip", a DateTimeInput for travel date, a horizontal divider, then a Row containing two Cards (one for departure city, one for return city) each with a TextField. Below the Row add a primary "Continue" Button whose action opens a Modal containing a confirmation Column with a summary Text and Confirm / Cancel Buttons.',
   },
+  {
+    label: 'Smoke: media + layout kitchen sink',
+    value:
+      'Render a Card containing a Tabs component with two tabs labeled "Media" and "Layout". Under the Media tab show a Column containing: a header Image (use https://placehold.co/600x300/4f8df5/ffffff.png as the URL), an Icon (any icon name from the canonical set, e.g. star), a short Text caption, an AudioPlayer (use https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3 as the URL), and a Video (use https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4 as the URL). Under the Layout tab show: a Row containing two Text components separated by a vertical Divider, then a horizontal Divider, then a List of three Text bullet items, then a Column containing two Text components.',
+  },
+  {
+    label: 'Smoke: interactive form kitchen sink',
+    value:
+      'Render a Card titled "Profile setup" containing a Column with: a TextField for display name, a Slider for "experience years" (range 0-30), a CheckBox for "subscribe to newsletter", a DateTimeInput for birthday (date only), a MultipleChoice for "favorite frameworks" with options Angular, React, Vue, Svelte and maxAllowedSelections of 3 (multi-select), a horizontal Divider, a Row containing a primary "Save" Button and a secondary "Open details" Button whose action opens a Modal with a Column containing a Text summary and a Close Button.',
+  },
 ];

--- a/libs/chat/src/lib/a2ui/catalog/audio-player.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/audio-player.component.ts
@@ -6,14 +6,28 @@ import type { Spec } from '@json-render/core';
   selector: 'a2ui-audio-player',
   standalone: true,
   template: `
-    <audio
-      class="a2ui-audio"
-      [src]="url()"
-      [autoplay]="autoPlay()"
-      [controls]="controls()"
-    ></audio>
+    <div class="a2ui-audio-wrap">
+      @if (description()) {
+        <span class="a2ui-audio-description">{{ description() }}</span>
+      }
+      <audio
+        class="a2ui-audio"
+        [src]="url()"
+        [autoplay]="autoPlay()"
+        [controls]="controls()"
+      ></audio>
+    </div>
   `,
   styles: [`
+    .a2ui-audio-wrap {
+      display: flex;
+      flex-direction: column;
+      gap: var(--a2ui-spacing-1);
+    }
+    .a2ui-audio-description {
+      font-size: var(--a2ui-typography-caption-size);
+      color: var(--a2ui-on-surface-variant);
+    }
     .a2ui-audio {
       display: block;
       width: 100%;
@@ -22,6 +36,8 @@ import type { Spec } from '@json-render/core';
 })
 export class A2uiAudioPlayerComponent {
   readonly url = input<string>('');
+  /** v1 canonical prop: short description / title rendered above the player. */
+  readonly description = input<string>('');
   /** v1 prop name: autoPlay (camelCase). */
   readonly autoPlay = input<boolean>(false);
   readonly controls = input<boolean>(true);

--- a/libs/chat/src/lib/a2ui/catalog/check-box.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/check-box.component.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-import { Component, input, ChangeDetectionStrategy } from '@angular/core';
+import { Component, computed, input, ChangeDetectionStrategy } from '@angular/core';
 import type { Spec } from '@json-render/core';
 import { emitBinding } from './emit-binding';
 
@@ -9,7 +9,7 @@ import { emitBinding } from './emit-binding';
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <label class="a2ui-cb">
-      <input type="checkbox" [checked]="checked()" (change)="onChange($event)" class="a2ui-cb__input" />
+      <input type="checkbox" [checked]="effectiveValue()" (change)="onChange($event)" class="a2ui-cb__input" />
       {{ label() }}
     </label>
   `,
@@ -32,6 +32,9 @@ import { emitBinding } from './emit-binding';
 })
 export class A2uiCheckBoxComponent {
   readonly label = input<string>('');
+  /** v1 canonical prop: boolean checked state. */
+  readonly value = input<boolean | undefined>(undefined);
+  /** Pre-v1 alias retained for back-compat. */
   readonly checked = input<boolean>(false);
   readonly _bindings = input<Record<string, string>>({});
   readonly emit = input<(event: string) => void>(() => { /* noop */ });
@@ -41,8 +44,17 @@ export class A2uiCheckBoxComponent {
   readonly childKeys = input<string[]>([]);
   readonly spec = input<Spec | undefined>(undefined);
 
+  protected readonly effectiveValue = computed(() => this.value() ?? this.checked());
+
   onChange(event: Event): void {
     const val = (event.target as HTMLInputElement).checked;
-    emitBinding(this.emit(), this._bindings(), 'checked', val);
+    // Emit on whichever binding the surface declared. v1 surfaces use
+    // `value`; pre-v1 used `checked`.
+    const bound = this._bindings();
+    if (bound['value']) {
+      emitBinding(this.emit(), bound, 'value', val);
+    } else {
+      emitBinding(this.emit(), bound, 'checked', val);
+    }
   }
 }

--- a/libs/chat/src/lib/a2ui/catalog/icon.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/icon.component.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-import { Component, input } from '@angular/core';
+import { Component, computed, input } from '@angular/core';
 import type { Spec } from '@json-render/core';
 
 @Component({
@@ -9,7 +9,8 @@ import type { Spec } from '@json-render/core';
     <span
       class="a2ui-icon"
       [style.font-size]="size() ? size() + 'px' : '1.125rem'"
-    >{{ icon() }}</span>
+      [attr.aria-label]="effectiveName()"
+    >{{ effectiveName() }}</span>
   `,
   styles: [`
     .a2ui-icon {
@@ -21,7 +22,9 @@ import type { Spec } from '@json-render/core';
   `],
 })
 export class A2uiIconComponent {
-  /** v1 prop name: icon (resolved string, e.g. a Unicode symbol or ligature name). */
+  /** v1 canonical prop. */
+  readonly name = input<string | undefined>(undefined);
+  /** Pre-v1 alias retained for back-compat. */
   readonly icon = input<string>('');
   readonly size = input<number | null>(null);
   // Framework inputs required by the render harness.
@@ -30,4 +33,6 @@ export class A2uiIconComponent {
   readonly loading = input<boolean>(false);
   readonly childKeys = input<string[]>([]);
   readonly spec = input<Spec | undefined>(undefined);
+
+  protected readonly effectiveName = computed(() => this.name() ?? this.icon());
 }

--- a/libs/chat/src/lib/a2ui/catalog/image.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/image.component.ts
@@ -2,6 +2,23 @@
 import { Component, input } from '@angular/core';
 import type { Spec } from '@json-render/core';
 
+/** v1 fit values mapped 1:1 to CSS object-fit. */
+type ImageFit = 'contain' | 'cover' | 'fill' | 'none' | 'scale-down';
+
+/** v1 usageHint maps to a sizing preset. The component renders fluid by
+ * default; usageHint sets a max-width / aspect-ratio to match common
+ * intents. */
+type ImageUsageHint = 'icon' | 'avatar' | 'smallFeature' | 'mediumFeature' | 'largeFeature' | 'header';
+
+const USAGE_HINT_STYLE: Record<ImageUsageHint, { maxWidth: string; aspectRatio?: string; borderRadius?: string }> = {
+  icon:          { maxWidth: '24px', aspectRatio: '1 / 1' },
+  avatar:        { maxWidth: '48px', aspectRatio: '1 / 1', borderRadius: '50%' },
+  smallFeature:  { maxWidth: '160px' },
+  mediumFeature: { maxWidth: '320px' },
+  largeFeature:  { maxWidth: '480px' },
+  header:        { maxWidth: '100%', aspectRatio: '16 / 5' },
+};
+
 @Component({
   selector: 'a2ui-image',
   standalone: true,
@@ -10,8 +27,12 @@ import type { Spec } from '@json-render/core';
       class="a2ui-img"
       [src]="url()"
       [alt]="alt()"
-      [style.width]="width() ? width() + 'px' : null"
-      [style.height]="height() ? height() + 'px' : null"
+      [style.width]="explicitWidth()"
+      [style.height]="explicitHeight()"
+      [style.object-fit]="fit()"
+      [style.max-width]="hintStyle()?.maxWidth"
+      [style.aspect-ratio]="hintStyle()?.aspectRatio || null"
+      [style.border-radius]="hintStyle()?.borderRadius || null"
     />
   `,
   styles: [`
@@ -27,10 +48,25 @@ export class A2uiImageComponent {
   readonly alt = input<string>('');
   readonly width = input<number | null>(null);
   readonly height = input<number | null>(null);
+  /** v1 prop: CSS object-fit equivalent. */
+  readonly fit = input<ImageFit | undefined>(undefined);
+  /** v1 prop: sizing preset. */
+  readonly usageHint = input<ImageUsageHint | undefined>(undefined);
   // Framework inputs required by the render harness.
   readonly bindings = input<Record<string, string>>({});
   readonly emit = input<(event: string) => void>(() => { /* noop */ });
   readonly loading = input<boolean>(false);
   readonly childKeys = input<string[]>([]);
   readonly spec = input<Spec | undefined>(undefined);
+
+  protected explicitWidth(): string | null {
+    return this.width() != null ? this.width() + 'px' : null;
+  }
+  protected explicitHeight(): string | null {
+    return this.height() != null ? this.height() + 'px' : null;
+  }
+  protected hintStyle(): { maxWidth: string; aspectRatio?: string; borderRadius?: string } | null {
+    const h = this.usageHint();
+    return h ? USAGE_HINT_STYLE[h] : null;
+  }
 }

--- a/libs/chat/src/lib/a2ui/catalog/list.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/list.component.ts
@@ -8,7 +8,7 @@ import { RenderElementComponent } from '@ngaf/render';
   standalone: true,
   imports: [RenderElementComponent],
   template: `
-    <div [class]="listClass()">
+    <div [class]="listClass()" [style.align-items]="alignmentCss()">
       @for (key of childKeys(); track key) {
         <render-element [elementKey]="key" [spec]="spec()" />
       }
@@ -34,6 +34,8 @@ export class A2uiListComponent {
   readonly childKeys = input<string[]>([]);
   readonly spec = input.required<Spec>();
   readonly direction = input<'vertical' | 'horizontal'>('vertical');
+  /** v1 canonical prop: cross-axis alignment. */
+  readonly alignment = input<'start' | 'center' | 'end' | 'stretch' | undefined>(undefined);
   // Framework inputs required by the render harness.
   readonly bindings = input<Record<string, string>>({});
   readonly emit = input<(event: string) => void>(() => { /* noop */ });
@@ -43,5 +45,13 @@ export class A2uiListComponent {
     return this.direction() === 'horizontal'
       ? 'a2ui-list--horizontal'
       : 'a2ui-list--vertical';
+  });
+
+  protected readonly alignmentCss = computed<string | null>(() => {
+    const a = this.alignment();
+    if (!a) return null;
+    return a === 'start' ? 'flex-start'
+         : a === 'end' ? 'flex-end'
+         : a; // center / stretch are valid CSS values as-is
   });
 }

--- a/libs/chat/src/lib/a2ui/surface.component.ts
+++ b/libs/chat/src/lib/a2ui/surface.component.ts
@@ -21,102 +21,12 @@ import { buildA2uiActionMessage } from './build-action-message';
     '[style.--a2ui-primary]': 'primaryColor()',
     '[style.font-family]': 'fontFamily()',
   },
-  styles: [`
-    :host {
-      /* === Spacing scale (4px base) === */
-      --a2ui-spacing-1: 4px;
-      --a2ui-spacing-2: 8px;
-      --a2ui-spacing-3: 12px;
-      --a2ui-spacing-4: 16px;
-      --a2ui-spacing-5: 24px;
-      --a2ui-spacing-6: 32px;
-      --a2ui-spacing-7: 40px;
-
-      /* === Typography (per Text usageHint) === */
-      /* h1 — display heading */
-      --a2ui-typography-h1-size: 32px;
-      --a2ui-typography-h1-weight: 700;
-      --a2ui-typography-h1-line-height: 1.2;
-      /* h2 — section heading */
-      --a2ui-typography-h2-size: 24px;
-      --a2ui-typography-h2-weight: 600;
-      --a2ui-typography-h2-line-height: 1.3;
-      /* h3 — subsection heading */
-      --a2ui-typography-h3-size: 20px;
-      --a2ui-typography-h3-weight: 600;
-      --a2ui-typography-h3-line-height: 1.3;
-      /* h4 */
-      --a2ui-typography-h4-size: 18px;
-      --a2ui-typography-h4-weight: 500;
-      --a2ui-typography-h4-line-height: 1.4;
-      /* h5 */
-      --a2ui-typography-h5-size: 16px;
-      --a2ui-typography-h5-weight: 500;
-      --a2ui-typography-h5-line-height: 1.4;
-      /* body */
-      --a2ui-typography-body-size: 14px;
-      --a2ui-typography-body-weight: 400;
-      --a2ui-typography-body-line-height: 1.5;
-      /* caption */
-      --a2ui-typography-caption-size: 12px;
-      --a2ui-typography-caption-weight: 400;
-      --a2ui-typography-caption-line-height: 1.4;
-      /* label (used by TextField/Slider/etc. labels) */
-      --a2ui-typography-label-size: 12px;
-      --a2ui-typography-label-weight: 500;
-
-      /* === Shape radius === */
-      --a2ui-shape-extra-small: 4px;
-      --a2ui-shape-small: 8px;
-      --a2ui-shape-medium: 12px;
-      --a2ui-shape-large: 16px;
-      --a2ui-shape-extra-large: 28px;
-
-      /* === Focus ring === */
-      --a2ui-focus-ring-color: var(--a2ui-primary);
-      --a2ui-focus-ring-width: 2px;
-
-      /* === Motion === */
-      --a2ui-motion-duration-short: 100ms;
-      --a2ui-motion-duration-medium: 200ms;
-      --a2ui-motion-duration-long: 300ms;
-      --a2ui-motion-easing-standard: cubic-bezier(0.2, 0, 0, 1);
-      --a2ui-motion-easing-emphasized: cubic-bezier(0.2, 0, 0, 1.4);
-
-      /* === Elevation (box-shadow) === */
-      --a2ui-elevation-0: none;
-      --a2ui-elevation-1: 0 1px 2px rgba(0, 0, 0, 0.3);
-      --a2ui-elevation-2: 0 2px 4px rgba(0, 0, 0, 0.35);
-      --a2ui-elevation-3: 0 4px 8px rgba(0, 0, 0, 0.4);
-      --a2ui-elevation-4: 0 8px 16px rgba(0, 0, 0, 0.45);
-      --a2ui-elevation-5: 0 16px 32px rgba(0, 0, 0, 0.5);
-
-      /* === Color === */
-      /* (--a2ui-primary is set by host binding from beginRendering.styles, default below) */
-      --a2ui-primary: #4f8df5;
-      --a2ui-on-primary: #ffffff;
-      --a2ui-primary-hover: #6699f7;
-      --a2ui-secondary: #8a92a3;
-      --a2ui-on-secondary: #ffffff;
-      --a2ui-surface: #1a1d23;
-      --a2ui-on-surface: #ffffff;
-      --a2ui-surface-variant: rgba(255, 255, 255, 0.05);
-      --a2ui-on-surface-variant: rgba(255, 255, 255, 0.7);
-      --a2ui-outline: rgba(255, 255, 255, 0.1);
-      --a2ui-outline-variant: rgba(255, 255, 255, 0.05);
-      --a2ui-error: #f5524f;
-      --a2ui-on-error: #ffffff;
-      --a2ui-scrim: rgba(0, 0, 0, 0.6);
-
-      /* === Carry-over from existing tokens (kept for back-compat) === */
-      --a2ui-card-bg: var(--a2ui-surface);
-      --a2ui-input-bg: var(--a2ui-surface-variant);
-      --a2ui-input-text: var(--a2ui-on-surface);
-      --a2ui-label: var(--a2ui-on-surface-variant);
-      --a2ui-caption: var(--a2ui-on-surface-variant);
-      --a2ui-border: var(--a2ui-outline);
-    }
-  `],
+  // Token defaults live in chat.css at :root so :root[data-theme=...]
+  // preset overrides take precedence (specificity: same selector + a
+  // matching attribute beats bare :root by ~1 specificity unit). The
+  // host bindings above override --a2ui-primary per-surface for the
+  // agent's beginRendering.styles.primaryColor (highest specificity:
+  // inline style).
   template: `
     @if (spec(); as s) {
       <render-spec

--- a/libs/chat/src/lib/styles/chat.css
+++ b/libs/chat/src/lib/styles/chat.css
@@ -46,6 +46,101 @@
   --ngaf-chat-font-size-xs: 0.75rem;
   --ngaf-chat-line-height: 1.6;
   --ngaf-chat-line-height-tight: 1.5;
+
+  /*
+   * === A2UI surface tokens — dark-theme defaults ===
+   *
+   * Declared at :root so :root[data-theme=...] presets win via
+   * attribute-selector specificity, and so consumer overrides at :root
+   * cascade naturally to <a2ui-surface>. The surface component's
+   * agent-binding still wins per-surface (inline style on the host
+   * element from beginRendering.styles.primaryColor).
+   */
+
+  /* Spacing scale (4px base) */
+  --a2ui-spacing-1: 4px;
+  --a2ui-spacing-2: 8px;
+  --a2ui-spacing-3: 12px;
+  --a2ui-spacing-4: 16px;
+  --a2ui-spacing-5: 24px;
+  --a2ui-spacing-6: 32px;
+  --a2ui-spacing-7: 40px;
+
+  /* Typography (per Text usageHint) */
+  --a2ui-typography-h1-size: 32px;
+  --a2ui-typography-h1-weight: 700;
+  --a2ui-typography-h1-line-height: 1.2;
+  --a2ui-typography-h2-size: 24px;
+  --a2ui-typography-h2-weight: 600;
+  --a2ui-typography-h2-line-height: 1.3;
+  --a2ui-typography-h3-size: 20px;
+  --a2ui-typography-h3-weight: 600;
+  --a2ui-typography-h3-line-height: 1.3;
+  --a2ui-typography-h4-size: 18px;
+  --a2ui-typography-h4-weight: 500;
+  --a2ui-typography-h4-line-height: 1.4;
+  --a2ui-typography-h5-size: 16px;
+  --a2ui-typography-h5-weight: 500;
+  --a2ui-typography-h5-line-height: 1.4;
+  --a2ui-typography-body-size: 14px;
+  --a2ui-typography-body-weight: 400;
+  --a2ui-typography-body-line-height: 1.5;
+  --a2ui-typography-caption-size: 12px;
+  --a2ui-typography-caption-weight: 400;
+  --a2ui-typography-caption-line-height: 1.4;
+  --a2ui-typography-label-size: 12px;
+  --a2ui-typography-label-weight: 500;
+
+  /* Shape radius */
+  --a2ui-shape-extra-small: 4px;
+  --a2ui-shape-small: 8px;
+  --a2ui-shape-medium: 12px;
+  --a2ui-shape-large: 16px;
+  --a2ui-shape-extra-large: 28px;
+
+  /* Focus ring */
+  --a2ui-focus-ring-color: var(--a2ui-primary);
+  --a2ui-focus-ring-width: 2px;
+
+  /* Motion */
+  --a2ui-motion-duration-short: 100ms;
+  --a2ui-motion-duration-medium: 200ms;
+  --a2ui-motion-duration-long: 300ms;
+  --a2ui-motion-easing-standard: cubic-bezier(0.2, 0, 0, 1);
+  --a2ui-motion-easing-emphasized: cubic-bezier(0.2, 0, 0, 1.4);
+
+  /* Elevation (box-shadow) */
+  --a2ui-elevation-0: none;
+  --a2ui-elevation-1: 0 1px 2px rgba(0, 0, 0, 0.3);
+  --a2ui-elevation-2: 0 2px 4px rgba(0, 0, 0, 0.35);
+  --a2ui-elevation-3: 0 4px 8px rgba(0, 0, 0, 0.4);
+  --a2ui-elevation-4: 0 8px 16px rgba(0, 0, 0, 0.45);
+  --a2ui-elevation-5: 0 16px 32px rgba(0, 0, 0, 0.5);
+
+  /* Color (--a2ui-primary is also set by host binding from
+   * beginRendering.styles.primaryColor for per-surface override) */
+  --a2ui-primary: #4f8df5;
+  --a2ui-on-primary: #ffffff;
+  --a2ui-primary-hover: #6699f7;
+  --a2ui-secondary: #8a92a3;
+  --a2ui-on-secondary: #ffffff;
+  --a2ui-surface: #1a1d23;
+  --a2ui-on-surface: #ffffff;
+  --a2ui-surface-variant: rgba(255, 255, 255, 0.05);
+  --a2ui-on-surface-variant: rgba(255, 255, 255, 0.7);
+  --a2ui-outline: rgba(255, 255, 255, 0.1);
+  --a2ui-outline-variant: rgba(255, 255, 255, 0.05);
+  --a2ui-error: #f5524f;
+  --a2ui-on-error: #ffffff;
+  --a2ui-scrim: rgba(0, 0, 0, 0.6);
+
+  /* Aliases (kept for back-compat) */
+  --a2ui-card-bg: var(--a2ui-surface);
+  --a2ui-input-bg: var(--a2ui-surface-variant);
+  --a2ui-input-text: var(--a2ui-on-surface);
+  --a2ui-label: var(--a2ui-on-surface-variant);
+  --a2ui-caption: var(--a2ui-on-surface-variant);
+  --a2ui-border: var(--a2ui-outline);
 }
 
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
## Summary

Systematic live-smoke pass against the A2UI catalog using two new \"kitchen sink\" welcome suggestions designed to elicit LLM-generated surfaces that exercise all 18 components across two prompts. Pass uncovered **6 real bugs** — 5 catalog components missing canonical v1 props, plus one cross-cutting theme-cascade specificity inversion.

## Bugs found + fixed

### Component v1-prop gaps (5 NG0303 runtime errors → 0)

| Component | Missing v1 prop(s) | Behavior |
|---|---|---|
| \`Image\` | \`fit\`, \`usageHint\` | Added inputs; \`usageHint\` maps to a sizing preset (max-width / aspect-ratio / border-radius for the avatar circle); \`fit\` passes through to CSS \`object-fit\` |
| \`Icon\` | \`name\` (canonical) | Added as canonical input alongside the pre-v1 \`icon\` alias resolved via \`effectiveName\` computed |
| \`AudioPlayer\` | \`description\` | Added input + caption rendered above the audio control |
| \`List\` | \`alignment\` (start/center/end/stretch) | Added input mapped to flex \`align-items\` |
| \`CheckBox\` | \`value\` (canonical) | Added as canonical input alongside the pre-v1 \`checked\` alias resolved via \`effectiveValue\` computed; emit-binding uses \`value\` when surface declares that path |

### Theme cascade specificity inversion

\`:host\` \`--a2ui-*\` defaults on \`<a2ui-surface>\` won over inherited \`:root[data-theme=...]\` overrides because the host element is closer to the rendered children than \`:root\` in the CSS custom-property inheritance chain. Setting \`:root[data-theme=material-light] { --a2ui-primary: #6750A4 }\` had no effect — the surface kept the lib's default \`#4f8df5\`.

**Fix:** moved the ~50-token defaults block from \`surface.component.ts\` \`:host\` into \`libs/chat/src/lib/styles/chat.css\` \`:root\`. Cascade now works:

1. **\`:root\`** in \`chat.css\` — lib defaults (lowest)
2. **\`:root[data-theme=...]\`** from preset — overrides the lib defaults (slightly higher specificity)
3. **\`<a2ui-surface>\` host inline-style binding** — agent's \`beginRendering.styles.primaryColor\` overrides per-surface (highest, inline)

## New welcome suggestions

- \"Smoke: media + layout kitchen sink\" — exercises Card, Tabs, Column, Row, List, Divider, Text, Image, Icon, Video, AudioPlayer (11 components)
- \"Smoke: interactive form kitchen sink\" — exercises Card, Column, TextField, Slider, CheckBox, DateTimeInput, MultipleChoice, Divider, Row, Button, Modal (11 components, with overlap)

Together they cover all 18 catalog components when the LLM honors the prompts. Intended as the canonical smoke triggers for catalog regression testing.

## Test plan

- [x] \`nx run-many -t test,lint,build -p chat,examples-chat-angular\` — all green
- [x] **Live verified post-fix:** Material light theme correctly applies (\`--a2ui-primary = #6750A4\`, surface = \`#FFFBFE\`), all 18 components render with proper labels and styling, zero NG0303 console errors. Screenshots show: bold \"Profile setup\" Card title, M3 purple Slider/Save button, M3 outline \"Open details\" secondary button, all CheckBox + MultipleChoice labels visible, Divider, DateTimeInput.

🤖 Generated with [Claude Code](https://claude.com/claude-code)