### PR TITLE
fix(rate-limit): SQL interval parameterization — Phase 3 hotfix

### DIFF
--- a/scripts/rate-limit.ts
+++ b/scripts/rate-limit.ts
@@ -44,12 +44,18 @@ if (!databaseUrl) {
 
 const ALLOW_PASSTHROUGH: RateLimitResult = { allowed: true, retryAfterSec: 0, count: 0 };
 
+// Pre-built `interval` literal. Splicing WINDOW_SECONDS via the tagged-template
+// parameter machinery would emit `interval '$1 seconds'`, which Postgres rejects
+// (parameters can't substitute inside string literals). The constant is hardcoded
+// at module load instead.
+const WINDOW_INTERVAL = `${WINDOW_SECONDS} seconds`;
+
 export async function checkRateLimit(ip: string): Promise<RateLimitResult> {
   if (!sql) return ALLOW_PASSTHROUGH;
   try {
-    await sql`DELETE FROM rate_limit_events WHERE ip = ${ip} AND ts < now() - interval '${WINDOW_SECONDS} seconds'`;
+    await sql`DELETE FROM rate_limit_events WHERE ip = ${ip} AND ts < now() - ${WINDOW_INTERVAL}::interval`;
     await sql`INSERT INTO rate_limit_events (ip, ts) VALUES (${ip}, now())`;
-    const rows = await sql`SELECT count(*)::int AS c FROM rate_limit_events WHERE ip = ${ip}`;
+    const rows = await sql`SELECT count(*)::int AS c FROM rate_limit_events WHERE ip = ${ip} AND ts > now() - ${WINDOW_INTERVAL}::interval`;
     const count = (rows[0] as { c?: number } | undefined)?.c ?? 0;
     return {
       allowed: count <= limit,


### PR DESCRIPTION
## Summary

Hotfix for #315. The Phase 3 rate limit was a silent no-op in
production. Symptom: 12 streaming requests in a row from one IP all
returned 200; the \`rate_limit_events\` table stayed empty.

## Root cause

The SQL used \`interval '\${WINDOW_SECONDS} seconds'\` inside a
\`@neondatabase/serverless\` tagged template. The driver substitutes
\`\${...}\` placeholders as \`\$N\` parameters, but parameters cannot
appear inside a Postgres string literal. The driver emitted
\`interval '\$2 seconds'\`, Postgres rejected it with
\`invalid input syntax for type interval\`, and the proxy's
fail-open catch allowed the request through silently.

## Fix

Build \`WINDOW_INTERVAL = '60 seconds'\` at module load and splice it
as a parameterized value cast to \`::interval\`:

\`\`\`ts
ts < now() - \${WINDOW_INTERVAL}::interval
\`\`\`

That emits \`ts < now() - \$2::interval\`, which Postgres evaluates
correctly. Also added the same window filter to the SELECT so
DELETE+SELECT share the same boundary.

## Verification

Smoke-tested against the live Neon DB before pushing:

\`\`\`
Request 1: count=1, allowed=true
...
Request 10: count=10, allowed=true
Request 11: count=11, allowed=false  ← rate limited
Request 12: count=12, allowed=false
\`\`\`

## Test plan

- [x] Existing 5 rate-limit unit tests still pass (mocks unaffected)
- [x] Live SQL smoke-test against Neon confirms 1-10 allowed, 11+ denied
- [ ] After merge: re-run the 12-request HTTP smoke against \`demo.cacheplane.ai\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)