### PR TITLE
feat(examples-chat,chat): drop bubble-level GenUI skeleton

### DIFF
--- a/libs/chat/src/lib/compositions/chat/chat.component.spec.ts
+++ b/libs/chat/src/lib/compositions/chat/chat.component.spec.ts
@@ -404,3 +404,19 @@ describe('ChatComponent — isGenuiTurn', () => {
     expect(isGenuiTurn(null, undefined)).toBe(false);
   });
 });
+
+describe('ChatComponent — no bubble-level GenUI skeleton', () => {
+  // Regression for the progressive-GenUI cleanup: the chat composition
+  // template must NOT render <chat-genui-skeleton> from within the
+  // assistant message bubble. The skeleton/coalescing belongs to a
+  // dedicated outer slot (chat-message-list / coalescer), not the bubble.
+  it('chat.component.ts source contains no <chat-genui-skeleton> tag', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const url = await import('node:url');
+    const here = path.dirname(url.fileURLToPath(import.meta.url));
+    const src = fs.readFileSync(path.join(here, 'chat.component.ts'), 'utf8');
+    expect(src.includes('chat-genui-skeleton')).toBe(false);
+    expect(src.includes('ChatGenuiSkeletonComponent')).toBe(false);
+  });
+});

--- a/libs/chat/src/lib/compositions/chat/chat.component.ts
+++ b/libs/chat/src/lib/compositions/chat/chat.component.ts
@@ -29,7 +29,6 @@ import { ChatMessageActionsComponent } from '../../primitives/chat-message-actio
 import { ChatWelcomeComponent } from '../../primitives/chat-welcome/chat-welcome.component';
 import { ChatSelectComponent, type ChatSelectOption } from '../../primitives/chat-select/chat-select.component';
 import { A2uiSurfaceComponent } from '../../a2ui/surface.component';
-import { ChatGenuiSkeletonComponent } from '../../primitives/chat-genui-skeleton/chat-genui-skeleton.component';
 import { ChatScrollBubbleComponent } from '../../primitives/chat-scroll-bubble/chat-scroll-bubble.component';
 import { createContentClassifier, type ContentClassifier } from '../../streaming/content-classifier';
 import { messageContent } from '../shared/message-utils';
@@ -59,7 +58,7 @@ export function isPinned(
     ChatThreadListComponent, ChatGenerativeUiComponent,
     ChatStreamingMdComponent, ChatToolCallsComponent, ChatSubagentsComponent, A2uiSurfaceComponent,
     ChatMessageActionsComponent, ChatWelcomeComponent, ChatSelectComponent, ChatReasoningComponent,
-    ChatGenuiSkeletonComponent, ChatScrollBubbleComponent,
+    ChatScrollBubbleComponent,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   styles: [CHAT_HOST_TOKENS, `
@@ -155,7 +154,6 @@ export function isPinned(
                 @let content = messageContent(message);
                 @let classified = classifyMessage(content, message);
                 @let pending = classified.type() === 'pending';
-                @let genuiTurn = isGenuiTurn(message, prevMessage(i), i);
                 <chat-message
                   [role]="'assistant'"
                   [message]="message"
@@ -179,16 +177,7 @@ export function isPinned(
                     </ng-container>
                   </chat-tool-calls>
                   <chat-subagents [agent]="agent()" />
-                  @if (genuiTurn && classified.type() !== 'a2ui' && classified.type() !== 'json-render') {
-                    <!-- GenUI turn awaiting the rendered surface — skeleton suppresses
-                         any streaming markdown that may flow before the classifier
-                         resolves (e.g. raw sub-LLM JSON envelopes streaming before
-                         emit_generated_surface prepends its A2UI sentinel prefix). -->
-                    <chat-genui-skeleton />
-                  } @else if (classified.type() === 'a2ui' && classified.a2uiSurfaces().size === 0 && genuiTurn) {
-                    <!-- Surface event arrived but envelopes haven't yet parsed into surfaces. -->
-                    <chat-genui-skeleton />
-                  } @else if (classified.markdown(); as md) {
+                  @if (classified.markdown(); as md) {
                     <chat-streaming-md [content]="md" [streaming]="agent().isLoading() && i === agent().messages().length - 1" />
                   }
                   @if (classified.spec(); as spec) {


### PR DESCRIPTION
## Summary

Removes the two bubble-level `<chat-genui-skeleton>` branches from the
chat composition's assistant-message template. The skeleton and any
coalescing behavior belong to a dedicated outer slot, not inside the
message bubble itself. The kept branch renders `<chat-streaming-md>`
for markdown content. `ChatGenuiSkeletonComponent` remains exported
from `@ngaf/chat`'s public API for downstream consumers.

## Changes

- `libs/chat/src/lib/compositions/chat/chat.component.ts`: collapse
  the `@if`/`@else if` chain around the assistant bubble content to
  just the `<chat-streaming-md>` markdown branch; remove the now-unused
  `ChatGenuiSkeletonComponent` import and `imports` entry; drop the
  unused `genuiTurn` `@let` binding.
- `libs/chat/src/lib/compositions/chat/chat.component.spec.ts`: add a
  regression test asserting the composition source contains neither
  the `<chat-genui-skeleton>` tag nor the `ChatGenuiSkeletonComponent`
  import.

## Test plan

- [x] `nx test chat` passes
- [x] `nx build chat` passes
- [x] `nx lint chat` passes
- [x] `npm run generate-api-docs` regenerates cleanly (no public-API drift)