### PR TITLE
feat(website): homepage content fills — ProofStrip claim, Promises refresh, HomeFAQ expansion

### DIFF
--- a/apps/website/src/components/landing/HomeFAQ.tsx
+++ b/apps/website/src/components/landing/HomeFAQ.tsx
@@ -7,7 +7,7 @@ import { FAQ, type FAQItem } from '../ui/FAQ';
 const ITEMS: FAQItem[] = [
   {
     q: 'How is this different from CopilotKit or AG-UI directly?',
-    a: 'CopilotKit ports React patterns to Angular. AG-UI is a protocol — you still build the Angular side. Angular Agent Framework is Angular-native: signals, DI, zoneless support, and adapters that hide the protocol so you can swap LangGraph for AG-UI without rewriting your UI.',
+    a: 'CopilotKit has an Angular SDK; we made different choices (signals, DI, zoneless-first). AG-UI is a protocol, not a UI library — you still build the Angular side. Angular Agent Framework gives you signal-native primitives plus adapters that hide the protocol, so you can swap LangGraph for AG-UI without rewriting your UI.',
   },
   {
     q: 'Does it work with my existing Angular app?',
@@ -31,11 +31,23 @@ const ITEMS: FAQItem[] = [
   },
   {
     q: 'Is this production-ready today?',
-    a: 'Yes — the Cockpit reference app runs the full stack. We track Angular’s release cadence and ship against current and one previous major.',
+    a: 'It runs the full stack in our reference deployment (cockpit.cacheplane.ai), and breaking changes are called out in release notes. We track current and previous Angular majors.',
   },
   {
     q: 'Where do I report issues?',
     a: 'GitHub Issues. Pilot customers also get a private channel.',
+  },
+  {
+    q: 'I’m using CopilotKit today — how hard is the migration?',
+    a: 'Component-by-component. useChat-style hooks map to the agent() signal API; actions map to LangGraph/AG-UI tool calls. Thread state lives in a service (not the component tree), so plan a session to port that. There isn’t a one-shot codemod.',
+  },
+  {
+    q: 'Does it work with Angular Universal / SSR?',
+    a: 'Streaming is client-side by design — agents are stateful and signal-based. If your shell is SSR’d, the chat compositions render with a loading state on the server and hydrate; the agent-talking parts stay client-only.',
+  },
+  {
+    q: 'How do I test agent-driven components?',
+    a: 'The agent is provided through Angular DI, so test doubles work the way you’re used to — supply a stub agent in your test module, drive it with signals, assert on the rendered output. See /docs/agent/guides/testing.',
   },
 ];
 
@@ -44,7 +56,9 @@ export function HomeFAQ() {
     <Section surface="white" ariaLabelledBy="faq-heading">
       <Container>
         <div style={{ textAlign: 'center', marginBottom: 48 }}>
-          <Eyebrow tone="accent" style={{ marginBottom: 16 }}>Questions</Eyebrow>
+          <Eyebrow tone="accent" style={{ marginBottom: 16 }}>
+            Questions
+          </Eyebrow>
           <h2
             id="faq-heading"
             style={{

--- a/apps/website/src/components/landing/HomeFAQ.tsx
+++ b/apps/website/src/components/landing/HomeFAQ.tsx
@@ -7,15 +7,11 @@ import { FAQ, type FAQItem } from '../ui/FAQ';
 const ITEMS: FAQItem[] = [
   {
     q: 'How is this different from CopilotKit or AG-UI directly?',
-    a: 'CopilotKit has an Angular SDK; we made different choices (signals, DI, zoneless-first). AG-UI is a protocol, not a UI library — you still build the Angular side. Angular Agent Framework gives you signal-native primitives plus adapters that hide the protocol, so you can swap LangGraph for AG-UI without rewriting your UI.',
+    a: 'CopilotKit has an Angular SDK; ours is built around signals and DI as the substrate, not a port. AG-UI is a protocol, not a UI library — you still build the Angular side. Angular Agent Framework gives you signal-native primitives plus adapters that hide the protocol, so you can swap LangGraph for AG-UI without rewriting your UI.',
   },
   {
     q: 'Does it work with my existing Angular app?',
     a: 'Yes. Drop provideAgent (or provideAgUiAgent) into your app.config.ts. The headless primitives don’t impose any UI; the chat compositions are opt-in.',
-  },
-  {
-    q: 'Is it zoneless-compatible?',
-    a: 'Yes. All signal flows are zoneless-safe. We test against zoneless apps.',
   },
   {
     q: 'Can I use this without LangGraph?',
@@ -31,7 +27,7 @@ const ITEMS: FAQItem[] = [
   },
   {
     q: 'Is this production-ready today?',
-    a: 'It runs the full stack in our reference deployment (cockpit.cacheplane.ai), and breaking changes are called out in release notes. We track current and previous Angular majors.',
+    a: 'It runs the full stack in our reference deployment (cockpit.cacheplane.ai), and breaking changes are called out in release notes. We support Angular’s current and previous LTS versions.',
   },
   {
     q: 'Where do I report issues?',
@@ -39,11 +35,11 @@ const ITEMS: FAQItem[] = [
   },
   {
     q: 'I’m using CopilotKit today — how hard is the migration?',
-    a: 'Component-by-component. useChat-style hooks map to the agent() signal API; actions map to LangGraph/AG-UI tool calls. Thread state lives in a service (not the component tree), so plan a session to port that. There isn’t a one-shot codemod.',
+    a: 'Component-by-component. CopilotKit’s chat hooks have rough equivalents in our agent() signal API, and CopilotKit actions map to LangGraph/AG-UI tool calls. Thread state lives in a service (not the component tree), so plan a session to port that. There isn’t a one-shot codemod.',
   },
   {
     q: 'Does it work with Angular Universal / SSR?',
-    a: 'Streaming is client-side by design — agents are stateful and signal-based. If your shell is SSR’d, the chat compositions render with a loading state on the server and hydrate; the agent-talking parts stay client-only.',
+    a: 'Streaming is client-side by design — agents are stateful and signal-based. If your shell is SSR’d, the agent-talking parts stay client-only; render fallbacks during hydration via standard Angular SSR patterns.',
   },
   {
     q: 'How do I test agent-driven components?',

--- a/apps/website/src/components/landing/Promises.tsx
+++ b/apps/website/src/components/landing/Promises.tsx
@@ -6,24 +6,24 @@ import { Card } from '../ui/Card';
 
 const PROMISES = [
   {
-    title: "No closed core",
-    body: "MIT today, MIT tomorrow. Primitives and compositions both stay in the open repo. Pilot-to-Prod is the only paid thing.",
+    title: 'No closed core',
+    body: 'MIT today, MIT tomorrow. Primitives and compositions both stay in the open repo. Pilot-to-Prod is the only paid thing.',
   },
   {
-    title: "No abandoned majors",
-    body: "We follow Angular’s LTS. When Angular ships, we ship.",
+    title: 'No abandoned majors',
+    body: 'We follow Angular’s LTS. When Angular ships, we ship.',
   },
   {
-    title: "No required cloud",
-    body: "Self-host LangGraph + your Angular app. Run it all in your VPC.",
+    title: 'No required cloud',
+    body: 'Self-host LangGraph + your Angular app. Run it all in your VPC.',
   },
   {
-    title: "No telemetry",
-    body: "We don’t collect anything from your app. Not at install, not at runtime.",
+    title: 'No telemetry',
+    body: 'We don’t collect anything from your app. Not at install, not at runtime.',
   },
   {
-    title: "No model lock-in",
-    body: "Adapters work with any LLM your runtime supports. Swap providers without changing Angular code.",
+    title: 'No model lock-in',
+    body: 'Adapters work with any LLM your runtime supports. Swap providers without changing Angular code.',
   },
 ];
 
@@ -32,7 +32,9 @@ export function Promises() {
     <Section surface="canvas" ariaLabelledBy="promises-heading">
       <Container>
         <div style={{ textAlign: 'center', marginBottom: 56 }}>
-          <Eyebrow tone="accent" style={{ marginBottom: 16 }}>Built on principles</Eyebrow>
+          <Eyebrow tone="accent" style={{ marginBottom: 16 }}>
+            Built on principles
+          </Eyebrow>
           <h2
             id="promises-heading"
             style={{

--- a/apps/website/src/components/landing/Promises.tsx
+++ b/apps/website/src/components/landing/Promises.tsx
@@ -5,11 +5,26 @@ import { Eyebrow } from '../ui/Eyebrow';
 import { Card } from '../ui/Card';
 
 const PROMISES = [
-  { title: 'No vendor lock-in', body: 'MIT today, MIT tomorrow. Use without us.' },
-  { title: 'No paid Angular tier', body: 'The libraries stay open. Pilot-to-Prod is the only paid offering.' },
-  { title: 'No abandoned majors', body: 'We follow Angular’s LTS. When Angular ships, we ship.' },
-  { title: 'No closed primitives', body: 'Headless primitives stay in the open repo.' },
-  { title: 'No required cloud', body: 'Self-host LangGraph + your Angular app. No phone-home.' },
+  {
+    title: "No closed core",
+    body: "MIT today, MIT tomorrow. Primitives and compositions both stay in the open repo. Pilot-to-Prod is the only paid thing.",
+  },
+  {
+    title: "No abandoned majors",
+    body: "We follow Angular’s LTS. When Angular ships, we ship.",
+  },
+  {
+    title: "No required cloud",
+    body: "Self-host LangGraph + your Angular app. Run it all in your VPC.",
+  },
+  {
+    title: "No telemetry",
+    body: "We don’t collect anything from your app. Not at install, not at runtime.",
+  },
+  {
+    title: "No model lock-in",
+    body: "Adapters work with any LLM your runtime supports. Swap providers without changing Angular code.",
+  },
 ];
 
 export function Promises() {

--- a/apps/website/src/components/landing/Promises.tsx
+++ b/apps/website/src/components/landing/Promises.tsx
@@ -11,7 +11,7 @@ const PROMISES = [
   },
   {
     title: 'No abandoned majors',
-    body: 'We follow Angular’s LTS. When Angular ships, we ship.',
+    body: 'We support Angular’s current and previous LTS versions.',
   },
   {
     title: 'No required cloud',

--- a/apps/website/src/components/landing/ProofStrip.tsx
+++ b/apps/website/src/components/landing/ProofStrip.tsx
@@ -16,7 +16,7 @@ const SIGNALS: Signal[] = [
     value: 'Open source',
     href: 'https://github.com/cacheplane/angular-agent-framework/blob/main/LICENSE',
   },
-  { label: 'Built for Angular 20+', value: 'Zoneless ready', href: null },
+  { label: 'Built for', value: 'Angular 20+', href: null },
   {
     label: 'Adapter contract',
     value: 'LangGraph + AG-UI + your own',

--- a/apps/website/src/components/landing/ProofStrip.tsx
+++ b/apps/website/src/components/landing/ProofStrip.tsx
@@ -11,11 +11,27 @@ interface Signal {
 }
 
 const SIGNALS: Signal[] = [
-  { label: 'MIT licensed', value: 'Open source', href: 'https://github.com/cacheplane/angular-agent-framework/blob/main/LICENSE' },
+  {
+    label: 'MIT licensed',
+    value: 'Open source',
+    href: 'https://github.com/cacheplane/angular-agent-framework/blob/main/LICENSE',
+  },
   { label: 'Built for Angular 20+', value: 'Zoneless ready', href: null },
-  { label: 'LangGraph + AG-UI', value: 'Two adapters', href: null },
-  { label: 'Reference app', value: 'cockpit.cacheplane.ai', href: 'https://cockpit.cacheplane.ai' },
-  { label: 'On npm', value: '@ngaf/chat', href: 'https://www.npmjs.com/package/@ngaf/chat' },
+  {
+    label: 'Adapter contract',
+    value: 'LangGraph + AG-UI + your own',
+    href: null,
+  },
+  {
+    label: 'Reference app',
+    value: 'cockpit.cacheplane.ai',
+    href: 'https://cockpit.cacheplane.ai',
+  },
+  {
+    label: 'On npm',
+    value: '@ngaf/* — 7 packages',
+    href: 'https://www.npmjs.com/search?q=%40ngaf',
+  },
 ];
 
 function SignalCard({ s }: { s: Signal }) {
@@ -51,9 +67,23 @@ export function ProofStrip() {
   return (
     <Section surface="canvas" tight>
       <Container>
-        <Eyebrow style={{ textAlign: 'center', marginBottom: 20 }}>
+        <Eyebrow style={{ textAlign: 'center', marginBottom: 12 }}>
           Built in the open
         </Eyebrow>
+        <p
+          style={{
+            fontFamily: tokens.typography.bodyLg.family,
+            fontSize: tokens.typography.bodyLg.size,
+            lineHeight: tokens.typography.bodyLg.line,
+            fontWeight: 600,
+            color: tokens.colors.textPrimary,
+            textAlign: 'center',
+            margin: 0,
+            marginBottom: 20,
+          }}
+        >
+          Open code, open packages, a live reference app.
+        </p>
         <div
           style={{
             display: 'grid',
@@ -78,7 +108,7 @@ export function ProofStrip() {
               <div key={s.label}>
                 <SignalCard s={s} />
               </div>
-            ),
+            )
           )}
         </div>
       </Container>

--- a/docs/superpowers/plans/2026-05-12-homepage-content-fills.md
+++ b/docs/superpowers/plans/2026-05-12-homepage-content-fills.md
@@ -1,0 +1,394 @@
+# Homepage content fills Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Editorial pass on three Phase-4 landing components — fill the gaps identified in the analysis: missing ProofStrip claim line, redundant adapter signal, undersold npm signal, two overlapping Promises (now consolidated), two new Promises (telemetry, model lock-in), softened FAQ Q1/Q7, and three new FAQ entries (migration, SSR, testing).
+
+**Architecture:** Pure content edits to three React Server Component files. No new components, no new dependencies, no schema changes. ProofStrip gains one new `<p>` element above the existing grid; Promises and HomeFAQ are data-array swaps. Verification is visual (preview server) plus TypeScript build.
+
+**Tech Stack:** TypeScript, Next.js 16 RSC, `@ngaf/design-tokens`, existing UI primitives (`Section`, `Container`, `Eyebrow`, `Card`, `FAQ`).
+
+**Spec:** `docs/superpowers/specs/2026-05-12-homepage-content-fills-design.md`
+
+---
+
+## File Structure
+
+Three files modified, no files created:
+
+- `apps/website/src/components/landing/ProofStrip.tsx` — add claim line `<p>`, edit two entries in `SIGNALS`
+- `apps/website/src/components/landing/Promises.tsx` — full `PROMISES` array replacement
+- `apps/website/src/components/landing/HomeFAQ.tsx` — full `ITEMS` array replacement (8 → 11 entries, Q1 and Q7 reworded, Q9/Q10/Q11 appended)
+
+Each task is one file = one commit. After all three commits, one verification pass against the preview server and the TypeScript build.
+
+---
+
+## Task 1: ProofStrip — claim line + signal #3 + signal #5
+
+**Files:**
+- Modify: `apps/website/src/components/landing/ProofStrip.tsx`
+
+- [ ] **Step 1: Open the file and locate the `SIGNALS` array (lines 13–19)**
+
+Replace the third entry. Current:
+
+```ts
+{ label: 'LangGraph + AG-UI', value: 'Two adapters', href: null },
+```
+
+Replace with:
+
+```ts
+{ label: 'Adapter contract', value: 'LangGraph + AG-UI + your own', href: null },
+```
+
+- [ ] **Step 2: Replace the fifth entry in `SIGNALS`**
+
+Current:
+
+```ts
+{ label: 'On npm', value: '@ngaf/chat', href: 'https://www.npmjs.com/package/@ngaf/chat' },
+```
+
+Replace with:
+
+```ts
+{ label: 'On npm', value: '@ngaf/* — 7 packages', href: 'https://www.npmjs.com/search?q=%40ngaf' },
+```
+
+- [ ] **Step 3: Add the claim line in the JSX**
+
+Locate the `Eyebrow` block (currently around line 54). Immediately after the closing `</Eyebrow>` tag and before the signals grid `<div>`, insert a centered `<p>` element. The full replacement region (from `<Eyebrow ...>` through the opening of the signals grid `<div>`) should look like:
+
+```tsx
+        <Eyebrow style={{ textAlign: 'center', marginBottom: 12 }}>
+          Built in the open
+        </Eyebrow>
+        <p
+          style={{
+            fontFamily: tokens.typography.bodyLg.family,
+            fontSize: tokens.typography.bodyLg.size,
+            lineHeight: tokens.typography.bodyLg.line,
+            fontWeight: 600,
+            color: tokens.colors.textPrimary,
+            textAlign: 'center',
+            margin: 0,
+            marginBottom: 20,
+          }}
+        >
+          Open code, open packages, a live reference app.
+        </p>
+        <div
+          style={{
+            display: 'grid',
+```
+
+Note two changes from the prior layout:
+1. `Eyebrow`'s `marginBottom` drops from `20` → `12` (the claim line now carries the gap below it).
+2. The new `<p>` has `marginBottom: 20` so the total visual gap above the grid is unchanged.
+
+- [ ] **Step 4: Verify the diff is clean**
+
+Run:
+
+```bash
+git diff apps/website/src/components/landing/ProofStrip.tsx
+```
+
+Expected: changes to lines in `SIGNALS` entries 3 and 5, the `Eyebrow` `marginBottom` value, and a new `<p>` element. No other lines changed.
+
+- [ ] **Step 5: TypeScript check**
+
+Run:
+
+```bash
+npx nx run website:lint --no-cloud 2>&1 | tail -20
+```
+
+Expected: no new lint errors introduced by this change.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/website/src/components/landing/ProofStrip.tsx
+git commit -m "feat(website): polish ProofStrip — claim line, adapter signal, npm scope"
+```
+
+---
+
+## Task 2: Promises — 5-card refresh
+
+**Files:**
+- Modify: `apps/website/src/components/landing/Promises.tsx`
+
+- [ ] **Step 1: Replace the `PROMISES` array (lines 7–13)**
+
+Current:
+
+```ts
+const PROMISES = [
+  { title: 'No vendor lock-in', body: 'MIT today, MIT tomorrow. Use without us.' },
+  { title: 'No paid Angular tier', body: 'The libraries stay open. Pilot-to-Prod is the only paid offering.' },
+  { title: 'No abandoned majors', body: 'We follow Angular’s LTS. When Angular ships, we ship.' },
+  { title: 'No closed primitives', body: 'Headless primitives stay in the open repo.' },
+  { title: 'No required cloud', body: 'Self-host LangGraph + your Angular app. No phone-home.' },
+];
+```
+
+Replace with:
+
+```ts
+const PROMISES = [
+  {
+    title: 'No closed core',
+    body: 'MIT today, MIT tomorrow. Primitives and compositions both stay in the open repo. Pilot-to-Prod is the only paid thing.',
+  },
+  {
+    title: 'No abandoned majors',
+    body: 'We follow Angular’s LTS. When Angular ships, we ship.',
+  },
+  {
+    title: 'No required cloud',
+    body: 'Self-host LangGraph + your Angular app. Run it all in your VPC.',
+  },
+  {
+    title: 'No telemetry',
+    body: 'We don’t collect anything from your app. Not at install, not at runtime.',
+  },
+  {
+    title: 'No model lock-in',
+    body: 'Adapters work with any LLM your runtime supports. Swap providers without changing Angular code.',
+  },
+];
+```
+
+Note: the apostrophes in `Angular's`, `don't`, and `you're` use the curly Unicode character (`’`), matching the existing file's style (e.g. `Angular's` on line 11 already uses `’`).
+
+- [ ] **Step 2: Verify the diff is clean**
+
+Run:
+
+```bash
+git diff apps/website/src/components/landing/Promises.tsx
+```
+
+Expected: only the `PROMISES` array content changed. JSX and styling untouched.
+
+- [ ] **Step 3: TypeScript check**
+
+Run:
+
+```bash
+npx nx run website:lint --no-cloud 2>&1 | tail -20
+```
+
+Expected: no new lint errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/website/src/components/landing/Promises.tsx
+git commit -m "feat(website): refresh Promises — consolidate openness beats, add telemetry + model lock-in"
+```
+
+---
+
+## Task 3: HomeFAQ — Q1/Q7 reword + Q9/Q10/Q11 append
+
+**Files:**
+- Modify: `apps/website/src/components/landing/HomeFAQ.tsx`
+
+- [ ] **Step 1: Replace the `ITEMS` array (lines 7–40)**
+
+Full replacement of the `const ITEMS: FAQItem[] = [...]` block. Replace with:
+
+```ts
+const ITEMS: FAQItem[] = [
+  {
+    q: 'How is this different from CopilotKit or AG-UI directly?',
+    a: 'CopilotKit has an Angular SDK; we made different choices (signals, DI, zoneless-first). AG-UI is a protocol, not a UI library — you still build the Angular side. Angular Agent Framework gives you signal-native primitives plus adapters that hide the protocol, so you can swap LangGraph for AG-UI without rewriting your UI.',
+  },
+  {
+    q: 'Does it work with my existing Angular app?',
+    a: 'Yes. Drop provideAgent (or provideAgUiAgent) into your app.config.ts. The headless primitives don’t impose any UI; the chat compositions are opt-in.',
+  },
+  {
+    q: 'Is it zoneless-compatible?',
+    a: 'Yes. All signal flows are zoneless-safe. We test against zoneless apps.',
+  },
+  {
+    q: 'Can I use this without LangGraph?',
+    a: 'Yes. Use the @ngaf/ag-ui adapter for any AG-UI compliant backend, or implement the agent contract yourself. The Angular side doesn’t know which runtime is behind it.',
+  },
+  {
+    q: 'Is the Pilot-to-Prod program required?',
+    a: 'No. The libraries are MIT-licensed and complete on their own. Pilot-to-Prod is for teams who want concierge delivery, not a paywall.',
+  },
+  {
+    q: 'What does it cost?',
+    a: 'Libraries: free, MIT. Pilot-to-Prod: scoped per engagement — see the pricing page.',
+  },
+  {
+    q: 'Is this production-ready today?',
+    a: 'It runs the full stack in our reference deployment (cockpit.cacheplane.ai), and breaking changes are called out in release notes. We track current and previous Angular majors.',
+  },
+  {
+    q: 'Where do I report issues?',
+    a: 'GitHub Issues. Pilot customers also get a private channel.',
+  },
+  {
+    q: 'I’m using CopilotKit today — how hard is the migration?',
+    a: 'Component-by-component. useChat-style hooks map to the agent() signal API; actions map to LangGraph/AG-UI tool calls. Thread state lives in a service (not the component tree), so plan a session to port that. There isn’t a one-shot codemod.',
+  },
+  {
+    q: 'Does it work with Angular Universal / SSR?',
+    a: 'Streaming is client-side by design — agents are stateful and signal-based. If your shell is SSR’d, the chat compositions render with a loading state on the server and hydrate; the agent-talking parts stay client-only.',
+  },
+  {
+    q: 'How do I test agent-driven components?',
+    a: 'The agent is provided through Angular DI, so test doubles work the way you’re used to — supply a stub agent in your test module, drive it with signals, assert on the rendered output. See /docs/agent/guides/testing.',
+  },
+];
+```
+
+Notes on what's different vs the existing array:
+- Q1 body is reworded (the "CopilotKit ports React patterns" claim is softened).
+- Q2 through Q6 are byte-identical to the current file.
+- Q7 body is reworded (drops the unqualified "Yes —", lets the evidence carry).
+- Q8 is byte-identical to the current file.
+- Q9, Q10, Q11 are new.
+
+Apostrophes use the curly Unicode `’` to match the existing file (e.g. `Angular’s` on line 34 of the current file).
+
+In the FAQ answer copy, `useChat`, `agent()`, `provideAgent`, `provideAgUiAgent`, `@ngaf/ag-ui` are written as plain text (not backtick-fenced inline code) because the existing answers (Q2, Q4) follow that convention. The `FAQ` primitive isn't rich-text; the strings render as plain text.
+
+- [ ] **Step 2: Verify the diff is clean**
+
+Run:
+
+```bash
+git diff apps/website/src/components/landing/HomeFAQ.tsx
+```
+
+Expected: only the `ITEMS` array changed. Component JSX and `Section`/`Container`/`Eyebrow` markup untouched. Line count grows (~33 lines).
+
+- [ ] **Step 3: TypeScript check**
+
+Run:
+
+```bash
+npx nx run website:lint --no-cloud 2>&1 | tail -20
+```
+
+Expected: no new lint errors. Strings with apostrophes (`don’t`, `isn’t`, `you’re`, `Angular’s`) shouldn't trip `react/no-unescaped-entities` because the existing file already uses the curly form.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/website/src/components/landing/HomeFAQ.tsx
+git commit -m "feat(website): expand HomeFAQ — soften CopilotKit + production claims, add migration/SSR/testing"
+```
+
+---
+
+## Task 4: Verification (preview + build)
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Start the preview server**
+
+If a preview is not already running, start it:
+
+```bash
+# Use the preview_start MCP tool (do not start via Bash):
+#   preview_start with command "npx nx run website:dev"
+```
+
+Expected: server boots, homepage at `/` renders.
+
+- [ ] **Step 2: Visually verify ProofStrip**
+
+Navigate to `/`. Scroll to the section directly below the hero (`Built in the open`).
+
+Confirm:
+- The `Built in the open` eyebrow is followed by the new claim line `Open code, open packages, a live reference app.` (centered, weight 600, textPrimary).
+- The third signal card now reads `Adapter contract` / `LangGraph + AG-UI + your own`.
+- The fifth signal card now reads `On npm` / `@ngaf/* — 7 packages`, and clicking it opens `https://www.npmjs.com/search?q=%40ngaf` in a new tab with results.
+
+Capture a screenshot of the ProofStrip section for the PR description.
+
+- [ ] **Step 3: Visually verify Promises**
+
+Scroll to the `What we won't do.` section.
+
+Confirm five cards in this order:
+1. No closed core
+2. No abandoned majors
+3. No required cloud
+4. No telemetry
+5. No model lock-in
+
+Each body reads as drafted in Task 2. No old cards (`No vendor lock-in`, `No paid Angular tier`, `No closed primitives`) remain.
+
+- [ ] **Step 4: Visually verify HomeFAQ**
+
+Scroll to `Frequently asked questions.`
+
+Confirm 11 entries total, in this order:
+1. How is this different from CopilotKit or AG-UI directly?
+2. Does it work with my existing Angular app?
+3. Is it zoneless-compatible?
+4. Can I use this without LangGraph?
+5. Is the Pilot-to-Prod program required?
+6. What does it cost?
+7. Is this production-ready today?
+8. Where do I report issues?
+9. I'm using CopilotKit today — how hard is the migration?
+10. Does it work with Angular Universal / SSR?
+11. How do I test agent-driven components?
+
+Expand Q1 — verify it reads as the new softened text (no "ports React patterns").
+Expand Q7 — verify it does NOT start with "Yes —" and references release notes.
+Expand Q11 — verify the `/docs/agent/guides/testing` reference is present.
+
+- [ ] **Step 5: Verify the testing-doc link resolves**
+
+In the same preview server, navigate to `/docs/agent/guides/testing`.
+
+Expected: the testing guide page renders (it's at `apps/website/content/docs/agent/guides/testing.mdx`).
+
+- [ ] **Step 6: Verify the pricing-page link from Q6 resolves**
+
+Navigate to `/pricing`. Expected: pricing page renders (file exists at `apps/website/src/app/pricing/page.tsx`).
+
+- [ ] **Step 7: Run the full TypeScript build**
+
+```bash
+npx nx run website:build --no-cloud 2>&1 | tail -30
+```
+
+Expected: build succeeds with no new TS errors.
+
+- [ ] **Step 8: Stop the preview server**
+
+Use the `preview_stop` MCP tool.
+
+---
+
+## Self-review notes
+
+**Spec coverage check:**
+- ProofStrip claim line → Task 1, Step 3 ✓
+- ProofStrip signal #3 → Task 1, Step 1 ✓
+- ProofStrip signal #5 → Task 1, Step 2 ✓
+- Promises 5-card refresh (collapse + 2 new) → Task 2 ✓
+- HomeFAQ Q1 reword → Task 3, Step 1 ✓
+- HomeFAQ Q7 reword → Task 3, Step 1 ✓
+- HomeFAQ Q9/Q10/Q11 adds → Task 3, Step 1 ✓
+- Pricing-page link verification (spec verification §2) → Task 4, Step 6 ✓
+- Testing-doc link verification → Task 4, Step 5 ✓
+- TS build → Task 4, Step 7 ✓
+
+**Out-of-scope items flagged in spec, not in plan:**
+- Broken `/docs/agent/guides/production` link in the Ship FeatureBlock — left for a separate fix.

--- a/docs/superpowers/specs/2026-05-12-homepage-content-fills-design.md
+++ b/docs/superpowers/specs/2026-05-12-homepage-content-fills-design.md
@@ -1,0 +1,142 @@
+# Homepage content fills — ProofStrip / Promises / HomeFAQ
+
+**Date:** 2026-05-12
+**Scope:** Editorial pass on three landing components shipped in Phase 4 (PR #270). Fill gaps identified in the full analysis: missing claim line, redundant signal, undersold package family, two overlapping Promises, two over-stated FAQ answers, three missing FAQ questions.
+
+**Out of scope:** Hero, Differentiator, Stream/Render/Ship FeatureBlocks, PilotBlock, WhitePaperBlock, FinalCTA. Screenshot pipeline (separate workstream). The broken `/docs/agent/guides/production` link in the Ship block (flagged for a follow-up task).
+
+---
+
+## Files touched
+
+- `apps/website/src/components/landing/ProofStrip.tsx`
+- `apps/website/src/components/landing/Promises.tsx`
+- `apps/website/src/components/landing/HomeFAQ.tsx`
+
+No new components. No structural changes — only data-array edits plus one new heading element in ProofStrip.
+
+---
+
+## 1. ProofStrip
+
+### Add a claim line
+
+Insert a single sentence heading between the existing `Eyebrow` ("Built in the open") and the signals grid:
+
+> **Open code, open packages, a live reference app.**
+
+Styling: render as a centered `<p>` (not a section h2) using `tokens.typography.bodyLg`, `fontWeight: 600`, `color: tokens.colors.textPrimary`, with the existing `Eyebrow` keeping its current spacing above and the signals grid retaining its spacing below. This keeps ProofStrip's `tight` Section rhythm — the claim is an emphasis line, not a new section heading.
+
+### Replace signal #3 (currently redundant)
+
+| Field | Current | New |
+|---|---|---|
+| `label` | `LangGraph + AG-UI` | `Adapter contract` |
+| `value` | `Two adapters` | `LangGraph + AG-UI + your own` |
+| `href` | `null` | `null` |
+
+### Reframe signal #5 (currently undersells the package family)
+
+| Field | Current | New |
+|---|---|---|
+| `label` | `On npm` | `On npm` |
+| `value` | `@ngaf/chat` | `@ngaf/* — 7 packages` |
+| `href` | `https://www.npmjs.com/package/@ngaf/chat` | `https://www.npmjs.com/search?q=%40ngaf` |
+
+(`7 packages` = current count of non-private `libs/*/package.json` files: a2ui, ag-ui, chat, langgraph, licensing, partial-json, render. If that count changes before merge, update.)
+
+---
+
+## 2. Promises
+
+Full replacement of the `PROMISES` array. Same shape (`{ title, body }`), same card count (5), same section heading and surrounding copy.
+
+```ts
+const PROMISES = [
+  {
+    title: 'No closed core',
+    body: 'MIT today, MIT tomorrow. Primitives and compositions both stay in the open repo. Pilot-to-Prod is the only paid thing.',
+  },
+  {
+    title: 'No abandoned majors',
+    body: 'We follow Angular’s LTS. When Angular ships, we ship.',
+  },
+  {
+    title: 'No required cloud',
+    body: 'Self-host LangGraph + your Angular app. Run it all in your VPC.',
+  },
+  {
+    title: 'No telemetry',
+    body: 'We don’t collect anything from your app. Not at install, not at runtime.',
+  },
+  {
+    title: 'No model lock-in',
+    body: 'Adapters work with any LLM your runtime supports. Swap providers without changing Angular code.',
+  },
+];
+```
+
+Beat changes:
+- Old `No vendor lock-in` + `No paid Angular tier` + `No closed primitives` → consolidated into new `No closed core` (one distinct beat instead of three overlapping ones).
+- Old `No required cloud` body reworded from "No phone-home" to "Run it all in your VPC" — leaves "phone-home" framing to the new `No telemetry` card.
+- New `No telemetry` — explicit promise that matches the `FinalCTA` caption.
+- New `No model lock-in` — net-new beat not duplicated upstream.
+
+---
+
+## 3. HomeFAQ
+
+Full replacement of the `ITEMS` array. Same shape (`FAQItem[]`), expands from 8 to 11 entries. Two existing answers reworded; three new questions appended.
+
+```ts
+const ITEMS: FAQItem[] = [
+  {
+    q: 'How is this different from CopilotKit or AG-UI directly?',
+    a: 'CopilotKit has an Angular SDK; we made different choices (signals, DI, zoneless-first). AG-UI is a protocol, not a UI library — you still build the Angular side. Angular Agent Framework gives you signal-native primitives plus adapters that hide the protocol, so you can swap LangGraph for AG-UI without rewriting your UI.',
+  },
+  // Q2 unchanged: existing-app
+  // Q3 unchanged: zoneless
+  // Q4 unchanged: without LangGraph
+  // Q5 unchanged: P2P required
+  // Q6 unchanged: cost
+  {
+    q: 'Is this production-ready today?',
+    a: 'It runs the full stack in our reference deployment (cockpit.cacheplane.ai), and breaking changes are called out in release notes. We track current and previous Angular majors.',
+  },
+  // Q8 unchanged: where to report issues
+  {
+    q: 'I’m using CopilotKit today — how hard is the migration?',
+    a: 'Component-by-component. `useChat`-style hooks map to the `agent()` signal API; actions map to LangGraph/AG-UI tool calls. Thread state lives in a service (not the component tree), so plan a session to port that. There isn’t a one-shot codemod.',
+  },
+  {
+    q: 'Does it work with Angular Universal / SSR?',
+    a: 'Streaming is client-side by design — agents are stateful and signal-based. If your shell is SSR’d, the chat compositions render with a loading state on the server and hydrate; the agent-talking parts stay client-only.',
+  },
+  {
+    q: 'How do I test agent-driven components?',
+    a: 'The agent is provided through Angular DI, so test doubles work the way you’re used to — supply a stub agent in your test module, drive it with signals, assert on the rendered output. See /docs/agent/guides/testing.',
+  },
+];
+```
+
+Final order: Q1 (reworded) → Q2 → Q3 → Q4 → Q5 → Q6 → Q7 (reworded) → Q8 → Q9 (new) → Q10 (new) → Q11 (new).
+
+Edits in detail:
+- **Q1:** softens the "ports React patterns to Angular" claim about CopilotKit (factually shaky — CopilotKit's Angular SDK exists and may not be a literal port). Keeps the positioning beat without the risk.
+- **Q7:** drops unqualified "Yes — production-ready today." We're at 0.0.x with patch-level versioning; the previous answer doesn't cash. New copy lets evidence (Cockpit + release notes) carry it.
+- **Q9 (new):** the obvious follow-up to Q1. The most commercially-relevant question this section can answer.
+- **Q10 (new):** SSR is a hard-stop for many enterprise Angular shops. Silence reads as "doesn't support it." Honest answer is better than no answer.
+- **Q11 (new):** Angular teams care about testing; silence here suggests it's hard. Links to existing `apps/website/content/docs/agent/guides/testing.mdx`.
+
+---
+
+## Verification
+
+- Visit `/` in the preview dev server, confirm ProofStrip claim renders above the cards, Promises shows the new 5-card lineup, FAQ shows 11 items in the expected order.
+- Verify the new signal #5 link (`npm search ?q=%40ngaf`) opens to a populated results page.
+- Verify the `/docs/agent/guides/testing` link from Q11 resolves.
+- TypeScript build passes (`nx build website`).
+
+## Risk / rollback
+
+Single PR, three file edits, no schema or shape changes. Rollback is `git revert`. No dependencies on screenshot work or other in-flight PRs.

--- a/docs/superpowers/specs/2026-05-12-homepage-content-fills-design.md
+++ b/docs/superpowers/specs/2026-05-12-homepage-content-fills-design.md
@@ -1,9 +1,15 @@
 # Homepage content fills — ProofStrip / Promises / HomeFAQ
 
-**Date:** 2026-05-12
-**Scope:** Editorial pass on three landing components shipped in Phase 4 (PR #270). Fill gaps identified in the full analysis: missing claim line, redundant signal, undersold package family, two overlapping Promises, two over-stated FAQ answers, three missing FAQ questions.
+**Date:** 2026-05-12 (revised after PR #275 landed)
+**Scope:** Editorial pass on three landing components shipped in PR #270. Fill gaps identified in the full analysis: missing ProofStrip claim line, redundant adapter signal, undersold npm signal, two overlapping Promises (now consolidated), two new Promises (telemetry, model lock-in), softened HomeFAQ Q1 (CopilotKit claim) and Q-production (production-ready), three new HomeFAQ entries (CopilotKit migration, Angular Universal / SSR, testing).
 
 **Out of scope:** Hero, Differentiator, Stream/Render/Ship FeatureBlocks, PilotBlock, WhitePaperBlock, FinalCTA. Screenshot pipeline (separate workstream). The broken `/docs/agent/guides/production` link in the Ship block (flagged for a follow-up task).
+
+**Baseline:** This spec is written against `origin/main` after PR #275 (`refactor(website): editorial sweep — drop zoneless claims, honest LTS commitment`) landed. #275 already:
+- Dropped all "zoneless" claims sitewide (ProofStrip signal #2 became `Built for / Angular 20+`; HomeFAQ Q1 lost the `zoneless support` mention; HomeFAQ's `Is it zoneless-compatible?` question was removed).
+- Locked the LTS commitment phrasing to `We support Angular's current and previous LTS versions.` in both Promises card 2 and HomeFAQ Q-production.
+
+This spec does **not** reintroduce any "zoneless" language, and **uses #275's LTS phrasing verbatim** where it overlaps.
 
 ---
 
@@ -13,7 +19,7 @@
 - `apps/website/src/components/landing/Promises.tsx`
 - `apps/website/src/components/landing/HomeFAQ.tsx`
 
-No new components. No structural changes — only data-array edits plus one new heading element in ProofStrip.
+No new components. No structural changes — data-array edits plus one new heading element in ProofStrip.
 
 ---
 
@@ -21,7 +27,7 @@ No new components. No structural changes — only data-array edits plus one new 
 
 ### Add a claim line
 
-Insert a single sentence heading between the existing `Eyebrow` ("Built in the open") and the signals grid:
+Insert a single sentence between the existing `Eyebrow` ("Built in the open") and the signals grid:
 
 > **Open code, open packages, a live reference app.**
 
@@ -29,7 +35,7 @@ Styling: render as a centered `<p>` (not a section h2) using `tokens.typography.
 
 ### Replace signal #3 (currently redundant)
 
-| Field | Current | New |
+| Field | Current on main | New |
 |---|---|---|
 | `label` | `LangGraph + AG-UI` | `Adapter contract` |
 | `value` | `Two adapters` | `LangGraph + AG-UI + your own` |
@@ -37,13 +43,17 @@ Styling: render as a centered `<p>` (not a section h2) using `tokens.typography.
 
 ### Reframe signal #5 (currently undersells the package family)
 
-| Field | Current | New |
+| Field | Current on main | New |
 |---|---|---|
 | `label` | `On npm` | `On npm` |
 | `value` | `@ngaf/chat` | `@ngaf/* — 7 packages` |
 | `href` | `https://www.npmjs.com/package/@ngaf/chat` | `https://www.npmjs.com/search?q=%40ngaf` |
 
-(`7 packages` = current count of non-private `libs/*/package.json` files: a2ui, ag-ui, chat, langgraph, licensing, partial-json, render. If that count changes before merge, update.)
+(`7 packages` = current count of non-private `libs/*/package.json` files: a2ui, ag-ui, chat, langgraph, licensing, partial-json, render. Update if the count drifts before merge.)
+
+### Do NOT touch signal #2
+
+Signal #2 on main is `Built for / Angular 20+` (post-#275). Keep it byte-identical. Do not reintroduce `Zoneless ready`.
 
 ---
 
@@ -59,7 +69,7 @@ const PROMISES = [
   },
   {
     title: 'No abandoned majors',
-    body: 'We follow Angular’s LTS. When Angular ships, we ship.',
+    body: 'We support Angular’s current and previous LTS versions.',
   },
   {
     title: 'No required cloud',
@@ -76,8 +86,9 @@ const PROMISES = [
 ];
 ```
 
-Beat changes:
+Beat changes vs current main:
 - Old `No vendor lock-in` + `No paid Angular tier` + `No closed primitives` → consolidated into new `No closed core` (one distinct beat instead of three overlapping ones).
+- `No abandoned majors` body is **byte-identical to #275's wording** — kept unchanged on purpose.
 - Old `No required cloud` body reworded from "No phone-home" to "Run it all in your VPC" — leaves "phone-home" framing to the new `No telemetry` card.
 - New `No telemetry` — explicit promise that matches the `FinalCTA` caption.
 - New `No model lock-in` — net-new beat not duplicated upstream.
@@ -86,31 +97,30 @@ Beat changes:
 
 ## 3. HomeFAQ
 
-Full replacement of the `ITEMS` array. Same shape (`FAQItem[]`), expands from 8 to 11 entries. Two existing answers reworded; three new questions appended.
+Full replacement of the `ITEMS` array. Same shape (`FAQItem[]`), expands from **7 to 10** entries (main has 7 after #275 removed the zoneless question). Two existing answers reworded; three new questions appended.
 
 ```ts
 const ITEMS: FAQItem[] = [
   {
     q: 'How is this different from CopilotKit or AG-UI directly?',
-    a: 'CopilotKit has an Angular SDK; we made different choices (signals, DI, zoneless-first). AG-UI is a protocol, not a UI library — you still build the Angular side. Angular Agent Framework gives you signal-native primitives plus adapters that hide the protocol, so you can swap LangGraph for AG-UI without rewriting your UI.',
+    a: 'CopilotKit has an Angular SDK; ours is built around signals and DI as the substrate, not a port. AG-UI is a protocol, not a UI library — you still build the Angular side. Angular Agent Framework gives you signal-native primitives plus adapters that hide the protocol, so you can swap LangGraph for AG-UI without rewriting your UI.',
   },
   // Q2 unchanged: existing-app
-  // Q3 unchanged: zoneless
-  // Q4 unchanged: without LangGraph
-  // Q5 unchanged: P2P required
-  // Q6 unchanged: cost
+  // Q3 unchanged: without LangGraph
+  // Q4 unchanged: P2P required
+  // Q5 unchanged: cost
   {
     q: 'Is this production-ready today?',
-    a: 'It runs the full stack in our reference deployment (cockpit.cacheplane.ai), and breaking changes are called out in release notes. We track current and previous Angular majors.',
+    a: 'It runs the full stack in our reference deployment (cockpit.cacheplane.ai), and breaking changes are called out in release notes. We support Angular’s current and previous LTS versions.',
   },
-  // Q8 unchanged: where to report issues
+  // Q7 unchanged: where to report issues
   {
     q: 'I’m using CopilotKit today — how hard is the migration?',
-    a: 'Component-by-component. `useChat`-style hooks map to the `agent()` signal API; actions map to LangGraph/AG-UI tool calls. Thread state lives in a service (not the component tree), so plan a session to port that. There isn’t a one-shot codemod.',
+    a: 'Component-by-component. CopilotKit’s chat hooks have rough equivalents in our `agent()` signal API, and CopilotKit actions map to LangGraph/AG-UI tool calls. Thread state lives in a service (not the component tree), so plan a session to port that. There isn’t a one-shot codemod.',
   },
   {
     q: 'Does it work with Angular Universal / SSR?',
-    a: 'Streaming is client-side by design — agents are stateful and signal-based. If your shell is SSR’d, the chat compositions render with a loading state on the server and hydrate; the agent-talking parts stay client-only.',
+    a: 'Streaming is client-side by design — agents are stateful and signal-based. If your shell is SSR’d, the agent-talking parts stay client-only; render fallbacks during hydration via standard Angular SSR patterns.',
   },
   {
     q: 'How do I test agent-driven components?',
@@ -119,24 +129,26 @@ const ITEMS: FAQItem[] = [
 ];
 ```
 
-Final order: Q1 (reworded) → Q2 → Q3 → Q4 → Q5 → Q6 → Q7 (reworded) → Q8 → Q9 (new) → Q10 (new) → Q11 (new).
+Final order (10 entries): Q1 (reworded) → Q2 → Q3 → Q4 → Q5 → Q6-production (reworded) → Q7-report-issues → Q8 (new migration) → Q9 (new SSR) → Q10 (new testing).
 
-Edits in detail:
-- **Q1:** softens the "ports React patterns to Angular" claim about CopilotKit (factually shaky — CopilotKit's Angular SDK exists and may not be a literal port). Keeps the positioning beat without the risk.
-- **Q7:** drops unqualified "Yes — production-ready today." We're at 0.0.x with patch-level versioning; the previous answer doesn't cash. New copy lets evidence (Cockpit + release notes) carry it.
-- **Q9 (new):** the obvious follow-up to Q1. The most commercially-relevant question this section can answer.
-- **Q10 (new):** SSR is a hard-stop for many enterprise Angular shops. Silence reads as "doesn't support it." Honest answer is better than no answer.
-- **Q11 (new):** Angular teams care about testing; silence here suggests it's hard. Links to existing `apps/website/content/docs/agent/guides/testing.mdx`.
+Edits in detail (vs current main):
+- **Q1:** softens "CopilotKit ports React patterns to Angular" — replaced with the substrate-not-port framing. Deliberately does **not** mention "zoneless" (per #275).
+- **Q6-production-ready:** drops the unqualified "Yes —" opener, leads with deployment evidence and release-notes commitment, then keeps **#275's LTS phrasing verbatim** as the closer.
+- **Q8 (new):** the obvious follow-up to Q1. The most commercially-relevant question this section can answer. Phrased to hedge on the CopilotKit Angular SDK API surface ("rough equivalents") rather than naming specific hooks I can't verify.
+- **Q9 (new):** SSR is a hard-stop for many enterprise Angular shops. Silence reads as "doesn't support it." Honest answer with a known boundary (agent parts stay client-only) and a pointer at standard SSR-fallback patterns, without claiming a specific built-in loading-state primitive.
+- **Q10 (new):** Angular teams care about testing; silence here suggests it's hard. Links to existing `apps/website/content/docs/agent/guides/testing.mdx`.
 
 ---
 
 ## Verification
 
-- Visit `/` in the preview dev server, confirm ProofStrip claim renders above the cards, Promises shows the new 5-card lineup, FAQ shows 11 items in the expected order.
+- Visit `/` in the preview dev server (if available), confirm ProofStrip claim renders above the cards, Promises shows the new 5-card lineup, FAQ shows 10 items in the expected order.
 - Verify the new signal #5 link (`npm search ?q=%40ngaf`) opens to a populated results page.
-- Verify the `/docs/agent/guides/testing` link from Q11 resolves.
-- TypeScript build passes (`nx build website`).
+- Verify the `/docs/agent/guides/testing` link from Q10 resolves (file exists on disk).
+- Verify the `/pricing` link from the unchanged Q5 still resolves.
+- `npx nx run website:lint` and `npx prettier --check` pass on all three modified files.
+- `nx run website:build` is blocked by a pre-existing `posthog-node` missing-dependency issue in this worktree — track separately, not a blocker for this PR if the same build runs clean on CI.
 
 ## Risk / rollback
 
-Single PR, three file edits, no schema or shape changes. Rollback is `git revert`. No dependencies on screenshot work or other in-flight PRs.
+Single PR, three file edits, no schema or shape changes. Rollback is `git revert`. No dependencies on screenshot work or other in-flight PRs. The branch must be rebased onto `origin/main` so #275's edits are the baseline and there's no merge conflict left over.


### PR DESCRIPTION
## Summary

Editorial pass on the three landing components shipped in [#270](https://github.com/cacheplane/angular-agent-framework/pull/270) (Phase 4 homepage), filling the gaps surfaced in a full analysis and reconciling with [#275](https://github.com/cacheplane/angular-agent-framework/pull/275) (the editorial sweep that dropped zoneless claims and locked the LTS phrasing).

- **ProofStrip**: add a claim line above the signals (`Open code, open packages, a live reference app.`), fix the redundant adapter signal (`Adapter contract / LangGraph + AG-UI + your own`), and reframe the npm signal to gesture at the package family (`@ngaf/* — 7 packages`, linking to a scoped npm search). Signal #2 left as #275 set it.
- **Promises**: collapse the three overlapping "openness" beats (`No vendor lock-in` + `No paid Angular tier` + `No closed primitives`) into one `No closed core` card; replace `No phone-home` with the stronger `Run it all in your VPC`; add two net-new commitments — `No telemetry` and `No model lock-in`. Net card count stays at 5. Card 2 (`No abandoned majors`) uses #275's LTS phrasing verbatim.
- **HomeFAQ**: soften Q1 (replace the shaky "CopilotKit ports React patterns" claim with a substrate-not-port framing, no zoneless mention) and the production-ready answer (drop the unqualified "Yes —", lead with deployment evidence, end with #275's LTS line). Add three new questions covering CopilotKit migration, Angular Universal / SSR, and testing. Final count: 10 entries.

Design + plan checked in to `docs/superpowers/specs/2026-05-12-homepage-content-fills-design.md` and `docs/superpowers/plans/2026-05-12-homepage-content-fills.md`.

## Test plan

- [ ] Visit `/` on the deploy preview — confirm ProofStrip shows the claim line above the cards, Promises shows the new 5-card lineup, HomeFAQ shows 10 entries with the reworded Q1 / production-ready answers and the three new questions.
- [ ] Click the new ProofStrip signal #5 link — should open `npm search ?q=%40ngaf` in a new tab with results for the `@ngaf/*` packages.
- [ ] Expand HomeFAQ Q10 (testing) — `/docs/agent/guides/testing` link resolves.
- [ ] `nx lint website` passes (0 new errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)