### PR TITLE
feat(chat,langgraph): nav v2 — thread drawer + checkpoint marker primitives

### DIFF
--- a/apps/website/content/docs/agent/api/api-docs.json
+++ b/apps/website/content/docs/agent/api/api-docs.json
@@ -929,6 +929,12 @@
         "optional": false
       },
       {
+        "name": "messageCheckpoints",
+        "type": "Signal<ReadonlyMap<string, string>>",
+        "description": "Optional reactive map of `messageId → checkpointId`, computed by\nwalking history once: for each checkpoint, find the most recent\nassistant message present in its `values.messages` and pair them.\nUIs use this to anchor inline checkpoint markers on each assistant\nturn. Missing on adapters that don't compute it.",
+        "optional": true
+      },
+      {
         "name": "messages",
         "type": "Signal<Message[]>",
         "description": "",
@@ -1291,6 +1297,12 @@
         "type": "WritableSignal<ToolCallWithResult<>[]>",
         "description": "Raw LangGraph tool calls (with run-state). Use `toolCalls` for chat rendering.",
         "optional": false
+      },
+      {
+        "name": "messageCheckpoints",
+        "type": "Signal<ReadonlyMap<string, string>>",
+        "description": "Optional reactive map of `messageId → checkpointId`, computed by\nwalking history once: for each checkpoint, find the most recent\nassistant message present in its `values.messages` and pair them.\nUIs use this to anchor inline checkpoint markers on each assistant\nturn. Missing on adapters that don't compute it.",
+        "optional": true
       },
       {
         "name": "messages",

--- a/apps/website/content/docs/chat/api/api-docs.json
+++ b/apps/website/content/docs/chat/api/api-docs.json
@@ -1439,6 +1439,40 @@
     "methods": []
   },
   {
+    "name": "ChatCheckpointMarkerComponent",
+    "kind": "class",
+    "description": "",
+    "params": [],
+    "examples": [],
+    "properties": [
+      {
+        "name": "checkpointId",
+        "type": "InputSignal<string>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "forkRequested",
+        "type": "OutputEmitterRef<string>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "isActive",
+        "type": "InputSignal<boolean>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "replayRequested",
+        "type": "OutputEmitterRef<string>",
+        "description": "",
+        "optional": false
+      }
+    ],
+    "methods": []
+  },
+  {
     "name": "ChatCitationCardTemplateDirective",
     "kind": "class",
     "description": "ContentChild template directive for custom citation card rendering.\nUsage: <ng-template chatCitationCard let-citation>...</ng-template>",
@@ -1803,7 +1837,7 @@
     "properties": [
       {
         "name": "agent",
-        "type": "InputSignal<AgentWithHistory>",
+        "type": "InputSignal<AgentWithHistory<unknown>>",
         "description": "",
         "optional": false
       },
@@ -2237,6 +2271,18 @@
         "optional": false
       },
       {
+        "name": "checkpointActive",
+        "type": "InputSignal<boolean>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "checkpointId",
+        "type": "InputSignal<string | undefined>",
+        "description": "Optional checkpoint id to anchor a gutter marker. When set, a\n chat-checkpoint-marker is rendered in the left gutter and emits\n bubble through this component's replayRequested / forkRequested outputs.",
+        "optional": false
+      },
+      {
         "name": "current",
         "type": "InputSignal<boolean>",
         "description": "",
@@ -2249,6 +2295,12 @@
         "optional": false
       },
       {
+        "name": "forkRequested",
+        "type": "OutputEmitterRef<string>",
+        "description": "",
+        "optional": false
+      },
+      {
         "name": "message",
         "type": "InputSignal<Message | undefined>",
         "description": "",
@@ -2257,6 +2309,12 @@
       {
         "name": "prevRole",
         "type": "InputSignal<ChatMessageRole | undefined>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "replayRequested",
+        "type": "OutputEmitterRef<string>",
         "description": "",
         "optional": false
       },
@@ -2729,6 +2787,34 @@
     "methods": []
   },
   {
+    "name": "ChatThreadDrawerComponent",
+    "kind": "class",
+    "description": "",
+    "params": [],
+    "examples": [],
+    "properties": [
+      {
+        "name": "mode",
+        "type": "InputSignal<ChatThreadDrawerMode>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "open",
+        "type": "InputSignal<boolean>",
+        "description": "",
+        "optional": false
+      },
+      {
+        "name": "openChange",
+        "type": "OutputEmitterRef<boolean>",
+        "description": "",
+        "optional": false
+      }
+    ],
+    "methods": []
+  },
+  {
     "name": "ChatThreadListComponent",
     "kind": "class",
     "description": "",
@@ -2774,6 +2860,19 @@
     ],
     "methods": [
       {
+        "name": "relativeTime",
+        "signature": "relativeTime(epochMs: number)",
+        "description": "",
+        "params": [
+          {
+            "name": "epochMs",
+            "type": "number",
+            "description": "",
+            "optional": false
+          }
+        ]
+      },
+      {
         "name": "selectThread",
         "signature": "selectThread(threadId: string)",
         "description": "",
@@ -2810,7 +2909,7 @@
     "properties": [
       {
         "name": "agent",
-        "type": "InputSignal<AgentWithHistory>",
+        "type": "InputSignal<AgentWithHistory<unknown>>",
         "description": "",
         "optional": false
       },
@@ -2858,7 +2957,7 @@
     "properties": [
       {
         "name": "agent",
-        "type": "InputSignal<AgentWithHistory>",
+        "type": "InputSignal<AgentWithHistory<unknown>>",
         "description": "",
         "optional": false
       },
@@ -4140,7 +4239,7 @@
   {
     "name": "AgentWithHistory",
     "kind": "interface",
-    "description": "Extends Agent with a required `history` signal.\n\nCompositions that need time-travel / checkpoint data (chat-timeline,\nchat-debug) take this richer contract. Adapters that cannot supply\nhistory should return plain Agent instead of stubbing an empty array.",
+    "description": "Extension of Agent that exposes checkpoint history for time-travel UIs.\n\nConcrete adapters that record per-node checkpoints (e.g. LangGraph) should\nimplement this. Pure request/response runtimes that don't have checkpoints\nshould implement plain Agent.",
     "properties": [
       {
         "name": "error",
@@ -4171,6 +4270,12 @@
         "type": "Signal<boolean>",
         "description": "",
         "optional": false
+      },
+      {
+        "name": "messageCheckpoints",
+        "type": "Signal<ReadonlyMap<string, string>>",
+        "description": "Optional reactive map of `messageId → checkpointId`, computed by\nwalking history once: for each checkpoint, find the most recent\nassistant message present in its `values.messages` and pair them.\nUIs use this to anchor inline checkpoint markers on each assistant\nturn. Missing on adapters that don't compute it.",
+        "optional": true
       },
       {
         "name": "messages",
@@ -4904,6 +5009,13 @@
     "kind": "type",
     "description": "",
     "signature": "\"user\" | \"assistant\" | \"system\" | \"tool\"",
+    "examples": []
+  },
+  {
+    "name": "ChatThreadDrawerMode",
+    "kind": "type",
+    "description": "",
+    "signature": "\"push\" | \"overlay\"",
     "examples": []
   },
   {

--- a/apps/website/content/docs/chat/api/api-docs.json
+++ b/apps/website/content/docs/chat/api/api-docs.json
@@ -1837,7 +1837,7 @@
     "properties": [
       {
         "name": "agent",
-        "type": "InputSignal<AgentWithHistory<unknown>>",
+        "type": "InputSignal<AgentWithHistory>",
         "description": "",
         "optional": false
       },
@@ -2909,7 +2909,7 @@
     "properties": [
       {
         "name": "agent",
-        "type": "InputSignal<AgentWithHistory<unknown>>",
+        "type": "InputSignal<AgentWithHistory>",
         "description": "",
         "optional": false
       },
@@ -2957,7 +2957,7 @@
     "properties": [
       {
         "name": "agent",
-        "type": "InputSignal<AgentWithHistory<unknown>>",
+        "type": "InputSignal<AgentWithHistory>",
         "description": "",
         "optional": false
       },

--- a/libs/chat/src/lib/agent/agent-with-history.ts
+++ b/libs/chat/src/lib/agent/agent-with-history.ts
@@ -4,12 +4,20 @@ import type { Agent } from './agent';
 import type { AgentCheckpoint } from './agent-checkpoint';
 
 /**
- * Extends Agent with a required `history` signal.
+ * Extension of Agent that exposes checkpoint history for time-travel UIs.
  *
- * Compositions that need time-travel / checkpoint data (chat-timeline,
- * chat-debug) take this richer contract. Adapters that cannot supply
- * history should return plain Agent instead of stubbing an empty array.
+ * Concrete adapters that record per-node checkpoints (e.g. LangGraph) should
+ * implement this. Pure request/response runtimes that don't have checkpoints
+ * should implement plain Agent.
  */
-export interface AgentWithHistory extends Agent {
+export interface AgentWithHistory<S = unknown> extends Agent {
   history: Signal<AgentCheckpoint[]>;
+  /**
+   * Optional reactive map of `messageId → checkpointId`, computed by
+   * walking history once: for each checkpoint, find the most recent
+   * assistant message present in its `values.messages` and pair them.
+   * UIs use this to anchor inline checkpoint markers on each assistant
+   * turn. Missing on adapters that don't compute it.
+   */
+  messageCheckpoints?: Signal<ReadonlyMap<string, string>>;
 }

--- a/libs/chat/src/lib/agent/agent-with-history.ts
+++ b/libs/chat/src/lib/agent/agent-with-history.ts
@@ -10,7 +10,7 @@ import type { AgentCheckpoint } from './agent-checkpoint';
  * implement this. Pure request/response runtimes that don't have checkpoints
  * should implement plain Agent.
  */
-export interface AgentWithHistory<S = unknown> extends Agent {
+export interface AgentWithHistory extends Agent {
   history: Signal<AgentCheckpoint[]>;
   /**
    * Optional reactive map of `messageId → checkpointId`, computed by

--- a/libs/chat/src/lib/compositions/chat-thread-drawer/chat-thread-drawer.component.spec.ts
+++ b/libs/chat/src/lib/compositions/chat-thread-drawer/chat-thread-drawer.component.spec.ts
@@ -1,0 +1,82 @@
+// libs/chat/src/lib/compositions/chat-thread-drawer/chat-thread-drawer.component.spec.ts
+// SPDX-License-Identifier: MIT
+import { describe, it, expect, beforeEach } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { Component } from '@angular/core';
+import { ChatThreadDrawerComponent } from './chat-thread-drawer.component';
+
+@Component({
+  standalone: true,
+  imports: [ChatThreadDrawerComponent],
+  template: `<chat-thread-drawer
+    [open]="open"
+    [mode]="mode"
+    (openChange)="onOpenChange($event)">
+    <div data-testid="drawer-body">child content</div>
+  </chat-thread-drawer>`,
+})
+class HostComponent {
+  open = false;
+  mode: 'push' | 'overlay' = 'push';
+  changes: boolean[] = [];
+  onOpenChange(v: boolean): void { this.changes.push(v); }
+}
+
+describe('ChatThreadDrawerComponent', () => {
+  beforeEach(() => TestBed.configureTestingModule({ imports: [HostComponent] }));
+
+  it('hides the drawer when open=false (translated off-screen)', () => {
+    const fx = TestBed.createComponent(HostComponent);
+    fx.detectChanges();
+    const drawer = fx.nativeElement.querySelector('.chat-thread-drawer') as HTMLElement;
+    expect(drawer.getAttribute('data-open')).toBe('false');
+  });
+
+  it('shows the drawer when open=true', () => {
+    const fx = TestBed.createComponent(HostComponent);
+    fx.componentInstance.open = true;
+    fx.detectChanges();
+    expect(fx.nativeElement.querySelector('.chat-thread-drawer').getAttribute('data-open')).toBe('true');
+  });
+
+  it('renders no scrim in push mode', () => {
+    const fx = TestBed.createComponent(HostComponent);
+    fx.componentInstance.open = true;
+    fx.componentInstance.mode = 'push';
+    fx.detectChanges();
+    expect(fx.nativeElement.querySelector('.chat-thread-drawer__scrim')).toBeNull();
+  });
+
+  it('renders a scrim in overlay mode when open', () => {
+    const fx = TestBed.createComponent(HostComponent);
+    fx.componentInstance.open = true;
+    fx.componentInstance.mode = 'overlay';
+    fx.detectChanges();
+    expect(fx.nativeElement.querySelector('.chat-thread-drawer__scrim')).toBeTruthy();
+  });
+
+  it('scrim click emits openChange(false)', () => {
+    const fx = TestBed.createComponent(HostComponent);
+    fx.componentInstance.open = true;
+    fx.componentInstance.mode = 'overlay';
+    fx.detectChanges();
+    (fx.nativeElement.querySelector('.chat-thread-drawer__scrim') as HTMLElement).click();
+    expect(fx.componentInstance.changes).toEqual([false]);
+  });
+
+  it('Escape keydown on drawer host emits openChange(false)', () => {
+    const fx = TestBed.createComponent(HostComponent);
+    fx.componentInstance.open = true;
+    fx.detectChanges();
+    const drawer = fx.nativeElement.querySelector('.chat-thread-drawer') as HTMLElement;
+    drawer.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(fx.componentInstance.changes).toEqual([false]);
+  });
+
+  it('projects child content into the drawer body', () => {
+    const fx = TestBed.createComponent(HostComponent);
+    fx.componentInstance.open = true;
+    fx.detectChanges();
+    expect(fx.nativeElement.querySelector('[data-testid="drawer-body"]')).toBeTruthy();
+  });
+});

--- a/libs/chat/src/lib/compositions/chat-thread-drawer/chat-thread-drawer.component.ts
+++ b/libs/chat/src/lib/compositions/chat-thread-drawer/chat-thread-drawer.component.ts
@@ -1,0 +1,67 @@
+// libs/chat/src/lib/compositions/chat-thread-drawer/chat-thread-drawer.component.ts
+// SPDX-License-Identifier: MIT
+import {
+  Component, ChangeDetectionStrategy, input, output,
+} from '@angular/core';
+import { CHAT_HOST_TOKENS } from '../../styles/chat-tokens';
+
+export type ChatThreadDrawerMode = 'push' | 'overlay';
+
+@Component({
+  selector: 'chat-thread-drawer',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  styles: [CHAT_HOST_TOKENS, `
+    :host {
+      --chat-thread-drawer-width: 280px;
+      display: contents;
+    }
+    .chat-thread-drawer__scrim {
+      position: fixed;
+      inset: 0;
+      background: rgba(0, 0, 0, 0.4);
+      z-index: 1000;
+    }
+    .chat-thread-drawer {
+      position: fixed;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      width: var(--chat-thread-drawer-width);
+      background: var(--ngaf-chat-bg);
+      border-right: 1px solid var(--ngaf-chat-separator);
+      z-index: 1001;
+      transform: translateX(-100%);
+      transition: transform 200ms ease;
+      overflow-y: auto;
+      display: flex;
+      flex-direction: column;
+    }
+    .chat-thread-drawer[data-open="true"] { transform: translateX(0); }
+    @media (max-width: 767px) {
+      .chat-thread-drawer { width: 100%; }
+    }
+  `],
+  template: `
+    @if (open() && mode() === 'overlay') {
+      <div class="chat-thread-drawer__scrim" (click)="openChange.emit(false)"></div>
+    }
+    <aside
+      class="chat-thread-drawer"
+      role="dialog"
+      aria-label="Conversations"
+      tabindex="-1"
+      [attr.data-open]="open() ? 'true' : 'false'"
+      [attr.data-mode]="mode()"
+      (keydown.escape)="openChange.emit(false)"
+    >
+      <ng-content />
+    </aside>
+  `,
+})
+export class ChatThreadDrawerComponent {
+  readonly open = input.required<boolean>();
+  readonly mode = input<ChatThreadDrawerMode>('push');
+
+  readonly openChange = output<boolean>();
+}

--- a/libs/chat/src/lib/compositions/chat-thread-drawer/chat-thread-drawer.component.ts
+++ b/libs/chat/src/lib/compositions/chat-thread-drawer/chat-thread-drawer.component.ts
@@ -21,6 +21,9 @@ export type ChatThreadDrawerMode = 'push' | 'overlay';
       inset: 0;
       background: rgba(0, 0, 0, 0.4);
       z-index: 1000;
+      border: 0;
+      padding: 0;
+      cursor: pointer;
     }
     .chat-thread-drawer {
       position: fixed;
@@ -44,7 +47,12 @@ export type ChatThreadDrawerMode = 'push' | 'overlay';
   `],
   template: `
     @if (open() && mode() === 'overlay') {
-      <div class="chat-thread-drawer__scrim" (click)="openChange.emit(false)"></div>
+      <button
+        type="button"
+        class="chat-thread-drawer__scrim"
+        aria-label="Close conversations"
+        (click)="openChange.emit(false)"
+      ></button>
     }
     <aside
       class="chat-thread-drawer"

--- a/libs/chat/src/lib/primitives/chat-checkpoint-marker/chat-checkpoint-marker.component.spec.ts
+++ b/libs/chat/src/lib/primitives/chat-checkpoint-marker/chat-checkpoint-marker.component.spec.ts
@@ -1,0 +1,58 @@
+// libs/chat/src/lib/primitives/chat-checkpoint-marker/chat-checkpoint-marker.component.spec.ts
+// SPDX-License-Identifier: MIT
+import { describe, it, expect, beforeEach } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { Component } from '@angular/core';
+import { ChatCheckpointMarkerComponent } from './chat-checkpoint-marker.component';
+
+@Component({
+  standalone: true,
+  imports: [ChatCheckpointMarkerComponent],
+  template: `<chat-checkpoint-marker
+    [checkpointId]="cpId"
+    [isActive]="active"
+    (replayRequested)="onReplay($event)"
+    (forkRequested)="onFork($event)" />`,
+})
+class HostComponent {
+  cpId = 'cp-1';
+  active = false;
+  replayed: string[] = [];
+  forked: string[] = [];
+  onReplay(id: string): void { this.replayed.push(id); }
+  onFork(id: string): void { this.forked.push(id); }
+}
+
+describe('ChatCheckpointMarkerComponent', () => {
+  beforeEach(() => TestBed.configureTestingModule({ imports: [HostComponent] }));
+
+  it('renders a dot button labelled with the checkpoint id', () => {
+    const fx = TestBed.createComponent(HostComponent);
+    fx.detectChanges();
+    const dot = fx.nativeElement.querySelector('.chat-checkpoint-marker__dot') as HTMLButtonElement;
+    expect(dot).toBeTruthy();
+    expect(dot.getAttribute('aria-label')).toContain('cp-1');
+  });
+
+  it('applies the active class when isActive=true', () => {
+    const fx = TestBed.createComponent(HostComponent);
+    fx.componentInstance.active = true;
+    fx.detectChanges();
+    const dot = fx.nativeElement.querySelector('.chat-checkpoint-marker__dot');
+    expect(dot.getAttribute('data-active')).toBe('true');
+  });
+
+  it('emits replayRequested with the checkpointId when Rewind is clicked', () => {
+    const fx = TestBed.createComponent(HostComponent);
+    fx.detectChanges();
+    (fx.nativeElement.querySelector('[data-action="rewind"]') as HTMLButtonElement).click();
+    expect(fx.componentInstance.replayed).toEqual(['cp-1']);
+  });
+
+  it('emits forkRequested with the checkpointId when Fork is clicked', () => {
+    const fx = TestBed.createComponent(HostComponent);
+    fx.detectChanges();
+    (fx.nativeElement.querySelector('[data-action="fork"]') as HTMLButtonElement).click();
+    expect(fx.componentInstance.forked).toEqual(['cp-1']);
+  });
+});

--- a/libs/chat/src/lib/primitives/chat-checkpoint-marker/chat-checkpoint-marker.component.ts
+++ b/libs/chat/src/lib/primitives/chat-checkpoint-marker/chat-checkpoint-marker.component.ts
@@ -1,0 +1,107 @@
+// libs/chat/src/lib/primitives/chat-checkpoint-marker/chat-checkpoint-marker.component.ts
+// SPDX-License-Identifier: MIT
+import {
+  Component, ChangeDetectionStrategy, input, output,
+} from '@angular/core';
+import { CHAT_HOST_TOKENS } from '../../styles/chat-tokens';
+
+@Component({
+  selector: 'chat-checkpoint-marker',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  styles: [CHAT_HOST_TOKENS, `
+    :host {
+      display: inline-flex;
+      align-items: center;
+      width: 14px;
+      height: 100%;
+      flex: 0 0 14px;
+    }
+    .chat-checkpoint-marker__dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      padding: 0;
+      cursor: pointer;
+      background: transparent;
+      box-shadow: inset 0 0 0 1px var(--a2ui-primary, var(--ngaf-chat-primary));
+      transition: background 120ms ease;
+      position: relative;
+    }
+    .chat-checkpoint-marker__dot:hover,
+    .chat-checkpoint-marker__dot:focus-visible {
+      background: var(--a2ui-primary, var(--ngaf-chat-primary));
+      outline: none;
+    }
+    .chat-checkpoint-marker__dot[data-active="true"] {
+      background: var(--a2ui-primary, var(--ngaf-chat-primary));
+    }
+    .chat-checkpoint-marker__pill {
+      position: absolute;
+      left: 18px;
+      top: 50%;
+      transform: translateY(-50%);
+      display: none;
+      gap: 6px;
+      padding: 4px 8px;
+      background: var(--ngaf-chat-surface-alt);
+      border: 1px solid var(--ngaf-chat-separator);
+      border-radius: var(--ngaf-chat-radius-button);
+      white-space: nowrap;
+      font-size: 11px;
+      z-index: 5;
+    }
+    .chat-checkpoint-marker__dot:hover + .chat-checkpoint-marker__pill,
+    .chat-checkpoint-marker__dot:focus-visible + .chat-checkpoint-marker__pill,
+    .chat-checkpoint-marker__pill:hover {
+      display: inline-flex;
+    }
+    @media (pointer: coarse) {
+      .chat-checkpoint-marker__dot:hover + .chat-checkpoint-marker__pill,
+      .chat-checkpoint-marker__dot:focus-visible + .chat-checkpoint-marker__pill {
+        display: none;
+      }
+      .chat-checkpoint-marker__dot[data-open="true"] + .chat-checkpoint-marker__pill {
+        display: inline-flex;
+      }
+    }
+    .chat-checkpoint-marker__action {
+      background: transparent;
+      border: 0;
+      color: var(--ngaf-chat-text);
+      cursor: pointer;
+      padding: 2px 4px;
+      font-size: 11px;
+    }
+    .chat-checkpoint-marker__action:hover { color: var(--a2ui-primary, var(--ngaf-chat-primary)); }
+  `],
+  template: `
+    <button
+      type="button"
+      class="chat-checkpoint-marker__dot"
+      [attr.data-active]="isActive() ? 'true' : null"
+      [attr.aria-label]="'Checkpoint ' + checkpointId()"
+    ></button>
+    <span class="chat-checkpoint-marker__pill" role="group" aria-label="Checkpoint actions">
+      <button
+        type="button"
+        class="chat-checkpoint-marker__action"
+        data-action="rewind"
+        (click)="replayRequested.emit(checkpointId())"
+      >↶ Rewind</button>
+      <button
+        type="button"
+        class="chat-checkpoint-marker__action"
+        data-action="fork"
+        (click)="forkRequested.emit(checkpointId())"
+      >⑂ Fork</button>
+    </span>
+  `,
+})
+export class ChatCheckpointMarkerComponent {
+  readonly checkpointId = input.required<string>();
+  readonly isActive = input<boolean>(false);
+
+  readonly replayRequested = output<string>();
+  readonly forkRequested = output<string>();
+}

--- a/libs/chat/src/lib/primitives/chat-message/chat-message.component.spec.ts
+++ b/libs/chat/src/lib/primitives/chat-message/chat-message.component.spec.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 import { describe, it, expect } from 'vitest';
 import { TestBed } from '@angular/core/testing';
+import { Component } from '@angular/core';
 import { ChatMessageComponent } from './chat-message.component';
 import { CitationsResolverService } from '../../markdown/citations-resolver.service';
 
@@ -13,5 +14,57 @@ describe('ChatMessageComponent', () => {
       component = new ChatMessageComponent();
     });
     expect(component).toBeTruthy();
+  });
+});
+
+@Component({
+  standalone: true,
+  imports: [ChatMessageComponent],
+  template: `<chat-message
+    role="assistant"
+    [checkpointId]="cpId"
+    (replayRequested)="replayed.push($event)"
+    (forkRequested)="forked.push($event)">Hello</chat-message>`,
+})
+class GutterHost {
+  cpId: string | undefined = undefined;
+  replayed: string[] = [];
+  forked: string[] = [];
+}
+
+describe('ChatMessageComponent — gutter checkpoint marker', () => {
+  it('does not render a marker when checkpointId is unset', () => {
+    TestBed.configureTestingModule({ imports: [GutterHost] });
+    const fx = TestBed.createComponent(GutterHost);
+    fx.detectChanges();
+    expect(fx.nativeElement.querySelector('chat-checkpoint-marker')).toBeNull();
+  });
+
+  it('renders a marker in the gutter when checkpointId is set', () => {
+    TestBed.configureTestingModule({ imports: [GutterHost] });
+    const fx = TestBed.createComponent(GutterHost);
+    fx.componentInstance.cpId = 'cp-99';
+    fx.detectChanges();
+    const marker = fx.nativeElement.querySelector('chat-checkpoint-marker');
+    expect(marker).toBeTruthy();
+    expect(marker.querySelector('[aria-label]').getAttribute('aria-label')).toContain('cp-99');
+  });
+
+  it('bubbles replayRequested from the marker as a message-level output', () => {
+    TestBed.configureTestingModule({ imports: [GutterHost] });
+    const fx = TestBed.createComponent(GutterHost);
+    fx.componentInstance.cpId = 'cp-99';
+    fx.detectChanges();
+    (fx.nativeElement.querySelector('[data-action="rewind"]') as HTMLButtonElement).click();
+    expect(fx.componentInstance.replayed).toEqual(['cp-99']);
+  });
+
+  it('bubbles forkRequested from the marker as a message-level output', () => {
+    TestBed.configureTestingModule({ imports: [GutterHost] });
+    const fx = TestBed.createComponent(GutterHost);
+    fx.componentInstance.cpId = 'cp-99';
+    fx.detectChanges();
+    (fx.nativeElement.querySelector('[data-action="fork"]') as HTMLButtonElement).click();
+    expect(fx.componentInstance.forked).toEqual(['cp-99']);
   });
 });

--- a/libs/chat/src/lib/primitives/chat-message/chat-message.component.ts
+++ b/libs/chat/src/lib/primitives/chat-message/chat-message.component.ts
@@ -1,9 +1,10 @@
 // libs/chat/src/lib/primitives/chat-message/chat-message.component.ts
 // SPDX-License-Identifier: MIT
-import { Component, ChangeDetectionStrategy, input, computed, effect, inject } from '@angular/core';
+import { Component, ChangeDetectionStrategy, input, output, computed, effect, inject } from '@angular/core';
 import { CHAT_HOST_TOKENS } from '../../styles/chat-tokens';
 import { CHAT_MESSAGE_STYLES } from '../../styles/chat-message.styles';
 import { ChatCitationsComponent } from '../chat-citations/chat-citations.component';
+import { ChatCheckpointMarkerComponent } from '../chat-checkpoint-marker/chat-checkpoint-marker.component';
 import { CitationsResolverService } from '../../markdown/citations-resolver.service';
 import type { Message } from '../../agent/message';
 
@@ -12,9 +13,14 @@ export type ChatMessageRole = 'user' | 'assistant' | 'system' | 'tool';
 @Component({
   selector: 'chat-message',
   standalone: true,
-  imports: [ChatCitationsComponent],
+  imports: [ChatCitationsComponent, ChatCheckpointMarkerComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  styles: [CHAT_HOST_TOKENS, CHAT_MESSAGE_STYLES],
+  styles: [CHAT_HOST_TOKENS, CHAT_MESSAGE_STYLES, `
+    .chat-message__layout { display: flex; gap: 8px; align-items: flex-start; }
+    .chat-message__gutter { flex: 0 0 14px; display: flex; align-items: flex-start; padding-top: 4px; }
+    .chat-message__gutter:empty { flex-basis: 0; }
+    .chat-message__main { flex: 1; min-width: 0; }
+  `],
   providers: [CitationsResolverService],
   host: {
     '[attr.data-role]': 'role()',
@@ -23,15 +29,29 @@ export type ChatMessageRole = 'user' | 'assistant' | 'system' | 'tool';
     '[attr.data-prev-role]': 'prevRole() ?? null',
   },
   template: `
-    <div [class]="bodyClass()">
-      <ng-content />
-      <span class="chat-message__caret" aria-hidden="true"></span>
-    </div>
-    @if (message()?.role === 'assistant' && message(); as msg) {
-      <chat-citations [message]="msg" />
-    }
-    <div class="chat-message__controls">
-      <ng-content select="[chatMessageControls]" />
+    <div class="chat-message__layout">
+      <div class="chat-message__gutter">
+        @if (checkpointId(); as cpId) {
+          <chat-checkpoint-marker
+            [checkpointId]="cpId"
+            [isActive]="checkpointActive()"
+            (replayRequested)="replayRequested.emit($event)"
+            (forkRequested)="forkRequested.emit($event)"
+          />
+        }
+      </div>
+      <div class="chat-message__main">
+        <div [class]="bodyClass()">
+          <ng-content />
+          <span class="chat-message__caret" aria-hidden="true"></span>
+        </div>
+        @if (message()?.role === 'assistant' && message(); as msg) {
+          <chat-citations [message]="msg" />
+        }
+        <div class="chat-message__controls">
+          <ng-content select="[chatMessageControls]" />
+        </div>
+      </div>
     </div>
   `,
 })
@@ -41,6 +61,15 @@ export class ChatMessageComponent {
   readonly streaming = input(false);
   readonly prevRole = input<ChatMessageRole | undefined>(undefined);
   readonly message = input<Message | undefined>(undefined);
+
+  /** Optional checkpoint id to anchor a gutter marker. When set, a
+   *  chat-checkpoint-marker is rendered in the left gutter and emits
+   *  bubble through this component's replayRequested / forkRequested outputs. */
+  readonly checkpointId = input<string | undefined>(undefined);
+  readonly checkpointActive = input<boolean>(false);
+
+  readonly replayRequested = output<string>();
+  readonly forkRequested = output<string>();
 
   private readonly resolver = inject(CitationsResolverService);
 

--- a/libs/chat/src/lib/primitives/chat-thread-list/chat-thread-list.component.spec.ts
+++ b/libs/chat/src/lib/primitives/chat-thread-list/chat-thread-list.component.spec.ts
@@ -77,3 +77,44 @@ describe('ChatThreadListComponent — structure', () => {
     expect(threads$()).toHaveLength(3);
   });
 });
+
+describe('ChatThreadListComponent — default item template', () => {
+  // Helper function that mirrors the component's relativeTime method
+  const relativeTime = (epochMs: number): string => {
+    const delta = Date.now() - epochMs;
+    if (delta < 60_000) return 'just now';
+    if (delta < 3_600_000) return `${Math.floor(delta / 60_000)} min ago`;
+    if (delta < 86_400_000) return `${Math.floor(delta / 3_600_000)} hr ago`;
+    return `${Math.floor(delta / 86_400_000)} day ago`;
+  };
+
+  it('Thread type includes optional updatedAt field', () => {
+    const threadWithTime: Thread = { id: 'a', title: 'Test', updatedAt: Date.now() };
+    const threadWithoutTime: Thread = { id: 'b', title: 'Test' };
+    expect(threadWithTime.updatedAt).toBeDefined();
+    expect(threadWithoutTime.updatedAt).toBeUndefined();
+  });
+
+  it('relativeTime returns "just now" for < 60s delta', () => {
+    const now = Date.now();
+    expect(relativeTime(now - 30_000)).toBe('just now');
+  });
+
+  it('relativeTime returns "X min ago" for < 1h delta', () => {
+    const now = Date.now();
+    const result = relativeTime(now - 300_000); // 5 min ago
+    expect(result).toMatch(/\d+ min ago/);
+  });
+
+  it('relativeTime returns "X hr ago" for < 1d delta', () => {
+    const now = Date.now();
+    const result = relativeTime(now - 7_200_000); // 2 hr ago
+    expect(result).toMatch(/\d+ hr ago/);
+  });
+
+  it('relativeTime returns "X day ago" for >= 1d delta', () => {
+    const now = Date.now();
+    const result = relativeTime(now - 172_800_000); // 2 day ago
+    expect(result).toMatch(/\d+ day ago/);
+  });
+});

--- a/libs/chat/src/lib/primitives/chat-thread-list/chat-thread-list.component.ts
+++ b/libs/chat/src/lib/primitives/chat-thread-list/chat-thread-list.component.ts
@@ -50,7 +50,7 @@ export type Thread = {
               (click)="selectThread(thread.id)"
             >
               <span class="chat-thread-list__item-title">{{ threadLabel(thread) }}</span>
-              @if (thread.updatedAt != null) {
+              @if (thread.updatedAt !== undefined) {
                 <span class="chat-thread-list__item-time">{{ relativeTime(thread.updatedAt) }}</span>
               }
             </button>

--- a/libs/chat/src/lib/primitives/chat-thread-list/chat-thread-list.component.ts
+++ b/libs/chat/src/lib/primitives/chat-thread-list/chat-thread-list.component.ts
@@ -12,7 +12,16 @@ import { NgTemplateOutlet } from '@angular/common';
 import { CHAT_HOST_TOKENS } from '../../styles/chat-tokens';
 import { CHAT_THREAD_LIST_STYLES } from '../../styles/chat-thread-list.styles';
 
-export type Thread = { id: string; [key: string]: unknown };
+export type Thread = {
+  id: string;
+  /** Optional human-friendly label. Falls back to a slice of the id. */
+  title?: string;
+  /** Optional epoch-ms timestamp used by the default item template to
+   *  render a relative-time line ("just now" / "5 min ago"). When absent
+   *  the default template omits the second line. */
+  updatedAt?: number;
+  [key: string]: unknown;
+};
 
 @Component({
   selector: 'chat-thread-list',
@@ -39,7 +48,12 @@ export type Thread = { id: string; [key: string]: unknown };
               [attr.data-active]="thread.id === activeThreadId() ? 'true' : null"
               [attr.aria-current]="thread.id === activeThreadId() ? 'true' : null"
               (click)="selectThread(thread.id)"
-            >{{ threadLabel(thread) }}</button>
+            >
+              <span class="chat-thread-list__item-title">{{ threadLabel(thread) }}</span>
+              @if (thread.updatedAt != null) {
+                <span class="chat-thread-list__item-time">{{ relativeTime(thread.updatedAt) }}</span>
+              }
+            </button>
           }
         </li>
       }
@@ -64,5 +78,13 @@ export class ChatThreadListComponent {
     const title = thread['title'];
     if (typeof title === 'string' && title.length > 0) return title;
     return thread.id;
+  }
+
+  protected relativeTime(epochMs: number): string {
+    const delta = Date.now() - epochMs;
+    if (delta < 60_000) return 'just now';
+    if (delta < 3_600_000) return `${Math.floor(delta / 60_000)} min ago`;
+    if (delta < 86_400_000) return `${Math.floor(delta / 3_600_000)} hr ago`;
+    return `${Math.floor(delta / 86_400_000)} day ago`;
   }
 }

--- a/libs/chat/src/lib/styles/chat-thread-list.styles.ts
+++ b/libs/chat/src/lib/styles/chat-thread-list.styles.ts
@@ -3,16 +3,15 @@ export const CHAT_THREAD_LIST_STYLES = `
   :host { display: block; padding: var(--ngaf-chat-space-2); }
   .chat-thread-list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 2px; }
   .chat-thread-list__item {
-    display: block;
-    height: 36px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-height: 36px;
     padding: 8px 12px;
     border-radius: var(--ngaf-chat-radius-button);
     cursor: pointer;
     color: var(--ngaf-chat-text);
     font-size: var(--ngaf-chat-font-size-sm);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
     background: transparent;
     border: 0;
     text-align: left;
@@ -21,7 +20,22 @@ export const CHAT_THREAD_LIST_STYLES = `
     transition: background-color 150ms ease;
   }
   .chat-thread-list__item:hover { background: color-mix(in srgb, var(--ngaf-chat-text) 5%, transparent); }
-  .chat-thread-list__item[data-active="true"] { background: var(--ngaf-chat-surface-alt); font-weight: 500; }
+  .chat-thread-list__item[data-active="true"] {
+    background: var(--ngaf-chat-surface-alt);
+    font-weight: 500;
+    box-shadow: inset 2px 0 0 var(--a2ui-primary, var(--ngaf-chat-primary));
+  }
+  .chat-thread-list__item-title {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    display: block;
+  }
+  .chat-thread-list__item-time {
+    font-size: 11px;
+    color: var(--ngaf-chat-text-muted);
+    display: block;
+  }
   .chat-thread-list__new {
     display: block;
     width: 100%;

--- a/libs/chat/src/public-api.ts
+++ b/libs/chat/src/public-api.ts
@@ -54,6 +54,7 @@ export type { ChatToolCallTemplateContext } from './lib/primitives/chat-tool-cal
 export { ChatSubagentsComponent } from './lib/primitives/chat-subagents/chat-subagents.component';
 export { ChatThreadListComponent } from './lib/primitives/chat-thread-list/chat-thread-list.component';
 export type { Thread } from './lib/primitives/chat-thread-list/chat-thread-list.component';
+export { ChatCheckpointMarkerComponent } from './lib/primitives/chat-checkpoint-marker/chat-checkpoint-marker.component';
 export { ChatTimelineComponent } from './lib/primitives/chat-timeline/chat-timeline.component';
 export { ChatGenerativeUiComponent } from './lib/primitives/chat-generative-ui/chat-generative-ui.component';
 export { ChatWelcomeComponent } from './lib/primitives/chat-welcome/chat-welcome.component';
@@ -73,6 +74,8 @@ export { ChatPopupComponent } from './lib/compositions/chat-popup/chat-popup.com
 export { ChatSidebarComponent } from './lib/compositions/chat-sidebar/chat-sidebar.component';
 export { ChatDebugComponent } from './lib/compositions/chat-debug/chat-debug.component';
 export { ChatTimelineSliderComponent } from './lib/compositions/chat-timeline-slider/chat-timeline-slider.component';
+export { ChatThreadDrawerComponent } from './lib/compositions/chat-thread-drawer/chat-thread-drawer.component';
+export type { ChatThreadDrawerMode } from './lib/compositions/chat-thread-drawer/chat-thread-drawer.component';
 export { ChatInterruptPanelComponent } from './lib/compositions/chat-interrupt-panel/chat-interrupt-panel.component';
 export type { InterruptAction } from './lib/compositions/chat-interrupt-panel/chat-interrupt-panel.component';
 export { ChatToolCallCardComponent } from './lib/compositions/chat-tool-call-card/chat-tool-call-card.component';

--- a/libs/langgraph/src/lib/agent.fn.spec.ts
+++ b/libs/langgraph/src/lib/agent.fn.spec.ts
@@ -851,3 +851,63 @@ describe('agent', () => {
     });
   });
 });
+
+import { computeMessageCheckpoints } from './agent.fn';
+
+describe('computeMessageCheckpoints', () => {
+  it('returns an empty map when history is empty', () => {
+    expect(computeMessageCheckpoints([])).toEqual(new Map());
+  });
+
+  it('pairs each AIMessage with the most recent checkpoint containing it', () => {
+    const history = [
+      {
+        checkpoint: { checkpoint_id: 'cp-1' },
+        values: {
+          messages: [
+            { id: 'h-1', _getType: () => 'human' },
+            { id: 'a-1', _getType: () => 'ai' },
+          ],
+        },
+      },
+      {
+        checkpoint: { checkpoint_id: 'cp-2' },
+        values: {
+          messages: [
+            { id: 'h-1', _getType: () => 'human' },
+            { id: 'a-1', _getType: () => 'ai' },
+            { id: 'h-2', _getType: () => 'human' },
+            { id: 'a-2', _getType: () => 'ai' },
+          ],
+        },
+      },
+    ] as unknown as ThreadState<unknown>[];
+
+    const map = computeMessageCheckpoints(history);
+    expect(map.get('a-1')).toBe('cp-1');
+    expect(map.get('a-2')).toBe('cp-2');
+    expect(map.size).toBe(2);
+  });
+
+  it('skips checkpoints with no AIMessage in scope', () => {
+    const history = [
+      {
+        checkpoint: { checkpoint_id: 'cp-start' },
+        values: { messages: [{ id: 'h-1', _getType: () => 'human' }] },
+      },
+    ] as unknown as ThreadState<unknown>[];
+
+    expect(computeMessageCheckpoints(history).size).toBe(0);
+  });
+
+  it('skips checkpoints with no checkpoint_id', () => {
+    const history = [
+      {
+        checkpoint: {},
+        values: { messages: [{ id: 'a-1', _getType: () => 'ai' }] },
+      },
+    ] as unknown as ThreadState<unknown>[];
+
+    expect(computeMessageCheckpoints(history).size).toBe(0);
+  });
+});

--- a/libs/langgraph/src/lib/agent.fn.ts
+++ b/libs/langgraph/src/lib/agent.fn.ts
@@ -63,6 +63,39 @@ import { buildBranchTree } from './internals/branch-tree';
 import { extractCitations } from './internals/extract-citations';
 
 /**
+ * Walk LangGraph history (newest-first) and pair each AIMessage id with
+ * the most recent checkpoint that contains it as the tail message in
+ * `values.messages`.
+ *
+ * Implementation: iterate oldest → newest (i.e. reverse the input array)
+ * so later writes overwrite earlier ones; the final map has each
+ * AIMessage paired with the newest containing checkpoint where it is
+ * still the tail. Checkpoints with no AIMessage in scope are skipped.
+ * Checkpoints with no checkpoint_id are skipped.
+ */
+export function computeMessageCheckpoints(
+  history: ReadonlyArray<ThreadState<unknown>>,
+): ReadonlyMap<string, string> {
+  const out = new Map<string, string>();
+  for (let i = history.length - 1; i >= 0; i--) {
+    const state = history[i];
+    const cpId = state.checkpoint?.checkpoint_id;
+    if (typeof cpId !== 'string' || cpId.length === 0) continue;
+    const values = state.values as { messages?: unknown[] } | undefined;
+    const msgs = Array.isArray(values?.messages) ? values.messages : [];
+    for (let j = msgs.length - 1; j >= 0; j--) {
+      const m = msgs[j] as { id?: string; _getType?: () => string; type?: string };
+      const type = typeof m._getType === 'function' ? m._getType() : m.type;
+      if (type === 'ai' && typeof m.id === 'string') {
+        out.set(m.id, cpId);
+        break;
+      }
+    }
+  }
+  return out;
+}
+
+/**
  * Creates a LangGraph-backed Angular agent.
  *
  * Must be called within an Angular injection context (component constructor,
@@ -243,6 +276,9 @@ export function agent<
   const historyNeutral = computed<AgentCheckpoint[]>(() =>
     historySig().map(toCheckpoint),
   );
+  const messageCheckpointsSig = computed<ReadonlyMap<string, string>>(() =>
+    computeMessageCheckpoints(historySig() as ThreadState<unknown>[]),
+  );
   const experimentalBranchTree = computed(() =>
     buildBranchTree(historySig() as ThreadState<T>[]),
   );
@@ -260,7 +296,8 @@ export function agent<
     interrupt: interruptNeutral,
     subagents: subagentsNeutral,
     events$,
-    history:   historyNeutral,
+    history:            historyNeutral,
+    messageCheckpoints: messageCheckpointsSig,
     submit: (input: AgentSubmitInput | null | undefined, opts?: AgentSubmitOptions & LangGraphSubmitOptions) => {
       const request = buildSubmitRequest(input, opts);
       return manager.submit(request.payload, request.options);


### PR DESCRIPTION
## Summary
- Adds two new lib primitives: `chat-thread-drawer` (slide-in left-edge container with push/overlay modes + scrim) and `chat-checkpoint-marker` (10px gutter dot with hover/focus Rewind/Fork pill).
- Extends `chat-thread-list` default item template with optional `updatedAt` → relative-time line.
- Extends `chat-message` with optional `[checkpointId]` input mounting a marker in a 14px left gutter; replay/fork outputs bubble.
- Adds `agent.messageCheckpoints()` to the LangGraph adapter — `ReadonlyMap<messageId, checkpointId>` computed from history.

Together these primitives enable the threads + checkpoints nav v2 design. They are independently usable; follow-up PR will wire them into the canonical chat demo.

## Test plan
- [x] `nx test chat` green for new specs (chat-checkpoint-marker, chat-thread-drawer, chat-thread-list extensions, chat-message gutter)
- [x] `nx test langgraph` green for new computeMessageCheckpoints tests
- [x] `nx build chat` + `nx build langgraph` green
- [ ] CI green

Generated with Claude Code