### PR TITLE
chore(docs): regenerate telemetry api-docs (unblocks Deploy → Vercel)

### DIFF
--- a/apps/website/content/docs/telemetry/api/api-docs.json
+++ b/apps/website/content/docs/telemetry/api/api-docs.json
@@ -407,6 +407,25 @@
     "examples": []
   },
   {
+    "name": "isPersonalEmailDomain",
+    "kind": "function",
+    "description": "",
+    "signature": "isPersonalEmailDomain(domain: string | null | undefined): boolean",
+    "params": [
+      {
+        "name": "domain",
+        "type": "string | null | undefined",
+        "description": "",
+        "optional": false
+      }
+    ],
+    "returns": {
+      "type": "boolean",
+      "description": ""
+    },
+    "examples": []
+  },
+  {
     "name": "normalizePostHogHost",
     "kind": "function",
     "description": "",


### PR DESCRIPTION
## Summary

\`apps/website/content/docs/telemetry/api/api-docs.json\` has drifted 19 lines on main — a recent telemetry change added a public API entry but didn't regenerate the docs.

## Why this matters

The \`Verify generated API docs are committed\` step inside \`Website — lint / build\` has been failing on every push to main since the drift landed. That job **gates the entire \`Deploy → Vercel\` job** that handles auto-deploys for:
- cacheplane.ai (marketing site)
- cockpit.cacheplane.ai
- examples.cacheplane.ai
- **demo.cacheplane.ai** ← this is the immediate motivator

Result: the canonical demo at demo.cacheplane.ai has been stuck on a stale build for 3+ commits despite the auto-deploy wiring being correct. Discovered while diagnosing the missing root-tokens regression that ships in v0.0.32–v0.0.34 (fixed for npm consumers in v0.0.35 via PR #375).

## Fix

\`npm run generate-api-docs\` → commit the regenerated file. Diff is purely additive (19 inserts, 0 deletes) — a new API entry someone added to telemetry but forgot to regen.

## Test plan
- [x] Regen produces no further diff
- [ ] CI green
- [ ] After merge: next main push triggers \`Deploy → Vercel\`; demo.cacheplane.ai shows v0.0.35's lifecycle-guaranteed root token injection (verifiable via \`document.getElementById('ngaf-chat-root-tokens')\` returning a truthy element)

🤖 Generated with [Claude Code](https://claude.com/claude-code)