### PR TITLE
feat(chat,examples-chat): sidenav polish — header trim, dark mode contrast, mobile drawer

### DIFF
--- a/examples/chat/angular/src/index.html
+++ b/examples/chat/angular/src/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-ngaf-chat-theme="dark">
   <head>
     <meta charset="utf-8" />
     <title>NGAF chat — canonical demo</title>

--- a/libs/chat/src/lib/compositions/chat-sidenav/chat-sidenav.component.spec.ts
+++ b/libs/chat/src/lib/compositions/chat-sidenav/chat-sidenav.component.spec.ts
@@ -139,6 +139,39 @@ describe('ChatSidenavComponent', () => {
     expect(fixture.nativeElement.querySelector('.chat-sidenav__action--collapse')).toBeNull();
   });
 
+  it('renders a topbar containing the new-chat and collapse buttons in expanded mode', () => {
+    const fixture = render({ mode: 'expanded' });
+    const topbar = fixture.nativeElement.querySelector('.chat-sidenav__topbar') as HTMLElement;
+    expect(topbar).not.toBeNull();
+    expect(topbar.querySelector('.chat-sidenav__action--new')).not.toBeNull();
+    expect(topbar.querySelector('.chat-sidenav__action--collapse')).not.toBeNull();
+  });
+
+  it('search button is the only action in .chat-sidenav__actions row', () => {
+    const fixture = render({ mode: 'expanded' });
+    const actions = fixture.nativeElement.querySelector('.chat-sidenav__actions') as HTMLElement;
+    const buttons = actions.querySelectorAll('button');
+    expect(buttons.length).toBe(1);
+    expect(buttons[0].classList.contains('chat-sidenav__action--search')).toBe(true);
+  });
+
+  it('drawer mode: renders a close button in the topbar that emits openChange(false)', () => {
+    const fixture = render({ mode: 'drawer', open: true });
+    const topbar = fixture.nativeElement.querySelector('.chat-sidenav__topbar') as HTMLElement;
+    const close = topbar.querySelector('.chat-sidenav__action--close') as HTMLButtonElement;
+    expect(close).not.toBeNull();
+    expect(close.getAttribute('aria-label')).toBe('Close conversations');
+    let lastOpen: boolean | undefined;
+    fixture.componentInstance.openChange.subscribe((v: boolean) => { lastOpen = v; });
+    close.click();
+    expect(lastOpen).toBe(false);
+  });
+
+  it('non-drawer modes: no close button is rendered', () => {
+    expect(render({ mode: 'expanded' }).nativeElement.querySelector('.chat-sidenav__action--close')).toBeNull();
+    expect(render({ mode: 'collapsed' }).nativeElement.querySelector('.chat-sidenav__action--close')).toBeNull();
+  });
+
   it('clicking the chevron in expanded mode emits modeChange="collapsed"', () => {
     const fixture = render({ mode: 'expanded' });
     let last: string | undefined;

--- a/libs/chat/src/lib/compositions/chat-sidenav/chat-sidenav.component.ts
+++ b/libs/chat/src/lib/compositions/chat-sidenav/chat-sidenav.component.ts
@@ -50,7 +50,7 @@ export type ChatSidenavMode = 'expanded' | 'collapsed' | 'drawer';
         <ng-content select="[sidenavHeader]" />
       </div>
 
-      <div class="chat-sidenav__actions">
+      <div class="chat-sidenav__topbar">
         <button
           type="button"
           class="chat-sidenav__action chat-sidenav__action--new"
@@ -63,19 +63,6 @@ export type ChatSidenavMode = 'expanded' | 'collapsed' | 'drawer';
             <line x1="5" y1="12" x2="19" y2="12"/>
           </svg>
           <span class="chat-sidenav__action-label">New chat</span>
-        </button>
-        <button
-          type="button"
-          class="chat-sidenav__action chat-sidenav__action--search"
-          (click)="searchOpened.emit()"
-          aria-label="Search conversations"
-          title="Search conversations (⌘K)"
-        >
-          <svg class="chat-sidenav__action-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <circle cx="11" cy="11" r="7"/>
-            <line x1="21" y1="21" x2="16.65" y2="16.65"/>
-          </svg>
-          <span class="chat-sidenav__action-label">Search</span>
         </button>
         @if (mode() !== 'drawer') {
           <button
@@ -97,6 +84,37 @@ export type ChatSidenavMode = 'expanded' | 'collapsed' | 'drawer';
             <span class="chat-sidenav__action-label">{{ mode() === 'collapsed' ? 'Expand' : 'Collapse' }}</span>
           </button>
         }
+        @if (mode() === 'drawer') {
+          <button
+            type="button"
+            class="chat-sidenav__action chat-sidenav__action--close"
+            (click)="openChange.emit(false)"
+            aria-label="Close conversations"
+            title="Close conversations"
+          >
+            <svg class="chat-sidenav__action-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <line x1="18" y1="6" x2="6" y2="18"/>
+              <line x1="6" y1="6" x2="18" y2="18"/>
+            </svg>
+            <span class="chat-sidenav__action-label">Close</span>
+          </button>
+        }
+      </div>
+
+      <div class="chat-sidenav__actions">
+        <button
+          type="button"
+          class="chat-sidenav__action chat-sidenav__action--search"
+          (click)="searchOpened.emit()"
+          aria-label="Search conversations"
+          title="Search conversations (⌘K)"
+        >
+          <svg class="chat-sidenav__action-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <circle cx="11" cy="11" r="7"/>
+            <line x1="21" y1="21" x2="16.65" y2="16.65"/>
+          </svg>
+          <span class="chat-sidenav__action-label">Search</span>
+        </button>
       </div>
 
       <div class="chat-sidenav__primary">

--- a/libs/chat/src/lib/styles/chat-sidenav.styles.ts
+++ b/libs/chat/src/lib/styles/chat-sidenav.styles.ts
@@ -33,7 +33,12 @@ export const CHAT_SIDENAV_STYLES = `
     width: 100%;
   }
   :host([data-mode="drawer"]) {
-    position: relative;
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: var(--ngaf-chat-sidenav-width-drawer);
+    z-index: 1001;
   }
   .chat-sidenav {
     display: flex;
@@ -54,27 +59,42 @@ export const CHAT_SIDENAV_STYLES = `
     cursor: pointer;
   }
   :host([data-mode="drawer"]) .chat-sidenav {
-    position: fixed;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    width: var(--ngaf-chat-sidenav-width-drawer);
-    z-index: 1001;
+    width: 100%;
+    height: 100%;
     transition: transform 200ms ease;
     transform: translateX(-100%);
   }
   :host([data-mode="drawer"][data-open="true"]) .chat-sidenav {
     transform: translateX(0);
   }
-  @media (max-width: 767px) {
-    :host([data-mode="drawer"]) .chat-sidenav {
-      width: 100%;
-    }
-  }
   .chat-sidenav__header {
     flex-shrink: 0;
     padding: var(--ngaf-chat-space-3);
     border-bottom: 1px solid var(--ngaf-chat-separator);
+  }
+  .chat-sidenav__topbar {
+    flex-shrink: 0;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    gap: 4px;
+    padding: var(--ngaf-chat-space-2) var(--ngaf-chat-space-3);
+    border-bottom: 1px solid var(--ngaf-chat-separator);
+  }
+  :host([data-mode="collapsed"]) .chat-sidenav__topbar {
+    justify-content: center;
+    padding: var(--ngaf-chat-space-2);
+  }
+  .chat-sidenav__topbar .chat-sidenav__action {
+    width: 36px;
+    height: 36px;
+    padding: 0;
+    justify-content: center;
+    flex: 0 0 auto;
+  }
+  .chat-sidenav__topbar .chat-sidenav__action-label {
+    display: none;
   }
   .chat-sidenav__actions {
     flex-shrink: 0;


### PR DESCRIPTION
## Summary

Three fixes identified during visual review of #272.

### 1. Sidenav header trim (libs/chat)

The expanded sidenav previously stacked three full-width rows (New chat, Search, Collapse) which felt heavy. A new `.chat-sidenav__topbar` row hosts the New chat and Collapse/Expand buttons as icon-only controls with `justify-content: space-between`. The Search button becomes the sole full-width row in `.chat-sidenav__actions`. Topbar labels are hidden in every mode so the topbar stays icon-only in expanded mode and centers in collapsed mode.

```
┌─────────────────────┐
│ [+]            [<]  │  ← icon-only topbar (New + Collapse)
├─────────────────────┤
│ 🔍 Search           │  ← full-width row
├─────────────────────┤
│ RECENT              │
│   thread 1          │
└─────────────────────┘
```

### 2. GenUI dark mode contrast (examples/chat/angular)

**Root cause:** `examples/chat/angular/src/styles.css` sets a dark body background but never opted the chat lib into dark tokens. `--ngaf-chat-text` stayed at `rgb(28, 28, 28)`, and headings inside `<chat>` (including A2UI surface titles) inherited near-black on a dark background.

**Fix:** set `data-ngaf-chat-theme="dark"` on `<html>` in `index.html`. That activates the dark token block at `libs/chat/src/lib/styles/chat.css:166-182` so text becomes `rgb(245, 245, 245)`.

### 3. Mobile drawer fixes (libs/chat)

**Root cause:** drawer mode applied `position: relative` to the host (originally added in #272 to avoid reserving space when closed), which caused the host to stretch to its parent's full width and made the inner `.chat-sidenav` fill the entire viewport. The scrim was hidden behind the full-width drawer.

**Fix:**
- Host is now `position: fixed; top: 0; left: 0; bottom: 0; width: var(--ngaf-chat-sidenav-width-drawer)` (280px), with the inner wrapper handling the `translateX` open/close transition.
- A new icon-only Close (X) button is rendered in the topbar exclusively in drawer mode (`aria-label="Close conversations"`), wired to emit `openChange(false)`.
- The dark-mode fix from item 2 also resolves the drawer rendering in light mode (same root cause).

## Test plan

- [x] `npx nx test chat --testFile chat-sidenav.component.spec.ts` (26 specs pass, 5 new)
- [x] `npx nx build chat`
- [x] `npx nx lint chat`
- [x] `npx nx build examples-chat-angular`
- [x] `npm run generate-api-docs`
- [ ] Manual verification at <1024px viewport: drawer overlays 280px, scrim is visible, close button works
- [ ] Manual verification at >=1024px: topbar shows icon-only New + Collapse; Search is the only full row
- [ ] Manual verification GenUI surface titles are legible on dark background