### PR TITLE
fix(chat): GenUI turn skeleton suppresses markdown branch entirely

### DIFF
--- a/libs/chat/src/lib/compositions/chat/chat.component.ts
+++ b/libs/chat/src/lib/compositions/chat/chat.component.ts
@@ -164,10 +164,16 @@ import type { ChatRenderEvent } from './chat-render-event';
                     </ng-container>
                   </chat-tool-calls>
                   <chat-subagents [agent]="agent()" />
-                  @if ((pending || (classified.type() === 'a2ui' && classified.a2uiSurfaces().size === 0)) && genuiTurn) {
+                  @if (genuiTurn && classified.type() !== 'a2ui' && classified.type() !== 'json-render') {
+                    <!-- GenUI turn awaiting the rendered surface — skeleton suppresses
+                         any streaming markdown that may flow before the classifier
+                         resolves (e.g. raw sub-LLM JSON envelopes streaming before
+                         emit_generated_surface prepends its A2UI sentinel prefix). -->
                     <chat-genui-skeleton />
-                  }
-                  @if (classified.markdown(); as md) {
+                  } @else if (classified.type() === 'a2ui' && classified.a2uiSurfaces().size === 0 && genuiTurn) {
+                    <!-- Surface event arrived but envelopes haven't yet parsed into surfaces. -->
+                    <chat-genui-skeleton />
+                  } @else if (classified.markdown(); as md) {
                     <chat-streaming-md [content]="md" [streaming]="agent().isLoading() && i === agent().messages().length - 1" />
                   }
                   @if (classified.spec(); as spec) {


### PR DESCRIPTION
## Summary

Live smoke against PR #246 surfaced a second source of the streaming JSON jank: during the **sub-LLM phase** of a GenUI turn, raw envelopes stream into the assistant message's \`content\` **before** \`emit_generated_surface\` wraps them with the \`---a2ui_JSON---\` prefix. The first chunks arrive as \`[\` (JSON array opening), which the classifier — even with the dash-patience fix — commits to \`'markdown'\`. The skeleton (correctly) doesn't fire because the classifier resolved to a non-pending type.

This PR restructures the composition's AI template so that during a GenUI turn the markdown branch is **never** rendered. The skeleton holds until the classifier resolves to \`'a2ui'\` or \`'json-render'\`, then hands off to the actual surface mounting.

Once \`emit_generated_surface\` runs server-side and replaces the streamed content with the prefixed wrapper, the classifier's content-shrink reset path re-classifies to \`'a2ui'\` and the surface mounts.

## Test plan
- [x] \`nx build chat\` + \`nx lint chat\` green
- [ ] Live smoke at \`/embed\` with a UNIQUE GenUI prompt (so no cache replay):
  1. Typing indicator at bottom (existing)
  2. **Skeleton appears immediately**, no JSON visible
  3. Skeleton **stays put** through the entire ~6s streaming window
  4. Rendered surface mounts cleanly when the run completes
- [ ] Non-GenUI prompt unaffected — normal markdown streaming
- [ ] CI green

Follow-up to #246.

🤖 Generated with [Claude Code](https://claude.com/claude-code)