### PR TITLE
fix(website-e2e): assert differentiator section by stable id

### DIFF
--- a/apps/website/e2e/website.spec.ts
+++ b/apps/website/e2e/website.spec.ts
@@ -9,7 +9,9 @@ test('landing page renders hero headline', async ({ page }) => {
 
 test('landing page renders differentiator section', async ({ page }) => {
   await page.goto('/');
-  await expect(page.getByText('Built for Angular, not retrofitted.').first()).toBeVisible();
+  // Assert on the stable id, not the heading copy — landing-page text rewrites
+  // happen far more often than the section structure changes.
+  await expect(page.locator('#differentiator-heading')).toBeVisible();
 });
 
 test('landing page renders feature blocks (Stream/Render/Ship)', async ({ page }) => {


### PR DESCRIPTION
## Summary

Tiny test-only fix. The website e2e spec asserts a landing-page differentiator section by an outdated heading copy (\"Built for Angular, not retrofitted.\") that no longer appears on the page. The section's stable id (\`#differentiator-heading\`) is unchanged. Switching the assertion to the id mirrors what every other landing-page check in the same file already does (\`#hero-heading\`, \`#stream-heading\`, \`#render-heading\`, \`#ship-heading\`).

Test was failing on main, blocking every open PR's \`Website — e2e\` check.

## Test plan

- [x] Selector matches the existing component (\`apps/website/src/components/landing/Differentiator.tsx:62\` uses \`id=\"differentiator-heading\"\`)
- [ ] CI green