### PR TITLE
feat(examples-chat): palette v2 — status pill + shadcn panel

### DIFF
--- a/examples/chat/angular/src/app/shell/control-palette.component.css
+++ b/examples/chat/angular/src/app/shell/control-palette.component.css
@@ -5,110 +5,258 @@
   z-index: 1000;
 }
 
-.palette {
-  display: flex;
-  flex-direction: column;
+/* ── Status pill (collapsed) ─────────────────────────────────────────── */
+
+.palette-pill {
+  display: inline-flex;
+  align-items: center;
   gap: 8px;
-  background: #1a1d23;
-  color: #e6e9ef;
-  border: 1px solid #303540;
-  border-radius: 10px;
-  padding: 10px;
+  background: #18181b;
+  color: #fafafa;
+  border: 1px solid #27272a;
+  border-radius: 999px;
+  padding: 6px 12px;
+  font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
   font-size: 12px;
-  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.3);
-  min-width: 220px;
-}
-
-.palette--collapsed {
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
-  background: #1a1d23;
-  color: #e6e9ef;
-  border: 1px solid #303540;
   cursor: pointer;
-  font-size: 16px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.4);
+  transition: background 120ms ease, border-color 120ms ease;
+}
+.palette-pill:hover {
+  background: #1f1f23;
+  border-color: #3f3f46;
 }
 
