### PR TITLE
fix(examples-chat): responsive shell side panels at <=1024px

### DIFF
--- a/examples/chat/angular/src/app/shell/demo-shell.component.css
+++ b/examples/chat/angular/src/app/shell/demo-shell.component.css
@@ -76,3 +76,28 @@
   flex-direction: column;
   gap: 8px;
 }
+
+/* Narrow the side panels at tablet widths so the chat column keeps a usable
+   minimum (~480px) when both panels are open. */
+@media (max-width: 1024px) {
+  .demo-shell__threads-panel { width: 200px; }
+  .demo-shell__timeline-panel { width: 240px; }
+}
+
+/* Below tablet the fixed side panels would steal too much of the chat
+   surface. Promote them to a centered overlay sheet — still toggle-driven,
+   but full-width modulo gutter, and they stack above the chat instead of
+   crowding it. */
+@media (max-width: 768px) {
+  .demo-shell__threads-panel,
+  .demo-shell__timeline-panel {
+    left: 16px;
+    right: 16px;
+    width: auto;
+    top: 72px;
+    bottom: 112px;
+    border: 1px solid #303540;
+    border-radius: 10px;
+    box-shadow: 0 6px 24px rgba(0, 0, 0, 0.45);
+  }
+}


### PR DESCRIPTION
## Summary
- Smoke pass 2 of the canonical demo found that the threads + timeline side panels are pinned as fixed-width columns with no breakpoints, crowding the chat below ~1024px and overlapping it below ~768px.
- Adds two breakpoints to demo-shell.component.css: narrow at <=1024, promote to a centered floating sheet at <=768.
- No template/TS changes; toggle behaviour identical.

## Findings that drove this
From the smoke pass:

| VW | Threads | Timeline | Central free | Verdict before |
|----|---|---|---|---|
| 1440 | 248 | 296 | 896 | comfortable |
| 1024 | 248 | 296 | 480 | tight |
| 768 | 248 | 296 | 224 | too narrow |
| 480 | 248 | 296 | <0 | overlap |

After this change the central column never drops below ~560px down to 1024, and at 768 and below the panels turn into a sheet that floats above the chat.

## Test plan
- [x] `nx build examples-chat-angular` green
- [ ] DevTools device emulation: 1440 / 1024 / 768 / 480 with both panels toggled
- [ ] Toggle both panels at 768 — verify sheet styling and no overlap with composer

🤖 Generated with [Claude Code](https://claude.com/claude-code)