### PR TITLE
fix(release): align publishable package versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     name: Library — lint / test / build
     runs-on: ubuntu-latest
     env:
-      LIBS: chat,langgraph,ag-ui,render,a2ui,partial-json,licensing
+      LIBS: chat,langgraph,ag-ui,render,a2ui,licensing,telemetry
     steps:
       - uses: actions/checkout@v6.0.2
       - uses: actions/setup-node@v6.3.0
@@ -22,6 +22,7 @@ jobs:
       - run: npx nx run-many -t lint --projects=$LIBS
       - run: npx nx run-many -t test --projects=$LIBS --coverage
       - run: npx nx run-many -t build --projects=$LIBS --configuration=production
+      - run: node scripts/verify-release-versions.mjs
 
   website:
     name: Website — lint / build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
       contents: read
       id-token: write # required for npm trusted publishing + provenance
     env:
-      NPM_PUBLISHABLE_PROJECTS: chat,langgraph,ag-ui,render,a2ui,partial-json,licensing
+      NPM_PUBLISHABLE_PROJECTS: chat,langgraph,ag-ui,render,a2ui,licensing,telemetry
     steps:
       - uses: actions/checkout@v6.0.2
       # Node 24 ships npm 11+ which fully implements npm trusted publishing
@@ -42,6 +42,9 @@ jobs:
 
       - name: Lint, test, build publishable projects
         run: npx nx run-many -t lint,test,build --projects=$NPM_PUBLISHABLE_PROJECTS --skip-nx-cache
+
+      - name: Patch install telemetry into publishable manifests
+        run: node libs/telemetry/scripts/apply-install-telemetry.mjs dist/libs/chat dist/libs/langgraph dist/libs/ag-ui dist/libs/render dist/libs/a2ui dist/libs/licensing
 
       - name: Verify atomic release versions
         run: node scripts/verify-release-versions.mjs --tag "$RELEASE_TAG"

