### PR TITLE
Fix docs SEO metadata and crawlability

### DIFF
--- a/apps/website/content/docs/agent/concepts/agent-architecture.mdx
+++ b/apps/website/content/docs/agent/concepts/agent-architecture.mdx
@@ -609,7 +609,7 @@ export class DebugTimelineComponent {
 ```
 
 <Callout type="tip" title="Time-travel is branching">
-When you submit from a previous checkpoint, LangGraph creates a new branch from that point. The original timeline is preserved. The `branch()` signal tells you which branch is currently active. See the [Time Travel guide](/docs/guides/time-travel) for the full walkthrough.
+When you submit from a previous checkpoint, LangGraph creates a new branch from that point. The original timeline is preserved. The `branch()` signal tells you which branch is currently active. See the [Time Travel guide](/docs/agent/guides/time-travel) for the full walkthrough.
 </Callout>
 
 ## Choosing an Architecture
@@ -682,22 +682,22 @@ Begin with a single agent and tools. Add human-in-the-loop when you need approva
 ## What's Next
 
 <CardGroup cols={2}>
-  <Card title="LangGraph Basics" href="/docs/concepts/langgraph-basics">
+  <Card title="LangGraph Basics" href="/docs/agent/concepts/langgraph-basics">
     Learn the graph, node, and edge primitives that agents are built on.
   </Card>
-  <Card title="Streaming" href="/docs/guides/streaming">
+  <Card title="Streaming" href="/docs/agent/guides/streaming">
     Stream token-by-token responses with multiple stream modes.
   </Card>
-  <Card title="Interrupts" href="/docs/guides/interrupts">
+  <Card title="Interrupts" href="/docs/agent/guides/interrupts">
     Build human-in-the-loop approval flows that pause and resume agents.
   </Card>
-  <Card title="Subgraphs" href="/docs/guides/subgraphs">
+  <Card title="Subgraphs" href="/docs/agent/guides/subgraphs">
     Compose multi-agent systems with orchestrators and specialist workers.
   </Card>
-  <Card title="Time Travel" href="/docs/guides/time-travel">
+  <Card title="Time Travel" href="/docs/agent/guides/time-travel">
     Debug agents by stepping through checkpoint history and branching.
   </Card>
-  <Card title="Angular Signals" href="/docs/concepts/angular-signals">
+  <Card title="Angular Signals" href="/docs/agent/concepts/angular-signals">
     How Signals power the reactive model behind agent().
   </Card>
 </CardGroup>

--- a/apps/website/content/docs/agent/concepts/angular-signals.mdx
+++ b/apps/website/content/docs/agent/concepts/angular-signals.mdx
@@ -527,22 +527,22 @@ Signals use referential equality (`===`) by default. agent() creates new array r
 ## What's Next
 
 <CardGroup cols={2}>
-  <Card title="State Management" href="/docs/concepts/state-management">
+  <Card title="State Management" href="/docs/agent/concepts/state-management">
     How LangGraph agent state flows into Angular Signals and how to structure complex state.
   </Card>
-  <Card title="Streaming" href="/docs/guides/streaming">
+  <Card title="Streaming" href="/docs/agent/guides/streaming">
     Configure stream modes, handle token-by-token rendering, and manage concurrent streams.
   </Card>
-  <Card title="LangGraph Basics" href="/docs/concepts/langgraph-basics">
+  <Card title="LangGraph Basics" href="/docs/agent/concepts/langgraph-basics">
     Understand the Python agent patterns that produce the events Signals consume.
   </Card>
-  <Card title="API Reference" href="/docs/api/angular">
+  <Card title="API Reference" href="/docs/agent/api/agent">
     Full reference for every Signal, method, and option on LangGraphAgent.
   </Card>
-  <Card title="Interrupts" href="/docs/guides/interrupts">
+  <Card title="Interrupts" href="/docs/agent/guides/interrupts">
     Build human-in-the-loop approval flows that pause and resume the agent.
   </Card>
-  <Card title="OnPush Guide" href="/docs/guides/change-detection">
+  <Card title="OnPush Guide" href="/docs/agent/concepts/angular-signals">
     Deep dive into change detection optimization for streaming applications.
   </Card>
 </CardGroup>

--- a/apps/website/content/docs/agent/concepts/langgraph-basics.mdx
+++ b/apps/website/content/docs/agent/concepts/langgraph-basics.mdx
@@ -363,22 +363,22 @@ Both APIs produce the same output and work identically with agent(). Choose the 
 ## What's Next
 
 <CardGroup cols={2}>
-  <Card title="Agent Architecture" href="/docs/concepts/agent-architecture">
+  <Card title="Agent Architecture" href="/docs/agent/concepts/agent-architecture">
     Deep dive into the planning, tool-calling, and execution lifecycle
   </Card>
-  <Card title="Streaming" href="/docs/guides/streaming">
+  <Card title="Streaming" href="/docs/agent/guides/streaming">
     Stream token-by-token responses with multiple stream modes
   </Card>
-  <Card title="Interrupts" href="/docs/guides/interrupts">
+  <Card title="Interrupts" href="/docs/agent/guides/interrupts">
     Build human-in-the-loop approval flows
   </Card>
-  <Card title="Subgraphs" href="/docs/guides/subgraphs">
+  <Card title="Subgraphs" href="/docs/agent/guides/subgraphs">
     Compose multi-agent systems with orchestrators
   </Card>
-  <Card title="Persistence" href="/docs/guides/persistence">
+  <Card title="Persistence" href="/docs/agent/guides/persistence">
     Thread-based conversation persistence
   </Card>
-  <Card title="Angular Signals" href="/docs/concepts/angular-signals">
+  <Card title="Angular Signals" href="/docs/agent/concepts/angular-signals">
     How Signals power agent's reactive model
   </Card>
 </CardGroup>

--- a/apps/website/content/docs/agent/concepts/state-management.mdx
+++ b/apps/website/content/docs/agent/concepts/state-management.mdx
@@ -361,7 +361,7 @@ const branch = agent.branch();               // Signal<string> — active branch
 const branchTree = agent.experimentalBranchTree();
 ```
 
-For full checkpoint and time-travel patterns, see the [Persistence guide](/docs/guides/persistence) and [Time Travel guide](/docs/guides/time-travel).
+For full checkpoint and time-travel patterns, see the [Persistence guide](/docs/agent/guides/persistence) and [Time Travel guide](/docs/agent/guides/time-travel).
 
 ## Custom State Fields
 
@@ -520,22 +520,22 @@ readonly reportTitle = computed(() => this.agent.value().report?.title ?? '');
 ## What's Next
 
 <CardGroup cols={2}>
-  <Card title="Angular Signals" href="/docs/concepts/angular-signals">
+  <Card title="Angular Signals" href="/docs/agent/concepts/angular-signals">
     How agent() uses Angular Signals for zero-subscription reactive rendering.
   </Card>
-  <Card title="Streaming" href="/docs/guides/streaming">
+  <Card title="Streaming" href="/docs/agent/guides/streaming">
     Configure stream modes — values, messages, events — for different use cases.
   </Card>
-  <Card title="Persistence" href="/docs/guides/persistence">
+  <Card title="Persistence" href="/docs/agent/guides/persistence">
     Thread-based conversation persistence and checkpoint configuration.
   </Card>
-  <Card title="Time Travel" href="/docs/guides/time-travel">
+  <Card title="Time Travel" href="/docs/agent/guides/time-travel">
     Fork threads at any checkpoint and replay with different input.
   </Card>
-  <Card title="Interrupts" href="/docs/guides/interrupts">
+  <Card title="Interrupts" href="/docs/agent/guides/interrupts">
     Human-in-the-loop approval flows and how interrupt state surfaces in Angular.
   </Card>
-  <Card title="LangGraph Basics" href="/docs/concepts/langgraph-basics">
+  <Card title="LangGraph Basics" href="/docs/agent/concepts/langgraph-basics">
     Nodes, edges, and the graph execution model behind the state machine.
   </Card>
 </CardGroup>

--- a/apps/website/content/docs/agent/getting-started/installation.mdx
+++ b/apps/website/content/docs/agent/getting-started/installation.mdx
@@ -123,16 +123,16 @@ console.log(test.status()); // 'idle' - setup is correct
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Quick Start" href="/docs/getting-started/quickstart">
+  <Card title="Quick Start" href="/docs/agent/getting-started/quickstart">
     Build your first chat component in 5 minutes
   </Card>
-  <Card title="Angular Signals" href="/docs/concepts/angular-signals">
+  <Card title="Angular Signals" href="/docs/agent/concepts/angular-signals">
     Understand how Signals power agent
   </Card>
-  <Card title="LangGraph Basics" href="/docs/concepts/langgraph-basics">
+  <Card title="LangGraph Basics" href="/docs/agent/concepts/langgraph-basics">
     Graphs, nodes, edges, and state for Angular developers
   </Card>
-  <Card title="API Reference" href="/docs/api/angular">
+  <Card title="API Reference" href="/docs/agent/api/agent">
     Complete agent() function reference
   </Card>
 </CardGroup>

--- a/apps/website/content/docs/agent/getting-started/introduction.mdx
+++ b/apps/website/content/docs/agent/getting-started/introduction.mdx
@@ -307,31 +307,31 @@ Your Angular app is a stateless client. All agent state — threads, checkpoints
 ## What's Next
 
 <CardGroup cols={2}>
-  <Card title="Quick Start" href="/docs/getting-started/quickstart">
+  <Card title="Quick Start" href="/docs/agent/getting-started/quickstart">
     Detailed 5-minute walkthrough with a complete chat component
   </Card>
-  <Card title="Streaming" href="/docs/guides/streaming">
+  <Card title="Streaming" href="/docs/agent/guides/streaming">
     Token-by-token updates, stream modes, and status tracking
   </Card>
-  <Card title="Persistence" href="/docs/guides/persistence">
+  <Card title="Persistence" href="/docs/agent/guides/persistence">
     Thread persistence across sessions and reactive thread switching
   </Card>
-  <Card title="Interrupts" href="/docs/guides/interrupts">
+  <Card title="Interrupts" href="/docs/agent/guides/interrupts">
     Human-in-the-loop approval and confirmation flows
   </Card>
-  <Card title="Testing" href="/docs/guides/testing">
+  <Card title="Testing" href="/docs/agent/guides/testing">
     Deterministic testing with MockAgentTransport
   </Card>
   <Card title="Lifecycle Signals" href="/docs/agent/guides/lifecycle">
     Subscribe to per-agent lifecycle signals via AGENT_LIFECYCLE
   </Card>
-  <Card title="Angular Signals" href="/docs/concepts/angular-signals">
+  <Card title="Angular Signals" href="/docs/agent/concepts/angular-signals">
     Deep dive into how Signals power agent
   </Card>
-  <Card title="LangGraph Basics" href="/docs/concepts/langgraph-basics">
+  <Card title="LangGraph Basics" href="/docs/agent/concepts/langgraph-basics">
     Graphs, nodes, edges, and state for Angular developers
   </Card>
-  <Card title="API Reference" href="/docs/api/angular">
+  <Card title="API Reference" href="/docs/agent/api/agent">
     Complete agent() function reference
   </Card>
 </CardGroup>

--- a/apps/website/content/docs/agent/getting-started/quickstart.mdx
+++ b/apps/website/content/docs/agent/getting-started/quickstart.mdx
@@ -3,7 +3,7 @@
 Build a streaming chat component with agent() in 5 minutes.
 
 <Callout type="info" title="Prerequisites">
-Angular 20+ project with Node.js 18+. If you need setup help, see the [Installation](/docs/getting-started/installation) guide.
+Angular 20+ project with Node.js 18+. If you need setup help, see the [Installation](/docs/agent/getting-started/installation) guide.
 </Callout>
 
 <Steps>
@@ -129,22 +129,22 @@ Open `http://localhost:4200` and start chatting with your agent.
 ## Next steps
 
 <CardGroup cols={3}>
-  <Card title="Streaming" href="/docs/guides/streaming">
+  <Card title="Streaming" href="/docs/agent/guides/streaming">
     Learn about token-by-token updates and stream modes
   </Card>
-  <Card title="Persistence" href="/docs/guides/persistence">
+  <Card title="Persistence" href="/docs/agent/guides/persistence">
     Keep conversations alive across page refreshes
   </Card>
-  <Card title="Interrupts" href="/docs/guides/interrupts">
+  <Card title="Interrupts" href="/docs/agent/guides/interrupts">
     Add human-in-the-loop approval flows
   </Card>
-  <Card title="Angular Signals" href="/docs/concepts/angular-signals">
+  <Card title="Angular Signals" href="/docs/agent/concepts/angular-signals">
     Deep dive into how Signals power agent
   </Card>
-  <Card title="LangGraph Basics" href="/docs/concepts/langgraph-basics">
+  <Card title="LangGraph Basics" href="/docs/agent/concepts/langgraph-basics">
     Graphs, nodes, edges, and state for Angular developers
   </Card>
-  <Card title="API Reference" href="/docs/api/angular">
+  <Card title="API Reference" href="/docs/agent/api/agent">
     Complete agent() function reference
   </Card>
 </CardGroup>

--- a/apps/website/content/docs/agent/guides/deployment.mdx
+++ b/apps/website/content/docs/agent/guides/deployment.mdx
@@ -408,22 +408,22 @@ Confirm LangSmith traces are arriving and set up alerts for error rate spikes an
 ## What's Next
 
 <CardGroup cols={2}>
-  <Card title="Testing" href="/docs/guides/testing">
+  <Card title="Testing" href="/docs/agent/guides/testing">
     Test agent interactions deterministically before deploying to production.
   </Card>
-  <Card title="Persistence" href="/docs/guides/persistence">
+  <Card title="Persistence" href="/docs/agent/guides/persistence">
     Store thread IDs so users can resume conversations across sessions.
   </Card>
-  <Card title="Streaming" href="/docs/guides/streaming">
+  <Card title="Streaming" href="/docs/agent/guides/streaming">
     Tune streaming options like throttle and stream modes for production performance.
   </Card>
-  <Card title="LangGraph Basics" href="/docs/concepts/langgraph-basics">
+  <Card title="LangGraph Basics" href="/docs/agent/concepts/langgraph-basics">
     Understand the agent patterns your deployment will serve.
   </Card>
-  <Card title="API Reference" href="/docs/api/provide-angular">
+  <Card title="API Reference" href="/docs/agent/api/provide-agent">
     Full reference for provideAgent configuration options.
   </Card>
-  <Card title="Error Handling" href="/docs/guides/error-handling">
+  <Card title="Error Handling" href="/docs/agent/guides/deployment">
     Deep dive into error recovery patterns beyond basic error boundaries.
   </Card>
 </CardGroup>

--- a/apps/website/content/docs/agent/guides/interrupts.mdx
+++ b/apps/website/content/docs/agent/guides/interrupts.mdx
@@ -546,16 +546,16 @@ Because interrupts are checkpointed, the user can close their browser, come back
 ## What's Next
 
 <CardGroup cols={2}>
-  <Card title="Memory" href="/docs/guides/memory">
+  <Card title="Memory" href="/docs/agent/guides/memory">
     Give your agent short-term and long-term memory with the Store API.
   </Card>
-  <Card title="Persistence" href="/docs/guides/persistence">
+  <Card title="Persistence" href="/docs/agent/guides/persistence">
     Configure checkpointers that keep interrupt state across deployments.
   </Card>
-  <Card title="Streaming" href="/docs/guides/streaming">
+  <Card title="Streaming" href="/docs/agent/guides/streaming">
     Stream token-by-token responses alongside interrupt events.
   </Card>
-  <Card title="Testing" href="/docs/guides/testing">
+  <Card title="Testing" href="/docs/agent/guides/testing">
     Script interrupt events deterministically with MockAgentTransport.
   </Card>
 </CardGroup>

--- a/apps/website/content/docs/agent/guides/memory.mdx
+++ b/apps/website/content/docs/agent/guides/memory.mdx
@@ -397,16 +397,16 @@ Use hierarchical namespaces like `("memories", user_id)` or `("project", project
 ## What's Next
 
 <CardGroup cols={2}>
-  <Card title="Persistence" href="/docs/guides/persistence">
+  <Card title="Persistence" href="/docs/agent/guides/persistence">
     Configure checkpointers and thread storage for production deployments.
   </Card>
-  <Card title="Time Travel" href="/docs/guides/time-travel">
+  <Card title="Time Travel" href="/docs/agent/guides/time-travel">
     Replay and branch agent runs from any past checkpoint.
   </Card>
-  <Card title="Interrupts" href="/docs/guides/interrupts">
+  <Card title="Interrupts" href="/docs/agent/guides/interrupts">
     Pause for human input before the agent acts on its memory.
   </Card>
-  <Card title="State Management" href="/docs/concepts/state-management">
+  <Card title="State Management" href="/docs/agent/concepts/state-management">
     How agent state flows from LangGraph into Angular Signals.
   </Card>
 </CardGroup>

--- a/apps/website/content/docs/agent/guides/persistence.mdx
+++ b/apps/website/content/docs/agent/guides/persistence.mdx
@@ -336,16 +336,16 @@ Setting the `threadId` signal (or calling `switchThread()`) loads the target thr
 ## What's Next
 
 <CardGroup cols={2}>
-  <Card title="Interrupts" href="/docs/guides/interrupts">
+  <Card title="Interrupts" href="/docs/agent/guides/interrupts">
     Pause agent execution and wait for human approval before continuing.
   </Card>
-  <Card title="Memory" href="/docs/guides/memory">
+  <Card title="Memory" href="/docs/agent/guides/memory">
     Preserve long-term context across sessions with LangGraph's memory store.
   </Card>
-  <Card title="Streaming" href="/docs/guides/streaming">
+  <Card title="Streaming" href="/docs/agent/guides/streaming">
     Stream token-by-token responses and tool progress in real time.
   </Card>
-  <Card title="Testing" href="/docs/guides/testing">
+  <Card title="Testing" href="/docs/agent/guides/testing">
     Test thread persistence and switching deterministically with MockAgentTransport.
   </Card>
 </CardGroup>

--- a/apps/website/content/docs/agent/guides/streaming.mdx
+++ b/apps/website/content/docs/agent/guides/streaming.mdx
@@ -240,16 +240,16 @@ Each call to `chat.submit()` opens a new SSE connection. Connections are automat
 ## What's Next
 
 <CardGroup cols={2}>
-  <Card title="Persistence" href="/docs/guides/persistence">
+  <Card title="Persistence" href="/docs/agent/guides/persistence">
     Resume conversations across page reloads using thread IDs and checkpointers.
   </Card>
-  <Card title="Interrupts" href="/docs/guides/interrupts">
+  <Card title="Interrupts" href="/docs/agent/guides/interrupts">
     Pause agent execution mid-stream to collect human input before continuing.
   </Card>
-  <Card title="Testing" href="/docs/guides/testing">
+  <Card title="Testing" href="/docs/agent/guides/testing">
     Unit-test components that use agent with the built-in test harness.
   </Card>
-  <Card title="API Reference" href="/docs/api/angular">
+  <Card title="API Reference" href="/docs/agent/api/agent">
     Full option reference for agent(), including all configuration keys.
   </Card>
 </CardGroup>

--- a/apps/website/content/docs/agent/guides/subgraphs.mdx
+++ b/apps/website/content/docs/agent/guides/subgraphs.mdx
@@ -284,16 +284,16 @@ Use **subagents** when tasks are independent and can run in parallel, when each 
 ## What's Next
 
 <CardGroup cols={2}>
-  <Card title="Streaming" href="/docs/guides/streaming">
+  <Card title="Streaming" href="/docs/agent/guides/streaming">
     Understand how agent() surfaces tokens, status, and errors in real time.
   </Card>
-  <Card title="Time Travel" href="/docs/guides/time-travel">
+  <Card title="Time Travel" href="/docs/agent/guides/time-travel">
     Inspect earlier states and replay alternate execution paths with checkpoint history.
   </Card>
-  <Card title="Testing" href="/docs/guides/testing">
+  <Card title="Testing" href="/docs/agent/guides/testing">
     Write unit and integration tests for orchestrator graphs and subagent interactions.
   </Card>
-  <Card title="API Reference" href="/docs/api/angular">
+  <Card title="API Reference" href="/docs/agent/api/agent">
     Full reference for agent() options, signals, and subagent configuration.
   </Card>
 </CardGroup>

--- a/apps/website/content/docs/agent/guides/testing.mdx
+++ b/apps/website/content/docs/agent/guides/testing.mdx
@@ -515,16 +515,16 @@ Integration tests hit a real server and (potentially) a real LLM. Reserve them f
 ## What's Next
 
 <CardGroup cols={2}>
-  <Card title="Streaming" href="/docs/guides/streaming">
+  <Card title="Streaming" href="/docs/agent/guides/streaming">
     Understand the SSE event model your tests simulate.
   </Card>
-  <Card title="Interrupts" href="/docs/guides/interrupts">
+  <Card title="Interrupts" href="/docs/agent/guides/interrupts">
     Build human-in-the-loop approval flows tested with scripted interrupt events.
   </Card>
-  <Card title="Persistence" href="/docs/guides/persistence">
+  <Card title="Persistence" href="/docs/agent/guides/persistence">
     Thread persistence patterns that pair with thread-switching tests.
   </Card>
-  <Card title="API Reference" href="/docs/api/mock-stream-transport">
+  <Card title="API Reference" href="/docs/agent/api/mock-stream-transport">
     Full reference for MockAgentTransport options and methods.
   </Card>
 </CardGroup>

--- a/apps/website/content/docs/agent/guides/time-travel.mdx
+++ b/apps/website/content/docs/agent/guides/time-travel.mdx
@@ -297,16 +297,16 @@ Time travel is most useful during development. Inspect why an agent chose a part
 ## What's Next
 
 <CardGroup cols={2}>
-  <Card title="Persistence" href="/docs/guides/persistence">
+  <Card title="Persistence" href="/docs/agent/guides/persistence">
     Configure thread storage so checkpoints survive page reloads and are available across sessions.
   </Card>
-  <Card title="Streaming" href="/docs/guides/streaming">
+  <Card title="Streaming" href="/docs/agent/guides/streaming">
     Understand how agent() surfaces incremental updates and how history integrates with live streaming state.
   </Card>
-  <Card title="Subgraphs" href="/docs/guides/subgraphs">
+  <Card title="Subgraphs" href="/docs/agent/guides/subgraphs">
     Compose multi-agent systems with orchestrators and track subagent execution.
   </Card>
-  <Card title="API Reference" href="/docs/api/angular">
+  <Card title="API Reference" href="/docs/agent/api/agent">
     Full reference for agent() options, signals, and the submit() API including checkpoint parameters.
   </Card>
 </CardGroup>

--- a/apps/website/content/docs/render/a2ui/overview.mdx
+++ b/apps/website/content/docs/render/a2ui/overview.mdx
@@ -238,7 +238,7 @@ handlers = {
 
 Both paths render structured UI, but they optimize for different jobs.
 
-| | A2UI | json-render |
+| Dimension | A2UI | json-render |
 | --- | --- | --- |
 | Wire shape | JSONL message stream | Single JSON spec |
 | State | Surface data model | Spec state |

--- a/apps/website/e2e/website.spec.ts
+++ b/apps/website/e2e/website.spec.ts
@@ -68,6 +68,59 @@ test('/llms.txt returns plain text', async ({ page }) => {
   expect(response?.headers()['content-type']).toContain('text/plain');
 });
 
+test('/llms-full.txt includes generated API reference content', async ({ request }) => {
+  const response = await request.get('/llms-full.txt');
+  expect(response.ok()).toBe(true);
+  expect(response.headers()['content-type']).toContain('text/plain');
+
+  const body = await response.text();
+  expect(body).toContain('## API Reference (TypeDoc)');
+  expect(body).toContain('### agent');
+  expect(body).toContain('### chat');
+  expect(body).not.toContain('API reference not yet generated');
+});
+
+test('robots.txt allows crawling and points at the sitemap', async ({ request }) => {
+  const response = await request.get('/robots.txt');
+  expect(response.ok()).toBe(true);
+
+  const body = await response.text();
+  expect(body).toContain('User-Agent: *');
+  expect(body).toContain('Allow: /');
+  expect(body).toContain('Sitemap: https://cacheplane.ai/sitemap.xml');
+});
+
+test('sitemap.xml includes configured docs pages', async ({ request }) => {
+  const response = await request.get('/sitemap.xml');
+  expect(response.ok()).toBe(true);
+
+  const body = await response.text();
+  expect(body).toContain('https://cacheplane.ai/docs');
+  expect(body).toContain('https://cacheplane.ai/docs/agent/getting-started/introduction');
+  expect(body).toContain('https://cacheplane.ai/docs/render/a2ui/overview');
+});
+
+test('docs pages render canonical and social metadata', async ({ page }) => {
+  await page.goto('/docs/agent/guides/streaming');
+
+  await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+    'href',
+    'https://cacheplane.ai/docs/agent/guides/streaming',
+  );
+  await expect(page.locator('meta[property="og:title"]')).toHaveAttribute(
+    'content',
+    'Streaming - Agent Docs - Angular Agent Framework',
+  );
+  await expect(page.locator('meta[property="og:url"]')).toHaveAttribute(
+    'content',
+    'https://cacheplane.ai/docs/agent/guides/streaming',
+  );
+  await expect(page.locator('meta[name="twitter:title"]')).toHaveAttribute(
+    'content',
+    'Streaming - Agent Docs - Angular Agent Framework',
+  );
+});
+
 test('marketing pages link to downloadable whitepaper PDFs', async ({ page }) => {
   const expectedDownloads: Record<string, string> = {
     '/': '/whitepaper.pdf',

--- a/apps/website/src/app/docs/page.tsx
+++ b/apps/website/src/app/docs/page.tsx
@@ -6,11 +6,14 @@ import { Eyebrow } from '../../components/ui/Eyebrow';
 import { Card } from '../../components/ui/Card';
 import { Pill } from '../../components/ui/Pill';
 import { docsConfig } from '../../lib/docs-config';
+import { createPageMetadata } from '../../lib/site-metadata';
 
-export const metadata = {
+export const metadata = createPageMetadata({
   title: 'Documentation — Angular Agent Framework',
   description: 'Learn the framework. Library guides, API reference, and production patterns for Angular Agent Framework.',
-};
+  pathname: '/docs',
+  type: 'website',
+});
 
 interface PopularTopic {
   title: string;
@@ -78,7 +81,22 @@ export default function DocsLandingPage() {
       {/* Library grid */}
       <Section surface="canvas" tight ariaLabelledBy="library-grid-heading">
         <Container>
-          <Eyebrow id="library-grid-heading" style={{ marginBottom: 16 }}>Libraries</Eyebrow>
+          <h2
+            id="library-grid-heading"
+            style={{
+              fontFamily: tokens.typography.eyebrow.family,
+              fontSize: tokens.typography.eyebrow.size,
+              fontWeight: tokens.typography.eyebrow.weight,
+              letterSpacing: tokens.typography.eyebrow.letterSpacing,
+              textTransform: tokens.typography.eyebrow.transform,
+              lineHeight: tokens.typography.eyebrow.line,
+              color: tokens.colors.textMuted,
+              margin: 0,
+              marginBottom: 16,
+            }}
+          >
+            Libraries
+          </h2>
           <div
             style={{
               display: 'grid',
@@ -126,7 +144,22 @@ export default function DocsLandingPage() {
       {/* Popular topics */}
       <Section surface="canvas" tight ariaLabelledBy="popular-heading">
         <Container>
-          <Eyebrow id="popular-heading" style={{ marginBottom: 16 }}>Popular topics</Eyebrow>
+          <h2
+            id="popular-heading"
+            style={{
+              fontFamily: tokens.typography.eyebrow.family,
+              fontSize: tokens.typography.eyebrow.size,
+              fontWeight: tokens.typography.eyebrow.weight,
+              letterSpacing: tokens.typography.eyebrow.letterSpacing,
+              textTransform: tokens.typography.eyebrow.transform,
+              lineHeight: tokens.typography.eyebrow.line,
+              color: tokens.colors.textMuted,
+              margin: 0,
+              marginBottom: 16,
+            }}
+          >
+            Popular topics
+          </h2>
           <div
             style={{
               display: 'grid',

--- a/apps/website/src/app/global.css
+++ b/apps/website/src/app/global.css
@@ -105,8 +105,9 @@ html {
 .docs-prose ul, .docs-prose ol { margin-bottom: 1.25rem; }
 .docs-prose li { margin-bottom: 0.25rem; }
 
-.docs-prose table { width: 100%; border-collapse: collapse; font-size: 0.875rem; margin: 1.5rem 0; display: block; overflow-x: auto; }
-.docs-prose th { text-align: left; padding: 0.5rem 0.75rem; font-family: var(--font-mono); font-size: 0.75rem; text-transform: uppercase; color: #8b8fa3; border-bottom: 1px solid rgba(0, 64, 144, 0.15); }
+.docs-table-scroll { max-width: 100%; overflow-x: auto; margin: 1.5rem 0; }
+.docs-prose table { width: 100%; border-collapse: collapse; font-size: 0.875rem; margin: 0; }
+.docs-prose th { text-align: left; padding: 0.5rem 0.75rem; font-family: var(--font-mono); font-size: 0.75rem; text-transform: uppercase; color: #555770; border-bottom: 1px solid rgba(0, 64, 144, 0.15); }
 .docs-prose td { padding: 0.5rem 0.75rem; border-bottom: 1px solid rgba(0, 64, 144, 0.08); color: #555770; }
 .docs-prose td code { font-size: 0.8em; }
 

--- a/apps/website/src/app/layout.tsx
+++ b/apps/website/src/app/layout.tsx
@@ -4,6 +4,7 @@ import './global.css';
 import { Nav } from '../components/shared/Nav';
 import { Footer } from '../components/shared/Footer';
 import { AnnouncementToast } from '../components/shared/AnnouncementToast';
+import { DEFAULT_SOCIAL_IMAGE, SITE_NAME, SITE_ORIGIN } from '../lib/site-metadata';
 
 const garamond = EB_Garamond({
   subsets: ['latin'],
@@ -23,6 +24,7 @@ const mono = JetBrains_Mono({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL(SITE_ORIGIN),
   title: 'Angular Agent Framework — Signal-Native Streaming for Angular + LangGraph',
   description: 'The enterprise Angular agent framework for LangChain. Signal-native streaming, thread persistence, and production patterns for Angular 20+.',
   icons: {
@@ -32,12 +34,15 @@ export const metadata: Metadata = {
     title: 'Angular Agent Framework',
     description: 'Signal-native streaming for LangGraph — production patterns your Angular team can own.',
     type: 'website',
-    siteName: 'Angular Agent Framework',
+    siteName: SITE_NAME,
+    url: '/',
+    images: [DEFAULT_SOCIAL_IMAGE],
   },
   twitter: {
     card: 'summary_large_image',
     title: 'Angular Agent Framework',
     description: 'Signal-native streaming for LangGraph — production patterns your Angular team can own.',
+    images: [DEFAULT_SOCIAL_IMAGE],
   },
 };
 

--- a/apps/website/src/app/llms-full.txt/route.ts
+++ b/apps/website/src/app/llms-full.txt/route.ts
@@ -1,27 +1,22 @@
 import { NextResponse } from 'next/server';
 import fs from 'fs';
 import path from 'path';
+import agentApiDocs from '../../../content/docs/agent/api/api-docs.json';
+import agUiApiDocs from '../../../content/docs/ag-ui/api/api-docs.json';
+import chatApiDocs from '../../../content/docs/chat/api/api-docs.json';
+import renderApiDocs from '../../../content/docs/render/api/api-docs.json';
+
+const API_DOCS: Record<string, unknown> = {
+  'ag-ui': agUiApiDocs,
+  agent: agentApiDocs,
+  chat: chatApiDocs,
+  render: renderApiDocs,
+};
 
 function loadApiDocs(): string {
-  const roots = [
-    path.join(process.cwd(), 'apps', 'website', 'content', 'docs'),
-    path.join(process.cwd(), 'content', 'docs'),
-  ];
-
-  const docsRoot = roots.find((root) => fs.existsSync(root));
-  if (!docsRoot) {
-    return '(API reference not yet generated — run npm run generate-api-docs)';
-  }
-
-  const sections = fs.readdirSync(docsRoot)
-    .sort()
-    .map((library) => {
-      const apiDocsPath = path.join(docsRoot, library, 'api', 'api-docs.json');
-      if (!fs.existsSync(apiDocsPath)) return null;
-      const raw = fs.readFileSync(apiDocsPath, 'utf8');
-      return `### ${library}\n\n${raw}`;
-    })
-    .filter((section): section is string => section !== null);
+  const sections = Object.entries(API_DOCS)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([library, docs]) => `### ${library}\n\n${JSON.stringify(docs, null, 2)}`);
 
   return sections.length > 0
     ? sections.join('\n\n')
