### PR TITLE
fix(website): unbreak TS build (AnalyticsSurface + Button anchorAttrs)

### DIFF
--- a/apps/website/src/components/ui/Button.tsx
+++ b/apps/website/src/components/ui/Button.tsx
@@ -112,7 +112,7 @@ export function Button(props: ButtonProps) {
       className: _cn,
       style: _st,
       ...anchorAttrs
-    } = rest as AnchorButtonProps;
+    } = rest;
     return (
       <a
         href={href}

--- a/apps/website/src/lib/analytics/events.ts
+++ b/apps/website/src/lib/analytics/events.ts
@@ -26,6 +26,7 @@ export type AnalyticsSurface =
   | 'mobile_nav'
   | 'footer'
   | 'home'
+  | 'home_whitepaper'
   | 'pricing'
   | 'docs'
   | 'library_landing'


### PR DESCRIPTION
## Summary

Two pre-existing TypeScript errors on main introduced by the Statusbrew website refactor (PR #270). Both blocked the required \`Website — lint / build\` check on every unrelated PR.

1. **\`AnalyticsSurface\` union missing \`'home_whitepaper'\`** — \`WhitePaperBlock.tsx:42\` passes that value to \`track(...)\`.
2. **\`href\` specified more than once on \`<a>\` in Button.tsx:118** — the cast \`rest as AnchorButtonProps\` contradicted the prior destructure that pulled \`href\` out. TS then thought \`anchorAttrs\` still carried \`href\`.

## Test plan
- [x] TS errors gone locally
- [ ] CI green