### PR TITLE
fix(render): strip undeclared inputs in NgComponentOutlet (NG0303 silence)

### DIFF
--- a/libs/render/src/lib/render-element.component.ts
+++ b/libs/render/src/lib/render-element.component.ts
@@ -9,9 +9,11 @@ import {
   Injector,
   input,
   OnInit,
+  reflectComponentType,
   runInInjectionContext,
   signal,
   type Signal,
+  type Type,
 } from '@angular/core';
 import { NgComponentOutlet } from '@angular/common';
 import {
@@ -33,6 +35,38 @@ import type { AngularComponentRenderer } from './render.types';
  * store, sidestepping the normal `el.on[event]` handler binding which
  * the catalog components have no way to declare for arbitrary paths. */
 const A2UI_DATAMODEL_PREFIX = 'a2ui:datamodel:';
+
+/** Cache of declared input names per component class. NgComponentOutlet
+ * passes every key in its `inputs` prop to the target; Angular dev mode
+ * raises NG0303 for any input the component doesn't declare. We strip
+ * undeclared keys before mounting so simple view components (`StatCard`,
+ * `Container`, etc.) don't get spammed with framework-only inputs
+ * (`bindings`, `emit`, `loading`, `childKeys`, `spec`) they ignore. */
+/** `null` means reflection failed (likely uncompiled / non-component) — in
+ * that case we pass inputs through unmodified rather than swallow them.
+ * An empty Set means the component genuinely declares zero inputs (e.g. a
+ * pure presentational fallback) and ALL keys should be dropped. */
+const declaredInputsCache = new WeakMap<Type<unknown>, Set<string> | null>();
+function getDeclaredInputs(cls: Type<unknown>): Set<string> | null {
+  if (declaredInputsCache.has(cls)) return declaredInputsCache.get(cls)!;
+  const meta = reflectComponentType(cls);
+  const result = meta ? new Set<string>(meta.inputs.map(i => i.templateName)) : null;
+  declaredInputsCache.set(cls, result);
+  return result;
+}
+function filterInputsForClass(
+  cls: Type<unknown> | null,
+  inputs: Record<string, unknown>,
+): Record<string, unknown> {
+  if (!cls) return inputs;
+  const declared = getDeclaredInputs(cls);
+  if (declared === null) return inputs;
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(inputs)) {
+    if (declared.has(k)) out[k] = v;
+  }
+  return out;
+}
 
 /** Best-effort string→typed coercion for datamodel writes. Catalog
  * components emit raw string values; the underlying state may have
@@ -76,13 +110,13 @@ function coerceValue(raw: string): unknown {
     @if (!element()?.repeat) {
       @if (visible()) {
         <ng-container
-          *ngComponentOutlet="mountClass(); inputs: resolvedInputs(); injector: parentInjector"
+          *ngComponentOutlet="mountClass(); inputs: filteredResolvedInputs(); injector: parentInjector"
         />
       }
     } @else {
       @for (repeatInjector of repeatInjectors(); track $index) {
         <ng-container
-          *ngComponentOutlet="mountClass(); inputs: repeatInputs()[$index]; injector: repeatInjector"
+          *ngComponentOutlet="mountClass(); inputs: filteredRepeatInputs()[$index]; injector: repeatInjector"
         />
       }
     }
@@ -274,6 +308,14 @@ export class RenderElementComponent implements OnInit {
     };
   });
 
+  /** `resolvedInputs` filtered down to keys the target component actually
+   * declares — silences NG0303 dev-mode warnings from framework-only
+   * inputs (bindings/emit/loading/childKeys/spec) passed to simple view
+   * components that don't declare them. */
+  readonly filteredResolvedInputs = computed(() =>
+    filterInputsForClass(this.mountClass() as Type<unknown> | null, this.resolvedInputs()),
+  );
+
   // --- Repeat support ---
 
   /** Items from the state array for repeat elements. */
@@ -326,5 +368,11 @@ export class RenderElementComponent implements OnInit {
         spec: this.spec(),
       };
     });
+  });
+
+  /** `repeatInputs` filtered per-item to declared component inputs. */
+  readonly filteredRepeatInputs = computed(() => {
+    const cls = this.mountClass() as Type<unknown> | null;
+    return this.repeatInputs().map(inputs => filterInputsForClass(cls, inputs));
   });
 }


### PR DESCRIPTION
## Summary
`RenderElement` passes 5 framework-only inputs to every component it mounts (`bindings`, `emit`, `loading`, `childKeys`, `spec`) plus user-defined props from the spec. Angular dev mode raises **NG0303** for every key the target component doesn't declare. Live measurement on the chat-generative-ui dashboard: **~100 errors per turn**.

Breakdown of the 100 errors per dashboard turn:
- ~25 from the brief skeleton phase — `DefaultFallbackComponent` declares zero inputs and rejects all of them
- ~75 from user view components (`DashboardGrid`, `Container`, `StatCard`, `LineChart`, `BarChart`, `DataGrid`) that don't declare the 5 framework keys

## Fix
Filter `resolvedInputs` via `reflectComponentType()` before passing to `ngComponentOutlet`. Cache the declared-input set per component class via a `WeakMap`.

The key correctness call: distinguish **"0 declared inputs"** (filter all keys) from **"no metadata available"** (pass-through). The naive check `if (declared.size === 0) return inputs` treats `DefaultFallbackComponent` as no-metadata and keeps spamming. The fix stores `null` vs `Set` in the cache and only short-circuits on `null`.

## Test plan
- [x] `pnpm nx run cockpit-chat-generative-ui-angular:build` — clean
- [x] Chrome MCP after fix: 0 NG0303 errors per dashboard turn (was ~100), all 4 stat cards / 2 charts / 1 grid render correctly
- [ ] CI: `Library — lint / test / build`

## Files
- `libs/render/src/lib/render-element.component.ts` — add `getDeclaredInputs()` + `filterInputsForClass()` helpers, wire into both non-repeat and repeat input paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)