### PR TITLE
fix(chat): minimal tool-call styling + breathing room before downstream content

### DIFF
--- a/libs/chat/src/lib/compositions/chat-tool-call-card/chat-tool-call-card.component.ts
+++ b/libs/chat/src/lib/compositions/chat-tool-call-card/chat-tool-call-card.component.ts
@@ -21,23 +21,27 @@ export interface ToolCallInfo {
   changeDetection: ChangeDetectionStrategy.OnPush,
   styles: [CHAT_HOST_TOKENS, `
     :host { display: block; }
-    .tcc__name { font-family: var(--ngaf-chat-font-mono); color: var(--ngaf-chat-text); }
+    .tcc__name {
+      font-family: var(--ngaf-chat-font-mono);
+      font-size: var(--ngaf-chat-font-size-sm, 13px);
+      color: var(--ngaf-chat-text-muted);
+      font-weight: 400;
+      padding-left: 2px;
+    }
     .tcc__pill {
       display: inline-flex;
       align-items: center;
-      gap: 4px;
-      padding: 1px 7px;
+      gap: 3px;
+      padding: 1px 6px;
       border-radius: 9999px;
       background: var(--ngaf-chat-surface-alt);
       color: var(--ngaf-chat-text-muted);
-      font-size: 11px;
-      font-weight: 600;
+      font-size: 10px;
+      font-weight: 500;
       margin-left: 6px;
       line-height: 1.4;
     }
-    .tcc__pill[data-status="complete"] { color: var(--ngaf-chat-success); }
-    .tcc__pill[data-status="error"]    { color: var(--ngaf-chat-error-text); }
-    .tcc__pill svg { width: 11px; height: 11px; }
+    .tcc__pill svg { width: 10px; height: 10px; }
     .tcc__pill[data-status="running"] svg { animation: tcc-spin 0.8s linear infinite; }
     @keyframes tcc-spin { to { transform: rotate(360deg); } }
     .tcc__section { padding: 8px 0; }

--- a/libs/chat/src/lib/primitives/chat-tool-calls/chat-tool-calls.component.spec.ts
+++ b/libs/chat/src/lib/primitives/chat-tool-calls/chat-tool-calls.component.spec.ts
@@ -312,3 +312,17 @@ describe('ChatToolCallsComponent — excludeToolNames filter', () => {
     expect(text).not.toContain('research');
   });
 });
+
+describe('ChatToolCallsComponent — breathing room before downstream content', () => {
+  it('host has bottom margin >= 16px so the next sibling gets clear separation', () => {
+    TestBed.configureTestingModule({ imports: [FilterHost] });
+    const fx = TestBed.createComponent(FilterHost);
+    fx.detectChanges();
+    const host = fx.nativeElement.querySelector('chat-tool-calls') as HTMLElement;
+    document.body.appendChild(host);
+    const computed = getComputedStyle(host);
+    const marginBottom = parseFloat(computed.marginBottom || '0');
+    expect(marginBottom).toBeGreaterThanOrEqual(16);
+    document.body.removeChild(host);
+  });
+});

--- a/libs/chat/src/lib/primitives/chat-tool-calls/chat-tool-calls.component.ts
+++ b/libs/chat/src/lib/primitives/chat-tool-calls/chat-tool-calls.component.ts
@@ -22,11 +22,11 @@ interface Group {
   imports: [NgTemplateOutlet, ChatToolCallCardComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   styles: [`
-    :host { display: block; }
+    :host { display: block; margin-bottom: 20px; }
     .ctc__group {
       border: 1px solid var(--ngaf-chat-separator);
       border-radius: var(--ngaf-chat-radius-card);
-      margin: 0 0 8px;
+      margin: 0 0 4px;
     }
     .ctc__group-header {
       display: flex;


### PR DESCRIPTION
## Summary

Tool calls are an advanced-user signal that was visually competing with the actual rendered content (A2UI surfaces, markdown) inside assistant messages. This PR makes them quieter and gives downstream content room to breathe.

- Tool name dimmed to muted color, 13px, weight 400 (was full-brightness body color, weight inherited)
- Status pill is now monochrome muted regardless of state — dropped the saturated green (complete) and red (error) color overrides. Pill text shrinks to 10px and the icon shrinks to 10px
- 2px left padding on the name to separate it from the trace chevron
- `chat-tool-calls` host now contributes 20px bottom margin, giving the next sibling (A2UI surface, markdown, etc.) ~24px of clear space. Inter-group spacing inside tightens from 8px to 4px since the host carries the breathing room

## Test plan

- [x] `npx nx test chat` — 615 tests pass (added a host-margin breathing-room assertion)
- [x] `npx nx build chat`
- [x] `npx nx lint chat`
- [x] `npm run generate-api-docs`
- [ ] Visually confirm in the examples-chat app that the tool-call card looks subdued and an A2UI surface immediately below has visible separation