### PR TITLE
fix(telemetry): postinstall — symlink-safe isDirectRun, stdout flush, dead-code

### DIFF
--- a/libs/telemetry/src/node/postinstall.spec.ts
+++ b/libs/telemetry/src/node/postinstall.spec.ts
@@ -35,7 +35,7 @@ describe('postinstall script', () => {
     expect(stdout.join('')).toMatch(/DO_NOT_TRACK=1/);
   });
 
-  test('suppresses stdout notice when CI=true', async () => {
+  test('CI=true is full opt-out: no event sent and no stdout notice', async () => {
     const stdout: string[] = [];
     await capturePostinstallScript({
       readPackageJson: () => ({ name: '@ngaf/telemetry', version: '0.0.31' }),
@@ -43,6 +43,18 @@ describe('postinstall script', () => {
       env: { ...process.env, CI: 'true' },
     });
     expect(stdout).toEqual([]);
+    expect(capturePostinstall).not.toHaveBeenCalled();
+  });
+
+  test('DO_NOT_TRACK=1 is full opt-out: no event sent and no stdout notice', async () => {
+    const stdout: string[] = [];
+    await capturePostinstallScript({
+      readPackageJson: () => ({ name: '@ngaf/telemetry', version: '0.0.31' }),
+      write: (s: string) => stdout.push(s),
+      env: { ...process.env, DO_NOT_TRACK: '1' },
+    });
+    expect(stdout).toEqual([]);
+    expect(capturePostinstall).not.toHaveBeenCalled();
   });
 
   test('swallows readPackageJson errors silently', async () => {

--- a/libs/telemetry/src/node/postinstall.ts
+++ b/libs/telemetry/src/node/postinstall.ts
@@ -1,5 +1,5 @@
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
+import { readFileSync, realpathSync } from 'node:fs';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { dirname, join } from 'node:path';
 import { capturePostinstall } from './client.js';
 import { isTelemetryDisabled } from '../shared/env.js';
@@ -11,6 +11,9 @@ interface PostinstallDeps {
 }
 
 export async function capturePostinstallScript(deps: PostinstallDeps): Promise<void> {
+  // Single opt-out gate. DO_NOT_TRACK, NGAF_TELEMETRY_DISABLED, and CI envs
+  // all funnel through isTelemetryDisabled and return early — no event sent,
+  // no stdout notice. Matches libs/telemetry/README.md trust contract.
   if (isTelemetryDisabled(deps.env)) return;
   let pkg: { name: string; version: string };
   try {
@@ -20,16 +23,28 @@ export async function capturePostinstallScript(deps: PostinstallDeps): Promise<v
   }
   try {
     await capturePostinstall({ pkg: pkg.name, version: pkg.version });
-    if (!deps.env.CI) {
-      deps.write(
-        `@ngaf/telemetry: sent install ping (${pkg.name}@${pkg.version}). ` +
-        `Disable: DO_NOT_TRACK=1 or NGAF_TELEMETRY_DISABLED=1. ` +
-        `See https://github.com/cacheplane/angular-agent-framework/blob/main/libs/telemetry/README.md\n`,
-      );
-    }
+    deps.write(
+      `@ngaf/telemetry: sent install ping (${pkg.name}@${pkg.version}). ` +
+      `Disable: DO_NOT_TRACK=1 or NGAF_TELEMETRY_DISABLED=1. ` +
+      `See https://github.com/cacheplane/angular-agent-framework/blob/main/libs/telemetry/README.md\n`,
+    );
   } catch {
     // never break npm install
   }
+}
+
+// Flush stdout so the opt-out notice is visible to npm. Without this,
+// posthog-node's await chain can leave the notice in stdout's pipe buffer
+// when the process exits, and npm reaps the script before the buffer drains.
+async function flushStdout(): Promise<void> {
+  return new Promise((resolve) => {
+    if (process.stdout.writableNeedDrain) {
+      process.stdout.once('drain', () => resolve());
+    } else {
+      // Yield one tick so any pending write callbacks run before exit.
+      setImmediate(() => resolve());
+    }
+  });
 }
 
 // Entry point — invoked by package.json scripts.postinstall.
@@ -42,9 +57,19 @@ async function main(): Promise<void> {
     write: (s) => process.stdout.write(s),
     env: process.env,
   });
+  await flushStdout();
 }
 
 // Only run as main entry, not when imported by tests.
-const isDirectRun =
-  process.argv[1] && import.meta.url === `file://${process.argv[1]}`;
-if (isDirectRun) main();
+// Resolves symlinks on both sides so `/tmp` vs `/private/tmp` on macOS,
+// pnpm content-addressed stores, and similar setups all match correctly.
+function isDirectRun(): boolean {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  try {
+    return pathToFileURL(realpathSync(entry)).href === import.meta.url;
+  } catch {
+    return false;
+  }
+}
+if (isDirectRun()) main();


### PR DESCRIPTION
## Summary

Three small fixes uncovered while smoke-testing the npm install flow against a local capture server. All confirmed working end-to-end before opening the PR.

### Bug 1 — `isDirectRun` symlink-blindness (macOS, pnpm stores)

`process.argv[1]` keeps the unresolved path (e.g. `/tmp/foo.js`), but `import.meta.url` resolves through realpath (`file:///private/tmp/foo.js` on macOS, content-addressed paths under pnpm). The naive `import.meta.url === \`file://${process.argv[1]}\`` comparison failed even when both pointed at the same file — so `node /tmp/.../postinstall.js` was a silent no-op.

Fixed by normalizing both sides through realpath:

\`\`\`ts
pathToFileURL(realpathSync(process.argv[1])).href === import.meta.url
\`\`\`

### Bug 2 — stdout opt-out notice was invisible to `npm install --foreground-scripts`

posthog-node's `shutdown()` await chain left the notice in stdout's pipe buffer at process exit. npm reaped the script before the buffer drained, so the user never saw the trust-contract opt-out line. Added `await flushStdout()` (drains via the stream's `drain` event or one `setImmediate` tick) before `main()` returns.

Before: install output silent.
After:
\`\`\`
> @ngaf/telemetry@0.0.0 postinstall
@ngaf/telemetry: sent install ping (@ngaf/telemetry@0.0.0). Disable: DO_NOT_TRACK=1 or NGAF_TELEMETRY_DISABLED=1. See https://github.com/cacheplane/angular-agent-framework/blob/main/libs/telemetry/README.md
\`\`\`

### Bug 3 — Redundant `if (!deps.env.CI)` guard

`isTelemetryDisabled(deps.env)` already short-circuits on `CI=true`, `DO_NOT_TRACK`, and `NGAF_TELEMETRY_DISABLED`. The second CI check was unreachable. The README's trust contract correctly says CI = full opt-out; the implementation now has a single source-of-truth gate matching that contract.

## Tests

- 46 passing (was 45)
- New test pins DO_NOT_TRACK as full opt-out (no event AND no notice)
- CI=true test gained `capturePostinstall.not.toHaveBeenCalled()` assertion

## End-to-end smoke verification (manual)

- `npm install --foreground-scripts /tmp/ngaf-telemetry-smoke.tgz` → notice visible ✓
- `node /tmp/.../postinstall.js` (direct, with /tmp symlink) → main() triggers ✓
- `DO_NOT_TRACK=1 npm install …` → no event, no notice ✓
- `CI=true npm install …` → no event, no notice ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)