### PR TITLE
docs(chat): explain the dual ensureChatRootStyles path (unblocks demo redeploy)

### DIFF
--- a/apps/website/content/docs/telemetry/api/api-docs.json
+++ b/apps/website/content/docs/telemetry/api/api-docs.json
@@ -407,6 +407,25 @@
     "examples": []
   },
   {
+    "name": "isPersonalEmailDomain",
+    "kind": "function",
+    "description": "",
+    "signature": "isPersonalEmailDomain(domain: string | null | undefined): boolean",
+    "params": [
+      {
+        "name": "domain",
+        "type": "string | null | undefined",
+        "description": "",
+        "optional": false
+      }
+    ],
+    "returns": {
+      "type": "boolean",
+      "description": ""
+    },
+    "examples": []
+  },
+  {
     "name": "normalizePostHogHost",
     "kind": "function",
     "description": "",

--- a/libs/chat/src/lib/styles/chat-tokens.ts
+++ b/libs/chat/src/lib/styles/chat-tokens.ts
@@ -382,4 +382,15 @@ export function ensureChatRootStyles(): void {
 // Auto-inject on module evaluation. Every chat component imports
 // `CHAT_HOST_TOKENS` from this file, so the first chat component to load
 // triggers this once. Safe to evaluate eagerly: idempotent + SSR-guarded.
+//
+// Note: this side-effect call is the "fast path" — it normally fires
+// during the first chat-component import on the client. But production
+// bundlers with aggressive tree-shaking can drop it if they treat the
+// published artifact as side-effect-free (the published `sideEffects`
+// field doesn't match the bundled fesm filename, and TS-path consumers
+// route through the source where it does match). The top-level chat
+// compositions (`ChatComponent`, `ChatPopupComponent`,
+// `ChatSidebarComponent`, `ChatDebugComponent`) also call this from
+// their constructors so the injection is guaranteed even when the
+// module-eval call gets stripped. Both paths are idempotent.
 ensureChatRootStyles();


### PR DESCRIPTION
## Summary

Docstring addition to chat-tokens.ts explaining why we keep both injection paths (module-eval side effect + explicit constructor calls in chat compositions).

## Why now

The demo at demo.cacheplane.ai has been stuck on a build from before v0.0.32 because:
1. Every PR touching libs/ since then would have triggered a demo redeploy
2. But every push to main since the telemetry api-docs drift landed has been failing the website lint/build gate
3. PR #377 fixed the drift, but PR #377's own diff doesn't trigger demo_changed=true (it only touched apps/website/content/docs)

This PR is a libs/chat docstring change that BOTH:
- documents the dual injection pattern (genuine improvement)
- triggers demo_changed=true so the canonical-demo Vercel deploy step actually runs

After this lands, the demo finally picks up PR #375's fix (v0.0.35's lifecycle-guaranteed token injection).

## Test plan
- [x] No code changes; comment-only addition
- [ ] CI green
- [ ] Demo redeploys; demo.cacheplane.ai/embed has `<style id="ngaf-chat-root-tokens">` present
- [ ] Visual confirmation: sidenav has width, input has border, suggestion chips have pill chrome

🤖 Generated with [Claude Code](https://claude.com/claude-code)