### PR TITLE
fix(c-generative-ui): emit_state → get_stream_writer (LangGraph 1.x)

### DIFF
--- a/cockpit/chat/generative-ui/python/src/graph.py
+++ b/cockpit/chat/generative-ui/python/src/graph.py
@@ -67,8 +67,13 @@ def should_call_tools(state: DashboardState) -> Literal["call_tools", "respond"]
 
 
 async def emit_state(state: DashboardState) -> DashboardState:
-    """Emit state_update custom events from tool results."""
-    from langchain_core.callbacks import adispatch_custom_event
+    """Emit state_update custom events from tool results.
+
+    Uses LangGraph 1.x's `get_stream_writer()` — `adispatch_custom_event`
+    no longer flows into the `custom` stream channel. The chat-lib bridge
+    parses the payload as `{name: 'state_update', data: <patches>}`.
+    """
+    from langgraph.config import get_stream_writer
 
     tool_results = {}
     for msg in reversed(state["messages"]):
@@ -93,7 +98,12 @@ async def emit_state(state: DashboardState) -> DashboardState:
             break
 
     if tool_results:
-        await adispatch_custom_event("state_update", {"updates": tool_results})
+        # The chat-lib bridge (stream-manager.bridge.ts handles the 'custom'
+        # case) parses `eventData['name']` for routing and `eventData['data']`
+        # for payload; chat.component.ts then forwards data to
+        # signal-state-store.update() which expects flat Record<jsonPointer, value>.
+        writer = get_stream_writer()
+        writer({"name": "state_update", "data": tool_results})
 
     return state
 

--- a/cockpit/langgraph/streaming/python/src/dashboard_graph.py
+++ b/cockpit/langgraph/streaming/python/src/dashboard_graph.py
@@ -67,8 +67,13 @@ def should_call_tools(state: DashboardState) -> Literal["call_tools", "respond"]
 
 
 async def emit_state(state: DashboardState) -> DashboardState:
-    """Emit state_update custom events from tool results."""
-    from langchain_core.callbacks import adispatch_custom_event
+    """Emit state_update custom events from tool results.
+
+    Uses LangGraph 1.x's `get_stream_writer()` — `adispatch_custom_event`
+    no longer flows into the `custom` stream channel. The chat-lib bridge
+    parses the payload as `{name: 'state_update', data: <patches>}`.
+    """
+    from langgraph.config import get_stream_writer
 
     tool_results = {}
     for msg in reversed(state["messages"]):
@@ -94,7 +99,12 @@ async def emit_state(state: DashboardState) -> DashboardState:
             break
 
     if tool_results:
-        await adispatch_custom_event("state_update", {"updates": tool_results})
+        # The chat-lib bridge (stream-manager.bridge.ts handles the 'custom'
+        # case) parses `eventData['name']` for routing and `eventData['data']`
+        # for payload; chat.component.ts then forwards data to
+        # signal-state-store.update() which expects flat Record<jsonPointer, value>.
+        writer = get_stream_writer()
+        writer({"name": "state_update", "data": tool_results})
 
     return state
 


### PR DESCRIPTION
## Summary
- Dashboard cards/charts/tables in the c-generative-ui demo never populated past the "Building UI…" skeleton — verified via chrome MCP that 7 placeholders remained and ~67 NG0303 input-spam errors fired per turn.
- **Root cause:** `adispatch_custom_event` no longer flows into the `custom` stream channel in LangGraph 1.x. Live SSE inspection: **0 custom events** with the old API, **1 custom event** with `get_stream_writer()`.
- Payload also needed to match the chat-lib bridge contract — `{name: "state_update", data: <flat-patches>}` — so the bridge's `eventData.name` routing and `eventData.data` extraction hit the right slots, then `signal-state-store.update()` receives the flat `{"/on_time/value": "84.2%", …}` map it expects.

## Test plan
- [x] Direct uv test of `adispatch_custom_event` in a minimal graph → 0 custom events emitted (confirms the regression)
- [x] Direct uv test of `get_stream_writer()` in a minimal graph → custom events emit correctly
- [x] Curl-driven SSE test against the umbrella backend with my fix → 1 `event: custom` with all 7 state paths in payload
- [x] Manual chrome MCP smoke (real LLM via repo-root .env): "Show me the dashboard" → 4 stat_cards populated, 1 line_chart with 12 monthly data points, 1 bar_chart with 4 airlines, 1 data_grid with 5 disruptions, **zero** render-default-fallback components, **zero** NG0303 errors

## Files
- `cockpit/langgraph/streaming/python/src/dashboard_graph.py` — switch `emit_state` to `get_stream_writer()`, wrap payload as `{name, data}`
- `cockpit/chat/generative-ui/python/src/graph.py` — same fix in the standalone copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)