### PR TITLE
fix(c-generative-ui): use gpt-5 + minimal reasoning for planner LLM

### DIFF
--- a/cockpit/chat/generative-ui/python/src/graph.py
+++ b/cockpit/chat/generative-ui/python/src/graph.py
@@ -20,7 +20,21 @@ from src.dashboard_tools import ALL_TOOLS
 _PROMPT = (Path(__file__).parent.parent / "prompts" / "dashboard.md").read_text()
 
 _llm = ChatOpenAI(model="gpt-5-mini", temperature=0, streaming=True)
-_llm_with_tools = _llm.bind_tools(ALL_TOOLS)
+
+# Dedicated planner: full gpt-5 with minimal reasoning effort.
+# gpt-5-mini at default reasoning ignores the "EXACTLY ONE tool" directive
+# in plan_tools and reflexively calls all four data tools on every
+# follow-up — verified in chrome MCP after PR #363 tightened the prompt
+# but the model still over-called. Bumping the planner to gpt-5 sharpens
+# instruction-following, and reasoning_effort='minimal' suppresses the
+# "let me be thorough" deliberation that drives the fan-out.
+_planner_llm = ChatOpenAI(
+    model="gpt-5",
+    temperature=0,
+    streaming=True,
+    reasoning_effort="minimal",
+)
+_llm_with_tools = _planner_llm.bind_tools(ALL_TOOLS)
 
 
 class DashboardState(MessagesState):

--- a/cockpit/langgraph/streaming/python/src/dashboard_graph.py
+++ b/cockpit/langgraph/streaming/python/src/dashboard_graph.py
@@ -20,7 +20,21 @@ from src.dashboard_tools import ALL_TOOLS
 _PROMPT = (Path(__file__).parent.parent / "prompts" / "dashboard.md").read_text()
 
 _llm = ChatOpenAI(model="gpt-5-mini", temperature=0, streaming=True)
-_llm_with_tools = _llm.bind_tools(ALL_TOOLS)
+
+# Dedicated planner: full gpt-5 with minimal reasoning effort.
+# gpt-5-mini at default reasoning ignores the "EXACTLY ONE tool" directive
+# in plan_tools and reflexively calls all four data tools on every
+# follow-up — verified in chrome MCP after PR #363 tightened the prompt
+# but the model still over-called. Bumping the planner to gpt-5 sharpens
+# instruction-following, and reasoning_effort='minimal' suppresses the
+# "let me be thorough" deliberation that drives the fan-out.
+_planner_llm = ChatOpenAI(
+    model="gpt-5",
+    temperature=0,
+    streaming=True,
+    reasoning_effort="minimal",
+)
+_llm_with_tools = _planner_llm.bind_tools(ALL_TOOLS)
 
 
 class DashboardState(MessagesState):


### PR DESCRIPTION
## Summary
`gpt-5-mini` ignored the "**EXACTLY ONE tool**" directive added in PR #363 and kept calling all four data tools on every filter follow-up. The prompt rewrite was strict and explicit ("call EXACTLY ONE tool", "Do NOT call the other tools") but the model's default reasoning prefers thoroughness over literal directive-following.

## Fix
Split the LLMs in `dashboard_graph.py` / `graph.py`:
- **`_llm`** (`gpt-5-mini`) — unchanged for `generate_shell` + `respond`. Cheap, good enough for prose + JSON-spec emission.
- **`_planner_llm`** (`gpt-5`, `reasoning_effort="minimal"`) — bound to tools, used in `plan_tools`. `gpt-5` follows directives more precisely; `reasoning_effort="minimal"` suppresses the "let me be thorough" deliberation that drives the fan-out.

## Test plan
- [x] Standalone smoke against the planner directly:
  ```python
  llm = ChatOpenAI(model='gpt-5', reasoning_effort='minimal').bind_tools(ALL_TOOLS)
  await llm.ainvoke([sys, HumanMessage("Filter to cancelled flights only")])
  # → ['query_recent_disruptions']
  ```
- [x] Chrome MCP end-to-end with backend running real LLM:
  - "Show me the dashboard" → 4 stat cards + 2 charts + 1 grid populate
  - "Filter to cancelled flights only" → **backend `AI tool_calls: ['query_recent_disruptions']`** (one tool, not four), data grid updates to 3 cancelled rows
- [ ] CI
- Cost note: planner now uses gpt-5 per dashboard turn — one extra-effort call per follow-up. Worth it for the directive adherence; can revisit if cost becomes material.

## Files
- `cockpit/langgraph/streaming/python/src/dashboard_graph.py` — add `_planner_llm`; swap `_llm_with_tools` source
- `cockpit/chat/generative-ui/python/src/graph.py` — same in standalone

🤖 Generated with [Claude Code](https://claude.com/claude-code)