### PR TITLE
ci: gate fixture drift workflow on manual dispatch only

### DIFF
--- a/.github/workflows/aimock-drift.yml
+++ b/.github/workflows/aimock-drift.yml
@@ -1,9 +1,11 @@
 name: aimock fixture drift
 
 on:
-  schedule:
-    - cron: '0 7 * * *'
   workflow_dispatch:
+  # NOTE: scheduled cron is intentionally omitted. The committed fixtures are
+  # handwritten seeds — drift detection only becomes meaningful once a phase
+  # lands recorded fixtures. Re-enable a `schedule:` trigger here at that
+  # point (weekly cron is a reasonable starting cadence).
 
 jobs:
   drift:


### PR DESCRIPTION
## Summary

Drops the daily cron from the fixture-drift workflow.

The Phase 2a fixture (`hi.json`) is a handwritten seed — `{"content": "Hi! How can I help?"}` — not a real captured upstream response. The drift script compares byte sizes against a fresh recording; against a handwritten seed it will almost always trip the 20% threshold and open a false-positive issue on day one.

Keeps the `workflow_dispatch` trigger so the workflow stays runnable on demand. When recorded fixtures land in a later phase, re-add a `schedule:` block (weekly cron is a reasonable starting cadence) — the comment in the file flags this.

## Test plan

- [x] YAML still parses
- [x] `workflow_dispatch` trigger remains in place