### PR TITLE
feat(examples-chat): app-wide Light/Dark color scheme toggle

### DIFF
--- a/examples/chat/angular/src/app/shell/demo-shell.component.html
+++ b/examples/chat/angular/src/app/shell/demo-shell.component.html
@@ -88,6 +88,11 @@
         />
       </chat-debug-section>
       <chat-debug-section label="Appearance">
+        <chat-debug-segmented
+          [options]="colorSchemeOptions"
+          [value]="colorScheme()"
+          (valueChange)="onColorSchemeChange($event)"
+        />
         <chat-debug-select
           label="Theme"
           [options]="themeOptions()"

--- a/examples/chat/angular/src/app/shell/demo-shell.component.ts
+++ b/examples/chat/angular/src/app/shell/demo-shell.component.ts
@@ -83,6 +83,28 @@ export class DemoShell {
       this.document.documentElement.setAttribute('data-theme', this.theme());
     });
 
+    // App-wide color scheme: drives the demo page bg/text via
+    // `data-color-scheme` and the chat-lib internals via
+    // `data-ngaf-chat-theme`. The pre-bootstrap script in index.html
+    // applies the initial value before stylesheets load; this effect
+    // keeps both attrs synced after Angular takes over and also
+    // auto-syncs the A2UI theme dropdown when it sits on a default
+    // preset — material picks are left alone since the user opted in.
+    effect(() => {
+      const scheme = this.colorScheme();
+      const html = this.document.documentElement;
+      html.setAttribute('data-color-scheme', scheme);
+      html.setAttribute('data-ngaf-chat-theme', scheme);
+      const currentTheme = this.theme();
+      if (currentTheme === 'default-dark' || currentTheme === 'default-light') {
+        const next = scheme === 'light' ? 'default-light' : 'default-dark';
+        if (currentTheme !== next) {
+          this.theme.set(next);
+          this.persistence.write('theme', next);
+        }
+      }
+    });
+
     // Refresh threads list whenever the active thread changes (e.g. after
     // create or switch) so the panel stays up to date. The effect also
     // covers the initial load (fires synchronously on first reactive read).
@@ -151,6 +173,15 @@ export class DemoShell {
    * scoped `--a2ui-*` overrides off. Persisted across reloads.
    */
   readonly theme = signal<string>(this.persistence.read('theme') ?? 'default-dark');
+
+  /**
+   * App-wide color scheme. Single source of truth for the demo page bg,
+   * the chat lib's internal `data-ngaf-chat-theme`, and (when the A2UI
+   * theme is on a default preset) the base A2UI theme. Persisted.
+   */
+  readonly colorScheme = signal<'light' | 'dark'>(
+    (this.persistence.read('colorScheme') as 'light' | 'dark' | null) ?? 'dark',
+  );
 
   /** Whether the threads drawer is open. Persisted across reloads. */
   protected readonly drawerOpen = signal<boolean>(this.persistence.read('drawerOpen') ?? false);
@@ -227,6 +258,11 @@ export class DemoShell {
     { value: 'a2ui',        label: 'A2UI v1' },
     { value: 'json-render', label: 'json-render' },
   ]);
