### PR TITLE
fix(telemetry): publish package as public

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,10 @@ on:
         description: 'Dry run (no actual publish)'
         type: boolean
         default: true
+      projects:
+        description: 'Optional comma-separated project list to publish instead of the full release group'
+        type: string
+        default: ''
 
 jobs:
   publish:
@@ -58,10 +62,29 @@ jobs:
 
       - name: Publish to npm
         if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry-run == false)
-        run: npx nx release publish --groups=publishable
+        run: |
+          if [ -n "${NPM_PUBLISH_PROJECTS}" ]; then
+            IFS=',' read -ra projects <<< "${NPM_PUBLISH_PROJECTS}"
+            for project in "${projects[@]}"; do
+              npx nx run "${project}:nx-release-publish"
+            done
+          else
+            npx nx release publish --groups=publishable
+          fi
         env:
           NPM_CONFIG_PROVENANCE: 'true'
+          NPM_PUBLISH_PROJECTS: ${{ github.event_name == 'workflow_dispatch' && inputs.projects || '' }}
 
       - name: Publish to npm (dry run)
         if: github.event_name == 'workflow_dispatch' && inputs.dry-run == true
-        run: npx nx release publish --groups=publishable --dry-run
+        run: |
+          if [ -n "${NPM_PUBLISH_PROJECTS}" ]; then
+            IFS=',' read -ra projects <<< "${NPM_PUBLISH_PROJECTS}"
+            for project in "${projects[@]}"; do
+              npx nx run "${project}:nx-release-publish" --dryRun
+            done
+          else
+            npx nx release publish --groups=publishable --dry-run
+          fi
+        env:
+          NPM_PUBLISH_PROJECTS: ${{ inputs.projects }}

--- a/libs/telemetry/package.json
+++ b/libs/telemetry/package.json
@@ -2,6 +2,9 @@
   "name": "@ngaf/telemetry",
   "version": "0.0.30",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/cacheplane/angular-agent-framework.git",


### PR DESCRIPTION
## Summary
- add `publishConfig.access=public` to `@ngaf/telemetry` so npm can publish the new scoped package with provenance
- add an optional workflow-dispatch `projects` input so the failed release can retry only `telemetry` without re-publishing the six packages that already succeeded
- keep tag-push behavior unchanged for normal full release publishes

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish.yml"); puts "publish workflow yaml ok"'`
- `PATH="/Users/blove/.nvm/versions/node/v22.14.0/bin:$PATH" node scripts/verify-release-versions.mjs`
- `git diff --check`
- `PATH="/Users/blove/.nvm/versions/node/v22.14.0/bin:$PATH" NX_DAEMON=false npx nx build telemetry --configuration=production --skip-nx-cache`
- `PATH="/Users/blove/.nvm/versions/node/v22.14.0/bin:$PATH" NX_DAEMON=false npx nx run telemetry:nx-release-publish --dryRun`

## Context
The `v0.0.30` tag publish successfully published `@ngaf/a2ui`, `@ngaf/licensing`, `@ngaf/render`, `@ngaf/chat`, `@ngaf/ag-ui`, and `@ngaf/langgraph`. `@ngaf/telemetry` failed because npm requires `access=public` for provenance on a new scoped package.