### PR TITLE
chore: add libs/* to npm workspaces; clean CSS import path for examples

### DIFF
--- a/cockpit/chat/timeline/angular/src/styles.css
+++ b/cockpit/chat/timeline/angular/src/styles.css
@@ -1,4 +1,4 @@
-@import "../../../../../libs/example-layouts/src/theme.css";
+@import "@ngaf/example-layouts/theme.css";
 
 /* App-specific globals (none for now; add below this line if needed). */
 html, body {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "license": "MIT",
       "workspaces": [
         "packages/*",
-        "apps/*"
+        "apps/*",
+        "libs/*"
       ],
       "dependencies": {
         "@ag-ui/client": "^0.0.52",
@@ -161,6 +162,141 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "libs/a2ui": {
+      "name": "@ngaf/a2ui",
+      "version": "0.0.29",
+      "license": "MIT"
+    },
+    "libs/ag-ui": {
+      "name": "@ngaf/ag-ui",
+      "version": "0.0.29",
+      "license": "MIT",
+      "peerDependencies": {
+        "@ag-ui/client": "*",
+        "@angular/core": "^20.0.0 || ^21.0.0",
+        "@ngaf/chat": "*",
+        "@ngaf/licensing": "*",
+        "rxjs": "~7.8.0"
+      }
+    },
+    "libs/chat": {
+      "name": "@ngaf/chat",
+      "version": "0.0.29",
+      "license": "MIT",
+      "dependencies": {
+        "@cacheplane/partial-json": ">=0.1.1 <0.3.0",
+        "@cacheplane/partial-markdown": "^0.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^20.0.0 || ^21.0.0",
+        "@angular/core": "^20.0.0 || ^21.0.0",
+        "@angular/forms": "^20.0.0 || ^21.0.0",
+        "@angular/platform-browser": "^20.0.0 || ^21.0.0",
+        "@json-render/core": "^0.16.0",
+        "@langchain/core": "^1.1.33",
+        "@ngaf/a2ui": "*",
+        "@ngaf/licensing": "*",
+        "@ngaf/render": "*",
+        "marked": "^15.0.0 || ^16.0.0",
+        "rxjs": "~7.8.0"
+      }
+    },
+    "libs/cockpit-docs": {
+      "name": "@ngaf/cockpit-docs",
+      "version": "0.0.29",
+      "license": "MIT"
+    },
+    "libs/cockpit-registry": {
+      "name": "@ngaf/cockpit-registry",
+      "version": "0.0.29",
+      "license": "MIT"
+    },
+    "libs/cockpit-shell": {
+      "name": "@ngaf/cockpit-shell",
+      "version": "0.0.29",
+      "license": "MIT"
+    },
+    "libs/cockpit-testing": {
+      "name": "@ngaf/cockpit-testing",
+      "version": "0.0.29",
+      "license": "MIT"
+    },
+    "libs/cockpit-ui": {
+      "name": "@ngaf/cockpit-ui",
+      "version": "0.0.29",
+      "license": "MIT"
+    },
+    "libs/db": {
+      "name": "@ngaf/db",
+      "version": "0.0.29",
+      "license": "MIT",
+      "peerDependencies": {
+        "drizzle-orm": "^0.45.0",
+        "postgres": "^3.4.0"
+      }
+    },
+    "libs/design-tokens": {
+      "name": "@ngaf/design-tokens",
+      "version": "0.0.33",
+      "license": "MIT"
+    },
+    "libs/example-layouts": {
+      "name": "@ngaf/example-layouts",
+      "version": "0.0.30",
+      "license": "MIT",
+      "peerDependencies": {
+        "@angular/common": "^20.0.0 || ^21.0.0",
+        "@angular/core": "^20.0.0 || ^21.0.0",
+        "tailwindcss": "^4.0.0"
+      }
+    },
+    "libs/langgraph": {
+      "name": "@ngaf/langgraph",
+      "version": "0.0.29",
+      "license": "MIT",
+      "peerDependencies": {
+        "@angular/core": "^20.0.0 || ^21.0.0",
+        "@langchain/core": "^1.1.33",
+        "@langchain/langgraph-sdk": "^1.7.4",
+        "@ngaf/chat": "*",
+        "@ngaf/licensing": "*",
+        "rxjs": "~7.8.0"
+      }
+    },
+    "libs/licensing": {
+      "name": "@ngaf/licensing",
+      "version": "0.0.29",
+      "license": "MIT",
+      "peerDependencies": {
+        "@noble/ed25519": "^2.2.3"
+      }
+    },
+    "libs/partial-json": {
+      "name": "@ngaf/partial-json",
+      "version": "0.0.29",
+      "deprecated": "Replaced by @cacheplane/partial-json. No further versions will be published from this package.",
+      "license": "MIT"
+    },
+    "libs/render": {
+      "name": "@ngaf/render",
+      "version": "0.0.29",
+      "license": "MIT",
+      "peerDependencies": {
+        "@angular/common": "^20.0.0 || ^21.0.0",
+        "@angular/core": "^20.0.0 || ^21.0.0",
+        "@json-render/core": "^0.16.0",
+        "@ngaf/licensing": "*"
+      }
+    },
+    "libs/ui-react": {
+      "name": "@ngaf/ui-react",
+      "version": "0.0.31",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
       }
     },
     "node_modules/@ag-ui/client": {
@@ -11779,8 +11915,72 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@ngaf/a2ui": {
+      "resolved": "libs/a2ui",
+      "link": true
+    },
+    "node_modules/@ngaf/ag-ui": {
+      "resolved": "libs/ag-ui",
+      "link": true
+    },
+    "node_modules/@ngaf/chat": {
+      "resolved": "libs/chat",
+      "link": true
+    },
+    "node_modules/@ngaf/cockpit-docs": {
+      "resolved": "libs/cockpit-docs",
+      "link": true
+    },
+    "node_modules/@ngaf/cockpit-registry": {
+      "resolved": "libs/cockpit-registry",
+      "link": true
+    },
+    "node_modules/@ngaf/cockpit-shell": {
+      "resolved": "libs/cockpit-shell",
+      "link": true
+    },
+    "node_modules/@ngaf/cockpit-testing": {
+      "resolved": "libs/cockpit-testing",
+      "link": true
+    },
+    "node_modules/@ngaf/cockpit-ui": {
+      "resolved": "libs/cockpit-ui",
+      "link": true
+    },
+    "node_modules/@ngaf/db": {
+      "resolved": "libs/db",
+      "link": true
+    },
+    "node_modules/@ngaf/design-tokens": {
+      "resolved": "libs/design-tokens",
+      "link": true
+    },
+    "node_modules/@ngaf/example-layouts": {
+      "resolved": "libs/example-layouts",
+      "link": true
+    },
+    "node_modules/@ngaf/langgraph": {
+      "resolved": "libs/langgraph",
+      "link": true
+    },
+    "node_modules/@ngaf/licensing": {
+      "resolved": "libs/licensing",
+      "link": true
+    },
     "node_modules/@ngaf/minting-service": {
       "resolved": "apps/minting-service",
+      "link": true
+    },
+    "node_modules/@ngaf/partial-json": {
+      "resolved": "libs/partial-json",
+      "link": true
+    },
+    "node_modules/@ngaf/render": {
+      "resolved": "libs/render",
+      "link": true
+    },
+    "node_modules/@ngaf/ui-react": {
+      "resolved": "libs/ui-react",
       "link": true
     },
     "node_modules/@ngtools/webpack": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
   },
   "workspaces": [
     "packages/*",
-    "apps/*"
+    "apps/*",
+    "libs/*"
   ],
   "dependencies": {
     "@ag-ui/client": "^0.0.52",


### PR DESCRIPTION
## Summary

Root \`package.json\` workspaces glob was \`["packages/*", "apps/*"]\` — \`libs/*\` was missing, so \`@ngaf/*\` libraries weren't symlinked into \`node_modules\`. TS imports still resolved via tsconfig \`paths\`, but esbuild's CSS resolver doesn't consult tsconfig — so the Stage 1 chat-timeline pilot ended up with a 5-level relative import for its \`theme.css\`.

Adding \`libs/*\` to the workspaces glob and running \`npm install\` symlinks all 14 \`@ngaf/*\` libs into \`node_modules/@ngaf/\`. The pilot's \`styles.css\` now uses the package import:

\`\`\`css
@import "@ngaf/example-layouts/theme.css";
\`\`\`

Stage 2 (remaining 31 Angular example apps) uses the clean path from day one — no per-app workaround.

## Verification

- [x] All 14 libs symlinked into \`node_modules/@ngaf/\` (verified \`ls -la\`)
- [x] Linux \`@next/swc-*\` bindings preserved: 4 entries before, 4 after (additive install, not regeneration)
- [x] \`pnpm nx run-many -t lint,test -p design-tokens,ui-react,example-layouts,cockpit\` — green
- [x] \`pnpm nx build cockpit-chat-timeline-angular\` — green (uses the new package import)
- [x] \`pnpm nx build website\` — green

## Risk

Lockfile churn: \`npm install\` added 16 packages (workspace metadata for the libs), 545 funding pings, no \`@next/swc-*\` Linux bindings dropped. Minimal — additive only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)