+
+  protected readonly colorSchemeOptions = [
+    { value: 'light', label: 'Light' },
+    { value: 'dark', label: 'Dark' },
+  ] as const;
 
   protected readonly themeOptions = signal<readonly { value: string; label: string }[]>([
     { value: 'default-dark',   label: 'Default dark' },
@@ -345,6 +381,12 @@ export class DemoShell {
   protected onThemeChange(next: string): void {
     this.theme.set(next);
     this.persistence.write('theme', next);
+  }
+
+  protected onColorSchemeChange(next: 'light' | 'dark' | string): void {
+    if (next !== 'light' && next !== 'dark') return;
+    this.colorScheme.set(next);
+    this.persistence.write('colorScheme', next);
   }
 
   protected onSidenavOpenChange(next: boolean): void {

--- a/examples/chat/angular/src/app/shell/palette-persistence.service.ts
+++ b/examples/chat/angular/src/app/shell/palette-persistence.service.ts
@@ -12,6 +12,7 @@ interface PaletteState {
   drawerOpen?: boolean | null;
   sidenavMode?: 'expanded' | 'collapsed' | null;
   selectedProjectId?: string | null;
+  colorScheme?: 'light' | 'dark' | null;
 }
 
 type PaletteKey = keyof PaletteState;

--- a/examples/chat/angular/src/index.html
+++ b/examples/chat/angular/src/index.html
@@ -1,10 +1,31 @@
 <!doctype html>
-<html lang="en" data-ngaf-chat-theme="dark">
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <title>NGAF chat — canonical demo</title>
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script>
+      // Pre-bootstrap color-scheme apply: read persisted palette and set
+      // both `data-color-scheme` (drives the demo page bg/text) and
+      // `data-ngaf-chat-theme` (drives the chat lib's internal theming)
+      // BEFORE stylesheets load to avoid FOUC. The DemoShell effect
+      // takes over at runtime once Angular bootstraps.
+      (function () {
+        try {
+          var raw = localStorage.getItem('ngaf-chat-demo:palette');
+          var scheme = 'dark';
+          if (raw) {
+            var p = JSON.parse(raw);
+            if (p && (p.colorScheme === 'light' || p.colorScheme === 'dark')) {
+              scheme = p.colorScheme;
+            }
+          }
+          document.documentElement.setAttribute('data-color-scheme', scheme);
+          document.documentElement.setAttribute('data-ngaf-chat-theme', scheme);
+        } catch (e) { /* localStorage blocked — defaults apply */ }
+      })();
+    </script>
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
   </head>
   <body>

--- a/examples/chat/angular/src/styles.css
+++ b/examples/chat/angular/src/styles.css
@@ -11,8 +11,24 @@ html, body {
   padding: 0;
   height: 100%;
   font-family: system-ui, -apple-system, sans-serif;
-  background: #0f1116;
-  color: #e6e9ef;
+  background: var(--demo-page-bg);
+  color: var(--demo-page-text);
+}
+
+/*
+ * Demo page color scheme — driven by `data-color-scheme` on <html>.
+ * The pre-bootstrap inline script in index.html sets the attribute
+ * from persisted state before any stylesheet applies; the runtime
+ * effect in DemoShell keeps it in sync afterwards. Default (no
+ * attribute) is dark to match prior behavior.
+ */
+html {
+  --demo-page-bg: #0f1116;
+  --demo-page-text: #e6e9ef;
+}
+html[data-color-scheme="light"] {
+  --demo-page-bg: #ffffff;
+  --demo-page-text: #1c1c1c;
 }
 
 /*


### PR DESCRIPTION
## Summary

The smoke-test demo previously hardcoded dark mode (`<html data-ngaf-chat-theme="dark">` plus literal `#0f1116`/`#e6e9ef` in `styles.css`). The palette's existing A2UI **Theme** dropdown only restyled the `<a2ui-surface>` inside the chat composition, so switching it to `default-light` left the page background and chat composition unreadably dark.

This PR adds a runtime app-wide **Light/Dark** color-scheme toggle above the Theme dropdown. A single selection drives:

- demo page bg/text via `data-color-scheme` on `<html>` (CSS custom props in `styles.css`)
- chat lib internals via `data-ngaf-chat-theme` on `<html>`
- base A2UI theme via `data-theme` — **only** when the dropdown is on a `default-*` preset. Material picks are preserved since the user explicitly opted in.

To avoid FOUC on reload, a tiny pre-bootstrap inline script in `index.html` reads the persisted scheme from localStorage and sets the two attrs synchronously before any stylesheet loads. The `DemoShell` effect takes over once Angular bootstraps.

## Files

- `examples/chat/angular/src/styles.css` — body bg/text now use `var(--demo-page-bg)`/`var(--demo-page-text)`; `html[data-color-scheme="light"]` override block
- `examples/chat/angular/src/index.html` — drops hardcoded `data-ngaf-chat-theme="dark"`; adds pre-bootstrap script
- `examples/chat/angular/src/app/shell/palette-persistence.service.ts` — extends `PaletteState` with `colorScheme`
- `examples/chat/angular/src/app/shell/demo-shell.component.ts` — `colorScheme` signal, `colorSchemeOptions`, `onColorSchemeChange`, effect that syncs `data-color-scheme` + `data-ngaf-chat-theme` and (conditionally) the A2UI theme
- `examples/chat/angular/src/app/shell/demo-shell.component.html` — new `<chat-debug-segmented>` above the Theme `<chat-debug-select>`

## Test plan

- [x] `nx test chat` passes
- [x] `nx build chat` passes
- [x] `nx lint chat` clean
- [x] `nx build examples-chat-angular` passes
- [ ] Manual: open `/embed` — palette shows Light/Dark segmented above Theme; default is Dark
- [ ] Manual: switch to Light — page bg flips to white, chat composition updates, A2UI dropdown auto-switches `default-dark` → `default-light`
- [ ] Manual: pick `material-light` then toggle scheme — Material stays selected (no auto-sync)
- [ ] Manual: reload — scheme persists, no flash of light/dark before bootstrap