@@ -29,8 +24,12 @@ function loadApiDocs(): string {
 }
 
 function loadAllPrompts(): string {
-  const dir = path.join(process.cwd(), 'content', 'prompts');
-  if (!fs.existsSync(dir)) return '(no prompt recipes found)';
+  const roots = [
+    path.join(process.cwd(), 'apps', 'website', 'content', 'prompts'),
+    path.join(process.cwd(), 'content', 'prompts'),
+  ];
+  const dir = roots.find((root) => fs.existsSync(root));
+  if (!dir) return '(no prompt recipes found)';
   return fs.readdirSync(dir)
     .filter((f) => f.endsWith('.md'))
     .map((f) => {

--- a/apps/website/src/app/robots.ts
+++ b/apps/website/src/app/robots.ts
@@ -1,0 +1,12 @@
+import type { MetadataRoute } from 'next';
+import { getCanonicalUrl } from '../lib/site-metadata';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+    },
+    sitemap: getCanonicalUrl('/sitemap.xml'),
+  };
+}

--- a/apps/website/src/app/sitemap.ts
+++ b/apps/website/src/app/sitemap.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from 'next';
+import { getCanonicalUrl, getSitemapRoutes } from '../lib/site-metadata';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const now = new Date();
+
+  return getSitemapRoutes().map((route) => ({
+    url: getCanonicalUrl(route),
+    lastModified: now,
+    changeFrequency: route.startsWith('/docs') ? 'weekly' : 'monthly',
+    priority: route === '/' ? 1 : route.startsWith('/docs') ? 0.8 : 0.7,
+  }));
+}

