### PR TITLE
fix(chat-sidebar): position launcher at bottom-right via fixed wrapper

### DIFF
--- a/libs/chat/src/lib/compositions/chat-sidebar/chat-sidebar.component.ts
+++ b/libs/chat/src/lib/compositions/chat-sidebar/chat-sidebar.component.ts
@@ -52,10 +52,21 @@ import { CHAT_HOST_TOKENS } from '../../styles/chat-tokens';
       justify-content: center;
     }
     .chat-sidebar__close:hover { background: var(--ngaf-chat-surface-alt); color: var(--ngaf-chat-text); }
+    .chat-sidebar__launcher {
+      position: fixed;
+      bottom: 1rem;
+      right: 1rem;
+      z-index: 30;
+    }
+    /* Hide the launcher when the sidebar is open — the close button on the
+       panel handles dismissal, and the panel covers the launcher anyway. */
+    :host([data-open="true"]) .chat-sidebar__launcher { display: none; }
   `],
   template: `
     <div class="chat-sidebar__content"><ng-content /></div>
-    <chat-launcher-button (click)="toggle()" />
+    <div class="chat-sidebar__launcher">
+      <chat-launcher-button (click)="toggle()" />
+    </div>
     <aside class="chat-sidebar__panel" [attr.data-open]="open() ? 'true' : 'false'" role="complementary" [attr.aria-hidden]="open() ? 'false' : 'true'">
       <button type="button" class="chat-sidebar__close" (click)="closeWindow()" aria-label="Close chat">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>


### PR DESCRIPTION
## Summary

Follow-up to #308. The previous fix added \`<chat-launcher-button>\` to the chat-sidebar template, but the launcher itself has no inherent fixed positioning — it's a 56×56 div with \`display: inline-block\`. chat-popup positions its launcher via \`:host { position: fixed }\`, but chat-sidebar's \`:host\` is \`display: block\` to allow the content-pushes-on-open behavior.

The newly-added launcher in chat-sidebar flowed into the document at the natural position of the component — which on demo.cacheplane.ai ended up at (280, 1972), well off-screen.

## Fix

Wrap the launcher in a \`.chat-sidebar__launcher\` div with:

\`\`\`css
position: fixed;
bottom: 1rem;
right: 1rem;
z-index: 30;
\`\`\`

Matches chat-popup's launcher coordinates exactly. Also hides the launcher when the sidebar is open (the panel covers it; the panel has its own close button).

## Test plan

- [x] Existing chat-sidebar tests pass
- [ ] Browser smoke on demo.cacheplane.ai/sidebar after merge:
  - [ ] Launcher visible at bottom-right
  - [ ] Click → sidebar slides in
  - [ ] Close button (panel) → sidebar slides out

🤖 Generated with [Claude Code](https://claude.com/claude-code)