### PR TITLE
fix(chat): chat-sidenav host must be position:fixed so it doesn't push siblings

### DIFF
--- a/libs/chat/src/lib/styles/chat-sidenav.styles.ts
+++ b/libs/chat/src/lib/styles/chat-sidenav.styles.ts
@@ -1,15 +1,36 @@
 // libs/chat/src/lib/styles/chat-sidenav.styles.ts
 // SPDX-License-Identifier: MIT
 export const CHAT_SIDENAV_STYLES = `
+  /*
+   * In expanded / collapsed modes the sidenav is "always visible" beside the
+   * main content — the consumer reserves space with padding-left on the
+   * layout container. The host must be position: fixed so it doesn't
+   * participate in document flow; otherwise its display: block stretches
+   * to the parent's full width and pushes siblings below the viewport.
+   */
   :host {
     display: block;
     height: 100%;
   }
-  :host([data-mode="expanded"]) .chat-sidenav {
+  :host([data-mode="expanded"]),
+  :host([data-mode="collapsed"]) {
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    z-index: 100;
+  }
+  :host([data-mode="expanded"]) {
     width: var(--ngaf-chat-sidenav-width-expanded);
   }
-  :host([data-mode="collapsed"]) .chat-sidenav {
+  :host([data-mode="collapsed"]) {
     width: var(--ngaf-chat-sidenav-width-collapsed);
+  }
+  :host([data-mode="expanded"]) .chat-sidenav {
+    width: 100%;
+  }
+  :host([data-mode="collapsed"]) .chat-sidenav {
+    width: 100%;
   }
   :host([data-mode="drawer"]) {
     position: relative;


### PR DESCRIPTION
## Summary

The new `<chat-sidenav>` from [#253](https://github.com/cacheplane/angular-agent-framework/pull/253) sets `:host { display: block; height: 100% }` and **per-mode width on the inner `.chat-sidenav`** (not the host). The host then stretches to the parent's full width (1800px on a 1080p viewport) and participates in document flow, pushing its sibling `.demo-shell__main` (router-outlet + chat) below the viewport.

The demo shell uses `padding-left: 280px` on `.demo-shell__main--push` to reserve space — a pattern that only works if the sidenav is positioned out of flow.

**Fix:** put the host into `position: fixed; top: 0; left: 0; bottom: 0` in `expanded` and `collapsed` modes, and move the per-mode width from the inner `.chat-sidenav` onto the host (inner stays 100% wide). Drawer mode is unaffected (its inner `.chat-sidenav` is already `position: fixed`).

Browser-verified at `localhost:4201/embed` post-fix:
- `chat-sidenav` host: `position: fixed`, width 280px, left=0, top=0 ✓
- `embed-mode`: x=280, y=**0**, w=1520 (was y=930 → off-screen) ✓
- `main`: y=0 with `padding-left: 280px` ✓

## Test plan

- [ ] `npx vitest run chat-sidenav` — existing 10 tests pass
- [ ] `npx nx lint chat` — clean
- [ ] `npx nx build examples-chat-angular` — succeeds
- [ ] Open `http://localhost:4201/embed` — chat content visible to the right of the 280px sidenav, not pushed off-screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)