### PR TITLE
test(examples-chat): aimock interrupt-approval scenario — Phase 2e

### DIFF
--- a/examples/chat/aimock-e2e/fixtures/interrupt-approval.json
+++ b/examples/chat/aimock-e2e/fixtures/interrupt-approval.json
@@ -1,0 +1,19 @@
+{
+  "fixtures": [
+    {
+      "match": {
+        "userMessage": "I want to clean up old database backups older than 90 days. Walk me through what you would delete, and call request_approval before doing anything destructive so I can review your plan."
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "name": "request_approval",
+            "arguments": {
+              "reason": "Requesting approval to delete database backups older than 90 days across configured storage locations. Planned actions: 1) inventory existing backups (S3/GCS/Azure/local/RDS/EBS/manual snapshots/backup DB table), 2) run dry-run listing of items matching backup patterns older than 90 days for your review, 3) after final confirmation, delete the identified objects/snapshots (or move to quarantine/archive) and record audit logs. Please approve or deny; describe any exclusions or storage locations to omit."
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/examples/chat/aimock-e2e/interrupt-approval.spec.ts
+++ b/examples/chat/aimock-e2e/interrupt-approval.spec.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+import { test, expect } from '@playwright/test';
+
+const PROMPT =
+  'I want to clean up old database backups older than 90 days. Walk me through ' +
+  'what you would delete, and call request_approval before doing anything ' +
+  'destructive so I can review your plan.';
+
+test('interrupt approval: pause renders the interrupt panel with the captured reason', async ({
+  page,
+}) => {
+  await page.goto('/embed');
+
+  const input = page.getByRole('textbox', { name: /message|prompt/i });
+  await input.fill(PROMPT);
+  await page.getByRole('button', { name: /send/i }).click();
+
+  // When the parent emits request_approval, the langgraph node calls
+  // interrupt({...}) and the graph pauses. The chat composition surfaces a
+  // <chat-interrupt-panel> with the captured 'reason' text. We don't wait on
+  // data-streaming="false" here because the agent stays in the paused state
+  // until the human responds — the interrupt panel is the durable signal.
+  const panel = page.locator('chat-interrupt-panel');
+  await expect(panel).toBeAttached({ timeout: 45_000 });
+
+  // The panel title is "Agent paused" (per the smoke checklist) — verifies
+  // the panel actually rendered, not just the host element being attached.
+  await expect(panel).toContainText(/agent paused/i);
+
+  // The captured reason mentions "approval" and "delete" — assert one is in
+  // the panel body so the reason text is plumbing through.
+  await expect.poll(
+    async () => (await panel.innerText()).toLowerCase(),
+    { timeout: 30_000 },
+  ).toMatch(/approval|delete|backup/i);
+});


### PR DESCRIPTION
## Summary

Adds an end-to-end Playwright scenario for the **interrupt / human-in-the-loop** flow through the harness:

- Parent LLM emits a `tool_call` to `request_approval(reason="...")` 
- LangGraph dispatches the tool; the tool calls `interrupt({...})`; the graph pauses
- The chat composition surfaces `<chat-interrupt-panel>` with the captured `reason` text
- Test asserts: panel attached, title "Agent paused", body contains reason-text terms

Single-LLM-call fixture (no continuation needed — graph stays paused until human responds).

Sits on Phase 2d ([#330](https://github.com/cacheplane/angular-agent-framework/pull/330)).

## Test plan

- [x] New spec passes solo locally: 1/1 in ~2.6s
- [x] Full suite passes 3/3 consecutive runs (7/7 specs each)
- [x] No production code touched
- [ ] CI green

## Notes for reviewers

- Skipped `data-streaming="false"` wait — the agent stays in the paused state, not the idle state, until the human responds. The interrupt panel is the durable DOM signal here.
- Captured `reason` from real `gpt-5-mini` is a real plan-the-cleanup paragraph, so the body assertion uses a loose phrase match (`approval|delete|backup`) rather than locking in a specific phrasing.
- Accept/Edit/Ignore interactions are deferred — could be a follow-up that clicks Accept then asserts the AI continues, but requires a captured continuation response.