### PR TITLE
fix(chat): post-merge sidenav polish — semantic <nav> + rename close→closed

### DIFF
--- a/apps/website/content/docs/chat/api/api-docs.json
+++ b/apps/website/content/docs/chat/api/api-docs.json
@@ -2369,7 +2369,7 @@
         "optional": false
       },
       {
-        "name": "close",
+        "name": "closed",
         "type": "OutputEmitterRef<void>",
         "description": "",
         "optional": false

--- a/examples/chat/angular/src/app/shell/demo-shell.component.html
+++ b/examples/chat/angular/src/app/shell/demo-shell.component.html
@@ -40,7 +40,7 @@
     [(query)]="searchQuery"
     [results]="searchResults()"
     (threadSelected)="onSearchSelect($event)"
-    (close)="paletteOpen.set(false)"
+    (closed)="paletteOpen.set(false)"
   />
 
   <chat-debug

--- a/libs/chat/src/lib/compositions/chat-sidenav/chat-sidenav.component.ts
+++ b/libs/chat/src/lib/compositions/chat-sidenav/chat-sidenav.component.ts
@@ -35,10 +35,10 @@ export type ChatSidenavMode = 'expanded' | 'collapsed' | 'drawer';
         (click)="openChange.emit(false)"
       ></button>
     }
-    <aside
+    <nav
       class="chat-sidenav"
-      role="navigation"
       aria-label="Sidebar navigation"
+      tabindex="-1"
       (keydown.escape)="onEscape()"
     >
       <div class="chat-sidenav__header">
@@ -96,7 +96,7 @@ export type ChatSidenavMode = 'expanded' | 'collapsed' | 'drawer';
       <div class="chat-sidenav__account">
         <ng-content select="[sidenavAccount]" />
       </div>
-    </aside>
+    </nav>
   `,
 })
 export class ChatSidenavComponent {

--- a/libs/chat/src/lib/primitives/chat-history-search-palette/chat-history-search-palette.component.spec.ts
+++ b/libs/chat/src/lib/primitives/chat-history-search-palette/chat-history-search-palette.component.spec.ts
@@ -114,7 +114,7 @@ describe('ChatHistorySearchPaletteComponent', () => {
   it('Esc emits close', () => {
     const fixture = render();
     let emits = 0;
-    fixture.componentInstance.close.subscribe(() => emits++);
+    fixture.componentInstance.closed.subscribe(() => emits++);
     const input = fixture.nativeElement.querySelector('input') as HTMLInputElement;
     input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
     expect(emits).toBe(1);
@@ -123,7 +123,7 @@ describe('ChatHistorySearchPaletteComponent', () => {
   it('Scrim click emits close', () => {
     const fixture = render();
     let emits = 0;
-    fixture.componentInstance.close.subscribe(() => emits++);
+    fixture.componentInstance.closed.subscribe(() => emits++);
     const scrim = fixture.nativeElement.querySelector('.chat-history-search-palette__scrim') as HTMLButtonElement;
     scrim.click();
     expect(emits).toBe(1);

--- a/libs/chat/src/lib/primitives/chat-history-search-palette/chat-history-search-palette.component.ts
+++ b/libs/chat/src/lib/primitives/chat-history-search-palette/chat-history-search-palette.component.ts
@@ -34,7 +34,7 @@ let paletteInstanceCounter = 0;
         type="button"
         class="chat-history-search-palette__scrim"
         aria-label="Close search"
-        (click)="close.emit()"
+        (click)="closed.emit()"
       ></button>
       <div
         class="chat-history-search-palette"
@@ -64,7 +64,7 @@ let paletteInstanceCounter = 0;
             type="button"
             class="chat-history-search-palette__close"
             aria-label="Close"
-            (click)="close.emit()"
+            (click)="closed.emit()"
           >
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
               <line x1="18" y1="6" x2="6" y2="18"/>
@@ -116,8 +116,7 @@ export class ChatHistorySearchPaletteComponent {
   readonly placeholder = input<string>('Search conversations');
 
   readonly threadSelected = output<string>();
-  // eslint-disable-next-line @angular-eslint/no-output-native
-  readonly close = output<void>();
+  readonly closed = output<void>();
 
   protected readonly activeIndex = signal<number>(0);
   protected readonly listId = `chat-history-search-palette__results-${++paletteInstanceCounter}`;
@@ -155,7 +154,7 @@ export class ChatHistorySearchPaletteComponent {
   protected onInputKeydown(e: KeyboardEvent): void {
     if (e.key === 'Escape') {
       e.preventDefault();
-      this.close.emit();
+      this.closed.emit();
       return;
     }
     if (e.key === 'ArrowDown') {


### PR DESCRIPTION
## Summary

Two minor cleanups flagged in the [#253](https://github.com/cacheplane/angular-agent-framework/pull/253) code review, deferred at that time and addressed now after browser verification.

- **`chat-sidenav`**: replace `<aside role=\"navigation\">` with semantic `<nav>` (HTML5 element of choice for navigation). Adds `tabindex=\"-1\"` so the existing Esc keydown binding still works without tripping the `@angular-eslint/template/interactive-supports-focus` rule.
- **`chat-history-search-palette`**: rename the `close` output to `closed`, dropping the `@angular-eslint/no-output-native` suppression. Past-tense matches the convention of state outputs (`opened`/`closed`) and removes the global-window-method shadow concern.
- Migrate the single consumer binding in `examples-chat-angular`.
- Regenerate chat API docs.

Browser-verified via `nx serve examples-chat-angular`: sidenav renders correctly in `drawer` and `expanded` modes, palette opens/closes via search button, Cmd+K, Esc, and scrim click; Enter selects + switches thread.

## Test plan

- [x] `nx run chat:test` — passes
- [x] `nx run chat:build` — passes
- [x] `nx lint chat` — passes (the new `<nav tabindex=\"-1\">` satisfies the interactive-supports-focus rule)
- [x] `nx run examples-chat-angular:build` — passes
- [x] Browser-verified live in Chrome MCP

🤖 Generated with [Claude Code](https://claude.com/claude-code)