--- a/apps/website/src/components/docs/MdxRenderer.tsx
+++ b/apps/website/src/components/docs/MdxRenderer.tsx
@@ -25,6 +25,11 @@ const mdxComponents = {
   ArchFlowDiagram,
   FeatureChips,
   pre: Pre,
+  table: ({ children, ...rest }: React.HTMLAttributes<HTMLTableElement>) => (
+    <div className="docs-table-scroll">
+      <table {...rest}>{children}</table>
+    </div>
+  ),
   h2: ({ id, children, ...rest }: React.HTMLAttributes<HTMLHeadingElement>) => (
     <h2 id={id} {...rest}>
       {id ? <a href={`#${id}`} aria-label={`Link to ${id}`} className="heading-anchor">#</a> : null}

--- a/apps/website/src/lib/docs.spec.ts
+++ b/apps/website/src/lib/docs.spec.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import { getAllDocSlugs, getDocBySlug, getDocMetadata } from './docs';
 import { allDocsPages } from './docs-config';
+import { getCanonicalUrl, getSitemapRoutes } from './site-metadata';
+
+const internalDocsLinkPattern = /(?:href=["']|\]\()(?<href>\/docs\/[^"')#\s]+)/g;
+
+function findInternalDocsLinks(content: string): string[] {
+  return Array.from(content.matchAll(internalDocsLinkPattern), (match) => match.groups?.href)
+    .filter((href): href is string => Boolean(href));
+}
 
 describe('website docs bindings', () => {
   it('lists all doc slugs from config', () => {
@@ -29,11 +37,65 @@ describe('website docs bindings', () => {
   });
 
   it('resolves page metadata for configured docs', () => {
-    expect(getDocMetadata('ag-ui', 'reference', 'event-mapping')).toEqual({
+    const metadata = getDocMetadata('ag-ui', 'reference', 'event-mapping');
+
+    expect(metadata).toMatchObject({
       title: 'Event Mapping - AG-UI Docs - Angular Agent Framework',
-      description:
-        'Adapter for any AG-UI-compatible backend (CrewAI, Mastra, Microsoft AF, AG2, Pydantic AI, AWS Strands, CopilotKit runtime)',
+      alternates: {
+        canonical: '/docs/ag-ui/reference/event-mapping',
+      },
+      openGraph: {
+        title: 'Event Mapping - AG-UI Docs - Angular Agent Framework',
+        url: '/docs/ag-ui/reference/event-mapping',
+      },
+      twitter: {
+        card: 'summary_large_image',
+        title: 'Event Mapping - AG-UI Docs - Angular Agent Framework',
+      },
     });
+    expect(metadata?.description).toContain('AG-UI protocol events');
+    expect(metadata?.description).not.toBe(
+      'Adapter for any AG-UI-compatible backend (CrewAI, Mastra, Microsoft AF, AG2, Pydantic AI, AWS Strands, CopilotKit runtime)',
+    );
+  });
+
+  it('derives mostly unique descriptions from page content', () => {
+    const descriptions = getAllDocSlugs()
+      .map(({ library, section, slug }) => getDocMetadata(library, section, slug)?.description)
+      .filter((description): description is string => Boolean(description));
+
+    const duplicateDescriptions = descriptions.filter((description, index) => descriptions.indexOf(description) !== index);
+    expect(duplicateDescriptions).toHaveLength(0);
+  });
+
+  it('includes every configured doc page in the sitemap routes', () => {
+    const sitemapRoutes = getSitemapRoutes();
+
+    for (const { library, section, slug } of getAllDocSlugs()) {
+      expect(sitemapRoutes).toContain(`/docs/${library}/${section}/${slug}`);
+    }
+  });
+
+  it('resolves canonical URLs against the production origin', () => {
+    expect(getCanonicalUrl('/docs/agent/guides/streaming')).toBe('https://cacheplane.ai/docs/agent/guides/streaming');
+  });
+
+  it('does not contain stale or broken internal docs links', () => {
+    const validDocsRoutes = new Set(['/docs', ...getSitemapRoutes().filter((route) => route.startsWith('/docs/'))]);
+    const brokenLinks: string[] = [];
+
+    for (const { library, section, slug } of getAllDocSlugs()) {
+      const doc = getDocBySlug(library, section, slug);
+      if (!doc) continue;
+
+      for (const href of findInternalDocsLinks(doc.content)) {
+        if (!validDocsRoutes.has(href)) {
+          brokenLinks.push(`${library}/${section}/${slug} -> ${href}`);
+        }
+      }
+    }
+
+    expect(brokenLinks).toEqual([]);
   });
 
   it('returns null for non-existent doc', () => {

--- a/apps/website/src/lib/docs.ts
+++ b/apps/website/src/lib/docs.ts
@@ -1,6 +1,8 @@
 import fs from 'fs';
 import path from 'path';
+import type { Metadata } from 'next';
 import { docsConfig, type DocsPage, getLibraryConfig, getLibraryPages } from './docs-config';
+import { createPageMetadata } from './site-metadata';
 
 const resolveContentDir = (library: string): string => {
   const workspacePath = path.join(process.cwd(), 'apps', 'website', 'content', 'docs', library);
@@ -14,9 +16,46 @@ export interface ResolvedDoc {
   title: string;
 }
 
-export interface ResolvedDocMetadata {
-  title: string;
-  description: string;
+export type ResolvedDocMetadata = Metadata;
+
+const FRONTMATTER_DESCRIPTION_PATTERN = /^---\s*\n[\s\S]*?\ndescription:\s*['"]?(?<description>[^'"\n]+)['"]?\s*\n[\s\S]*?\n---/;
+
+function normalizeDescription(description: string): string {
+  return description
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/<[^>]+>/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function extractFirstParagraph(content: string): string | null {
+  const withoutFrontmatter = content.replace(/^---\s*\n[\s\S]*?\n---\s*/, '');
+  const withoutImports = withoutFrontmatter.replace(/^import\s.+$/gm, '');
+  const paragraphs = withoutImports.split(/\n{2,}/);
+
+  for (const paragraph of paragraphs) {
+    const normalized = normalizeDescription(paragraph);
+    if (
+      normalized.length < 40 ||
+      normalized.startsWith('#') ||
+      normalized.startsWith('|') ||
+      normalized.startsWith('```') ||
+      normalized.startsWith('<')
+    ) {
+      continue;
+    }
+
+    return normalized.length > 180 ? `${normalized.slice(0, 177).trimEnd()}...` : normalized;
+  }
+
+  return null;
+}
+
+function getDocDescription(content: string, fallback: string): string {
+  const frontmatterDescription = content.match(FRONTMATTER_DESCRIPTION_PATTERN)?.groups?.description;
+  if (frontmatterDescription) return normalizeDescription(frontmatterDescription);
+  return extractFirstParagraph(content) ?? fallback;
 }
 
 export function getDocBySlug(library: string, section: string, slug: string): ResolvedDoc | null {
@@ -47,10 +86,11 @@ export function getDocMetadata(
 
   const lib = getLibraryConfig(library);
   const libraryTitle = lib?.title ?? 'Docs';
-  return {
-    title: `${doc.title} - ${libraryTitle} Docs - Angular Agent Framework`,
-    description: lib?.description ?? 'Angular Agent Framework documentation',
-  };
+  const title = `${doc.title} - ${libraryTitle} Docs - Angular Agent Framework`;
+  const description = getDocDescription(doc.content, lib?.description ?? 'Angular Agent Framework documentation');
+  const pathname = `/docs/${library}/${section}/${slug}`;
+
+  return createPageMetadata({ title, description, pathname });
 }
 
 export function getAllDocSlugs(): { library: string; section: string; slug: string }[] {

--- a/apps/website/src/lib/site-metadata.ts
+++ b/apps/website/src/lib/site-metadata.ts
@@ -1,0 +1,64 @@
+import type { Metadata } from 'next';
+import { getAllSolutionSlugs } from './solutions-data';
+import { docsConfig } from './docs-config';
+
+export const SITE_ORIGIN = 'https://cacheplane.ai';
+export const SITE_NAME = 'Angular Agent Framework';
+export const DEFAULT_SOCIAL_IMAGE = '/opengraph-image';
+
+export function getCanonicalPath(pathname: string): string {
+  if (pathname === '/') return '/';
+  return `/${pathname.replace(/^\/+|\/+$/g, '')}`;
+}
+
+export function getCanonicalUrl(pathname: string): string {
+  return new URL(getCanonicalPath(pathname), SITE_ORIGIN).toString();
+}
+
+export function createPageMetadata({
+  title,
+  description,
+  pathname,
+  type = 'article',
+}: {
+  title: string;
+  description: string;
+  pathname: string;
+  type?: 'article' | 'website';
+}): Metadata {
+  const canonicalPath = getCanonicalPath(pathname);
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: canonicalPath,
+    },
+    openGraph: {
+      title,
+      description,
+      url: canonicalPath,
+      siteName: SITE_NAME,
+      type,
+      images: [DEFAULT_SOCIAL_IMAGE],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: [DEFAULT_SOCIAL_IMAGE],
+    },
+  };
+}
+
+export function getSitemapRoutes(): string[] {
+  const staticRoutes = ['/', '/angular', '/render', '/chat', '/pricing', '/solutions', '/pilot-to-prod', '/docs'];
+  const solutionRoutes = getAllSolutionSlugs().map((slug) => `/solutions/${slug}`);
+  const docsRoutes = docsConfig.flatMap((library) =>
+    library.sections.flatMap((section) =>
+      section.pages.map((page) => `/docs/${library.id}/${page.section}/${page.slug}`),
+    ),
+  );
+
+  return [...staticRoutes, ...solutionRoutes, ...docsRoutes];
+}


### PR DESCRIPTION
## Summary

- add shared site metadata, canonical URLs, Open Graph/Twitter metadata, robots.txt, and sitemap.xml
- derive docs page descriptions from MDX content and add tests for sitemap coverage, duplicate descriptions, and broken internal docs links
- fix stale Agent docs links, docs table accessibility/scrolling, and production llms-full API reference output

## Verification

- PATH=/tmp/codex-node-bin:node_modules/.bin:/Users/blove/.cargo/bin:/Users/blove/.codex/tmp/arg0/codex-arg03ZsBnM:/usr/bin:/bin:/usr/sbin:/sbin:/Applications/Codex.app/Contents/Resources /tmp/codex-node-unsigned node_modules/vitest/vitest.mjs run apps/website/src/lib/docs.spec.ts
- PATH=/tmp/codex-node-bin:node_modules/.bin:/Users/blove/.cargo/bin:/Users/blove/.codex/tmp/arg0/codex-arg03ZsBnM:/usr/bin:/bin:/usr/sbin:/sbin:/Applications/Codex.app/Contents/Resources nx lint website
- PATH=/tmp/codex-node-bin:node_modules/.bin:/Users/blove/.cargo/bin:/Users/blove/.codex/tmp/arg0/codex-arg03ZsBnM:/usr/bin:/bin:/usr/sbin:/sbin:/Applications/Codex.app/Contents/Resources nx build website
- PATH=/tmp/codex-node-bin:node_modules/.bin:/Users/blove/.cargo/bin:/Users/blove/.codex/tmp/arg0/codex-arg03ZsBnM:/usr/bin:/bin:/usr/sbin:/sbin:/Applications/Codex.app/Contents/Resources BASE_URL=http://127.0.0.1:4308 nx e2e website --skipInstall
- production smoke: /llms-full.txt, /robots.txt, /sitemap.xml on nx serve website --configuration=production --port=4310