### PR TITLE
chore(diag): expose hasDatabaseUrl + instanceId in _proxy_debug

### DIFF
--- a/scripts/langgraph-proxy.ts
+++ b/scripts/langgraph-proxy.ts
@@ -105,6 +105,13 @@ export function createProxyHandler(config: ProxyConfig = {}): (req: VercelReques
         query: req.query,
         hasApiKey: !!apiKey,
         apiKeyPrefix: apiKey.substring(0, 10),
+        hasDatabaseUrl: !!process.env['DATABASE_URL'],
+        rateLimitConfigured: !!config.checkRateLimit,
+        instanceId: (() => {
+          const g = globalThis as { __instanceId?: string };
+          if (!g.__instanceId) g.__instanceId = Math.random().toString(36).slice(2, 10);
+          return g.__instanceId;
+        })(),
       });
       return;
     }


### PR DESCRIPTION
## Summary

Phase 3 rate-limit is partially working in production. 12 streaming requests inserted 7 rows but never returned 429. The most likely cause is some Vercel function instances cold-start without \`DATABASE_URL\` populated and silently fail-open for their lifetime.

This PR adds three diagnostic fields to \`/api/_proxy_debug\`:
- \`hasDatabaseUrl\` — is the env var visible at runtime
- \`rateLimitConfigured\` — was the proxy wired with the hook
- \`instanceId\` — random id per function instance

By hitting \`/api/_proxy_debug\` repeatedly, we can confirm whether multiple instances are running and whether DATABASE_URL is consistently set on all of them.

Stays in production after diagnosis (cheap, 4 lines).

## Test plan

- [x] All 10 langgraph-proxy unit tests still pass
- [ ] After merge: \`for i in {1..20}; do curl -s https://demo.cacheplane.ai/api/_proxy_debug | jq '{hasDatabaseUrl, instanceId}'; done\` — see if \`hasDatabaseUrl\` is ever \`false\` or if \`instanceId\` varies