### PR TITLE
fix(chat): user bubble width — move 80% cap to .chat-message__main

### DIFF
--- a/libs/chat/package.json
+++ b/libs/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/chat",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "exports": {
     ".": {
       "types": "./index.d.ts",

--- a/libs/chat/src/lib/styles/chat-message.styles.ts
+++ b/libs/chat/src/lib/styles/chat-message.styles.ts
@@ -8,6 +8,27 @@ export const CHAT_MESSAGE_STYLES = `
     margin-top: 0.5rem;
   }
   :host([data-role="user"][data-prev-role="assistant"]) { margin-top: 1.5rem; }
+  /*
+   * For user-role messages, the bubble's containing column must size to
+   * content rather than collapse via the flex chain. Without this, the
+   * bubble's max-width: 80% (defined below) resolves against a collapsed
+   * parent (~58px instead of the full row), capping the bubble below
+   * intrinsic single-word width and forcing mid-word wraps like
+   * "hello" → "hel" / "lo". See PR #313 follow-up.
+   */
+  :host([data-role="user"]) .chat-message__main {
+    flex: none;
+    width: fit-content;
+    max-width: 80%;
+  }
+  /*
+   * Assistant bubbles aren't in the flex collapse path, so the 80% cap
+   * lives on the bubble itself for that role. (User bubbles get the cap
+   * on .chat-message__main above instead.)
+   */
+  :host([data-role="assistant"]) .chat-message__bubble {
+    max-width: 80%;
+  }
   :host([data-role="assistant"]) {
     display: block;
     position: relative;
@@ -20,8 +41,12 @@ export const CHAT_MESSAGE_STYLES = `
   :host([data-role="assistant"]):first-child { margin-top: 0; }
 
   .chat-message__bubble {
+    /*
+     * No max-width here for user-role bubbles — the cap is applied on
+     * .chat-message__main above. Assistant-role bubbles inherit the
+     * host's max-width: 100% so no per-bubble cap needed either.
+     */
     width: fit-content;
-    max-width: 80%;
     padding: 8px 12px;
     border-radius: var(--ngaf-chat-radius-bubble);
     background: var(--ngaf-chat-primary);


### PR DESCRIPTION
## Summary

Follow-up to PR #313's text-wrap fix, which was insufficient. The bubble's \`width: fit-content\` couldn't escape a containing-block collapse: the bubble's \`max-width: 80%\` resolves against \`.chat-message__main\`, which collapsed to ~58px because of \`flex: 1; min-width: 0\` in the flex chain. Result: \`80% × 58px = 46px\` cap on the bubble — still narrower than \"hello\" — so \"hello\" rendered as \"hel\" / \"lo\".

**Fix:** for user-role messages, override \`.chat-message__main\`:

\`\`\`css
:host([data-role=\"user\"]) .chat-message__main {
  flex: none;
  width: fit-content;
  max-width: 80%;
}
\`\`\`

Now the 80% cap resolves against the host (full row, 720px), not the collapsed flex item. Bubble itself drops its percentage cap to avoid a circular constraint (bubble max-width 80% of fit-content main = 80% of bubble = recursive). Assistant-role bubbles retain the 80% cap on the bubble directly — they're not in the flex collapse path.

**Verified manually:** \"hello\" renders on one line, bubble 58.5px wide, main column 53px, sized to content. Tested via chrome MCP at localhost:4507 (cockpit-chat-timeline-angular standalone) after CSS hot-reload.

## Test plan

- [x] \`pnpm nx test chat\` — green
- [x] Manual chrome MCP: \"hello\" submitted in chat-timeline-angular; bubble renders on one line at intrinsic content width
- [ ] CI verifies full check stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)