### PR TITLE
chore(posthog): writeback activation-funnel id (post Spec 1C sync:apply)

### DIFF
--- a/tools/posthog/insights/activation-funnel.json
+++ b/tools/posthog/insights/activation-funnel.json
@@ -1,6 +1,6 @@
 {
   "slug": "activation-funnel",
-  "posthog_id": null,
+  "posthog_id": 8638740,
   "kind": "funnel",
   "name": "Activation funnel (30-min window)",
   "interval": "day",


### PR DESCRIPTION
## Summary

Phase 6.4 follow-up for Spec 1C. \`posthog:sync:apply\` created the new \`activation-funnel\` insight (id \`8638740\`) and updated the developer-funnel dashboard tile to reference it. This writeback locks the id so subsequent \`sync:plan\`/\`sync:apply\` invocations are no-ops on this insight.

## Plan output (apply)

\`\`\`
[create]  insight activation-funnel               → 8638740
[update]  dashboard developer-funnel              (1582272)
[update]  insight cockpit-recipe-completion       (8587348)  ← picks up recipe_start → recipe_opened
[orphan]  insight "Six-signal activation (30-min window)"  (8587351)  ← old; kept for safety
applied: 5, failed: 0
\`\`\`

## Test plan

- [x] \`nx run posthog-tools:sync:plan\` reports no diff on activation-funnel after this PR merges (id locked)
- [ ] Manual: PostHog UI shows the renamed tile on the developer-funnel dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)