-.palette__group {
+.palette-pill__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #4ade80;
+  box-shadow: 0 0 8px rgba(74, 222, 128, 0.6);
+}
+.palette-pill__dot--streaming {
+  background: #4f8df5;
+  box-shadow: 0 0 8px rgba(79, 141, 245, 0.7);
+  animation: palette-pill-pulse 1.2s ease-in-out infinite;
+}
+@keyframes palette-pill-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50%      { opacity: 0.6; transform: scale(0.85); }
+}
+
+.palette-pill__sep,
+.palette-pill__mode {
+  color: #a1a1aa;
+}
+.palette-pill__model {
+  font-weight: 600;
+}
+
+/* ── Panel (expanded) ────────────────────────────────────────────────── */
+
+.palette-panel {
+  width: 320px;
+  background: #18181b;
+  border: 1px solid #27272a;
+  border-radius: 12px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  color: #fafafa;
+  font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+  font-size: 13px;
+  overflow: hidden;
+  transform-origin: top right;
+  animation: palette-panel-enter 120ms ease;
+}
+@keyframes palette-panel-enter {
+  from { opacity: 0; transform: scale(0.96); }
+  to   { opacity: 1; transform: scale(1); }
+}
+
+.palette-panel__header {
   display: flex;
   align-items: center;
-  gap: 6px;
+  justify-content: space-between;
+  padding: 14px 16px;
+  border-bottom: 1px solid #27272a;
+}
+.palette-panel__title {
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+.palette-panel__close {
+  background: transparent;
+  border: 0;
+  color: #71717a;
+  cursor: pointer;
+  width: 24px;
+  height: 24px;
+  border-radius: 6px;
+  font-size: 16px;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.palette-panel__close:hover { background: #27272a; color: #fafafa; }
+
+.palette-panel__divider {
+  height: 1px;
+  background: #27272a;
 }
 
-.palette__group--mode {
-  background: #0f1116;
-  border-radius: 6px;
-  padding: 3px;
+.palette-panel__section {
+  padding: 14px 16px;
 }
-.palette__group--mode button {
+.palette-panel__section--action {
+  padding-top: 14px;
+  padding-bottom: 16px;
+}
+.palette-panel__section-title {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #71717a;
+  margin: 0 0 10px 0;
+}
+
+/* ── Segmented (Mode) ────────────────────────────────────────────────── */
+
+.palette-segmented {
+  display: flex;
+  background: #09090b;
+  border: 1px solid #27272a;
+  border-radius: 8px;
+  padding: 3px;
+  gap: 0;
+}
+.palette-segmented button {
   flex: 1;
   background: transparent;
   border: 0;
-  color: inherit;
-  padding: 5px 8px;
-  border-radius: 4px;
+  color: #a1a1aa;
+  padding: 6px 8px;
+  border-radius: 5px;
   font-size: 12px;
   cursor: pointer;
+  font-family: inherit;
+  transition: background 120ms ease, color 120ms ease;
 }
-.palette__group--mode button.is-active {
-  background: #2c313c;
-}
-
-.palette__group--model {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  align-items: center;
-}
-.palette__label {
-  opacity: 0.7;
-  margin-right: 8px;
-}
-.palette__group--model select {
-  background: #0f1116;
-  color: inherit;
-  border: 1px solid #303540;
-  border-radius: 4px;
-  padding: 4px 6px;
+.palette-segmented button:hover { background: #18181b; color: #fafafa; }
+.palette-segmented button.is-active {
+  background: #27272a;
+  color: #fafafa;
+  font-weight: 500;
 }
 
-.palette__toggle {
+/* ── Field rows (label left, control right) ──────────────────────────── */
+
+.palette-row {
   display: flex;
   align-items: center;
-  gap: 8px;
-  background: transparent;
-  border: 1px solid #303540;
-  color: inherit;
-  padding: 6px 8px;
-  border-radius: 6px;
-  cursor: pointer;
-  text-align: left;
+  justify-content: space-between;
+  gap: 12px;
 }
-.palette__toggle.is-on {
+.palette-row + .palette-row { margin-top: 10px; }
+.palette-row__label {
+  font-size: 13px;
+  color: #d4d4d8;
+}
+
+/* ── Styled select (native <select> visually replaced by trigger) ─── */
+
+.palette-select {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  min-width: 140px;
+  background: #09090b;
+  border: 1px solid #27272a;
+  border-radius: 6px;
+  padding: 6px 10px;
+  font-size: 12px;
+  color: #fafafa;
+  cursor: pointer;
+}
+.palette-select:focus-within {
   border-color: #4f8df5;
+  outline: 2px solid rgba(79, 141, 245, 0.3);
+  outline-offset: 1px;
 }
-.palette__toggle-dot {
-  width: 10px; height: 10px; border-radius: 50%;
-  background: #303540;
+.palette-select:hover { background: #0f0f12; }
+.palette-select__caret {
+  color: #71717a;
+  font-size: 10px;
 }
-.palette__toggle.is-on .palette__toggle-dot {
-  background: #4f8df5;
-}
-
-.palette__action {
-  background: transparent;
-  border: 1px solid #303540;
-  color: inherit;
-  padding: 6px 8px;
-  border-radius: 6px;
+.palette-select select {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
   cursor: pointer;
-}
-
-.palette__collapse {
-  background: transparent;
   border: 0;
-  color: #8a92a3;
+  background: transparent;
+  font: inherit;
+  color: inherit;
+}
+
+/* ── Switch (Debug toggle) ───────────────────────────────────────────── */
+
+.palette-switch {
+  position: relative;
+  width: 36px;
+  height: 20px;
+  background: #27272a;
+  border: 0;
+  border-radius: 999px;
   cursor: pointer;
-  align-self: flex-end;
-  font-size: 14px;
+  padding: 0;
+  transition: background 150ms ease;
+}
+.palette-switch.is-on { background: #4f8df5; }
+.palette-switch__thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  background: #fafafa;
+  border-radius: 50%;
+  transition: transform 150ms ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
+}
+.palette-switch.is-on .palette-switch__thumb { transform: translateX(16px); }
+
+/* ── Action button ───────────────────────────────────────────────────── */
+
+.palette-action {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  background: #27272a;
+  color: #fafafa;
+  border: 1px solid #3f3f46;
+  border-radius: 8px;
+  padding: 8px;
+  font-size: 13px;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background 120ms ease;
+}
+.palette-action:hover { background: #3f3f46; }
+.palette-action__icon { font-size: 14px; }
+
+/* ── Responsive ──────────────────────────────────────────────────────── */
+
+@media (max-width: 480px) {
+  .palette-panel {
+    width: calc(100vw - 24px);
+  }
 }

--- a/examples/chat/angular/src/app/shell/control-palette.component.html
+++ b/examples/chat/angular/src/app/shell/control-palette.component.html
@@ -1,96 +1,147 @@
 @if (collapsed()) {
   <button
     type="button"
-    class="palette palette--collapsed"
+    class="palette-pill"
     aria-label="Expand control palette"
-    (click)="toggleCollapsed()"
+    (click)="expand()"
   >
-    ⚙
+    <span
+      class="palette-pill__dot"
+      [class.palette-pill__dot--streaming]="streaming()"
+      aria-hidden="true"
+    ></span>
+    <span class="palette-pill__model">{{ model() }}</span>
+    <span class="palette-pill__sep" aria-hidden="true">·</span>
+    <span class="palette-pill__mode">{{ mode() }}</span>
   </button>
 } @else {
-  <div class="palette" role="region" aria-label="Demo control palette">
-    <div class="palette__group palette__group--mode" role="tablist" aria-label="Chat mode">
+  <div
+    class="palette-panel"
+    role="dialog"
+    aria-label="Control palette"
+    aria-modal="false"
+  >
+    <header class="palette-panel__header">
+      <span class="palette-panel__title">Control palette</span>
       <button
         type="button"
-        role="tab"
-        [attr.aria-selected]="mode() === 'embed'"
-        [class.is-active]="mode() === 'embed'"
-        (click)="pickMode('embed')"
-      >Embed</button>
+        class="palette-panel__close"
+        aria-label="Close control palette"
+        (click)="close()"
+      >×</button>
+    </header>
+
+    <section class="palette-panel__section">
+      <h3 class="palette-panel__section-title">Mode</h3>
+      <div class="palette-segmented" role="tablist" aria-label="Chat mode">
+        <button
+          type="button"
+          role="tab"
+          [attr.aria-selected]="mode() === 'embed'"
+          [class.is-active]="mode() === 'embed'"
+          (click)="pickMode('embed')"
+        >Embed</button>
+        <button
+          type="button"
+          role="tab"
+          [attr.aria-selected]="mode() === 'popup'"
+          [class.is-active]="mode() === 'popup'"
+          (click)="pickMode('popup')"
+        >Popup</button>
+        <button
+          type="button"
+          role="tab"
+          [attr.aria-selected]="mode() === 'sidebar'"
+          [class.is-active]="mode() === 'sidebar'"
+          (click)="pickMode('sidebar')"
+        >Sidebar</button>
+      </div>
+    </section>
+
+    <div class="palette-panel__divider"></div>
+
+    <section class="palette-panel__section">
+      <h3 class="palette-panel__section-title">Model</h3>
+      <div class="palette-row">
+        <label class="palette-row__label" for="palette-model">Provider</label>
+        <div class="palette-select">
+          <span class="palette-select__value">{{ labelFor(model(), modelOptions()) }}</span>
+          <span class="palette-select__caret" aria-hidden="true">▾</span>
+          <select id="palette-model" [value]="model()" (change)="pickModel($event)">
+            @for (opt of modelOptions(); track opt.value) {
+              <option [value]="opt.value" [selected]="opt.value === model()">{{ opt.label }}</option>
+            }
+          </select>
+        </div>
+      </div>
+      <div class="palette-row">
+        <label class="palette-row__label" for="palette-effort">Effort</label>
+        <div class="palette-select">
+          <span class="palette-select__value">{{ labelFor(effort(), effortOptions()) }}</span>
+          <span class="palette-select__caret" aria-hidden="true">▾</span>
+          <select id="palette-effort" [value]="effort()" (change)="pickEffort($event)">
+            @for (opt of effortOptions(); track opt.value) {
+              <option [value]="opt.value" [selected]="opt.value === effort()">{{ opt.label }}</option>
+            }
+          </select>
+        </div>
+      </div>
+      <div class="palette-row">
+        <label class="palette-row__label" for="palette-genui">Gen UI</label>
+        <div class="palette-select">
+          <span class="palette-select__value">{{ labelFor(genUiMode(), genUiOptions()) }}</span>
+          <span class="palette-select__caret" aria-hidden="true">▾</span>
+          <select id="palette-genui" [value]="genUiMode()" (change)="pickGenUiMode($event)">
+            @for (opt of genUiOptions(); track opt.value) {
+              <option [value]="opt.value" [selected]="opt.value === genUiMode()">{{ opt.label }}</option>
+            }
+          </select>
+        </div>
+      </div>
+    </section>
+
+    <div class="palette-panel__divider"></div>
+
+    <section class="palette-panel__section">
+      <h3 class="palette-panel__section-title">Appearance</h3>
+      <div class="palette-row">
+        <label class="palette-row__label" for="palette-theme">Theme</label>
+        <div class="palette-select">
+          <span class="palette-select__value">{{ labelFor(theme(), themeOptions()) }}</span>
+          <span class="palette-select__caret" aria-hidden="true">▾</span>
+          <select id="palette-theme" [value]="theme()" (change)="pickTheme($event)">
+            @for (opt of themeOptions(); track opt.value) {
+              <option [value]="opt.value" [selected]="opt.value === theme()">{{ opt.label }}</option>
+            }
+          </select>
+        </div>
+      </div>
+      <div class="palette-row">
+        <span class="palette-row__label">Debug overlay</span>
+        <button
+          type="button"
+          class="palette-switch"
+          role="switch"
+          [attr.aria-checked]="debugOpen()"
+          [class.is-on]="debugOpen()"
+          (click)="toggleDebug()"
+        >
+          <span class="palette-switch__thumb" aria-hidden="true"></span>
+        </button>
+      </div>
+    </section>
+
+    <div class="palette-panel__divider"></div>
+
+    <section class="palette-panel__section palette-panel__section--action">
       <button
         type="button"
-        role="tab"
-        [attr.aria-selected]="mode() === 'popup'"
-        [class.is-active]="mode() === 'popup'"
-        (click)="pickMode('popup')"
-      >Popup</button>
-      <button
-        type="button"
-        role="tab"
-        [attr.aria-selected]="mode() === 'sidebar'"
-        [class.is-active]="mode() === 'sidebar'"
-        (click)="pickMode('sidebar')"
-      >Sidebar</button>
-    </div>
-
-    <label class="palette__group palette__group--model">
-      <span class="palette__label">Model</span>
-      <select [value]="model()" (change)="pickModel($event)">
-        @for (opt of modelOptions(); track opt.value) {
-          <option [value]="opt.value" [selected]="opt.value === model()">{{ opt.label }}</option>
-        }
-      </select>
-    </label>
-
-    <label class="palette__group palette__group--model">
-      <span class="palette__label">Effort</span>
-      <select [value]="effort()" (change)="pickEffort($event)">
-        @for (opt of effortOptions(); track opt.value) {
-          <option [value]="opt.value" [selected]="opt.value === effort()">{{ opt.label }}</option>
-        }
-      </select>
-    </label>
-
-    <label class="palette__group palette__group--model">
-      <span class="palette__label">Gen UI</span>
-      <select [value]="genUiMode()" (change)="pickGenUiMode($event)">
-        @for (opt of genUiOptions(); track opt.value) {
-          <option [value]="opt.value" [selected]="opt.value === genUiMode()">{{ opt.label }}</option>
-        }
-      </select>
-    </label>
-
-    <label class="palette__group palette__group--model">
-      <span class="palette__label">Theme</span>
-      <select [value]="theme()" (change)="pickTheme($event)">
-        @for (opt of themeOptions(); track opt.value) {
-          <option [value]="opt.value" [selected]="opt.value === theme()">{{ opt.label }}</option>
-        }
-      </select>
-    </label>
-
-    <button
-      type="button"
-      class="palette__toggle"
-      [class.is-on]="debugOpen()"
-      [attr.aria-pressed]="debugOpen()"
-      (click)="toggleDebug()"
-    >
-      <span class="palette__toggle-dot"></span>
-      <span>Debug {{ debugOpen() ? 'on' : 'off' }}</span>
-    </button>
-
-    <button
-      type="button"
-      class="palette__action"
-      (click)="emitNewConversation()"
-    >↻ New conversation</button>
-
-    <button
-      type="button"
-      class="palette__collapse"
-      aria-label="Collapse control palette"
-      (click)="toggleCollapsed()"
-    >⌃</button>
+        class="palette-action"
+        (click)="emitNewConversation()"
+      >
+        <span class="palette-action__icon" aria-hidden="true">↻</span>
+        <span>New conversation</span>
+      </button>
+    </section>
   </div>
 }

--- a/examples/chat/angular/src/app/shell/control-palette.component.spec.ts
+++ b/examples/chat/angular/src/app/shell/control-palette.component.spec.ts
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: MIT
+import { describe, it, expect, beforeEach } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { Component, signal } from '@angular/core';
+import { ControlPalette } from './control-palette.component';
+import { PalettePersistence } from './palette-persistence.service';
+
+@Component({
+  standalone: true,
+  imports: [ControlPalette],
+  template: `<app-control-palette
+    [mode]="'embed'"
+    [model]="'gpt-5-mini'"
+    [modelOptions]="[{ value: 'gpt-5-mini', label: 'gpt-5-mini' }]"
+    [effort]="'minimal'"
+    [effortOptions]="[{ value: 'minimal', label: 'minimal' }]"
+    [genUiMode]="'a2ui'"
+    [genUiOptions]="[{ value: 'a2ui', label: 'A2UI v1' }]"
+    [theme]="'default-dark'"
+    [themeOptions]="[{ value: 'default-dark', label: 'Default dark' }]"
+    [debugOpen]="debug()"
+    [streaming]="streaming()"
+    (debugOpenChange)="debug.set($event)"
+  />`,
+})
+class HostComponent {
+  debug = signal(false);
+  streaming = signal(false);
+}
+
+class StubPersistence {
+  private store: Record<string, unknown> = {};
+  read<T>(key: string): T | undefined { return this.store[key] as T | undefined; }
+  write<T>(key: string, value: T): void { this.store[key] = value; }
+}
+
+describe('ControlPalette — pill / panel toggle', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HostComponent],
+      providers: [{ provide: PalettePersistence, useClass: StubPersistence }],
+    });
+  });
+
+  it('starts in the pill state (collapsed) on first run', () => {
+    const fx = TestBed.createComponent(HostComponent);
+    fx.detectChanges();
+    expect(fx.nativeElement.querySelector('.palette-pill')).toBeTruthy();
+    expect(fx.nativeElement.querySelector('.palette-panel')).toBeNull();
+  });
+
+  it('clicking the pill opens the panel', () => {
+    const fx = TestBed.createComponent(HostComponent);
+    fx.detectChanges();
+    (fx.nativeElement.querySelector('.palette-pill') as HTMLButtonElement).click();
+    fx.detectChanges();
+    expect(fx.nativeElement.querySelector('.palette-panel')).toBeTruthy();
+    expect(fx.nativeElement.querySelector('.palette-pill')).toBeNull();
+  });
+
+  it('clicking the close button collapses the panel back to a pill', () => {
+    const fx = TestBed.createComponent(HostComponent);
+    fx.detectChanges();
+    (fx.nativeElement.querySelector('.palette-pill') as HTMLButtonElement).click();
+    fx.detectChanges();
+    (fx.nativeElement.querySelector('.palette-panel__close') as HTMLButtonElement).click();
+    fx.detectChanges();
+    expect(fx.nativeElement.querySelector('.palette-pill')).toBeTruthy();
+  });
+
+  it('Escape keydown closes the panel', () => {
+    const fx = TestBed.createComponent(HostComponent);
+    fx.detectChanges();
+    (fx.nativeElement.querySelector('.palette-pill') as HTMLButtonElement).click();
+    fx.detectChanges();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    fx.detectChanges();
+    expect(fx.nativeElement.querySelector('.palette-pill')).toBeTruthy();
+  });
+
+  it('document click outside the palette closes it', () => {
+    const fx = TestBed.createComponent(HostComponent);
+    fx.detectChanges();
+    (fx.nativeElement.querySelector('.palette-pill') as HTMLButtonElement).click();
+    fx.detectChanges();
+
+    const outsideTarget = document.createElement('div');
+    document.body.appendChild(outsideTarget);
+    outsideTarget.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    fx.detectChanges();
+    document.body.removeChild(outsideTarget);
+
+    expect(fx.nativeElement.querySelector('.palette-pill')).toBeTruthy();
+  });
+
+  it('document click INSIDE the panel does not close it', () => {
+    const fx = TestBed.createComponent(HostComponent);
+    fx.detectChanges();
+    (fx.nativeElement.querySelector('.palette-pill') as HTMLButtonElement).click();
+    fx.detectChanges();
+
+    const title = fx.nativeElement.querySelector('.palette-panel__title') as HTMLElement;
+    title.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    fx.detectChanges();
+
+    expect(fx.nativeElement.querySelector('.palette-panel')).toBeTruthy();
+  });
+
+  it('streaming=true adds the streaming class on the dot when pill is visible', () => {
+    const fx = TestBed.createComponent(HostComponent);
+    fx.componentInstance.streaming.set(true);
+    fx.detectChanges();
+    expect(
+      fx.nativeElement.querySelector('.palette-pill__dot--streaming'),
+    ).toBeTruthy();
+  });
+
+  it('debug switch toggles aria-checked via output', () => {
+    const fx = TestBed.createComponent(HostComponent);
+    fx.detectChanges();
+    (fx.nativeElement.querySelector('.palette-pill') as HTMLButtonElement).click();
+    fx.detectChanges();
+    const sw = fx.nativeElement.querySelector('.palette-switch') as HTMLButtonElement;
+    expect(sw.getAttribute('aria-checked')).toBe('false');
+    sw.click();
+    fx.detectChanges();
+    expect(sw.getAttribute('aria-checked')).toBe('true');
+  });
+});

--- a/examples/chat/angular/src/app/shell/control-palette.component.ts
+++ b/examples/chat/angular/src/app/shell/control-palette.component.ts
@@ -7,6 +7,8 @@ import {
   signal,
   inject,
   effect,
+  ElementRef,
+  HostListener,
 } from '@angular/core';
 import { PalettePersistence } from './palette-persistence.service';
 import type { DemoMode } from './demo-shell.component';
@@ -20,6 +22,7 @@ import type { DemoMode } from './demo-shell.component';
 })
 export class ControlPalette {
   private readonly persistence = inject(PalettePersistence);
+  private readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
 
   readonly mode = input.required<DemoMode>();
   readonly model = input.required<string>();
@@ -31,6 +34,8 @@ export class ControlPalette {
   readonly theme = input.required<string>();
   readonly themeOptions = input.required<readonly { value: string; label: string }[]>();
   readonly debugOpen = input.required<boolean>();
+  /** True while the agent is streaming. Drives the status-dot pulse. */
+  readonly streaming = input<boolean>(false);
 
   readonly modeChange = output<DemoMode>();
   readonly modelChange = output<string>();
@@ -40,7 +45,12 @@ export class ControlPalette {
   readonly debugOpenChange = output<boolean>();
   readonly newConversation = output<void>();
 
-  protected readonly collapsed = signal<boolean>(this.persistence.read('collapsed') ?? false);
+  /**
+   * Whether the palette is collapsed to its status-pill state. Defaults
+   * to true (pill = resting state, matching Next.js dev tools). Persisted
+   * across reloads via PalettePersistence.
+   */
+  protected readonly collapsed = signal<boolean>(this.persistence.read('collapsed') ?? true);
 
   constructor() {
     effect(() => {
@@ -48,8 +58,12 @@ export class ControlPalette {
     });
   }
 
-  protected toggleCollapsed(): void {
-    this.collapsed.update((c) => !c);
+  protected expand(): void {
+    this.collapsed.set(false);
+  }
+
+  protected close(): void {
+    this.collapsed.set(true);
   }
 
   protected pickMode(next: DemoMode): void {
@@ -82,5 +96,37 @@ export class ControlPalette {
 
   protected emitNewConversation(): void {
     this.newConversation.emit();
+  }
+
+  /**
+   * Close the panel on document-level clicks outside the palette.
+   * No-ops when already collapsed; checks event.target containment so
+   * inside-panel clicks don't close.
+   */
+  @HostListener('document:click', ['$event'])
+  protected onDocumentClick(event: MouseEvent): void {
+    if (this.collapsed()) return;
+    const target = event.target as Node | null;
+    if (target && this.elementRef.nativeElement.contains(target)) return;
+    this.close();
+  }
+
+  /** Close on Escape anywhere in the document while the panel is open. */
+  @HostListener('document:keydown.escape')
+  protected onEscape(): void {
+    if (!this.collapsed()) this.close();
+  }
+
+  /**
+   * Selected-option label for a value across an options list. Used by the
+   * styled select trigger to show the human-friendly label rather than
+   * the raw value.
+   */
+  protected labelFor(
+    value: string,
+    options: readonly { value: string; label: string }[],
+  ): string {
+    const match = options.find(o => o.value === value);
+    return match?.label ?? value;
   }
 }

--- a/examples/chat/angular/src/app/shell/demo-shell.component.html
+++ b/examples/chat/angular/src/app/shell/demo-shell.component.html
@@ -18,6 +18,7 @@
     [theme]="theme()"
     [themeOptions]="themeOptions()"
     [debugOpen]="debugOpen()"
+    [streaming]="agent.status() === 'running'"
     (modeChange)="onModeChange($event)"
     (modelChange)="onModelChange($event)"
     (effortChange)="onEffortChange($event)"


### PR DESCRIPTION
## Summary

Replaces the floating vertical column palette in the canonical chat demo with a Next.js dev-tools-style **status pill** (top-right corner) that expands into a **shadcn-refined panel** with grouped sections.

- Pill shows live model + current mode (\`● gpt-5-mini · embed\`). Status dot pulses while the agent is streaming.
- Panel layout: \`Mode\` segmented control + \`Model\` section (provider / effort / gen UI) + \`Appearance\` section (theme / debug switch) + full-width \`New conversation\` button.
- Close affordances: × button, Escape key, click outside the palette.
- Native \`<select>\` elements preserved underneath shadcn-styled triggers via \`opacity: 0\` overlay — keyboard navigation and screen-reader behavior unchanged.

Spec: \`docs/superpowers/specs/2026-05-11-nav-v2-polish-palette-and-genui-suppression-design.md\` (\`Palette v2\` section).

## Test plan
- [x] \`nx test examples-chat-angular --testFile control-palette.component.spec.ts\` — 8 tests green
- [x] \`nx build examples-chat-angular\` green
- [x] \`nx lint examples-chat-angular\` + \`nx lint chat\` green
- [ ] Live smoke at \`/embed\`, \`/popup\`, \`/sidebar\`: pill visible top-right, click expands panel, all 7 controls work, Escape + outside-click close
- [ ] Streaming dot pulses while a run is in flight; settles to green when idle
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)