### PR TITLE
Editorial sweep: drop zoneless claims, honest LTS commitment

### DIFF
--- a/apps/website/src/app/angular/page.tsx
+++ b/apps/website/src/app/angular/page.tsx
@@ -48,7 +48,7 @@ export default async function AngularPage() {
                 maxWidth: 640,
               }}
             >
-              Ship LangGraph agents inside your Angular 20+ app. Thread state, interrupts, branch/history, and tool progress — all surfaced as zoneless-safe signals.
+              Ship LangGraph agents inside your Angular 20+ app. Thread state, interrupts, branch/history, and tool progress — all surfaced as signals.
             </p>
             <div style={{ display: 'flex', justifyContent: 'center', gap: 12, flexWrap: 'wrap', marginBottom: 20 }}>
               <Button variant="primary" size="lg" href="/docs/agent/getting-started/introduction">Get started</Button>
@@ -57,7 +57,6 @@ export default async function AngularPage() {
             <div style={{ display: 'flex', justifyContent: 'center', gap: 8, flexWrap: 'wrap' }}>
               <Pill variant="accent">MIT</Pill>
               <Pill variant="angular">Angular 20+</Pill>
-              <Pill variant="neutral">Zoneless ready</Pill>
               <Pill variant="neutral">LangGraph + AG-UI</Pill>
             </div>
           </div>
@@ -68,11 +67,11 @@ export default async function AngularPage() {
         id="providers"
         eyebrow="Providers"
         headline="Drop it into app.config.ts. Done."
-        body="provideAgent wires LangGraph (or AG-UI) into Angular's DI container. From any component, agent() returns a zoneless-safe handle with signals for messages, status, errors, and interrupts."
+        body="provideAgent wires LangGraph (or AG-UI) into Angular's DI container. From any component, agent() returns a signal-based handle for messages, status, errors, and interrupts."
         bullets={[
           'provideAgent + provideAgUiAgent — pick your runtime',
           'agent() returns a typed signal-based handle',
-          'OnPush + zoneless tested',
+          'OnPush tested',
           'Test transports for deterministic specs',
         ]}
         supportingCards={[

--- a/apps/website/src/components/landing/HomeFAQ.tsx
+++ b/apps/website/src/components/landing/HomeFAQ.tsx
@@ -7,15 +7,11 @@ import { FAQ, type FAQItem } from '../ui/FAQ';
 const ITEMS: FAQItem[] = [
   {
     q: 'How is this different from CopilotKit or AG-UI directly?',
-    a: 'CopilotKit ports React patterns to Angular. AG-UI is a protocol — you still build the Angular side. Angular Agent Framework is Angular-native: signals, DI, zoneless support, and adapters that hide the protocol so you can swap LangGraph for AG-UI without rewriting your UI.',
+    a: 'CopilotKit ports React patterns to Angular. AG-UI is a protocol — you still build the Angular side. Angular Agent Framework is Angular-native: signals, DI, and adapters that hide the protocol so you can swap LangGraph for AG-UI without rewriting your UI.',
   },
   {
     q: 'Does it work with my existing Angular app?',
     a: 'Yes. Drop provideAgent (or provideAgUiAgent) into your app.config.ts. The headless primitives don’t impose any UI; the chat compositions are opt-in.',
-  },
-  {
-    q: 'Is it zoneless-compatible?',
-    a: 'Yes. All signal flows are zoneless-safe. We test against zoneless apps.',
   },
   {
     q: 'Can I use this without LangGraph?',
@@ -31,7 +27,7 @@ const ITEMS: FAQItem[] = [
   },
   {
     q: 'Is this production-ready today?',
-    a: 'Yes — the Cockpit reference app runs the full stack. We track Angular’s release cadence and ship against current and one previous major.',
+    a: 'Yes — the Cockpit reference app runs the full stack. We support Angular’s current and previous LTS versions.',
   },
   {
     q: 'Where do I report issues?',

--- a/apps/website/src/components/landing/Promises.tsx
+++ b/apps/website/src/components/landing/Promises.tsx
@@ -7,7 +7,7 @@ import { Card } from '../ui/Card';
 const PROMISES = [
   { title: 'No vendor lock-in', body: 'MIT today, MIT tomorrow. Use without us.' },
   { title: 'No paid Angular tier', body: 'The libraries stay open. Pilot-to-Prod is the only paid offering.' },
-  { title: 'No abandoned majors', body: 'We follow Angular’s LTS. When Angular ships, we ship.' },
+  { title: 'No abandoned majors', body: 'We support Angular’s current and previous LTS versions.' },
   { title: 'No closed primitives', body: 'Headless primitives stay in the open repo.' },
   { title: 'No required cloud', body: 'Self-host LangGraph + your Angular app. No phone-home.' },
 ];

--- a/apps/website/src/components/landing/ProofStrip.tsx
+++ b/apps/website/src/components/landing/ProofStrip.tsx
@@ -12,7 +12,7 @@ interface Signal {
 
 const SIGNALS: Signal[] = [
   { label: 'MIT licensed', value: 'Open source', href: 'https://github.com/cacheplane/angular-agent-framework/blob/main/LICENSE' },
-  { label: 'Built for Angular 20+', value: 'Zoneless ready', href: null },
+  { label: 'Built for', value: 'Angular 20+', href: null },
   { label: 'LangGraph + AG-UI', value: 'Two adapters', href: null },
   { label: 'Reference app', value: 'cockpit.cacheplane.ai', href: 'https://cockpit.cacheplane.ai' },
   { label: 'On npm', value: '@ngaf/chat', href: 'https://www.npmjs.com/package/@ngaf/chat' },


### PR DESCRIPTION
## Summary

Two factual edits flagged in [#270](https://github.com/cacheplane/angular-agent-framework/pull/270) for review before final ship — Group A of the post-merge cleanup.

**1. Drop \"zoneless\" mentions across the site.** Six references across 4 files (HomeFAQ.tsx, Promises.tsx wasn't affected, ProofStrip.tsx, /angular page.tsx) made claims about zoneless support / zoneless testing that aren't substantiated by actual test coverage. Removed entirely rather than softened.

**2. Soften the Angular LTS commitment.** Two spots — Promises #3 (\"No abandoned majors\") and the HomeFAQ \"Is this production-ready today?\" answer — previously promised \"When Angular ships, we ship\" (implies same-week support for new majors). Replaced both with the honest version: \"We support Angular's current and previous LTS versions.\"

Other drafts originally flagged in #270:
- ProofStrip's \"Listed on LangChain Awesome\" claim — verified absent from the shipped code; nothing to do.
- solutions-data speculative metrics — already capability-reframed during Phase 7; no further changes.

## Test plan

- [x] \`pnpm nx e2e website\` — 35 passed
- [ ] Visual walkthrough confirms FAQ question count drops from 8 to 7 and the \"Zoneless ready\" Pill on /angular is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)