### PR TITLE
ci: include scripts/rate-limit.ts in demo redeploy gating (+ trigger redeploy of #316)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,7 +343,7 @@ jobs:
           if printf '%s\n' "$changed_files" | grep -E '^examples/chat/(angular|python)/' >/dev/null; then
             demo_changed=true
           fi
-          if printf '%s\n' "$changed_files" | grep -E '^(vercel\.demo\.json|scripts/(assemble-demo|demo-middleware|langgraph-proxy)\.ts)$' >/dev/null; then
+          if printf '%s\n' "$changed_files" | grep -E '^(vercel\.demo\.json|scripts/(assemble-demo|demo-middleware|langgraph-proxy|rate-limit)\.ts)$' >/dev/null; then
             demo_changed=true
           fi
           if printf '%s\n' "$changed_files" | grep -E '^libs/' >/dev/null; then

--- a/scripts/demo-middleware.ts
+++ b/scripts/demo-middleware.ts
@@ -8,6 +8,11 @@
  * The rate-limit hook is wired here (not in the shared factory) so the
  * cockpit-examples wrapper stays unaffected — its bundle does not pull
  * in @neondatabase/serverless.
+ *
+ * Note: changes to scripts/rate-limit.ts MUST trigger a redeploy of this
+ * function. The ci.yml `Check if demo changed` step watches
+ * scripts/(assemble-demo|demo-middleware|langgraph-proxy|rate-limit)\.ts.
+ * Keep that regex in sync if you split rate-limit into multiple files.
  */
 import { createProxyHandler } from './langgraph-proxy';
 import { checkRateLimit } from './rate-limit';


### PR DESCRIPTION
## Summary

The Phase 3 hotfix in #316 fixed a SQL bug in \`scripts/rate-limit.ts\` but never reached production. The CI \`Check if demo changed\` step's regex only watched assemble-demo, demo-middleware, and langgraph-proxy. A rate-limit.ts change alone evaluated \`demo_changed=false\`, the deploy step was skipped, and \`demo.cacheplane.ai\` kept serving the original broken bundle.

Verified by querying the latest Vercel deployment: still \`dpl_5ZCi...\` from before #316.

## Fix

1. Extend the watched regex to include \`scripts/rate-limit.ts\`.
2. Touch \`scripts/demo-middleware.ts\` with a documentation comment so THIS PR matches the existing watched paths and triggers the redeploy that picks up #316's SQL fix.

The doc comment also calls out the implicit coupling so future splits of rate-limit into multiple files don't silently break the gating.

## Test plan

- [ ] After merge: new Vercel deployment ID appears (not \`dpl_5ZCi...\`)
- [ ] After merge: 12-request rate-limit smoke against \`demo.cacheplane.ai\` returns 200 for 1–10 and 429 for 11–12

🤖 Generated with [Claude Code](https://claude.com/claude-code)