### PR TITLE
chore(release): publish v0.0.30

### DIFF
--- a/libs/a2ui/package.json
+++ b/libs/a2ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/a2ui",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/ag-ui/package.json
+++ b/libs/ag-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/ag-ui",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "peerDependencies": {
     "@ngaf/chat": "*",
     "@ngaf/licensing": "*",

--- a/libs/chat/package.json
+++ b/libs/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/chat",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "exports": {
     ".": {
       "types": "./index.d.ts",

--- a/libs/langgraph/package.json
+++ b/libs/langgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/langgraph",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "peerDependencies": {
     "@ngaf/chat": "*",
     "@ngaf/licensing": "*",

--- a/libs/licensing/package.json
+++ b/libs/licensing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/licensing",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/render/package.json
+++ b/libs/render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/render",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "peerDependencies": {
     "@angular/core": "^20.0.0 || ^21.0.0",
     "@angular/common": "^20.0.0 || ^21.0.0",

--- a/libs/telemetry/package.json
+++ b/libs/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/telemetry",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/package-lock.json
+++ b/package-lock.json
@@ -171,12 +171,12 @@
     },
     "libs/a2ui": {
       "name": "@ngaf/a2ui",
-      "version": "0.0.29",
+      "version": "0.0.30",
       "license": "MIT"
     },
     "libs/ag-ui": {
       "name": "@ngaf/ag-ui",
-      "version": "0.0.29",
+      "version": "0.0.30",
       "license": "MIT",
       "peerDependencies": {
         "@ag-ui/client": "*",
@@ -188,7 +188,7 @@
     },
     "libs/chat": {
       "name": "@ngaf/chat",
-      "version": "0.0.29",
+      "version": "0.0.30",
       "license": "MIT",
       "dependencies": {
         "@cacheplane/partial-json": ">=0.1.1 <0.3.0",
@@ -259,7 +259,7 @@
     },
     "libs/langgraph": {
       "name": "@ngaf/langgraph",
-      "version": "0.0.29",
+      "version": "0.0.30",
       "license": "MIT",
       "peerDependencies": {
         "@angular/core": "^20.0.0 || ^21.0.0",
@@ -272,7 +272,7 @@
     },
     "libs/licensing": {
       "name": "@ngaf/licensing",
-      "version": "0.0.29",
+      "version": "0.0.30",
       "license": "MIT",
       "peerDependencies": {
         "@noble/ed25519": "^2.2.3"
@@ -280,7 +280,7 @@
     },
     "libs/render": {
       "name": "@ngaf/render",
-      "version": "0.0.29",
+      "version": "0.0.30",
       "license": "MIT",
       "peerDependencies": {
         "@angular/common": "^20.0.0 || ^21.0.0",
@@ -291,7 +291,7 @@
     },
     "libs/telemetry": {
       "name": "@ngaf/telemetry",
-      "version": "0.0.29",
+      "version": "0.0.30",
       "license": "MIT",
       "bin": {
         "ngaf-telemetry-postinstall": "node/postinstall.js"


### PR DESCRIPTION
## Summary
- bump the fixed publishable release group from `0.0.29` to `0.0.30`
- include `@ngaf/telemetry` in the synchronized release version so the next `v0.0.30` tag can publish it to npm with the other six packages
- update the root lockfile package entries for the same fixed version

## Verification
- `PATH="/Users/blove/.nvm/versions/node/v22.14.0/bin:$PATH" NX_DAEMON=false npx nx release version --specifier=patch --dry-run`
- `PATH="/Users/blove/.nvm/versions/node/v22.14.0/bin:$PATH" node scripts/verify-release-versions.mjs`
- `git diff --check`
- `PATH="/Users/blove/.nvm/versions/node/v22.14.0/bin:$PATH" NX_DAEMON=false npx nx release publish --groups=publishable --dry-run`

## Notes
- `npx nx release changelog 0.0.30 --from=v0.0.29 --to=HEAD` could not run in this worktree because Nx invokes `gh auth token`, and `gh` is not installed here. I kept this PR limited to the version bump needed for publish.
- After this merges, tag the merge commit as `v0.0.30` and push the tag to trigger `.github/workflows/publish.yml`.