### PR TITLE
refactor(examples): Stage 2 PR-2 — langgraph wave (8 apps migrated)

### DIFF
--- a/cockpit/langgraph/deployment-runtime/angular/src/index.html
+++ b/cockpit/langgraph/deployment-runtime/angular/src/index.html
@@ -5,9 +5,8 @@
   <title>LangGraph Deployment & Runtime — Angular</title>
   <base href="/" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-950 text-gray-100 h-screen">
+<body>
   <app-deployment-runtime></app-deployment-runtime>
 </body>
 </html>

--- a/cockpit/langgraph/deployment-runtime/angular/src/styles.css
+++ b/cockpit/langgraph/deployment-runtime/angular/src/styles.css
@@ -1,30 +1,9 @@
-@import "../../../../../libs/design-tokens/src/lib/tokens.css";
-@import "tailwindcss";
-@source "../../../../../libs/chat/src/";
+@import "@ngaf/example-layouts/theme.css";
 
-@theme {
-  --color-bg: var(--ds-bg);
-  --color-surface: #ffffff;
-  --color-accent: var(--ds-accent);
-  --color-accent-light: var(--ds-accent-light);
-  --color-text-primary: var(--ds-text-primary);
-  --color-text-secondary: var(--ds-text-secondary);
-  --color-text-muted: var(--ds-text-muted);
-  --color-border: var(--ds-accent-border);
-  --color-error: #ef4444;
-  --color-success: #22c55e;
-  --font-sans: var(--ds-font-sans);
-  --font-serif: var(--ds-font-serif);
-  --font-mono: var(--ds-font-mono);
-}
-
-*, *::before, *::after { box-sizing: border-box; }
-
-body {
+html, body {
+  height: 100%;
   margin: 0;
-  font-family: var(--ds-font-sans);
-  background: var(--ds-bg);
-  color: var(--ds-text-primary);
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  background: var(--ngaf-chat-bg);
+  color: var(--ngaf-chat-text);
+  font-family: var(--ngaf-chat-font-family);
 }

--- a/cockpit/langgraph/durable-execution/angular/src/app/durable-execution.component.ts
+++ b/cockpit/langgraph/durable-execution/angular/src/app/durable-execution.component.ts
@@ -42,9 +42,9 @@ const STEP_LABELS: Record<string, string> = {
     <example-chat-layout sidebarWidth="w-64">
       <chat main [agent]="agent" [views]="ui" [store]="uiStore" class="flex-1 min-w-0" />
       <div sidebar class="p-4"
-           style="background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
+           style="background: var(--ngaf-chat-bg); color: var(--ngaf-chat-text);">
         <h3 class="text-xs font-semibold uppercase tracking-wide mb-6"
-            style="color: var(--chat-text-muted, #777);">Pipeline</h3>
+            style="color: var(--ngaf-chat-text-muted);">Pipeline</h3>
 
         <div class="space-y-0">
           @for (step of steps(); track step.id; let last = $last) {
@@ -68,15 +68,15 @@ const STEP_LABELS: Record<string, string> = {
                   }
                   @default {
                     <div class="w-7 h-7 rounded-full border-2 flex items-center justify-center"
-                         style="border-color: var(--chat-text-muted, #555);">
-                      <div class="w-2 h-2 rounded-full" style="background: var(--chat-text-muted, #555);"></div>
+                         style="border-color: var(--ngaf-chat-text-muted);">
+                      <div class="w-2 h-2 rounded-full" style="background: var(--ngaf-chat-text-muted);"></div>
                     </div>
                   }
                 }
                 <!-- Connecting line -->
                 @if (!last) {
                   <div class="w-0.5 h-8"
-                       [style.background]="step.status === 'complete' ? '#16a34a' : 'var(--chat-text-muted, #555)'">
+                       [style.background]="step.status === 'complete' ? '#16a34a' : 'var(--ngaf-chat-text-muted)'">
                   </div>
                 }
               </div>
@@ -84,7 +84,7 @@ const STEP_LABELS: Record<string, string> = {
               <!-- Label -->
               <span class="text-sm pt-1"
                     [class]="step.status === 'active' ? 'font-semibold text-amber-400' : step.status === 'complete' ? 'text-green-400' : ''"
-                    [style.color]="step.status === 'pending' ? 'var(--chat-text-muted, #777)' : ''">
+                    [style.color]="step.status === 'pending' ? 'var(--ngaf-chat-text-muted)' : ''">
                 {{ step.label }}
               </span>
             </div>

--- a/cockpit/langgraph/durable-execution/angular/src/app/views/step-pipeline.component.ts
+++ b/cockpit/langgraph/durable-execution/angular/src/app/views/step-pipeline.component.ts
@@ -9,7 +9,7 @@ interface PipelineStep {
   selector: 'step-pipeline',
   standalone: true,
   template: `
-    <div class="border rounded-xl p-4 my-2 overflow-x-auto" style="border-color: var(--chat-border); background: var(--chat-bg-alt);">
+    <div class="border rounded-xl p-4 my-2 overflow-x-auto" style="border-color: var(--ngaf-chat-separator); background: var(--ngaf-chat-surface-alt);">
       <div class="flex items-center gap-0 min-w-max">
         @for (step of steps(); track step.label; let i = $index; let last = $last) {
           <!-- Step node -->
@@ -18,7 +18,7 @@ interface PipelineStep {
             @switch (step.status) {
               @case ('complete') {
                 <div class="w-8 h-8 rounded-full flex items-center justify-center"
-                     style="background: var(--chat-success, #16a34a);">
+                     style="background: var(--ngaf-chat-success, #16a34a);">
                   <svg class="w-4 h-4 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
                   </svg>
@@ -26,24 +26,24 @@ interface PipelineStep {
               }
               @case ('active') {
                 <div class="w-8 h-8 rounded-full border-2 flex items-center justify-center animate-spin"
-                     style="border-color: var(--chat-warning-text, #f59e0b); animation-duration: 1.2s;">
-                  <div class="w-2 h-2 rounded-full" style="background: var(--chat-warning-text, #f59e0b);"></div>
+                     style="border-color: var(--ngaf-chat-warning-text, #f59e0b); animation-duration: 1.2s;">
+                  <div class="w-2 h-2 rounded-full" style="background: var(--ngaf-chat-warning-text, #f59e0b);"></div>
                 </div>
               }
               @default {
                 <div class="w-8 h-8 rounded-full border-2 flex items-center justify-center"
-                     style="border-color: var(--chat-text-muted, #555);">
-                  <div class="w-2 h-2 rounded-full" style="background: var(--chat-text-muted, #555);"></div>
+                     style="border-color: var(--ngaf-chat-text-muted, #555);">
+                  <div class="w-2 h-2 rounded-full" style="background: var(--ngaf-chat-text-muted, #555);"></div>
                 </div>
               }
             }
             <!-- Label -->
             <span class="text-xs whitespace-nowrap"
                   [style.color]="step.status === 'active'
-                    ? 'var(--chat-warning-text, #f59e0b)'
+                    ? 'var(--ngaf-chat-warning-text, #f59e0b)'
                     : step.status === 'complete'
-                      ? 'var(--chat-success, #16a34a)'
-                      : 'var(--chat-text-muted, #777)'"
+                      ? 'var(--ngaf-chat-success, #16a34a)'
+                      : 'var(--ngaf-chat-text-muted, #777)'"
                   [class.font-semibold]="step.status === 'active'">
               {{ step.label }}
             </span>
@@ -53,8 +53,8 @@ interface PipelineStep {
           @if (!last) {
             <div class="w-10 h-0.5 -mt-5 mx-1"
                  [style.background]="step.status === 'complete'
-                   ? 'var(--chat-success, #16a34a)'
-                   : 'var(--chat-text-muted, #555)'">
+                   ? 'var(--ngaf-chat-success, #16a34a)'
+                   : 'var(--ngaf-chat-text-muted, #555)'">
             </div>
           }
         }

--- a/cockpit/langgraph/durable-execution/angular/src/index.html
+++ b/cockpit/langgraph/durable-execution/angular/src/index.html
@@ -5,9 +5,8 @@
   <title>LangGraph Durable Execution — Angular</title>
   <base href="/" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-950 text-gray-100 h-screen">
+<body>
   <app-durable-execution></app-durable-execution>
 </body>
 </html>

--- a/cockpit/langgraph/durable-execution/angular/src/styles.css
+++ b/cockpit/langgraph/durable-execution/angular/src/styles.css
@@ -1,30 +1,9 @@
-@import "../../../../../libs/design-tokens/src/lib/tokens.css";
-@import "tailwindcss";
-@source "../../../../../libs/chat/src/";
+@import "@ngaf/example-layouts/theme.css";
 
-@theme {
-  --color-bg: var(--ds-bg);
-  --color-surface: #ffffff;
-  --color-accent: var(--ds-accent);
-  --color-accent-light: var(--ds-accent-light);
-  --color-text-primary: var(--ds-text-primary);
-  --color-text-secondary: var(--ds-text-secondary);
-  --color-text-muted: var(--ds-text-muted);
-  --color-border: var(--ds-accent-border);
-  --color-error: #ef4444;
-  --color-success: #22c55e;
-  --font-sans: var(--ds-font-sans);
-  --font-serif: var(--ds-font-serif);
-  --font-mono: var(--ds-font-mono);
-}
-
-*, *::before, *::after { box-sizing: border-box; }
-
-body {
+html, body {
+  height: 100%;
   margin: 0;
-  font-family: var(--ds-font-sans);
-  background: var(--ds-bg);
-  color: var(--ds-text-primary);
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  background: var(--ngaf-chat-bg);
+  color: var(--ngaf-chat-text);
+  font-family: var(--ngaf-chat-font-family);
 }

--- a/cockpit/langgraph/interrupts/angular/src/app/interrupts.component.ts
+++ b/cockpit/langgraph/interrupts/angular/src/app/interrupts.component.ts
@@ -28,7 +28,7 @@ import { ApprovalCardComponent } from './views/approval-card.component';
       <div main class="flex flex-col h-full">
         <chat [agent]="agent" [views]="ui" [store]="uiStore" class="flex-1 min-w-0" />
         @if (agent.interrupt()) {
-          <div class="p-4" style="border-top: 1px solid var(--chat-border, #333);">
+          <div class="p-4" style="border-top: 1px solid var(--ngaf-chat-separator);">
             <chat-interrupt-panel [agent]="agent" (action)="onInterruptAction($event)" />
           </div>
         }

--- a/cockpit/langgraph/interrupts/angular/src/app/views/approval-card.component.ts
+++ b/cockpit/langgraph/interrupts/angular/src/app/views/approval-card.component.ts
@@ -4,10 +4,10 @@ import { Component, input } from '@angular/core';
   selector: 'approval-card',
   standalone: true,
   template: `
-    <div class="border rounded-xl my-2 overflow-hidden" style="border-color: var(--chat-border); background: var(--chat-bg-alt);">
+    <div class="border rounded-xl my-2 overflow-hidden" style="border-color: var(--ngaf-chat-separator); background: var(--ngaf-chat-surface-alt);">
       <!-- Warning header -->
       <div class="flex items-center gap-2 px-4 py-2 text-sm font-semibold"
-           style="background: color-mix(in srgb, var(--chat-warning-text, #f59e0b) 15%, transparent); color: var(--chat-warning-text, #f59e0b);">
+           style="background: var(--ngaf-chat-warning-bg); color: var(--ngaf-chat-warning-text);">
         <svg class="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round"
                 d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" />
@@ -17,28 +17,28 @@ import { Component, input } from '@angular/core';
 
       <!-- Body -->
       <div class="px-4 py-3">
-        <p class="text-sm mb-4" style="color: var(--chat-text, #e0e0e0);">{{ description() }}</p>
+        <p class="text-sm mb-4" style="color: var(--ngaf-chat-text);">{{ description() }}</p>
 
         <div class="flex items-center gap-2">
           <button
             (click)="emit()('approve')"
             class="px-3 py-1.5 text-sm font-medium rounded-lg transition-colors"
-            style="background: var(--chat-success, #16a34a); color: #fff;"
+            style="background: var(--ngaf-chat-success); color: #fff;"
             onmouseover="this.style.opacity='0.85'" onmouseout="this.style.opacity='1'">
             Approve
           </button>
           <button
             (click)="emit()('edit')"
             class="px-3 py-1.5 text-sm font-medium rounded-lg border transition-colors"
-            style="border-color: var(--chat-border, #333); color: var(--chat-text, #e0e0e0); background: transparent;"
-            onmouseover="this.style.background='var(--chat-bg-hover, #222)'" onmouseout="this.style.background='transparent'">
+            style="border-color: var(--ngaf-chat-separator); color: var(--ngaf-chat-text); background: transparent;"
+            onmouseover="this.style.background='var(--ngaf-chat-surface-alt)'" onmouseout="this.style.background='transparent'">
             Edit
           </button>
           <button
             (click)="emit()('cancel')"
             class="px-3 py-1.5 text-sm font-medium rounded-lg transition-colors"
-            style="color: var(--chat-text-muted, #777); background: transparent;"
-            onmouseover="this.style.background='var(--chat-bg-hover, #222)'" onmouseout="this.style.background='transparent'">
+            style="color: var(--ngaf-chat-text-muted); background: transparent;"
+            onmouseover="this.style.background='var(--ngaf-chat-surface-alt)'" onmouseout="this.style.background='transparent'">
             Cancel
           </button>
         </div>

--- a/cockpit/langgraph/interrupts/angular/src/index.html
+++ b/cockpit/langgraph/interrupts/angular/src/index.html
@@ -5,9 +5,8 @@
   <title>LangGraph Interrupts — Angular</title>
   <base href="/" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-950 text-gray-100 h-screen">
+<body>
   <app-interrupts></app-interrupts>
 </body>
 </html>

--- a/cockpit/langgraph/interrupts/angular/src/styles.css
+++ b/cockpit/langgraph/interrupts/angular/src/styles.css
@@ -1,30 +1,9 @@
-@import "../../../../../libs/design-tokens/src/lib/tokens.css";
-@import "tailwindcss";
-@source "../../../../../libs/chat/src/";
+@import "@ngaf/example-layouts/theme.css";
 
-@theme {
-  --color-bg: var(--ds-bg);
-  --color-surface: #ffffff;
-  --color-accent: var(--ds-accent);
-  --color-accent-light: var(--ds-accent-light);
-  --color-text-primary: var(--ds-text-primary);
-  --color-text-secondary: var(--ds-text-secondary);
-  --color-text-muted: var(--ds-text-muted);
-  --color-border: var(--ds-accent-border);
-  --color-error: #ef4444;
-  --color-success: #22c55e;
-  --font-sans: var(--ds-font-sans);
-  --font-serif: var(--ds-font-serif);
-  --font-mono: var(--ds-font-mono);
-}
-
-*, *::before, *::after { box-sizing: border-box; }
-
-body {
+html, body {
+  height: 100%;
   margin: 0;
-  font-family: var(--ds-font-sans);
-  background: var(--ds-bg);
-  color: var(--ds-text-primary);
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  background: var(--ngaf-chat-bg);
+  color: var(--ngaf-chat-text);
+  font-family: var(--ngaf-chat-font-family);
 }

--- a/cockpit/langgraph/memory/angular/src/app/memory.component.ts
+++ b/cockpit/langgraph/memory/angular/src/app/memory.component.ts
@@ -25,16 +25,16 @@ import { environment } from '../environments/environment';
     <example-chat-layout>
       <chat main [agent]="agent" class="flex-1 min-w-0" />
       <div sidebar class="p-4 space-y-2"
-           style="background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
+           style="background: var(--ngaf-chat-bg); color: var(--ngaf-chat-text);">
         <h3 class="text-xs font-semibold uppercase tracking-wide"
-            style="color: var(--chat-text-muted, #777);">Learned Facts</h3>
+            style="color: var(--ngaf-chat-text-muted);">Learned Facts</h3>
         @if (memoryEntries().length === 0) {
-          <p class="text-sm italic" style="color: var(--chat-text-muted, #777);">No facts learned yet</p>
+          <p class="text-sm italic" style="color: var(--ngaf-chat-text-muted);">No facts learned yet</p>
         }
         @for (entry of memoryEntries(); track entry[0]) {
           <div class="text-sm py-1">
-            <span class="font-medium" style="color: var(--chat-text, #e0e0e0);">{{ entry[0] }}:</span>
-            <span style="color: var(--chat-text-muted, #777);"> {{ entry[1] }}</span>
+            <span class="font-medium" style="color: var(--ngaf-chat-text);">{{ entry[0] }}:</span>
+            <span style="color: var(--ngaf-chat-text-muted);"> {{ entry[1] }}</span>
           </div>
         }
       </div>

--- a/cockpit/langgraph/memory/angular/src/index.html
+++ b/cockpit/langgraph/memory/angular/src/index.html
@@ -5,9 +5,8 @@
   <title>LangGraph Memory — Angular</title>
   <base href="/" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-950 text-gray-100 h-screen">
+<body>
   <app-memory></app-memory>
 </body>
 </html>

--- a/cockpit/langgraph/memory/angular/src/styles.css
+++ b/cockpit/langgraph/memory/angular/src/styles.css
@@ -1,30 +1,9 @@
-@import "../../../../../libs/design-tokens/src/lib/tokens.css";
-@import "tailwindcss";
-@source "../../../../../libs/chat/src/";
+@import "@ngaf/example-layouts/theme.css";
 
-@theme {
-  --color-bg: var(--ds-bg);
-  --color-surface: #ffffff;
-  --color-accent: var(--ds-accent);
-  --color-accent-light: var(--ds-accent-light);
-  --color-text-primary: var(--ds-text-primary);
-  --color-text-secondary: var(--ds-text-secondary);
-  --color-text-muted: var(--ds-text-muted);
-  --color-border: var(--ds-accent-border);
-  --color-error: #ef4444;
-  --color-success: #22c55e;
-  --font-sans: var(--ds-font-sans);
-  --font-serif: var(--ds-font-serif);
-  --font-mono: var(--ds-font-mono);
-}
-
-*, *::before, *::after { box-sizing: border-box; }
-
-body {
+html, body {
+  height: 100%;
   margin: 0;
-  font-family: var(--ds-font-sans);
-  background: var(--ds-bg);
-  color: var(--ds-text-primary);
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  background: var(--ngaf-chat-bg);
+  color: var(--ngaf-chat-text);
+  font-family: var(--ngaf-chat-font-family);
 }

--- a/cockpit/langgraph/persistence/angular/src/app/persistence.component.ts
+++ b/cockpit/langgraph/persistence/angular/src/app/persistence.component.ts
@@ -30,11 +30,11 @@ interface Thread {
 
       <div sidebar
         class="flex flex-col"
-        style="background: var(--chat-bg-alt); color: var(--chat-text);"
+        style="background: var(--ngaf-chat-surface-alt); color: var(--ngaf-chat-text);"
       >
         <div
           class="px-3 py-2 text-xs font-semibold uppercase tracking-wide border-b"
-          style="border-color: var(--chat-border); color: var(--chat-text-muted)"
+          style="border-color: var(--ngaf-chat-separator); color: var(--ngaf-chat-text-muted)"
         >
           Threads
         </div>
@@ -44,9 +44,9 @@ interface Thread {
             <button
               class="w-full text-left px-3 py-2 text-sm truncate transition-colors"
               [class.font-semibold]="thread.id === activeThreadId()"
-              [style.background]="thread.id === activeThreadId() ? 'var(--chat-bg-hover)' : 'transparent'"
-              (mouseenter)="$event.currentTarget.style.background = 'var(--chat-bg-hover)'"
-              (mouseleave)="$event.currentTarget.style.background = thread.id === activeThreadId() ? 'var(--chat-bg-hover)' : 'transparent'"
+              [style.background]="thread.id === activeThreadId() ? 'var(--ngaf-chat-surface-alt)' : 'transparent'"
+              (mouseenter)="$event.currentTarget.style.background = 'var(--ngaf-chat-surface-alt)'"
+              (mouseleave)="$event.currentTarget.style.background = thread.id === activeThreadId() ? 'var(--ngaf-chat-surface-alt)' : 'transparent'"
               (click)="switchThread(thread.id)"
             >
               {{ thread.label }}
@@ -54,10 +54,10 @@ interface Thread {
           }
         </div>
 
-        <div class="p-2 border-t" style="border-color: var(--chat-border)">
+        <div class="p-2 border-t" style="border-color: var(--ngaf-chat-separator)">
           <button
             class="w-full rounded px-3 py-1.5 text-sm font-medium transition-colors"
-            style="background: var(--chat-bg-hover); color: var(--chat-text);"
+            style="background: var(--ngaf-chat-surface-alt); color: var(--ngaf-chat-text);"
             (mouseenter)="$event.currentTarget.style.opacity = '0.8'"
             (mouseleave)="$event.currentTarget.style.opacity = '1'"
             (click)="newThread()"

--- a/cockpit/langgraph/persistence/angular/src/index.html
+++ b/cockpit/langgraph/persistence/angular/src/index.html
@@ -5,9 +5,8 @@
   <title>LangGraph Persistence — Angular</title>
   <base href="/" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-950 text-gray-100 h-screen">
+<body>
   <app-persistence></app-persistence>
 </body>
 </html>

--- a/cockpit/langgraph/persistence/angular/src/styles.css
+++ b/cockpit/langgraph/persistence/angular/src/styles.css
@@ -1,30 +1,9 @@
-@import "../../../../../libs/design-tokens/src/lib/tokens.css";
-@import "tailwindcss";
-@source "../../../../../libs/chat/src/";
+@import "@ngaf/example-layouts/theme.css";
 
-@theme {
-  --color-bg: var(--ds-bg);
-  --color-surface: #ffffff;
-  --color-accent: var(--ds-accent);
-  --color-accent-light: var(--ds-accent-light);
-  --color-text-primary: var(--ds-text-primary);
-  --color-text-secondary: var(--ds-text-secondary);
-  --color-text-muted: var(--ds-text-muted);
-  --color-border: var(--ds-accent-border);
-  --color-error: #ef4444;
-  --color-success: #22c55e;
-  --font-sans: var(--ds-font-sans);
-  --font-serif: var(--ds-font-serif);
-  --font-mono: var(--ds-font-mono);
-}
-
-*, *::before, *::after { box-sizing: border-box; }
-
-body {
+html, body {
+  height: 100%;
   margin: 0;
-  font-family: var(--ds-font-sans);
-  background: var(--ds-bg);
-  color: var(--ds-text-primary);
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  background: var(--ngaf-chat-bg);
+  color: var(--ngaf-chat-text);
+  font-family: var(--ngaf-chat-font-family);
 }

--- a/cockpit/langgraph/streaming/angular/src/index.html
+++ b/cockpit/langgraph/streaming/angular/src/index.html
@@ -5,9 +5,8 @@
   <title>LangGraph Streaming — Angular</title>
   <base href="/" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-950 text-gray-100 h-screen">
+<body>
   <app-streaming></app-streaming>
 </body>
 </html>

--- a/cockpit/langgraph/streaming/angular/src/styles.css
+++ b/cockpit/langgraph/streaming/angular/src/styles.css
@@ -1,30 +1,9 @@
-@import "../../../../../libs/design-tokens/src/lib/tokens.css";
-@import "tailwindcss";
-@source "../../../../../libs/chat/src/";
+@import "@ngaf/example-layouts/theme.css";
 
-@theme {
-  --color-bg: var(--ds-bg);
-  --color-surface: #ffffff;
-  --color-accent: var(--ds-accent);
-  --color-accent-light: var(--ds-accent-light);
-  --color-text-primary: var(--ds-text-primary);
-  --color-text-secondary: var(--ds-text-secondary);
-  --color-text-muted: var(--ds-text-muted);
-  --color-border: var(--ds-accent-border);
-  --color-error: #ef4444;
-  --color-success: #22c55e;
-  --font-sans: var(--ds-font-sans);
-  --font-serif: var(--ds-font-serif);
-  --font-mono: var(--ds-font-mono);
-}
-
-*, *::before, *::after { box-sizing: border-box; }
-
-body {
+html, body {
+  height: 100%;
   margin: 0;
-  font-family: var(--ds-font-sans);
-  background: var(--ds-bg);
-  color: var(--ds-text-primary);
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  background: var(--ngaf-chat-bg);
+  color: var(--ngaf-chat-text);
+  font-family: var(--ngaf-chat-font-family);
 }

--- a/cockpit/langgraph/subgraphs/angular/src/app/subgraphs.component.ts
+++ b/cockpit/langgraph/subgraphs/angular/src/app/subgraphs.component.ts
@@ -34,7 +34,7 @@ import { environment } from '../environments/environment';
         @for (entry of subagentEntries(); track entry.id) {
           <div class="flex items-center gap-2 text-sm py-1">
             <span class="w-2 h-2 rounded-full shrink-0"
-                  [style.background]="entry.status === 'complete' ? 'var(--chat-success, #4ade80)' : entry.status === 'error' ? 'var(--chat-error-text, #f87171)' : 'var(--chat-warning-text, #fbbf24)'">
+                  [style.background]="entry.status === 'complete' ? 'var(--ngaf-chat-success, #4ade80)' : entry.status === 'error' ? 'var(--ngaf-chat-error-text, #f87171)' : 'var(--ngaf-chat-warning-text, #fbbf24)'">
             </span>
             <span class="font-mono text-xs truncate" style="color: var(--ngaf-chat-text);">{{ entry.id }}</span>
             <span class="text-xs ml-auto" style="color: var(--ngaf-chat-text-muted);">{{ entry.msgCount }} msgs</span>

--- a/cockpit/langgraph/subgraphs/angular/src/app/subgraphs.component.ts
+++ b/cockpit/langgraph/subgraphs/angular/src/app/subgraphs.component.ts
@@ -25,19 +25,19 @@ import { environment } from '../environments/environment';
     <example-chat-layout>
       <chat main [agent]="agent" class="flex-1 min-w-0" />
       <div sidebar class="p-4 space-y-2"
-           style="background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);">
+           style="background: var(--ngaf-chat-bg); color: var(--ngaf-chat-text);">
         <h3 class="text-xs font-semibold uppercase tracking-wide"
-            style="color: var(--chat-text-muted, #777);">Subagents</h3>
+            style="color: var(--ngaf-chat-text-muted);">Subagents</h3>
         @if (subagentEntries().length === 0) {
-          <p class="text-sm italic" style="color: var(--chat-text-muted, #777);">No subagents active</p>
+          <p class="text-sm italic" style="color: var(--ngaf-chat-text-muted);">No subagents active</p>
         }
         @for (entry of subagentEntries(); track entry.id) {
           <div class="flex items-center gap-2 text-sm py-1">
             <span class="w-2 h-2 rounded-full shrink-0"
                   [style.background]="entry.status === 'complete' ? 'var(--chat-success, #4ade80)' : entry.status === 'error' ? 'var(--chat-error-text, #f87171)' : 'var(--chat-warning-text, #fbbf24)'">
             </span>
-            <span class="font-mono text-xs truncate" style="color: var(--chat-text, #e0e0e0);">{{ entry.id }}</span>
-            <span class="text-xs ml-auto" style="color: var(--chat-text-muted, #777);">{{ entry.msgCount }} msgs</span>
+            <span class="font-mono text-xs truncate" style="color: var(--ngaf-chat-text);">{{ entry.id }}</span>
+            <span class="text-xs ml-auto" style="color: var(--ngaf-chat-text-muted);">{{ entry.msgCount }} msgs</span>
           </div>
         }
       </div>

--- a/cockpit/langgraph/subgraphs/angular/src/index.html
+++ b/cockpit/langgraph/subgraphs/angular/src/index.html
@@ -5,9 +5,8 @@
   <title>LangGraph Subgraphs — Angular</title>
   <base href="/" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-950 text-gray-100 h-screen">
+<body>
   <app-subgraphs></app-subgraphs>
 </body>
 </html>

--- a/cockpit/langgraph/subgraphs/angular/src/styles.css
+++ b/cockpit/langgraph/subgraphs/angular/src/styles.css
@@ -1,30 +1,9 @@
-@import "../../../../../libs/design-tokens/src/lib/tokens.css";
-@import "tailwindcss";
-@source "../../../../../libs/chat/src/";
+@import "@ngaf/example-layouts/theme.css";
 
-@theme {
-  --color-bg: var(--ds-bg);
-  --color-surface: #ffffff;
-  --color-accent: var(--ds-accent);
-  --color-accent-light: var(--ds-accent-light);
-  --color-text-primary: var(--ds-text-primary);
-  --color-text-secondary: var(--ds-text-secondary);
-  --color-text-muted: var(--ds-text-muted);
-  --color-border: var(--ds-accent-border);
-  --color-error: #ef4444;
-  --color-success: #22c55e;
-  --font-sans: var(--ds-font-sans);
-  --font-serif: var(--ds-font-serif);
-  --font-mono: var(--ds-font-mono);
-}
-
-*, *::before, *::after { box-sizing: border-box; }
-
-body {
+html, body {
+  height: 100%;
   margin: 0;
-  font-family: var(--ds-font-sans);
-  background: var(--ds-bg);
-  color: var(--ds-text-primary);
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  background: var(--ngaf-chat-bg);
+  color: var(--ngaf-chat-text);
+  font-family: var(--ngaf-chat-font-family);
 }

--- a/cockpit/langgraph/time-travel/angular/src/app/time-travel.component.ts
+++ b/cockpit/langgraph/time-travel/angular/src/app/time-travel.component.ts
@@ -27,7 +27,7 @@ import { environment } from '../environments/environment';
       <!-- Checkpoint timeline sidebar -->
       <div sidebar
         class="flex flex-col overflow-hidden"
-        style="background: var(--chat-bg, #171717); color: var(--chat-text, #e0e0e0);"
+        style="background: var(--ngaf-chat-bg); color: var(--ngaf-chat-text);"
       >
         <div class="px-4 py-3 border-b border-[var(--chat-border)]">
           <h2 class="text-sm font-semibold text-[var(--chat-text)] uppercase tracking-wide">

--- a/cockpit/langgraph/time-travel/angular/src/app/time-travel.component.ts
+++ b/cockpit/langgraph/time-travel/angular/src/app/time-travel.component.ts
@@ -29,18 +29,18 @@ import { environment } from '../environments/environment';
         class="flex flex-col overflow-hidden"
         style="background: var(--ngaf-chat-bg); color: var(--ngaf-chat-text);"
       >
-        <div class="px-4 py-3 border-b border-[var(--chat-border)]">
-          <h2 class="text-sm font-semibold text-[var(--chat-text)] uppercase tracking-wide">
+        <div class="px-4 py-3 border-b border-[var(--ngaf-chat-separator)]">
+          <h2 class="text-sm font-semibold text-[var(--ngaf-chat-text)] uppercase tracking-wide">
             Timeline
           </h2>
-          <p class="text-xs text-[var(--chat-text-muted)] mt-0.5">
+          <p class="text-xs text-[var(--ngaf-chat-text-muted)] mt-0.5">
             {{ checkpoints().length }} checkpoint(s)
           </p>
         </div>
 
         <div class="flex-1 overflow-y-auto px-3 py-2 space-y-1.5">
           @if (checkpoints().length === 0) {
-            <p class="text-xs text-[var(--chat-text-muted)] text-center py-6">
+            <p class="text-xs text-[var(--ngaf-chat-text-muted)] text-center py-6">
               No checkpoints yet. Send a message to begin.
             </p>
           }
@@ -50,8 +50,8 @@ import { environment } from '../environments/environment';
               class="flex items-center gap-2 rounded-lg border px-3 py-2 transition-colors"
               [class]="
                 i === selectedIndex()
-                  ? 'border-[var(--chat-input-focus-border)] bg-[var(--chat-bg-hover)]'
-                  : 'border-[var(--chat-border)] bg-[var(--chat-bg)] hover:bg-[var(--chat-bg-hover)]'
+                  ? 'border-[var(--ngaf-chat-primary)] bg-[var(--ngaf-chat-surface-alt)]'
+                  : 'border-[var(--ngaf-chat-separator)] bg-[var(--ngaf-chat-bg)] hover:bg-[var(--ngaf-chat-surface-alt)]'
               "
             >
               <!-- Numbered badge -->
@@ -59,8 +59,8 @@ import { environment } from '../environments/environment';
                 class="w-6 h-6 flex items-center justify-center rounded-full text-xs font-bold shrink-0"
                 [class]="
                   i === selectedIndex()
-                    ? 'bg-[var(--chat-send-bg)] text-[var(--chat-send-text)]'
-                    : 'bg-[var(--chat-bg-alt)] text-[var(--chat-text-muted)]'
+                    ? 'bg-[var(--ngaf-chat-primary)] text-[var(--ngaf-chat-on-primary)]'
+                    : 'bg-[var(--ngaf-chat-surface-alt)] text-[var(--ngaf-chat-text-muted)]'
                 "
               >
                 {{ i + 1 }}
@@ -68,11 +68,11 @@ import { environment } from '../environments/environment';
 
               <!-- Checkpoint info -->
               <div class="flex-1 min-w-0">
-                <p class="text-xs font-medium text-[var(--chat-text)] truncate">
+                <p class="text-xs font-medium text-[var(--ngaf-chat-text)] truncate">
                   {{ checkpointLabel(state, i) }}
                 </p>
                 @if (state.checkpoint?.checkpoint_id) {
-                  <p class="text-xs text-[var(--chat-text-muted)] font-mono truncate">
+                  <p class="text-xs text-[var(--ngaf-chat-text-muted)] font-mono truncate">
                     {{ state.checkpoint.checkpoint_id }}
                   </p>
                 }
@@ -81,14 +81,14 @@ import { environment } from '../environments/environment';
               <!-- Action buttons -->
               <div class="flex gap-1 shrink-0">
                 <button
-                  class="px-2 py-1 text-xs rounded bg-[var(--chat-bg-alt)] text-[var(--chat-text)] hover:bg-[var(--chat-bg-hover)] transition-colors"
+                  class="px-2 py-1 text-xs rounded bg-[var(--ngaf-chat-surface-alt)] text-[var(--ngaf-chat-text)] hover:bg-[var(--ngaf-chat-surface-alt)] transition-colors"
                   title="Replay from this checkpoint"
                   (click)="replay(state, i)"
                 >
                   Replay
                 </button>
                 <button
-                  class="px-2 py-1 text-xs rounded bg-[var(--chat-bg-alt)] text-[var(--chat-text)] hover:bg-[var(--chat-bg-hover)] transition-colors"
+                  class="px-2 py-1 text-xs rounded bg-[var(--ngaf-chat-surface-alt)] text-[var(--ngaf-chat-text)] hover:bg-[var(--ngaf-chat-surface-alt)] transition-colors"
                   title="Fork from this checkpoint"
                   (click)="fork(state, i)"
                 >

--- a/cockpit/langgraph/time-travel/angular/src/index.html
+++ b/cockpit/langgraph/time-travel/angular/src/index.html
@@ -5,9 +5,8 @@
   <title>LangGraph Time Travel — Angular</title>
   <base href="/" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-950 text-gray-100 h-screen">
+<body>
   <app-time-travel></app-time-travel>
 </body>
 </html>

--- a/cockpit/langgraph/time-travel/angular/src/styles.css
+++ b/cockpit/langgraph/time-travel/angular/src/styles.css
@@ -1,30 +1,9 @@
-@import "../../../../../libs/design-tokens/src/lib/tokens.css";
-@import "tailwindcss";
-@source "../../../../../libs/chat/src/";
+@import "@ngaf/example-layouts/theme.css";
 
-@theme {
-  --color-bg: var(--ds-bg);
-  --color-surface: #ffffff;
-  --color-accent: var(--ds-accent);
-  --color-accent-light: var(--ds-accent-light);
-  --color-text-primary: var(--ds-text-primary);
-  --color-text-secondary: var(--ds-text-secondary);
-  --color-text-muted: var(--ds-text-muted);
-  --color-border: var(--ds-accent-border);
-  --color-error: #ef4444;
-  --color-success: #22c55e;
-  --font-sans: var(--ds-font-sans);
-  --font-serif: var(--ds-font-serif);
-  --font-mono: var(--ds-font-mono);
-}
-
-*, *::before, *::after { box-sizing: border-box; }
-
-body {
+html, body {
+  height: 100%;
   margin: 0;
-  font-family: var(--ds-font-sans);
-  background: var(--ds-bg);
-  color: var(--ds-text-primary);
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  background: var(--ngaf-chat-bg);
+  color: var(--ngaf-chat-text);
+  font-family: var(--ngaf-chat-font-family);
 }


### PR DESCRIPTION
## Summary

Stage 2 PR-2 of 4 waves (spec: \`docs/superpowers/specs/2026-05-15-examples-theme-sync-stage-2-design.md\`). Migrates all 8 cockpit langgraph example apps to the Stage 2 theme sync convention, following the same proven 5-step pattern from PR-1 (chat wave).

### Apps migrated

- \`cockpit-langgraph-streaming-angular\` (port 4300)
- \`cockpit-langgraph-persistence-angular\` (port 4301)
- \`cockpit-langgraph-interrupts-angular\` (port 4302)
- \`cockpit-langgraph-memory-angular\` (port 4303)
- \`cockpit-langgraph-durable-execution-angular\` (port 4304)
- \`cockpit-langgraph-subgraphs-angular\` (port 4305)
- \`cockpit-langgraph-time-travel-angular\` (port 4306)
- \`cockpit-langgraph-deployment-runtime-angular\` (port 4307)

### Per-app migration

Identical to chat wave: drop Tailwind v3 CDN script + body classes, replace \`styles.css\` with the canonical \`@import "@ngaf/example-layouts/theme.css"\` + html/body globals, leave \`main.ts\` clean (auto-install handles theme sync), find/replace component template vars from \`var(--chat-*, hardcoded-hex)\` patterns to \`var(--ngaf-chat-*)\`.

### Wave-specific finding

This wave surfaced more \`--chat-*\` variants beyond the spec's original mapping table (\`--chat-border\`, \`--chat-bg-alt\`, \`--chat-bg-hover\`, \`--chat-input-focus-border\`, \`--chat-send-bg\`, \`--chat-send-text\`, \`--chat-success\`, \`--chat-error-text\`, \`--chat-warning-text\`). All previously dead references (the unprefixed \`--chat-*\` namespace doesn't exist in the chat lib; they were always falling through to fallback colors). Final commit in this PR is a consistency sweep mapping them to \`--ngaf-chat-*\` equivalents: \`--chat-border\` → \`--ngaf-chat-separator\`, \`--chat-bg-alt\` / \`--chat-bg-hover\` → \`--ngaf-chat-surface-alt\`, \`--chat-send-bg\` → \`--ngaf-chat-primary\`, status colors mapped 1:1.

## Test plan

- [x] \`pnpm nx run-many -t build -p\` all 8 langgraph apps — green
- [ ] CI verifies full check stack
- [ ] Manual chrome MCP smoke per app (post-merge — user-driven)

PR-3 (deep-agents, 6 apps), PR-4 (render + ag-ui, 7 apps) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)