--- a/libs/chat/package.json
+++ b/libs/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/chat",
-  "version": "0.0.32",
+  "version": "0.0.29",
   "exports": {
     ".": {
       "types": "./index.d.ts",

--- a/libs/telemetry/package.json
+++ b/libs/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/telemetry",
-  "version": "0.0.0",
+  "version": "0.0.29",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/telemetry/project.json
+++ b/libs/telemetry/project.json
@@ -36,6 +36,11 @@
         "command": "node libs/telemetry/scripts/assemble-dist.mjs"
       }
     },
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    },
     "test": {
       "executor": "@nx/vitest:test",
       "options": {

--- a/libs/telemetry/src/node/client.spec.ts
+++ b/libs/telemetry/src/node/client.spec.ts
@@ -14,7 +14,13 @@ describe('node client', () => {
     _resetDisableForTesting();
     delete process.env.DO_NOT_TRACK;
     delete process.env.NGAF_TELEMETRY_DISABLED;
+    delete process.env.npm_config_do_not_track;
+    delete process.env.NPM_CONFIG_DO_NOT_TRACK;
     delete process.env.CI;
+    delete process.env.GITHUB_ACTIONS;
+    delete process.env.CONTINUOUS_INTEGRATION;
+    delete process.env.BUILDKITE;
+    delete process.env.CIRCLECI;
     delete process.env.NGAF_TELEMETRY_SAMPLE_RATE;
     delete process.env.npm_config_user_agent;
     process.env.NGAF_TELEMETRY_INGEST_URL = 'https://test.example/api/ingest';

--- a/libs/telemetry/src/node/postinstall.spec.ts
+++ b/libs/telemetry/src/node/postinstall.spec.ts
@@ -18,8 +18,15 @@ describe('postinstall script', () => {
   beforeEach(() => {
     vi.mocked(capturePostinstall).mockClear();
     delete process.env.CI;
+    delete process.env.GITHUB_ACTIONS;
+    delete process.env.CONTINUOUS_INTEGRATION;
+    delete process.env.BUILDKITE;
+    delete process.env.CIRCLECI;
     delete process.env.DO_NOT_TRACK;
+    delete process.env.npm_config_do_not_track;
+    delete process.env.NPM_CONFIG_DO_NOT_TRACK;
     delete process.env.DEBUG;
+    delete process.env.NGAF_TELEMETRY_DISABLED;
   });
 
   test('calls capturePostinstall with the package name + version', async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -188,7 +188,7 @@
     },
     "libs/chat": {
       "name": "@ngaf/chat",
-      "version": "0.0.32",
+      "version": "0.0.29",
       "license": "MIT",
       "dependencies": {
         "@cacheplane/partial-json": ">=0.1.1 <0.3.0",
@@ -291,7 +291,7 @@
     },
     "libs/telemetry": {
       "name": "@ngaf/telemetry",
-      "version": "0.0.0",
+      "version": "0.0.29",
       "license": "MIT",
       "bin": {
         "ngaf-telemetry-postinstall": "node/postinstall.js"

--- a/scripts/verify-release-versions.mjs
+++ b/scripts/verify-release-versions.mjs
@@ -144,6 +144,14 @@ export async function verifyReleaseVersions({
     }
 
     const packageInfo = await getPackageForProject(workspaceRoot, project);
+    const publishRoot =
+      project.targets['nx-release-publish']?.options?.packageRoot;
+
+    if (publishRoot !== 'dist/{projectRoot}') {
+      throw new Error(
+        `Release project "${projectName}" must publish from dist/{projectRoot}.`
+      );
+    }
 
     if (packageInfo.packageJson.private === true) {
       throw new Error(

--- a/scripts/verify-release-versions.spec.mjs
+++ b/scripts/verify-release-versions.spec.mjs
@@ -30,6 +30,13 @@ async function createWorkspace(projectVersions) {
     await mkdir(projectRoot, { recursive: true });
     await writeJson(join(projectRoot, 'project.json'), {
       name: projectName,
+      targets: {
+        'nx-release-publish': {
+          options: {
+            packageRoot: 'dist/{projectRoot}',
+          },
+        },
+      },
     });
     await writeJson(join(projectRoot, 'package.json'), {
       name: `@ngaf/${projectName}`,
@@ -108,6 +115,25 @@ describe('verifyReleaseVersions', () => {
 
     await expect(verifyReleaseVersions({ workspaceRoot })).rejects.toThrow(
       'Public package @ngaf/render is not included in release group "publishable".'
+    );
+  });
+
+  it('rejects release projects without an explicit dist publish root', async () => {
+    const workspaceRoot = await createWorkspace({
+      chat: '0.0.13',
+      telemetry: '0.0.13',
+    });
+    await writeJson(join(workspaceRoot, 'libs', 'telemetry', 'project.json'), {
+      name: 'telemetry',
+      targets: {
+        'nx-release-publish': {
+          options: {},
+        },
+      },
+    });
+
+    await expect(verifyReleaseVersions({ workspaceRoot })).rejects.toThrow(
+      'Release project "telemetry" must publish from dist/{projectRoot}.'
     );
   });
 });


### PR DESCRIPTION
## Summary
- Align all publishable package manifests back to the current fixed release version `0.0.29`, including `@ngaf/chat` and `@ngaf/telemetry`.
- Add an explicit telemetry `nx-release-publish` target so release publish uses `dist/libs/telemetry`.
- Replace stale `partial-json` workflow project lists with `telemetry` and run the release version verifier in PR CI.
- Patch install telemetry into publishable dist manifests in the publish workflow before npm publish.
- Extend `scripts/verify-release-versions.mjs` to require release projects publish from `dist/{projectRoot}`.

## Verification
- Red: `PATH="/Users/blove/.nvm/versions/node/v22.14.0/bin:$PATH" npx vitest run scripts/verify-release-versions.spec.mjs` failed before the verifier implementation on the new dist publish root test.
- `PATH="/Users/blove/.nvm/versions/node/v22.14.0/bin:$PATH" npx vitest run scripts/verify-release-versions.spec.mjs`
- `PATH="/Users/blove/.nvm/versions/node/v22.14.0/bin:$PATH" node scripts/verify-release-versions.mjs`
- `PATH="/Users/blove/.nvm/versions/node/v22.14.0/bin:$PATH" node scripts/verify-release-versions.mjs --tag v0.0.29`
- `PATH="/Users/blove/.nvm/versions/node/v22.14.0/bin:$PATH" NX_DAEMON=false npx nx release version patch --dry-run`
- `PATH="/Users/blove/.nvm/versions/node/v22.14.0/bin:$PATH" NX_DAEMON=false npx nx run-many -t lint,test,build --projects=chat,langgraph,ag-ui,render,a2ui,licensing,telemetry --skip-nx-cache`
- `PATH="/Users/blove/.nvm/versions/node/v22.14.0/bin:$PATH" node libs/telemetry/scripts/apply-install-telemetry.mjs dist/libs/chat dist/libs/langgraph dist/libs/ag-ui dist/libs/render dist/libs/a2ui dist/libs/licensing`
- `PATH="/Users/blove/.nvm/versions/node/v22.14.0/bin:$PATH" NX_DAEMON=false npx nx release publish --groups=publishable --dry-run`
- `git diff --check`