### PR TITLE
refactor(examples-chat): onTimelineFork uses ThreadsService.create()

### DIFF
--- a/examples/chat/angular/src/app/shell/demo-shell.component.ts
+++ b/examples/chat/angular/src/app/shell/demo-shell.component.ts
@@ -312,17 +312,11 @@ export class DemoShell {
   }
 
   async onTimelineFork(checkpointId: string): Promise<void> {
-    await fetch('http://localhost:2024/threads', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: '{}',
-    })
-      .then((r) => r.json())
-      .then((t: { thread_id: string }) => {
-        this.threadIdSignal.set(t.thread_id);
-        this.persistence.write('threadId', t.thread_id);
-        void this.agent.submit(null as never, { checkpointId } as never);
-      });
+    const id = await this.threadsSvc.create();
+    if (!id) return;
+    this.threadIdSignal.set(id);
+    this.persistence.write('threadId', id);
+    void this.agent.submit(null as never, { checkpointId } as never);
   }
 
   /** Switch to an existing thread selected from the threads panel. */


### PR DESCRIPTION
## Summary

Last remaining raw-fetch call against LangGraph in the example shell. `ThreadsService.create()` already does the same `POST /threads` through `@langchain/langgraph-sdk`'s `Client` (added in Phase 3b) and returns the new thread id.

This closes out the SDK-audit follow-up tracked from Phase 3b — the codebase now uses the SDK Client uniformly for every thread CRUD operation.

```diff
 async onTimelineFork(checkpointId: string): Promise<void> {
-  await fetch('http://localhost:2024/threads', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: '{}',
-  })
-    .then((r) => r.json())
-    .then((t: { thread_id: string }) => {
-      this.threadIdSignal.set(t.thread_id);
-      this.persistence.write('threadId', t.thread_id);
-      void this.agent.submit(null as never, { checkpointId } as never);
-    });
+  const id = await this.threadsSvc.create();
+  if (!id) return;
+  this.threadIdSignal.set(id);
+  this.persistence.write('threadId', id);
+  void this.agent.submit(null as never, { checkpointId } as never);
 }
```

## Test plan

- [x] `nx run examples-chat-angular:build` — clean
- [ ] Live timeline-fork behavior: requires exercising the chat-debug timeline replay flow (deeper UI). Functionally equivalent to existing "New chat" path which uses the same `ThreadsService.create()` and is exercised every session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)