### PR TITLE
fix(chat): lifecycle-guaranteed root token injection (production regression)

### DIFF
--- a/libs/chat/package.json
+++ b/libs/chat/package.json
@@ -45,6 +45,7 @@
   },
   "sideEffects": [
     "**/chat-tokens.ts",
+    "./fesm2022/ngaf-chat.mjs",
     "**/*.css"
   ]
 }

--- a/libs/chat/src/lib/compositions/chat-debug/chat-debug.component.ts
+++ b/libs/chat/src/lib/compositions/chat-debug/chat-debug.component.ts
@@ -16,6 +16,7 @@ import {
 import { NgTemplateOutlet } from '@angular/common';
 import type { AgentWithHistory } from '../../agent';
 import { CHAT_DEBUG_TOKENS } from './chat-debug-tokens';
+import { ensureChatRootStyles } from '../../styles/chat-tokens';
 import { ChatDebugControlsDirective } from './chat-debug-controls.directive';
 import { ChatDebugInspectorDirective } from './chat-debug-inspector.directive';
 import { TimelineInspectorComponent } from './inspectors/timeline-inspector.component';
@@ -399,6 +400,10 @@ export class ChatDebugComponent {
   private readonly hostEl: ElementRef<HTMLElement> = inject(ElementRef);
 
   constructor() {
+    // Inject chat lib root CSS custom properties so the theme-attribute
+    // mappings + edge-claim primitive are in the document, even when
+    // chat-debug is mounted without a sibling chat composition.
+    ensureChatRootStyles();
     // Restore once from storage on construction; inputs seed the fallback.
     // `storageKey` is read-once: rebinding it at runtime is not supported.
     const restore = createPersistence(this.storageKey());

--- a/libs/chat/src/lib/compositions/chat-popup/chat-popup.component.ts
+++ b/libs/chat/src/lib/compositions/chat-popup/chat-popup.component.ts
@@ -6,7 +6,7 @@ import type { ViewRegistry } from '@ngaf/render';
 import { ChatComponent } from '../chat/chat.component';
 import type { ChatSelectOption } from '../../primitives/chat-select/chat-select.component';
 import { ChatLauncherButtonComponent } from '../../primitives/chat-launcher-button/chat-launcher-button.component';
-import { CHAT_HOST_TOKENS } from '../../styles/chat-tokens';
+import { CHAT_HOST_TOKENS, ensureChatRootStyles } from '../../styles/chat-tokens';
 
 @Component({
   selector: 'chat-popup',
@@ -106,6 +106,9 @@ export class ChatPopupComponent {
   private readonly document = inject(DOCUMENT);
 
   constructor() {
+    // Inject chat lib root CSS custom properties — see ChatComponent
+    // for the full rationale. Idempotent + lifecycle-guaranteed.
+    ensureChatRootStyles();
     effect(() => {
       // Re-bind whenever shortcut/closeOnEscape change.
       const shortcut = this.shortcut();

--- a/libs/chat/src/lib/compositions/chat-sidebar/chat-sidebar.component.ts
+++ b/libs/chat/src/lib/compositions/chat-sidebar/chat-sidebar.component.ts
@@ -6,7 +6,7 @@ import type { ViewRegistry } from '@ngaf/render';
 import { ChatComponent } from '../chat/chat.component';
 import { ChatLauncherButtonComponent } from '../../primitives/chat-launcher-button/chat-launcher-button.component';
 import type { ChatSelectOption } from '../../primitives/chat-select/chat-select.component';
-import { CHAT_HOST_TOKENS } from '../../styles/chat-tokens';
+import { CHAT_HOST_TOKENS, ensureChatRootStyles } from '../../styles/chat-tokens';
 
 @Component({
   selector: 'chat-sidebar',
@@ -104,6 +104,9 @@ export class ChatSidebarComponent {
   readonly forkRequested = output<string>();
 
   constructor() {
+    // Inject chat lib root CSS custom properties — see ChatComponent
+    // for the full rationale. Idempotent + lifecycle-guaranteed.
+    ensureChatRootStyles();
     // Publish the right-edge claim while the panel is open. Peer panels
     // (e.g. chat-debug) read --ngaf-chat-occupy-right to leave room.
     effect(() => {

--- a/libs/chat/src/lib/compositions/chat/chat.component.ts
+++ b/libs/chat/src/lib/compositions/chat/chat.component.ts
@@ -33,7 +33,7 @@ import { createContentClassifier, type ContentClassifier } from '../../streaming
 import { createPartialArgsBridge, type PartialArgsBridge } from '../../a2ui/partial-args-bridge';
 import { createA2uiSurfaceStore, type A2uiSurfaceStore } from '../../a2ui/surface-store';
 import { messageContent } from '../shared/message-utils';
-import { CHAT_HOST_TOKENS } from '../../styles/chat-tokens';
+import { CHAT_HOST_TOKENS, ensureChatRootStyles } from '../../styles/chat-tokens';
 import type { ChatRenderEvent } from './chat-render-event';
 import { CHAT_LIFECYCLE, type ChatLifecycle } from '../../lifecycle';
 
@@ -395,6 +395,19 @@ export class ChatComponent {
   private static readonly PIN_TOLERANCE_PX = 150;
 
   constructor() {
+    // Inject the chat lib's root CSS custom properties (--ngaf-chat-bg,
+    // --ngaf-chat-surface, --ngaf-chat-radius-input, etc.) the first
+    // time any chat composition is constructed. The module-eval side
+    // effect that previously handled this is unreliable under
+    // aggressive production tree-shaking — bundlers that don't see
+    // the source `chat-tokens.ts` path in the published artifact's
+    // `sideEffects` glob drop the call entirely, leaving consumers
+    // with zero token defaults (sidenav has no width, input has no
+    // border, chips have no chrome — everything renders as plain
+    // text on the page background). Calling from a constructor that
+    // is unconditionally reachable from user code defeats that
+    // tree-shaking and is idempotent. */
+    ensureChatRootStyles();
     effect(() => {
       if (this.eventsSubscribed) return;
       let agent: ReturnType<typeof this.agent>;


### PR DESCRIPTION
## Summary

Fixes the chrome-less production demo: sidenav too narrow, no border on the input, suggestion chips without pill background, etc. Root cause is \`ensureChatRootStyles()\` being tree-shaken out of the production bundle.

## Root cause (verified live + via manual style injection)

\`ensureChatRootStyles()\` is the function that injects \`<style id=\"ngaf-chat-root-tokens\">\` into \`<head>\`. That style element defines:
- All \`--ngaf-chat-*\` root tokens (bg, surface, text, separator, radius, sidenav width, font-family, …)
- The data-ngaf-chat-theme attribute → token mappings (light/dark switching)
- The edge-claim primitive defaults
- \`prefers-reduced-motion\` reset

Every host-encapsulated chat lib style references these via \`var()\`. Without them, sidenav has no width, input has no border, chips have no pill background, suggestions look like plain text on the page bg.

The function is wired as a module-evaluation side effect. The published artifact's \`sideEffects\` glob is \`[\"**/chat-tokens.ts\", \"**/*.css\"]\` — the chat-tokens.ts glob matches the source tree (workspace TS paths in this repo) but matches **nothing** in the bundled \`dist/libs/chat/fesm2022/ngaf-chat.mjs\` artifact. Production bundlers see no side-effect-marked files in the published package, treat the entire bundle as side-effect-free, and drop the call.

Manual proof: injecting the root tokens by hand via browser console at https://demo.cacheplane.ai restored every chrome element instantly.

This doesn't reproduce locally because dev mode skips tree-shaking and workspace TS paths match the source glob — which is exactly why we missed it in code review.

## Fix

1. **Lifecycle-guaranteed call.** Invoke \`ensureChatRootStyles()\` from the constructors of every top-level chat composition: \`ChatComponent\`, \`ChatPopupComponent\`, \`ChatSidebarComponent\`, \`ChatDebugComponent\`. The function is idempotent (early-returns if the style element already exists). Constructors are reachable from user code, so bundlers can't tree-shake the call.

2. **Defense-in-depth on the package manifest.** Extend \`libs/chat/package.json\` \`sideEffects\` to also include \`./fesm2022/ngaf-chat.mjs\` for any consumer bundler that DOES respect the field.

## Test plan

- [x] All 744 chat lib tests pass
- [x] \`npx nx build chat\` green
- [x] api-docs unchanged (constructor-internal change)
- [ ] CI green
- [ ] Post-merge: production demo at demo.cacheplane.ai renders with proper chrome after v0.0.35 ships

## Out of scope (separate follow-up)
- Suggestion-list reduction (top 3 + overflow dropdown)
- Top-level theme switcher (currently only in chat-debug palette)

🤖 Generated with [Claude Code](https://claude.com/claude-code)