### PR TITLE
fix(telemetry): use live ingest proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,9 +7,9 @@ POSTHOG_HOST=https://us.i.posthog.com
 POSTHOG_PROJECT_ID=
 
 # @ngaf/telemetry (libs/telemetry)
-# Default ingest URL points to the future Spec 1D reverse proxy. Self-hosters
+# Default ingest URL points to the Cacheplane website reverse proxy. Self-hosters
 # can redirect to their own ingest. See libs/telemetry/README.md.
-# NGAF_TELEMETRY_INGEST_URL=https://cacheplane.dev/api/ingest
+# NGAF_TELEMETRY_INGEST_URL=https://cacheplane.ai/api/ingest
 # NGAF_TELEMETRY_SAMPLE_RATE=1.0
 # DO_NOT_TRACK=1                          # cross-vendor opt-out
 # NGAF_TELEMETRY_DISABLED=1               # package-specific opt-out

--- a/libs/telemetry/README.md
+++ b/libs/telemetry/README.md
@@ -107,7 +107,7 @@ Enterprise users can redirect Node telemetry to their own ingest:
 NGAF_TELEMETRY_INGEST_URL=https://telemetry.acme-internal.example.com/api/ingest
 ```
 
-Default ingest (when env var is unset) is a thin proxy on the Cacheplane website (`https://cacheplane.dev/api/ingest`) that accepts the `@ngaf/telemetry` JSON payload and forwards `ngaf:*` events to our PostHog project without forwarding installer IP addresses. Source of the proxy lives in `apps/website/src/app/api/ingest/`.
+Default ingest (when env var is unset) is a thin proxy on the Cacheplane website (`https://cacheplane.ai/api/ingest`) that accepts the `@ngaf/telemetry` JSON payload and forwards `ngaf:*` events to our PostHog project without forwarding installer IP addresses. Source of the proxy lives in `apps/website/src/app/api/ingest/`.
 
 ## Verifying telemetry is silent
 

--- a/libs/telemetry/src/node/client.spec.ts
+++ b/libs/telemetry/src/node/client.spec.ts
@@ -56,6 +56,12 @@ describe('node client', () => {
     expect(fetchMock.mock.calls[0][0]).toBe('https://custom.example/api/ingest');
   });
 
+  test('capturePostinstall defaults to the live Cacheplane ingest proxy', async () => {
+    delete process.env.NGAF_TELEMETRY_INGEST_URL;
+    await capturePostinstall({ pkg: 'x', version: '1' });
+    expect(fetchMock.mock.calls[0][0]).toBe('https://cacheplane.ai/api/ingest');
+  });
+
   test('capturePostinstall sends sample_weight property', async () => {
     await capturePostinstall({ pkg: 'x', version: '1' });
     const body = JSON.parse(String(fetchMock.mock.calls[0][1].body));

--- a/libs/telemetry/src/node/client.ts
+++ b/libs/telemetry/src/node/client.ts
@@ -4,7 +4,7 @@ import { shouldSample } from '../shared/sample.js';
 import type { NgafNodeEvent } from '../shared/events.js';
 import { isProgrammaticallyDisabled } from './disable.js';
 
-const DEFAULT_INGEST = 'https://cacheplane.dev/api/ingest';
+const DEFAULT_INGEST = 'https://cacheplane.ai/api/ingest';
 const REQUEST_TIMEOUT_MS = 3_000;
 // Public identifier accepted by the Cacheplane ingest proxy. The proxy re-keys
 // server-side with the private PostHog token.


### PR DESCRIPTION
## Summary
- point the default Node install telemetry ingest URL at the live Cacheplane website proxy
- add a regression test for the default ingest URL
- update the telemetry README and env example to match the live proxy host

## Verification
- `PATH="/Users/blove/.nvm/versions/node/v22.14.0/bin:$PATH" NX_DAEMON=false npx nx test telemetry --coverage --skip-nx-cache`
- `git diff --check`
- `PATH="/Users/blove/.nvm/versions/node/v22.14.0/bin:$PATH" node scripts/verify-release-versions.mjs`
- `PATH="/Users/blove/.nvm/versions/node/v22.14.0/bin:$PATH" NX_DAEMON=false npx nx run-many -t build --projects=chat,langgraph,ag-ui,render,a2ui,licensing,telemetry --configuration=production --skip-nx-cache`
- packed all publishable package tarballs and installed them into a fresh npm project against a local ingest server; captured 7 `ngaf:postinstall` events with npm metadata
- live ingest smoke to `https://cacheplane.ai/api/ingest` returned `202 {"ok":true}`

## Follow-up
- `npm view @ngaf/telemetry` still returns E404, so the registry install smoke remains blocked until the next publish includes `@ngaf/telemetry`.