### PR TITLE
fix(chat): empty assistant bubble for plain LLM responses

### DIFF
--- a/libs/chat/src/lib/streaming/streaming-markdown.component.spec.ts
+++ b/libs/chat/src/lib/streaming/streaming-markdown.component.spec.ts
@@ -73,4 +73,32 @@ describe('ChatStreamingMdComponent', () => {
     expect(fixture.nativeElement.querySelector('p')).toBeNull();
     expect(fixture.nativeElement.querySelector('h1')).toBeNull();
   });
+
+  it('renders a paragraph for plain text WITHOUT a trailing newline (LLM-response shape)', () => {
+    // Regression: @cacheplane/partial-markdown@0.3 does not flush trailing
+    // text on finish() unless the buffer ends with '\n'. LLM responses
+    // typically omit the trailing newline. The component must push a
+    // sentinel newline before finish() so the message renders.
+    const fixture = TestBed.createComponent(HostComponent);
+    fixture.componentInstance.content.set('Hello — nice to meet you!');
+    fixture.componentInstance.streaming.set(false);
+    fixture.detectChanges();
+    const p = fixture.nativeElement.querySelector('p');
+    expect(p).toBeTruthy();
+    expect(p.textContent?.trim()).toBe('Hello — nice to meet you!');
+  });
+
+  it('renders plain text when streaming flips to false (mirrored else-branch)', () => {
+    // The else-if branch (no content change, streaming flipped to false)
+    // must also push a sentinel newline before finish().
+    const fixture = TestBed.createComponent(HostComponent);
+    fixture.componentInstance.content.set('Plain answer.');
+    fixture.componentInstance.streaming.set(true);
+    fixture.detectChanges();
+    fixture.componentInstance.streaming.set(false);
+    fixture.detectChanges();
+    const p = fixture.nativeElement.querySelector('p');
+    expect(p).toBeTruthy();
+    expect(p.textContent?.trim()).toBe('Plain answer.');
+  });
 });

--- a/libs/chat/src/lib/streaming/streaming-markdown.component.ts
+++ b/libs/chat/src/lib/streaming/streaming-markdown.component.ts
@@ -99,12 +99,20 @@ export class ChatStreamingMdComponent {
         if (c.length > 0) this.parser.push(c);
       }
       if (!isStreaming && !this.finished) {
+        // @cacheplane/partial-markdown@0.3 does not flush trailing text on
+        // finish() unless the buffer ends with a newline. Plain LLM
+        // responses often omit the trailing newline, which causes the
+        // parser to emit a document with zero children — i.e. the message
+        // renders empty. Push a sentinel newline first to force the open
+        // paragraph closed before we finalize.
+        if (!c.endsWith('\n')) this.parser.push('\n');
         this.parser.finish();
         this.finished = true;
       }
       this.prior = c;
     } else if (!isStreaming && !this.finished) {
       // Streaming flipped to false without new content; ensure parser is finalized.
+      if (!this.prior.endsWith('\n')) this.parser.push('\n');
       this.parser.finish();
       this.finished = true;
     }


### PR DESCRIPTION
## Summary

**Regression discovered during smoke-checklist walk.** Sending any prompt with a plain-text response (no markdown structure) produces an empty assistant bubble. The bubble shell renders (checkpoint marker, action buttons) but the message text is missing entirely.

### Reproduction
1. \`localStorage.clear()\` + reload \`/embed\`
2. Send: \`Say hello in one sentence.\` (or any prompt that returns plain text)
3. Backend completes successfully (~2s); \`agent.messages()\` carries the response
4. DOM \`<chat-streaming-md>\` has \`content="Hello — nice to meet you!"\`, \`streaming=false\`, \`finished=true\` — but \`root.children = []\` (empty)

### Root cause

\`@cacheplane/partial-markdown@0.3.0\` does NOT flush trailing text on \`finish()\` unless the buffer ends with \`\n\`. Verified with a direct test:

\`\`\`
"Hello world."     → 0 children ❌
"Hello world.\n"   → 1 paragraph ✅
"Hello world.\n\n" → 1 paragraph ✅
"# Hello\n\nworld" → 1 heading   ✅
\`\`\`

OpenAI responses for short turns typically omit the trailing newline, so \`finish()\` returns without committing the in-progress paragraph and the document is empty.

### Fix

In \`streaming-markdown.component.ts\`, push a sentinel \`\n\` before \`finish()\` in both branches of the \`root()\` computed:
- The content-changed-then-flush branch
- The streaming-flipped-to-false-without-new-content branch

The newline only exists inside the parser buffer; the \`content()\` signal stays unchanged.

### Tests
- 2 new regression tests in \`streaming-markdown.component.spec.ts\` covering plain text without trailing newline in both branches
- Existing 5 tests still pass
- \`nx test chat\` green

### Why this regression slipped through
- All existing tests passed strings ending in \`\n\` (\`"# Heading\n"\`, \`"Hello world.\n"\`, etc) — never exercised the trailing-newline-absent case
- The previous markdown integration via \`marked\` (pre-PR #193) was tolerant; the swap to \`@cacheplane/partial-markdown\` (#193) inherited an upstream library quirk that requires the newline

## Test plan
- [x] \`nx test chat\` green (7 streaming-md tests now)
- [ ] Live verify post-merge: send plain prompt → bubble shows response
- [ ] CI green