### PR TITLE
feat(gtm): Spec 2 — positioning & risks (hero + /contact + risk-cleanup sweeps)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <img
     src="https://cacheplane.ai/assets/hero.svg"
-    alt="Angular Agent Framework — agent UI primitives for Angular"
+    alt="Agent UI for Angular — agent UI primitives for Angular"
     width="100%"
   />
 </p>
@@ -109,7 +109,7 @@ That's it. `chat.messages()` and `chat.status()` are Angular Signals. Bind them 
 <p align="center">
   <img
     src="https://cacheplane.ai/assets/arch-diagram.svg"
-    alt="Angular Agent Framework architecture: Angular Component → agent() → StreamManager Bridge → LangGraph Platform, with signals returned reactively"
+    alt="Agent UI for Angular architecture: Angular Component → agent() → StreamManager Bridge → LangGraph Platform, with signals returned reactively"
     width="100%"
   />
 </p>

--- a/apps/cockpit/src/app/layout.tsx
+++ b/apps/cockpit/src/app/layout.tsx
@@ -6,17 +6,17 @@ import { AnalyticsBootstrap } from '../components/analytics-bootstrap';
 import './cockpit.css';
 
 export const metadata = {
-  title: 'Cockpit — Angular Agent Framework',
-  description: 'The live reference app for the Angular Agent Framework. Real LangGraph + AG-UI agents through the Angular surface you’ll ship.',
+  title: 'Cockpit — Agent UI for Angular',
+  description: 'The live reference app for Agent UI for Angular. Real LangGraph + AG-UI agents through the Angular surface you’ll ship.',
   openGraph: {
-    title: 'Cockpit — Angular Agent Framework',
+    title: 'Cockpit — Agent UI for Angular',
     description: 'The live reference app for the framework. Real LangGraph + AG-UI agents through the same Angular surface you’ll ship.',
     type: 'website',
     siteName: 'Cockpit',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Cockpit — Angular Agent Framework',
+    title: 'Cockpit — Agent UI for Angular',
     description: 'The live reference app for the framework. Real LangGraph + AG-UI agents through the Angular surface you’ll ship.',
   },
 };

--- a/apps/cockpit/src/app/opengraph-image.tsx
+++ b/apps/cockpit/src/app/opengraph-image.tsx
@@ -13,7 +13,7 @@ import { ImageResponse } from 'next/og';
 import { darkOverrides } from '@ngaf/design-tokens';
 
 export const runtime = 'edge';
-export const alt = 'Cockpit — the live reference app for the Angular Agent Framework';
+export const alt = 'Cockpit — the live reference app for Agent UI for Angular';
 export const size = { width: 1200, height: 630 };
 export const contentType = 'image/png';
 
@@ -71,7 +71,7 @@ export default async function OpenGraphImage() {
             marginBottom: 24,
           }}
         >
-          Cockpit · Angular Agent Framework
+          Cockpit · Agent UI for Angular
         </div>
 
         {/* Headline — Inter Bold (cockpit chrome is sans-serif Linear-style) */}

--- a/apps/cockpit/tsconfig.json
+++ b/apps/cockpit/tsconfig.json
@@ -15,10 +15,64 @@
       "@ngaf/design-tokens": ["../../libs/design-tokens/src/index.ts"],
       "@ngaf/ui-react": ["../../libs/ui-react/src/index.ts"],
       "@ngaf/cockpit-registry": ["../../libs/cockpit-registry/src/index.ts"],
-      "@ngaf/telemetry/shared": ["../../libs/telemetry/src/shared/public-api.ts"],
-      "@ngaf/telemetry/browser": ["../../libs/telemetry/src/browser/public-api.ts"]
+      "@ngaf/telemetry/shared": [
+        "../../libs/telemetry/src/shared/public-api.ts"
+      ],
+      "@ngaf/telemetry/browser": [
+        "../../libs/telemetry/src/browser/public-api.ts"
+      ]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules"],
+  "references": [
+    {
+      "path": "../../cockpit/deep-agents/sandboxes/python"
+    },
+    {
+      "path": "../../cockpit/deep-agents/skills/python"
+    },
+    {
+      "path": "../../cockpit/deep-agents/subagents/python"
+    },
+    {
+      "path": "../../cockpit/deep-agents/filesystem/python"
+    },
+    {
+      "path": "../../cockpit/deep-agents/planning/python"
+    },
+    {
+      "path": "../../cockpit/deep-agents/memory/python"
+    },
+    {
+      "path": "../../cockpit/langgraph/deployment-runtime/python"
+    },
+    {
+      "path": "../../cockpit/langgraph/time-travel/python"
+    },
+    {
+      "path": "../../cockpit/langgraph/subgraphs/python"
+    },
+    {
+      "path": "../../cockpit/langgraph/durable-execution/python"
+    },
+    {
+      "path": "../../cockpit/langgraph/memory/python"
+    },
+    {
+      "path": "../../cockpit/langgraph/interrupts/python"
+    },
+    {
+      "path": "../../cockpit/langgraph/persistence/python"
+    },
+    {
+      "path": "../../cockpit/langgraph/streaming/python"
+    },
+    {
+      "path": "../../libs/design-tokens"
+    },
+    {
+      "path": "../../libs/telemetry"
+    }
+  ]
 }

--- a/apps/minting-service/tsconfig.app.json
+++ b/apps/minting-service/tsconfig.app.json
@@ -11,5 +11,17 @@
     "emitDeclarationOnly": false
   },
   "include": ["src/**/*.ts", "handlers/**/*.ts", "scripts/**/*.ts"],
-  "exclude": ["src/**/*.spec.ts", "handlers/**/*.spec.ts", "scripts/**/*.spec.ts"]
+  "exclude": [
+    "src/**/*.spec.ts",
+    "handlers/**/*.spec.ts",
+    "scripts/**/*.spec.ts"
+  ],
+  "references": [
+    {
+      "path": "../../libs/licensing/tsconfig.lib.json"
+    },
+    {
+      "path": "../../libs/db/tsconfig.lib.json"
+    }
+  ]
 }

--- a/apps/website/content/AGENTS.md.template
+++ b/apps/website/content/AGENTS.md.template
@@ -1,4 +1,4 @@
-# Angular Agent Framework v@VERSION@
+# Agent UI for Angular v@VERSION@
 
 Agent UI primitives and LangGraph streaming adapters for Angular.
 

--- a/apps/website/content/CLAUDE.md.template
+++ b/apps/website/content/CLAUDE.md.template
@@ -1,4 +1,4 @@
-# Angular Agent Framework v@VERSION@
+# Agent UI for Angular v@VERSION@
 
 Agent UI primitives and LangGraph streaming adapters for Angular.
 

--- a/apps/website/e2e/website.spec.ts
+++ b/apps/website/e2e/website.spec.ts
@@ -117,7 +117,7 @@ test('docs pages render canonical and social metadata', async ({ page }) => {
   );
   await expect(page.locator('meta[property="og:title"]')).toHaveAttribute(
     'content',
-    'Streaming - Agent Docs - Angular Agent Framework',
+    'Streaming - Agent Docs - Agent UI for Angular',
   );
   await expect(page.locator('meta[property="og:url"]')).toHaveAttribute(
     'content',
@@ -125,7 +125,7 @@ test('docs pages render canonical and social metadata', async ({ page }) => {
   );
   await expect(page.locator('meta[name="twitter:title"]')).toHaveAttribute(
     'content',
-    'Streaming - Agent Docs - Angular Agent Framework',
+    'Streaming - Agent Docs - Agent UI for Angular',
   );
 });
 

--- a/apps/website/emails/email-wrapper.ts
+++ b/apps/website/emails/email-wrapper.ts
@@ -13,12 +13,12 @@ export function wrapEmail(opts: {
 <body style="font-family:Inter,Arial,sans-serif;background-color:#f4f6fb;padding:40px 16px;margin:0">
 <div style="max-width:520px;margin:0 auto;background:#ffffff;border:1px solid #e6e8ee;border-radius:14px;overflow:hidden">
   <div style="padding:20px 32px;border-bottom:1px solid #e6e8ee">
-    <div style="font-size:14px;font-weight:700;color:#1a1a2e;letter-spacing:-0.01em">🛩️ Angular Agent Framework</div>
+    <div style="font-size:14px;font-weight:700;color:#1a1a2e;letter-spacing:-0.01em">🛩️ Agent UI for Angular</div>
   </div>
   <div style="padding:32px">
     ${opts.body}
     <div style="border-top:1px solid #e6e8ee;margin-top:28px;padding-top:16px">
-      <p style="font-size:11px;color:#8b8fa3;line-height:1.5;margin:0">Angular Agent Framework — Signal-native streaming for LangGraph.</p>
+      <p style="font-size:11px;color:#8b8fa3;line-height:1.5;margin:0">Agent UI for Angular — Signal-native streaming for LangGraph.</p>
       ${opts.showUnsubscribe ? '<p style="font-size:10px;color:#8b8fa3;margin:6px 0 0"><a href="https://cacheplane.ai/api/unsubscribe?email=RECIPIENT" style="color:#8b8fa3;text-decoration:underline">Unsubscribe</a></p>' : ''}
     </div>
   </div>

--- a/apps/website/emails/lead-notification.ts
+++ b/apps/website/emails/lead-notification.ts
@@ -1,18 +1,19 @@
 import { wrapEmail, esc } from './email-wrapper';
 
 interface LeadNotificationProps {
-  name: string;
+  name?: string;
   email: string;
-  company: string;
-  message: string;
+  company?: string;
+  message?: string;
   ts: string;
 }
 
 export function leadNotificationHtml({ name, email, company, message, ts }: LeadNotificationProps): string {
+  const displayName = name && name.length > 0 ? name : 'No name provided';
   return wrapEmail({
     body: `
       <p style="font-size:11px;font-family:monospace;text-transform:uppercase;letter-spacing:0.08em;color:#DD0031;font-weight:700;margin:0 0 8px">New Lead</p>
-      <p style="font-size:20px;font-weight:700;color:#1a1a2e;margin:0 0 4px">${esc(name)}</p>
+      <p style="font-size:20px;font-weight:700;color:#1a1a2e;margin:0 0 4px">${esc(displayName)}</p>
       <p style="font-size:14px;color:#8b8fa3;margin:0 0 16px">${esc(email)}${company ? ` — ${esc(company)}` : ''}</p>
       ${message ? `<div style="border-top:1px solid #e6e8ee;padding-top:14px;margin-bottom:4px"><p style="font-size:14px;color:#555770;line-height:1.7;margin:0">${esc(message)}</p></div>` : ''}
       <div style="border-top:1px solid #e6e8ee;padding-top:14px;margin-top:14px">

--- a/apps/website/emails/newsletter-welcome.ts
+++ b/apps/website/emails/newsletter-welcome.ts
@@ -3,7 +3,7 @@ import { wrapEmail } from './email-wrapper';
 export function newsletterWelcomeHtml(): string {
   return wrapEmail({
     body: `
-      <p style="font-size:20px;font-weight:700;color:#1a1a2e;margin:0 0 8px;line-height:1.3">Welcome to Angular Agent Framework updates</p>
+      <p style="font-size:20px;font-weight:700;color:#1a1a2e;margin:0 0 8px;line-height:1.3">Welcome to Agent UI for Angular updates</p>
       <p style="font-size:14px;color:#555770;line-height:1.7;margin:0 0 24px">You'll receive updates on new capabilities, production patterns, and Angular agent best practices. We keep it focused and infrequent — no spam.</p>
       <a href="https://cacheplane.ai/docs" style="display:inline-block;background-color:#004090;color:#fff;padding:12px 28px;border-radius:8px;font-size:14px;font-weight:700;text-decoration:none">Explore the Docs</a>
     `,

--- a/apps/website/lib/resend.ts
+++ b/apps/website/lib/resend.ts
@@ -11,7 +11,7 @@ function getResend(): Resend | null {
 }
 
 export const AUDIENCE_ID = process.env.RESEND_AUDIENCE_ID || '';
-export const FROM = process.env.RESEND_FROM || 'Angular Agent Framework <hello@cacheplane.io>';
+export const FROM = process.env.RESEND_FROM || 'Agent UI for Angular <hello@cacheplane.io>';
 export const NOTIFY_TO = process.env.RESEND_NOTIFY_TO || 'hello@cacheplane.io';
 
 /** Send an email via Resend. No-ops when API key is missing. */

--- a/apps/website/public/AGENTS.md
+++ b/apps/website/public/AGENTS.md
@@ -1,4 +1,4 @@
-# Angular Agent Framework v0.0.32
+# Agent UI for Angular v0.0.32
 
 Agent UI primitives and LangGraph streaming adapters for Angular.
 

--- a/apps/website/public/CLAUDE.md
+++ b/apps/website/public/CLAUDE.md
@@ -1,4 +1,4 @@
-# Angular Agent Framework v0.0.32
+# Agent UI for Angular v0.0.32
 
 Agent UI primitives and LangGraph streaming adapters for Angular.
 

--- a/apps/website/public/assets/hero.svg
+++ b/apps/website/public/assets/hero.svg
@@ -24,7 +24,7 @@
     font-style="italic"
     fill="#8B96C8"
     opacity="0.9"
-  >The Angular Agent Framework for LangGraph</text>
+  >Agent UI for Angular — for LangGraph</text>
 
   <!-- Bottom horizontal rule -->
   <line x1="60" y1="252" x2="1140" y2="252" stroke="#6C8EFF" stroke-width="1" stroke-opacity="0.18"/>

--- a/apps/website/scripts/generate-narrative-docs.ts
+++ b/apps/website/scripts/generate-narrative-docs.ts
@@ -10,7 +10,7 @@ const API_DOCS_ROOT = 'apps/website/content/docs';
 const TOPICS = [
   {
     slug: 'introduction',
-    prompt: 'Write an introduction to the Angular Agent Framework library. Explain what it does, who it is for, and why it exists. Include a minimal getting-started example.',
+    prompt: 'Write an introduction to the Agent UI for Angular library. Explain what it does, who it is for, and why it exists. Include a minimal getting-started example.',
   },
   {
     slug: 'streaming',
@@ -36,7 +36,7 @@ async function generateDoc(slug: string, prompt: string, apiDocsJson: string): P
     max_tokens: 2048,
     messages: [{
       role: 'user',
-      content: `You are writing documentation for the Angular Agent Framework library.
+      content: `You are writing documentation for the Agent UI for Angular library.
 Here is the TypeDoc API reference JSON:\n\n${apiDocsJson}\n\n${prompt}
 
 Write clean, developer-friendly MDX documentation. Use precise, no-fluff prose. Include code examples. Start with a single # heading.`,

--- a/apps/website/scripts/generate-whitepaper.ts
+++ b/apps/website/scripts/generate-whitepaper.ts
@@ -11,7 +11,7 @@ if (!process.env['ANTHROPIC_API_KEY'] && loadEnvFile && fs.existsSync('.env')) {
 const client = new Anthropic();
 const MODEL = process.env['ANTHROPIC_MODEL'] ?? 'claude-opus-4-5';
 
-const CURRENT_API_CONTEXT = `You are writing public technical whitepapers for Cacheplane Angular Agent Framework.
+const CURRENT_API_CONTEXT = `You are writing public technical whitepapers for Cacheplane Agent UI for Angular.
 
 Use only the current API surface:
 - Package names are @ngaf/langgraph, @ngaf/render, @ngaf/chat, and @ngaf/ag-ui.

--- a/apps/website/src/app/api/email-preview/route.ts
+++ b/apps/website/src/app/api/email-preview/route.ts
@@ -16,7 +16,7 @@ const TEMPLATES: Record<string, () => { subject: string; html: string }> = {
     html: whitepaperDownloadHtml('Brian'),
   }),
   'newsletter-welcome': () => ({
-    subject: 'Welcome to Angular Agent Framework updates',
+    subject: 'Welcome to Agent UI for Angular updates',
     html: newsletterWelcomeHtml(),
   }),
   'lead-notification': () => ({

--- a/apps/website/src/app/api/leads/route.ts
+++ b/apps/website/src/app/api/leads/route.ts
@@ -19,8 +19,8 @@ export async function POST(req: NextRequest) {
   const company = sanitize(body.company, 200);
   const message = sanitize(body.message, 2000);
 
-  if (!name || !email) {
-    return NextResponse.json({ error: 'name and email required' }, { status: 400 });
+  if (!email) {
+    return NextResponse.json({ error: 'email required' }, { status: 400 });
   }
 
   const ts = new Date().toISOString();
@@ -40,7 +40,7 @@ export async function POST(req: NextRequest) {
       sendEmail({
         from: FROM,
         to: NOTIFY_TO,
-        subject: `New lead: ${name}${company ? ` at ${company}` : ''}`,
+        subject: `New lead: ${name || email}${company ? ` at ${company}` : ''}`,
         html: leadNotificationHtml({ name, email, company, message, ts }),
       }),
       addToAudience(email, name),

--- a/apps/website/src/app/api/newsletter/route.ts
+++ b/apps/website/src/app/api/newsletter/route.ts
@@ -26,7 +26,7 @@ export async function POST(req: NextRequest) {
       sendEmail({
         from: FROM,
         to: email,
-        subject: 'Welcome to Angular Agent Framework updates',
+        subject: 'Welcome to Agent UI for Angular updates',
         html: newsletterWelcomeHtml(),
       }),
       addToAudience(email),

--- a/apps/website/src/app/contact/page.tsx
+++ b/apps/website/src/app/contact/page.tsx
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+import type { Metadata } from 'next';
+import React, { Suspense } from 'react';
+import { tokens } from '@ngaf/design-tokens';
+import { Container } from '../../components/ui/Container';
+import { Section } from '../../components/ui/Section';
+import { Eyebrow } from '../../components/ui/Eyebrow';
+import { ContactForm } from '../../components/contact/ContactForm';
+import { GitHubStarsPill } from '../../components/contact/GitHubStarsPill';
+import { SlaCard } from '../../components/contact/SlaCard';
+import { AltChannelRow } from '../../components/contact/AltChannelRow';
+
+export const metadata: Metadata = {
+  title: 'Talk to an engineer — Cacheplane',
+  description:
+    "Tell us what you're shipping. We'll reply within one business day — usually with code, not a calendar invite.",
+  openGraph: {
+    title: 'Talk to an engineer — Cacheplane',
+    description: "Tell us what you're shipping. We'll reply within one business day.",
+    type: 'website',
+  },
+};
+
+export default function ContactPage() {
+  return (
+    <Section surface="canvas" ariaLabelledBy="contact-heading">
+      <Container>
+        <div style={{ maxWidth: 720 }}>
+          <Eyebrow tone="accent" style={{ marginBottom: 16 }}>Contact</Eyebrow>
+          <h1
+            id="contact-heading"
+            style={{
+              fontFamily: tokens.typography.h1.family,
+              fontSize: tokens.typography.h1.size,
+              lineHeight: tokens.typography.h1.line,
+              fontWeight: 700,
+              color: tokens.colors.textPrimary,
+              margin: 0,
+              marginBottom: 16,
+              letterSpacing: '-0.02em',
+            }}
+          >
+            Talk to an engineer.
+          </h1>
+          <p
+            style={{
+              fontFamily: tokens.typography.bodyLg.family,
+              fontSize: tokens.typography.bodyLg.size,
+              lineHeight: tokens.typography.bodyLg.line,
+              color: tokens.colors.textSecondary,
+              margin: 0,
+              marginBottom: 24,
+              maxWidth: '60ch',
+            }}
+          >
+            Tell us what you&apos;re shipping. We&apos;ll reply within one business day — usually with code, not a calendar invite.
+          </p>
+          <div style={{ marginBottom: 24 }}>
+            <SlaCard />
+          </div>
+          <Suspense>
+            <ContactForm />
+          </Suspense>
+          <div style={{ marginTop: 32, display: 'flex', flexDirection: 'column', gap: 16 }}>
+            <GitHubStarsPill />
+            <AltChannelRow />
+          </div>
+        </div>
+      </Container>
+    </Section>
+  );
+}

--- a/apps/website/src/app/docs/[library]/[section]/[slug]/page.tsx
+++ b/apps/website/src/app/docs/[library]/[section]/[slug]/page.tsx
@@ -45,8 +45,8 @@ export function generateStaticParams() {
 export async function generateMetadata({ params }: DocsRouteProps): Promise<Metadata> {
   const { library, section, slug } = await params;
   return getDocMetadata(library, section, slug) ?? {
-    title: 'Docs - Angular Agent Framework',
-    description: 'Angular Agent Framework documentation',
+    title: 'Docs - Agent UI for Angular',
+    description: 'Agent UI for Angular documentation',
   };
 }
 

--- a/apps/website/src/app/docs/page.tsx
+++ b/apps/website/src/app/docs/page.tsx
@@ -9,8 +9,8 @@ import { docsConfig } from '../../lib/docs-config';
 import { createPageMetadata } from '../../lib/site-metadata';
 
 export const metadata = createPageMetadata({
-  title: 'Documentation — Angular Agent Framework',
-  description: 'Learn the framework. Library guides, API reference, and production patterns for Angular Agent Framework.',
+  title: 'Documentation — Agent UI for Angular',
+  description: 'Learn the framework. Library guides, API reference, and production patterns for Agent UI for Angular.',
   pathname: '/docs',
   type: 'website',
 });
@@ -72,7 +72,7 @@ export default function DocsLandingPage() {
                 maxWidth: '52ch',
               }}
             >
-              Angular Agent Framework is a suite of MIT-licensed libraries for building AI agent interfaces. Pick a library to get started.
+              Agent UI for Angular is a suite of MIT-licensed libraries for building AI agent interfaces. Pick a library to get started.
             </p>
           </div>
         </Container>

--- a/apps/website/src/app/layout.tsx
+++ b/apps/website/src/app/layout.tsx
@@ -25,13 +25,13 @@ const mono = JetBrains_Mono({
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_ORIGIN),
-  title: 'Angular Agent Framework — Signal-Native Streaming for Angular + LangGraph',
+  title: 'Agent UI for Angular — Signal-Native Streaming for Angular + LangGraph',
   description: 'The enterprise Angular agent framework for LangChain. Signal-native streaming, thread persistence, and production patterns for Angular 20+.',
   icons: {
     icon: 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><text y=".9em" font-size="90">🛩️</text></svg>',
   },
   openGraph: {
-    title: 'Angular Agent Framework',
+    title: 'Agent UI for Angular',
     description: 'Signal-native streaming for LangGraph — production patterns your Angular team can own.',
     type: 'website',
     siteName: SITE_NAME,
@@ -40,7 +40,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Angular Agent Framework',
+    title: 'Agent UI for Angular',
     description: 'Signal-native streaming for LangGraph — production patterns your Angular team can own.',
     images: [DEFAULT_SOCIAL_IMAGE],
   },

--- a/apps/website/src/app/llms-full.txt/route.ts
+++ b/apps/website/src/app/llms-full.txt/route.ts
@@ -48,7 +48,7 @@ function loadAllPrompts(): string {
 
 export async function GET() {
   const sections = [
-    '# Angular Agent Framework — Full Reference\n\nSee /llms.txt for a compact summary.\n',
+    '# Agent UI for Angular — Full Reference\n\nSee /llms.txt for a compact summary.\n',
     '## API Reference (TypeDoc)\n\n' + loadApiDocs(),
     '## Prompt Recipes\n\n' + loadAllPrompts(),
     [

--- a/apps/website/src/app/llms.txt/route.ts
+++ b/apps/website/src/app/llms.txt/route.ts
@@ -16,9 +16,9 @@ function loadVersion(): string {
 function buildLlmsTxt(): string {
   const version = loadVersion();
   return [
-    `# Angular Agent Framework v${version}`,
+    `# Agent UI for Angular v${version}`,
     '',
-    "Angular Agent Framework is a runtime-neutral chat UI SDK for Angular. The @ngaf/chat library provides streaming chat primitives bound to a runtime-neutral 'Agent' contract; runtime adapters (@ngaf/langgraph, @ngaf/ag-ui) translate between the contract and the actual backend.",
+    "Agent UI for Angular is a runtime-neutral chat UI SDK for Angular. The @ngaf/chat library provides streaming chat primitives bound to a runtime-neutral 'Agent' contract; runtime adapters (@ngaf/langgraph, @ngaf/ag-ui) translate between the contract and the actual backend.",
     '',
     '## Packages',
     '- @ngaf/chat — chat UI primitives (messages, input, tool calls, interrupt, debug, etc.) consuming the Agent contract',

--- a/apps/website/src/app/not-found.tsx
+++ b/apps/website/src/app/not-found.tsx
@@ -5,7 +5,7 @@ import { Eyebrow } from '../components/ui/Eyebrow';
 import { Button } from '../components/ui/Button';
 
 export const metadata = {
-  title: 'Page not found — Angular Agent Framework',
+  title: 'Page not found — Agent UI for Angular',
   description: 'The page you were looking for doesn’t exist.',
 };
 

--- a/apps/website/src/app/opengraph-image.tsx
+++ b/apps/website/src/app/opengraph-image.tsx
@@ -9,7 +9,7 @@ import { ImageResponse } from 'next/og';
 
 // Node runtime (not edge) so we can read the bundled Garamond TTF off disk.
 export const runtime = 'nodejs';
-export const alt = 'Angular Agent Framework — Signal-native streaming for Angular + LangGraph';
+export const alt = 'Agent UI for Angular — Signal-native streaming for Angular + LangGraph';
 export const size = { width: 1200, height: 630 };
 export const contentType = 'image/png';
 
@@ -98,7 +98,7 @@ export default async function OpenGraphImage() {
             marginBottom: 28,
           }}
         >
-          Angular Agent Framework · MIT
+          Agent UI for Angular · MIT
         </div>
 
         {/* Headline — EB Garamond serif matches marketing-site h1 */}

--- a/apps/website/src/app/page.tsx
+++ b/apps/website/src/app/page.tsx
@@ -61,7 +61,7 @@ export default async function HomePage() {
         body="Server-emitted JSON specs become Angular components you already own. Vercel json-render and Google A2UI both supported, with per-component fallback and a readiness gate."
         bullets={[
           'Per-component fallback API + readiness gate',
-          'A2UI v1 protocol + Vercel json-render adapter',
+          'A2UI v0.9-compatible protocol + Vercel json-render adapter',
           'Renders into your existing component library',
           'Server-side schema, client-side trust',
         ]}

--- a/apps/website/src/app/pilot-to-prod/page.tsx
+++ b/apps/website/src/app/pilot-to-prod/page.tsx
@@ -12,7 +12,7 @@ import { Promises } from '../../components/landing/Promises';
 import { FinalCTA } from '../../components/landing/FinalCTA';
 
 export const metadata = {
-  title: 'Pilot to Production — Angular Agent Framework',
+  title: 'Pilot to Production — Agent UI for Angular',
   description: 'Close the last-mile gap. The 3-month pilot engagement is included with every app deployment license. We work alongside your Angular team to ship your first agent to production.',
 };
 

--- a/apps/website/src/app/pricing/page.tsx
+++ b/apps/website/src/app/pricing/page.tsx
@@ -4,6 +4,7 @@ import { Section } from '../../components/ui/Section';
 import { Eyebrow } from '../../components/ui/Eyebrow';
 import { PricingGrid } from '../../components/pricing/PricingGrid';
 import { CompareTable } from '../../components/pricing/CompareTable';
+import { CompatibilityMatrix } from '../../components/pricing/CompatibilityMatrix';
 import { LeadForm } from '../../components/pricing/LeadForm';
 import { FinalCTA } from '../../components/landing/FinalCTA';
 
@@ -50,6 +51,33 @@ export default function PricingPage() {
       </Section>
       <PricingGrid />
       <CompareTable />
+      <Section surface="canvas">
+        <Container>
+          <Eyebrow style={{ marginBottom: 12 }}>Compatibility</Eyebrow>
+          <h2
+            style={{
+              fontFamily: tokens.typography.h2.family,
+              fontSize: tokens.typography.h2.size,
+              margin: 0,
+              marginBottom: 16,
+              color: tokens.colors.textPrimary,
+            }}
+          >
+            Angular version support
+          </h2>
+          <p
+            style={{
+              margin: 0,
+              marginBottom: 24,
+              color: tokens.colors.textSecondary,
+              maxWidth: '60ch',
+            }}
+          >
+            We ship against the versions our CI tests. Other versions may work but aren&apos;t guaranteed.
+          </p>
+          <CompatibilityMatrix />
+        </Container>
+      </Section>
       <LeadForm />
       <FinalCTA />
     </>

--- a/apps/website/src/app/pricing/page.tsx
+++ b/apps/website/src/app/pricing/page.tsx
@@ -8,7 +8,7 @@ import { LeadForm } from '../../components/pricing/LeadForm';
 import { FinalCTA } from '../../components/landing/FinalCTA';
 
 export const metadata = {
-  title: 'Pricing — Angular Agent Framework',
+  title: 'Pricing — Agent UI for Angular',
   description: 'Simple, transparent pricing. MIT-licensed libraries are free forever. Enterprise contracts available.',
 };
 

--- a/apps/website/src/app/render/page.tsx
+++ b/apps/website/src/app/render/page.tsx
@@ -57,7 +57,7 @@ export default async function RenderPage() {
             <div style={{ display: 'flex', justifyContent: 'center', gap: 8, flexWrap: 'wrap' }}>
               <Pill variant="accent">MIT</Pill>
               <Pill variant="neutral">Vercel json-render</Pill>
-              <Pill variant="neutral">Google A2UI v1</Pill>
+              <Pill variant="neutral">Google A2UI v0.9-compatible</Pill>
             </div>
           </div>
         </Container>
@@ -70,13 +70,13 @@ export default async function RenderPage() {
         body="The agent emits structured UI as JSON. @ngaf/render maps each spec node to one of your Angular components — so the design system stays yours, and the agent gets to assemble it."
         bullets={[
           'Vercel json-render adapter',
-          'Google A2UI v1 protocol',
+          'Google A2UI v0.9-compatible protocol',
           'Component registry — declare once, use everywhere',
           'Server schema, client validation',
         ]}
         supportingCards={[
           { title: 'json-render', description: 'Vercel adapter.' },
-          { title: 'A2UI v1', description: 'Google protocol.' },
+          { title: 'A2UI v0.9-compatible', description: 'Google protocol.' },
           { title: 'registry', description: 'Spec → component.' },
         ]}
         cta={{ label: 'See @ngaf/render docs', href: '/docs/render/getting-started/introduction' }}

--- a/apps/website/src/app/solutions/page.tsx
+++ b/apps/website/src/app/solutions/page.tsx
@@ -10,8 +10,8 @@ import { FinalCTA } from '../../components/landing/FinalCTA';
 import { SOLUTIONS } from '../../lib/solutions-data';
 
 export const metadata = {
-  title: 'Solutions — Angular Agent Framework',
-  description: 'See how Angular Agent Framework solves enterprise challenges — compliance, analytics, and customer support.',
+  title: 'Solutions — Agent UI for Angular',
+  description: 'See how Agent UI for Angular solves enterprise challenges — compliance, analytics, and customer support.',
 };
 
 export default function SolutionsIndexPage() {

--- a/apps/website/src/components/contact/AltChannelRow.tsx
+++ b/apps/website/src/components/contact/AltChannelRow.tsx
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+import React from 'react';
+import { tokens } from '@ngaf/design-tokens';
+
+const linkStyle: React.CSSProperties = {
+  color: tokens.colors.accent,
+  textDecoration: 'none',
+  fontSize: tokens.typography.body.size,
+  fontFamily: tokens.typography.body.family,
+};
+
+export function AltChannelRow() {
+  return (
+    <p style={{ display: 'flex', gap: 16, alignItems: 'center', flexWrap: 'wrap', margin: 0 }}>
+      <a href="/docs" style={linkStyle}>docs</a>
+      <span style={{ color: tokens.colors.textMuted }}>·</span>
+      <a href="https://github.com/cacheplane/angular-agent-framework/issues" style={linkStyle}>GitHub issues</a>
+      <span style={{ color: tokens.colors.textMuted }}>·</span>
+      <a href="https://discord.gg/cacheplane" style={linkStyle}>Discord</a>
+    </p>
+  );
+}

--- a/apps/website/src/components/contact/ContactForm.spec.tsx
+++ b/apps/website/src/components/contact/ContactForm.spec.tsx
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: MIT
+// @vitest-environment jsdom
+import React from 'react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const trackMock = vi.hoisted(() => vi.fn());
+const fetchMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../../lib/analytics/client', () => ({ track: trackMock }));
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => new URLSearchParams('?source=home_hero&track=enterprise'),
+}));
+vi.mock('../ui/Button', () => ({
+  Button: ({
+    children,
+    type,
+    disabled,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    type?: 'submit' | 'button' | 'reset';
+    disabled?: boolean;
+    onClick?: () => void;
+  }) => (
+    <button type={type} disabled={disabled} onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+beforeEach(() => {
+  trackMock.mockClear();
+  fetchMock.mockReset();
+  vi.stubGlobal('fetch', fetchMock);
+  Object.defineProperty(document, 'referrer', {
+    value: 'https://cacheplane.ai/pricing',
+    configurable: true,
+  });
+});
+
+describe('ContactForm', () => {
+  it('submits with email only and fires lead_form_submit + lead_form_success', async () => {
+    fetchMock.mockResolvedValue({ ok: true });
+    const { ContactForm } = await import('./ContactForm');
+    render(<ContactForm />);
+
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'jane@acme.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.email).toBe('jane@acme.com');
+    expect(body.source_page).toBe('home_hero');
+    expect(body.track).toBe('enterprise');
+    expect(body.referrer_host).toBe('cacheplane.ai');
+
+    expect(trackMock).toHaveBeenCalledWith(
+      'marketing:lead_form_submit',
+      expect.objectContaining({ surface: 'contact' }),
+    );
+    expect(trackMock).toHaveBeenCalledWith(
+      'marketing:lead_form_success',
+      expect.objectContaining({ surface: 'contact' }),
+    );
+  });
+
+  it('submits with all optional fields populated', async () => {
+    fetchMock.mockResolvedValue({ ok: true });
+    const { ContactForm } = await import('./ContactForm');
+    render(<ContactForm />);
+
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'jane@acme.com' } });
+    fireEvent.change(screen.getByLabelText(/name/i), { target: { value: 'Jane Smith' } });
+    fireEvent.change(screen.getByLabelText(/company/i), { target: { value: 'Acme' } });
+    fireEvent.change(screen.getByLabelText(/message/i), { target: { value: 'Hi' } });
+    fireEvent.click(screen.getByRole('button', { name: /send/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body).toMatchObject({
+      email: 'jane@acme.com',
+      name: 'Jane Smith',
+      company: 'Acme',
+      message: 'Hi',
+    });
+  });
+
+  it('fires lead_form_fail on non-2xx', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500 });
+    const { ContactForm } = await import('./ContactForm');
+    render(<ContactForm />);
+
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'jane@acme.com' } });
+    fireEvent.click(screen.getByRole('button', { name: /send/i }));
+
+    await waitFor(() =>
+      expect(trackMock).toHaveBeenCalledWith(
+        'marketing:lead_form_fail',
+        expect.objectContaining({ surface: 'contact' }),
+      ),
+    );
+  });
+});

--- a/apps/website/src/components/contact/ContactForm.tsx
+++ b/apps/website/src/components/contact/ContactForm.tsx
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: MIT
+'use client';
+
+import React, { useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { tokens } from '@ngaf/design-tokens';
+import { Button } from '../ui/Button';
+import { track } from '../../lib/analytics/client';
+import { analyticsEvents } from '../../lib/analytics/events';
+
+type Status = 'idle' | 'sending' | 'sent' | 'error';
+
+function sanitizeReferrerHost(): string | undefined {
+  if (typeof document === 'undefined' || !document.referrer) return undefined;
+  try {
+    return new URL(document.referrer).hostname;
+  } catch {
+    return undefined;
+  }
+}
+
+export function ContactForm() {
+  const params = useSearchParams();
+  const [status, setStatus] = useState<Status>('idle');
+  const [email, setEmail] = useState('');
+  const [name, setName] = useState('');
+  const [company, setCompany] = useState('');
+  const [message, setMessage] = useState('');
+
+  const sourcePage = params.get('source') ?? 'contact_direct';
+  const trackParam = (params.get('track') ?? 'enterprise') as string;
+  const ctaId = params.get('cta_id') ?? undefined;
+  const paper = params.get('paper') ?? undefined;
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (!email) return;
+    setStatus('sending');
+    track(analyticsEvents.marketingLeadFormSubmit, {
+      surface: 'contact',
+      source_section: 'contact-form',
+    });
+    try {
+      const res = await fetch('/api/leads', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email,
+          name: name || undefined,
+          company: company || undefined,
+          message: message || undefined,
+          source_page: sourcePage,
+          track: trackParam,
+          cta_id: ctaId,
+          paper,
+          referrer_host: sanitizeReferrerHost(),
+        }),
+      });
+      if (res.ok) {
+        track(analyticsEvents.marketingLeadFormSuccess, {
+          surface: 'contact',
+          source_section: 'contact-form',
+        });
+        setStatus('sent');
+      } else {
+        track(analyticsEvents.marketingLeadFormFail, {
+          surface: 'contact',
+          source_section: 'contact-form',
+          error_reason: 'api_error',
+        });
+        setStatus('error');
+      }
+    } catch {
+      track(analyticsEvents.marketingLeadFormFail, {
+        surface: 'contact',
+        source_section: 'contact-form',
+        error_reason: 'network_error',
+      });
+      setStatus('error');
+    }
+  }
+
+  if (status === 'sent') {
+    return (
+      <div role="status" style={{ color: tokens.colors.textPrimary, padding: 24 }}>
+        Thanks. We&apos;ll be in touch within one business day.
+      </div>
+    );
+  }
+
+  const inputStyle: React.CSSProperties = {
+    display: 'block',
+    width: '100%',
+    padding: '10px 12px',
+    fontSize: tokens.typography.body.size,
+    fontFamily: tokens.typography.body.family,
+    color: tokens.colors.textPrimary,
+    background: tokens.surfaces.surface,
+    border: `1px solid ${tokens.surfaces.border}`,
+    borderRadius: 6,
+    marginTop: 4,
+  };
+
+  return (
+    <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 16, maxWidth: 480 }}>
+      <label style={{ fontSize: tokens.typography.body.size, color: tokens.colors.textPrimary }}>
+        Email
+        <input
+          type="email"
+          required
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          style={inputStyle}
+        />
+      </label>
+      <label style={{ fontSize: tokens.typography.body.size, color: tokens.colors.textPrimary }}>
+        Name <span style={{ color: tokens.colors.textMuted }}>(optional)</span>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          style={inputStyle}
+        />
+      </label>
+      <label style={{ fontSize: tokens.typography.body.size, color: tokens.colors.textPrimary }}>
+        Company <span style={{ color: tokens.colors.textMuted }}>(optional)</span>
+        <input
+          type="text"
+          value={company}
+          onChange={(e) => setCompany(e.target.value)}
+          style={inputStyle}
+        />
+      </label>
+      <label style={{ fontSize: tokens.typography.body.size, color: tokens.colors.textPrimary }}>
+        Message <span style={{ color: tokens.colors.textMuted }}>(optional)</span>
+        <textarea
+          rows={5}
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          placeholder="What are you shipping?"
+          style={{ ...inputStyle, resize: 'vertical' }}
+        />
+      </label>
+      <Button variant="primary" size="lg" type="submit" disabled={status === 'sending'}>
+        {status === 'sending' ? 'Sending…' : 'Send'}
+      </Button>
+      {status === 'error' && (
+        <div role="alert" style={{ color: '#c00' }}>
+          Something went wrong. Please try again or email us directly.
+        </div>
+      )}
+    </form>
+  );
+}

--- a/apps/website/src/components/contact/GitHubStarsPill.spec.tsx
+++ b/apps/website/src/components/contact/GitHubStarsPill.spec.tsx
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+// @vitest-environment jsdom
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+
+vi.mock('../../lib/github', () => ({
+  getGitHubStars: vi.fn(),
+}));
+vi.mock('../ui/Pill', () => ({
+  Pill: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+}));
+
+import { getGitHubStars } from '../../lib/github';
+import { GitHubStarsPill } from './GitHubStarsPill';
+
+describe('GitHubStarsPill', () => {
+  it('renders with star count when fetch succeeds', async () => {
+    (getGitHubStars as ReturnType<typeof vi.fn>).mockResolvedValue(1234);
+    const el = await GitHubStarsPill();
+    const { container } = render(el);
+    expect(container.textContent).toMatch(/1,234/);
+    expect(container.querySelector('a')?.getAttribute('href'))
+      .toBe('https://github.com/cacheplane/angular-agent-framework');
+  });
+
+  it('renders fallback when fetch returns null', async () => {
+    (getGitHubStars as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const el = await GitHubStarsPill();
+    const { container } = render(el);
+    expect(container.textContent).toMatch(/GitHub/);
+    expect(container.textContent).not.toMatch(/\d/);
+  });
+});

--- a/apps/website/src/components/contact/GitHubStarsPill.tsx
+++ b/apps/website/src/components/contact/GitHubStarsPill.tsx
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+import React from 'react';
+import { Pill } from '../ui/Pill';
+import { getGitHubStars } from '../../lib/github';
+
+const REPO = 'cacheplane/angular-agent-framework';
+const REPO_URL = `https://github.com/${REPO}`;
+
+export async function GitHubStarsPill() {
+  const stars = await getGitHubStars(REPO);
+  const label = stars != null ? `★ ${stars.toLocaleString()} on GitHub` : 'GitHub';
+  return (
+    <a
+      href={REPO_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      style={{ textDecoration: 'none' }}
+    >
+      <Pill variant="neutral">{label}</Pill>
+    </a>
+  );
+}

--- a/apps/website/src/components/contact/SlaCard.tsx
+++ b/apps/website/src/components/contact/SlaCard.tsx
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+import React from 'react';
+import { tokens } from '@ngaf/design-tokens';
+import { Card } from '../ui/Card';
+
+export function SlaCard() {
+  return (
+    <Card style={{ padding: 20, maxWidth: 480 }}>
+      <p
+        style={{
+          margin: 0,
+          color: tokens.colors.textPrimary,
+          fontSize: tokens.typography.body.size,
+          fontFamily: tokens.typography.body.family,
+          lineHeight: tokens.typography.body.line,
+        }}
+      >
+        Brian or someone on the team replies personally — from a real inbox, not <code>noreply@</code>. We read every message.
+      </p>
+    </Card>
+  );
+}

--- a/apps/website/src/components/docs/CopyPromptButton.tsx
+++ b/apps/website/src/components/docs/CopyPromptButton.tsx
@@ -7,7 +7,7 @@ import { track } from '../../lib/analytics/client';
 interface Props {
   prompt: string;
   variant?: 'hero' | 'docs';
-  label?: string;
+  label?: `copy_${string}`;
 }
 
 export function CopyPromptButton({ prompt, variant = 'docs', label }: Props) {

--- a/apps/website/src/components/landing/Hero.spec.tsx
+++ b/apps/website/src/components/landing/Hero.spec.tsx
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+// @vitest-environment jsdom
+import React from 'react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+const trackMock = vi.hoisted(() => vi.fn());
+const writeTextMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
+vi.mock('../../lib/analytics/client', () => ({
+  track: trackMock,
+}));
+
+// Stub design-system primitives — they don't import React (rely on Next's
+// automatic JSX runtime) but the vitest transform here doesn't auto-inject.
+// We're testing Hero's CTA wiring, not the wrappers.
+vi.mock('../ui/Container', () => ({
+  Container: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock('../ui/Section', () => ({
+  Section: ({ children }: { children: React.ReactNode }) => <section>{children}</section>,
+}));
+vi.mock('../ui/Eyebrow', () => ({
+  Eyebrow: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+}));
+vi.mock('../ui/BrowserFrame', () => ({
+  BrowserFrame: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock('../ui/Pill', () => ({
+  Pill: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+}));
+vi.mock('../ui/Button', () => ({
+  Button: ({ children, href, onClick }: { children: React.ReactNode; href?: string; onClick?: () => void }) =>
+    href ? (
+      <a href={href} onClick={onClick}>{children}</a>
+    ) : (
+      <button onClick={onClick}>{children}</button>
+    ),
+}));
+
+beforeEach(() => {
+  trackMock.mockClear();
+  writeTextMock.mockClear();
+  Object.assign(navigator, { clipboard: { writeText: writeTextMock } });
+});
+
+describe('Hero', () => {
+  it('renders the locked H1 and subhead', async () => {
+    const { Hero } = await import('./Hero');
+    render(<Hero />);
+    expect(screen.getByRole('heading', { level: 1 }).textContent)
+      .toMatch(/Ship production agent UIs in Angular\./);
+    expect(screen.getByText(/Signal-native chat, threads, interrupts/)).toBeTruthy();
+  });
+
+  it('primary CTA copies the install command and fires cta_id=hero_install', async () => {
+    const { Hero } = await import('./Hero');
+    render(<Hero />);
+    const btn = screen.getByRole('button', { name: /Install @ngaf\/chat/i });
+    fireEvent.click(btn);
+    expect(writeTextMock).toHaveBeenCalledWith('npm install @ngaf/chat');
+    expect(trackMock).toHaveBeenCalledWith('marketing:cta_click', expect.objectContaining({
+      cta_id: 'hero_install',
+      track: 'developer',
+      surface: 'home',
+    }));
+  });
+
+  it('secondary CTA links to /contact and fires cta_id=hero_talk_to_engineers', async () => {
+    const { Hero } = await import('./Hero');
+    render(<Hero />);
+    const link = screen.getByRole('link', { name: /Talk to our engineers/i });
+    expect(link.getAttribute('href')).toBe('/contact?source=home_hero&track=enterprise');
+    fireEvent.click(link);
+    expect(trackMock).toHaveBeenCalledWith('marketing:cta_click', expect.objectContaining({
+      cta_id: 'hero_talk_to_engineers',
+      track: 'enterprise',
+      surface: 'home',
+    }));
+  });
+});

--- a/apps/website/src/components/landing/Hero.tsx
+++ b/apps/website/src/components/landing/Hero.tsx
@@ -22,7 +22,7 @@ export function Hero() {
           {/* Left column */}
           <div>
             <Eyebrow tone="accent" style={{ marginBottom: 16 }}>
-              Angular Agent Framework · MIT
+              Agent UI for Angular · MIT
             </Eyebrow>
             <h1
               id="hero-heading"

--- a/apps/website/src/components/landing/Hero.tsx
+++ b/apps/website/src/components/landing/Hero.tsx
@@ -1,3 +1,6 @@
+'use client';
+
+import React, { useCallback, useState } from 'react';
 import { tokens } from '@ngaf/design-tokens';
 import { Container } from '../ui/Container';
 import { Section } from '../ui/Section';
@@ -5,6 +8,57 @@ import { Eyebrow } from '../ui/Eyebrow';
 import { Button } from '../ui/Button';
 import { BrowserFrame } from '../ui/BrowserFrame';
 import { Pill } from '../ui/Pill';
+import { track } from '../../lib/analytics/client';
+import { analyticsEvents } from '../../lib/analytics/events';
+
+const INSTALL_COMMAND = 'npm install @ngaf/chat';
+const COPY_FEEDBACK_MS = 1500;
+
+function PrimaryInstallButton() {
+  const [copied, setCopied] = useState(false);
+
+  const onClick = useCallback(async () => {
+    track(analyticsEvents.marketingCtaClick, {
+      cta_id: 'hero_install',
+      track: 'developer',
+      surface: 'home',
+    });
+    try {
+      await navigator.clipboard?.writeText(INSTALL_COMMAND);
+      setCopied(true);
+      setTimeout(() => setCopied(false), COPY_FEEDBACK_MS);
+    } catch {
+      // Silent fail. Event still fires; users can copy from the docs page.
+    }
+  }, []);
+
+  return (
+    <Button variant="primary" size="lg" onClick={onClick}>
+      {copied ? 'Copied ✓' : 'Install @ngaf/chat'}
+    </Button>
+  );
+}
+
+function SecondaryTalkButton() {
+  const onClick = useCallback(() => {
+    track(analyticsEvents.marketingCtaClick, {
+      cta_id: 'hero_talk_to_engineers',
+      track: 'enterprise',
+      surface: 'home',
+    });
+  }, []);
+
+  return (
+    <Button
+      variant="ghost"
+      size="lg"
+      href="/contact?source=home_hero&track=enterprise"
+      onClick={onClick}
+    >
+      Talk to our engineers
+    </Button>
+  );
+}
 
 export function Hero() {
   return (
@@ -37,7 +91,7 @@ export function Hero() {
                 letterSpacing: '-0.02em',
               }}
             >
-              Build fullstack agentic Angular apps.
+              Ship production agent UIs in Angular.
             </h1>
             <p
               style={{
@@ -47,33 +101,47 @@ export function Hero() {
                 color: tokens.colors.textSecondary,
                 margin: 0,
                 marginBottom: 32,
-                maxWidth: '52ch',
+                maxWidth: '54ch',
               }}
             >
-              Build fullstack agentic Angular apps with signal-native streaming, runtime adapters, generative UI, and production-ready primitives.
+              Signal-native chat, threads, interrupts, tool progress, and generative UI for LangGraph, AG-UI, and A2UI. MIT-licensed, self-hostable, app telemetry off by default, no React rewrite.
             </p>
             <div style={{ display: 'flex', gap: 12, marginBottom: 24, flexWrap: 'wrap' }}>
-              <Button variant="primary" size="lg" href="/docs">
-                Get started
-              </Button>
-              <Button
-                variant="ghost"
-                size="lg"
-                href="https://demo.cacheplane.ai"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Try the demo →
-              </Button>
+              <PrimaryInstallButton />
+              <SecondaryTalkButton />
             </div>
-            <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
-              <Pill variant="accent">MIT licensed</Pill>
-              <Pill variant="neutral">Works with LangGraph + AG-UI</Pill>
-              <Pill variant="angular">Angular 20+</Pill>
+            <div
+              style={{
+                display: 'flex',
+                gap: 8,
+                alignItems: 'center',
+                flexWrap: 'wrap',
+                marginBottom: 12,
+              }}
+            >
+              <Pill variant="accent">MIT</Pill>
+              <Pill variant="neutral">Angular-native Signals</Pill>
+              <Pill variant="neutral">LangGraph + AG-UI</Pill>
+              <Pill variant="neutral">A2UI-compatible</Pill>
+              <Pill variant="neutral">Self-hostable</Pill>
+              <Pill variant="neutral">App telemetry off by default</Pill>
             </div>
+            <p
+              style={{
+                margin: 0,
+                fontFamily: tokens.typography.body.family,
+                fontSize: tokens.typography.body.size,
+                lineHeight: tokens.typography.body.line,
+                color: tokens.colors.textMuted,
+                fontStyle: 'italic',
+                maxWidth: '60ch',
+              }}
+            >
+              Not another backend agent runtime. Keep LangGraph, Genkit, Mastra, CrewAI, or your own service. Cacheplane solves the Angular UI layer.
+            </p>
           </div>
 
-          {/* Right column — layered collage */}
+          {/* Right column — layered collage (preserved verbatim from prior Hero.tsx) */}
           <div style={{ position: 'relative', minHeight: 420 }} aria-hidden="true">
             <BrowserFrame
               url="demo.cacheplane.ai"

--- a/apps/website/src/components/landing/HomeFAQ.tsx
+++ b/apps/website/src/components/landing/HomeFAQ.tsx
@@ -7,7 +7,7 @@ import { FAQ, type FAQItem } from '../ui/FAQ';
 const ITEMS: FAQItem[] = [
   {
     q: 'How is this different from CopilotKit or AG-UI directly?',
-    a: 'CopilotKit has an Angular SDK; ours is built around signals and DI as the substrate, not a port. AG-UI is a protocol, not a UI library — you still build the Angular side. Angular Agent Framework gives you signal-native primitives plus adapters that hide the protocol, so you can swap LangGraph for AG-UI without rewriting your UI.',
+    a: 'CopilotKit has an Angular SDK; ours is built around signals and DI as the substrate, not a port. AG-UI is a protocol, not a UI library — you still build the Angular side. Agent UI for Angular gives you signal-native primitives plus adapters that hide the protocol, so you can swap LangGraph for AG-UI without rewriting your UI.',
   },
   {
     q: 'Does it work with my existing Angular app?',

--- a/apps/website/src/components/landing/WhitePaperBlock.tsx
+++ b/apps/website/src/components/landing/WhitePaperBlock.tsx
@@ -295,7 +295,7 @@ export function WhitePaperBlock({ paper = 'overview' }: WhitePaperBlockProps = {
                     letterSpacing: '0.1em',
                   }}
                 >
-                  Angular Agent Framework
+                  Agent UI for Angular
                 </div>
               </div>
             </BrowserFrame>

--- a/apps/website/src/components/pricing/CompareTable.tsx
+++ b/apps/website/src/components/pricing/CompareTable.tsx
@@ -4,7 +4,7 @@ import { tokens } from '@ngaf/design-tokens';
 const ROWS = [
   { feature: 'npm install', oss: true, seat: true, app: true, enterprise: true },
   { feature: 'Commercial use', oss: false, seat: true, app: true, enterprise: true },
-  { feature: 'All Angular versions', oss: true, seat: true, app: true, enterprise: true },
+  { feature: 'See compatibility matrix below', oss: true, seat: true, app: true, enterprise: true },
   { feature: 'Email support', oss: false, seat: true, app: true, enterprise: true },
   { feature: 'Source access', oss: true, seat: true, app: true, enterprise: true },
   { feature: 'Per-app deployment', oss: false, seat: false, app: true, enterprise: true },

--- a/apps/website/src/components/pricing/CompatibilityMatrix.spec.tsx
+++ b/apps/website/src/components/pricing/CompatibilityMatrix.spec.tsx
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+// @vitest-environment jsdom
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { CompatibilityMatrix } from './CompatibilityMatrix';
+
+describe('CompatibilityMatrix', () => {
+  it('renders four buckets with the conservative content', () => {
+    render(<CompatibilityMatrix />);
+    expect(screen.getByText(/Supported/)).toBeTruthy();
+    expect(screen.getByText(/Angular 20, 21/)).toBeTruthy();
+    expect(screen.getByText(/Experimental/)).toBeTruthy();
+    expect(screen.getByText(/Planned/)).toBeTruthy();
+    expect(screen.getByText(/Angular 22/)).toBeTruthy();
+    expect(screen.getByText(/Unsupported/)).toBeTruthy();
+    expect(screen.getByText(/≤19/)).toBeTruthy();
+  });
+});

--- a/apps/website/src/components/pricing/CompatibilityMatrix.tsx
+++ b/apps/website/src/components/pricing/CompatibilityMatrix.tsx
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+import React from 'react';
+import { tokens } from '@ngaf/design-tokens';
+
+interface Row {
+  label: string;
+  versions: string;
+  tone: 'success' | 'warn' | 'info' | 'muted';
+}
+
+const ROWS: ReadonlyArray<Row> = [
+  { label: 'Supported',    versions: 'Angular 20, 21', tone: 'success' },
+  { label: 'Experimental', versions: '—',              tone: 'warn'    },
+  { label: 'Planned',      versions: 'Angular 22',     tone: 'info'    },
+  { label: 'Unsupported',  versions: 'Angular ≤19',    tone: 'muted'   },
+];
+
+const TONE_COLORS: Record<Row['tone'], string> = {
+  success: '#16a34a',
+  warn:    '#d97706',
+  info:    tokens.colors.accent,
+  muted:   tokens.colors.textMuted,
+};
+
+export function CompatibilityMatrix() {
+  return (
+    <div
+      style={{
+        border: `1px solid ${tokens.surfaces.border}`,
+        borderRadius: 8,
+        overflow: 'hidden',
+      }}
+    >
+      <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+        <thead>
+          <tr style={{ background: tokens.surfaces.surface }}>
+            <th
+              style={{
+                textAlign: 'left',
+                padding: '12px 16px',
+                fontWeight: 600,
+                color: tokens.colors.textPrimary,
+                fontSize: tokens.typography.body.size,
+                borderBottom: `1px solid ${tokens.surfaces.border}`,
+              }}
+            >
+              Status
+            </th>
+            <th
+              style={{
+                textAlign: 'left',
+                padding: '12px 16px',
+                fontWeight: 600,
+                color: tokens.colors.textPrimary,
+                fontSize: tokens.typography.body.size,
+                borderBottom: `1px solid ${tokens.surfaces.border}`,
+              }}
+            >
+              Angular versions
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {ROWS.map((row) => (
+            <tr key={row.label}>
+              <td
+                style={{
+                  padding: '12px 16px',
+                  fontSize: tokens.typography.body.size,
+                  color: TONE_COLORS[row.tone],
+                  fontWeight: 500,
+                  borderBottom: `1px solid ${tokens.surfaces.border}`,
+                }}
+              >
+                {row.label}
+              </td>
+              <td
+                style={{
+                  padding: '12px 16px',
+                  fontSize: tokens.typography.body.size,
+                  color: tokens.colors.textSecondary,
+                  fontFamily: tokens.typography.fontMono,
+                  borderBottom: `1px solid ${tokens.surfaces.border}`,
+                }}
+              >
+                {row.versions}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/website/src/components/shared/Footer.tsx
+++ b/apps/website/src/components/shared/Footer.tsx
@@ -300,7 +300,7 @@ export function Footer() {
         {/* Bottom bar */}
         <div className="mt-12 pt-8 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2 text-xs"
           style={{ borderTop: `1px solid ${tokens.surfaces.border}`, color: tokens.colors.textMuted }}>
-          <span>&copy; {new Date().getFullYear()} Angular Agent Framework. All rights reserved.</span>
+          <span>&copy; {new Date().getFullYear()} Agent UI for Angular. All rights reserved.</span>
           <span>MIT License &middot; <Link href="/pricing" className="transition-colors"
             onClick={() => trackFooterCta('Pricing Bottom', '/pricing')}
             onMouseEnter={(e) => (e.currentTarget.style.color = tokens.colors.accent)}

--- a/apps/website/src/components/shared/Nav.tsx
+++ b/apps/website/src/components/shared/Nav.tsx
@@ -94,7 +94,9 @@ export function Nav() {
 
   const currentLib = docsConfig.find(lib => lib.id === mobileLibrary);
   const trackNavLink = (label: string, href: string, external: boolean, surface: 'nav' | 'mobile_nav') => {
-    const ctaId = `${surface}_${label.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_|_$/g, '')}`;
+    const slug = label.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_|_$/g, '');
+    const ctaId: `nav_${string}` | `mobile_nav_${string}` =
+      surface === 'nav' ? `nav_${slug}` : `mobile_nav_${slug}`;
     if (external) {
       trackExternalLinkClick(href, { surface, cta_id: ctaId, cta_text: label });
       return;

--- a/apps/website/src/components/ui/LogoMark.tsx
+++ b/apps/website/src/components/ui/LogoMark.tsx
@@ -41,7 +41,7 @@ export function LogoMark({
       {...rest}
     >
       <span aria-hidden="true" style={{ fontSize: s.icon, lineHeight: 1 }}>🛩️</span>
-      {iconOnly ? null : <span>Angular Agent Framework</span>}
+      {iconOnly ? null : <span>Agent UI for Angular</span>}
     </span>
   );
 }

--- a/apps/website/src/lib/analytics/events.ts
+++ b/apps/website/src/lib/analytics/events.ts
@@ -34,6 +34,33 @@ export type AnalyticsSurface =
   | 'solution'
   | 'toast';
 
+/**
+ * Stable identifiers for marketing CTAs. New CTAs must be added to this
+ * union so PostHog gets consistent slicing — misspellings then become
+ * a build-time error.
+ *
+ * Template-literal members (e.g. `nav_${string}`) cover callsites that
+ * derive cta_id dynamically from a human label.
+ */
+export type CtaId =
+  // Hero (Spec 2)
+  | 'hero_install'
+  | 'hero_talk_to_engineers'
+  // Whitepaper block on home
+  | 'home_whitepaper_direct'
+  | 'home_whitepaper_direct_inline'
+  // Announcement toast
+  | 'toast_get_guide'
+  | 'toast_direct_download'
+  // Docs surfaces — copy buttons take a dynamic label fallback
+  | 'copy_code'
+  | 'copy_prompt'
+  | `copy_${string}`
+  // Nav + footer derive ids from labels at runtime
+  | `nav_${string}`
+  | `mobile_nav_${string}`
+  | `footer_${string}`;
+
 export type AnalyticsLibrary = 'agent' | 'render' | 'chat' | 'unknown';
 
 export type WhitepaperId = 'overview' | 'angular' | 'render' | 'chat';
@@ -42,7 +69,7 @@ export type AnalyticsProperties = {
   source_page?: string;
   source_section?: string;
   destination_url?: string;
-  cta_id?: string;
+  cta_id?: CtaId;
   cta_text?: string;
   surface?: AnalyticsSurface;
   library?: AnalyticsLibrary;

--- a/apps/website/src/lib/analytics/events.ts
+++ b/apps/website/src/lib/analytics/events.ts
@@ -32,7 +32,8 @@ export type AnalyticsSurface =
   | 'docs'
   | 'library_landing'
   | 'solution'
-  | 'toast';
+  | 'toast'
+  | 'contact';
 
 /**
  * Stable identifiers for marketing CTAs. New CTAs must be added to this

--- a/apps/website/src/lib/docs.spec.ts
+++ b/apps/website/src/lib/docs.spec.ts
@@ -72,17 +72,17 @@ describe('website docs bindings', () => {
     const metadata = getDocMetadata('ag-ui', 'reference', 'event-mapping');
 
     expect(metadata).toMatchObject({
-      title: 'Event Mapping - AG-UI Docs - Angular Agent Framework',
+      title: 'Event Mapping - AG-UI Docs - Agent UI for Angular',
       alternates: {
         canonical: '/docs/ag-ui/reference/event-mapping',
       },
       openGraph: {
-        title: 'Event Mapping - AG-UI Docs - Angular Agent Framework',
+        title: 'Event Mapping - AG-UI Docs - Agent UI for Angular',
         url: '/docs/ag-ui/reference/event-mapping',
       },
       twitter: {
         card: 'summary_large_image',
-        title: 'Event Mapping - AG-UI Docs - Angular Agent Framework',
+        title: 'Event Mapping - AG-UI Docs - Agent UI for Angular',
       },
     });
     expect(metadata?.description).toContain('AG-UI protocol events');

--- a/apps/website/src/lib/docs.ts
+++ b/apps/website/src/lib/docs.ts
@@ -86,8 +86,8 @@ export function getDocMetadata(
 
   const lib = getLibraryConfig(library);
   const libraryTitle = lib?.title ?? 'Docs';
-  const title = `${doc.title} - ${libraryTitle} Docs - Angular Agent Framework`;
-  const description = getDocDescription(doc.content, lib?.description ?? 'Angular Agent Framework documentation');
+  const title = `${doc.title} - ${libraryTitle} Docs - Agent UI for Angular`;
+  const description = getDocDescription(doc.content, lib?.description ?? 'Agent UI for Angular documentation');
   const pathname = `/docs/${library}/${section}/${slug}`;
 
   return createPageMetadata({ title, description, pathname });

--- a/apps/website/src/lib/github.spec.ts
+++ b/apps/website/src/lib/github.spec.ts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { getGitHubStars } from './github';
+
+const fetchMock = vi.hoisted(() => vi.fn());
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+describe('getGitHubStars', () => {
+  it('returns the stargazers_count on 2xx', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ stargazers_count: 1234 }),
+    });
+    const stars = await getGitHubStars('cacheplane/angular-agent-framework');
+    expect(stars).toBe(1234);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.github.com/repos/cacheplane/angular-agent-framework',
+      expect.objectContaining({
+        next: { revalidate: 86400 },
+      }),
+    );
+  });
+
+  it('returns null on non-2xx', async () => {
+    fetchMock.mockResolvedValue({ ok: false, json: async () => ({}) });
+    expect(await getGitHubStars('owner/repo')).toBeNull();
+  });
+
+  it('returns null when fetch throws', async () => {
+    fetchMock.mockRejectedValue(new Error('network'));
+    expect(await getGitHubStars('owner/repo')).toBeNull();
+  });
+
+  it('returns null when payload lacks stargazers_count', async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({}) });
+    expect(await getGitHubStars('owner/repo')).toBeNull();
+  });
+});

--- a/apps/website/src/lib/github.ts
+++ b/apps/website/src/lib/github.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+export async function getGitHubStars(
+  repo = 'cacheplane/angular-agent-framework',
+): Promise<number | null> {
+  try {
+    const res = await fetch(`https://api.github.com/repos/${repo}`, {
+      next: { revalidate: 86400 },
+      headers: { Accept: 'application/vnd.github+json' },
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { stargazers_count?: number };
+    return typeof data.stargazers_count === 'number' ? data.stargazers_count : null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/website/src/lib/site-metadata.ts
+++ b/apps/website/src/lib/site-metadata.ts
@@ -3,7 +3,7 @@ import { getAllSolutionSlugs } from './solutions-data';
 import { docsConfig } from './docs-config';
 
 export const SITE_ORIGIN = 'https://cacheplane.ai';
-export const SITE_NAME = 'Angular Agent Framework';
+export const SITE_NAME = 'Agent UI for Angular';
 export const DEFAULT_SOCIAL_IMAGE = '/opengraph-image';
 
 export function getCanonicalPath(pathname: string): string {

--- a/apps/website/src/lib/solutions-data.ts
+++ b/apps/website/src/lib/solutions-data.ts
@@ -84,7 +84,7 @@ export const SOLUTIONS: SolutionConfig[] = [
     ],
     ctaHeadline: 'Ship compliant AI agents — without the compliance tax',
     ctaSubtext: 'Download the field report or start a pilot. Your compliance team will thank you.',
-    metaTitle: 'Compliance & Audit — Angular Agent Framework Solutions',
+    metaTitle: 'Compliance & Audit — Agent UI for Angular Solutions',
     metaDescription: 'Ship AI agents with human-in-the-loop approvals, auditable thread history, and deterministic testing. Built for SOX, HIPAA, and GDPR workflows.',
   },
   {
@@ -133,7 +133,7 @@ export const SOLUTIONS: SolutionConfig[] = [
     ],
     ctaHeadline: 'Turn your data into conversations',
     ctaSubtext: 'Download the field report or start a pilot. Ship a conversational BI experience in weeks, not quarters.',
-    metaTitle: 'Analytics & BI — Angular Agent Framework Solutions',
+    metaTitle: 'Analytics & BI — Agent UI for Angular Solutions',
     metaDescription: 'Build conversational BI with natural language queries, streaming results, and generative UI — all in Angular.',
   },
   {
@@ -182,7 +182,7 @@ export const SOLUTIONS: SolutionConfig[] = [
     ],
     ctaHeadline: 'Support agents that make your team better',
     ctaSubtext: 'Download the field report or start a pilot. Resolve routine tickets, escalate the rest with full context, keep your customers happy.',
-    metaTitle: 'Customer Support — Angular Agent Framework Solutions',
+    metaTitle: 'Customer Support — Agent UI for Angular Solutions',
     metaDescription: 'Build AI support agents with human escalation, full context handoff, and production-ready chat UI in Angular.',
   },
 ];

--- a/apps/website/tsconfig.json
+++ b/apps/website/tsconfig.json
@@ -21,13 +21,15 @@
     "paths": {
       "@/*": ["./src/*"],
       "@ngaf/cockpit-docs": ["../../libs/cockpit-docs/src/index.ts"],
-      "@ngaf/cockpit-registry": [
-        "../../libs/cockpit-registry/src/index.ts"
-      ],
+      "@ngaf/cockpit-registry": ["../../libs/cockpit-registry/src/index.ts"],
       "@ngaf/cockpit-shell": ["../../libs/cockpit-shell/src/index.ts"],
       "@ngaf/design-tokens": ["../../libs/design-tokens/src/index.ts"],
-      "@ngaf/telemetry/shared": ["../../libs/telemetry/src/shared/public-api.ts"],
-      "@ngaf/telemetry/browser": ["../../libs/telemetry/src/browser/public-api.ts"]
+      "@ngaf/telemetry/shared": [
+        "../../libs/telemetry/src/shared/public-api.ts"
+      ],
+      "@ngaf/telemetry/browser": [
+        "../../libs/telemetry/src/browser/public-api.ts"
+      ]
     }
   },
   "include": [
@@ -47,5 +49,13 @@
     "src/**/*.spec.ts",
     "src/**/*.test.ts",
     ".next"
+  ],
+  "references": [
+    {
+      "path": "../../libs/design-tokens"
+    },
+    {
+      "path": "../../libs/telemetry"
+    }
   ]
 }

--- a/cockpit/ag-ui/streaming/angular/tsconfig.app.json
+++ b/cockpit/ag-ui/streaming/angular/tsconfig.app.json
@@ -7,5 +7,16 @@
     "emitDeclarationOnly": false
   },
   "files": ["src/main.ts"],
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "references": [
+    {
+      "path": "../../../../libs/example-layouts"
+    },
+    {
+      "path": "../../../../libs/chat"
+    },
+    {
+      "path": "../../../../libs/ag-ui"
+    }
+  ]
 }

--- a/cockpit/chat/a2ui/angular/tsconfig.app.json
+++ b/cockpit/chat/a2ui/angular/tsconfig.app.json
@@ -5,5 +5,19 @@
     "types": []
   },
   "files": ["src/main.ts"],
-  "include": ["src/**/*.d.ts", "src/**/*.ts"]
+  "include": ["src/**/*.d.ts", "src/**/*.ts"],
+  "references": [
+    {
+      "path": "../../../../libs/cockpit-telemetry"
+    },
+    {
+      "path": "../../../../libs/langgraph"
+    },
+    {
+      "path": "../../../../libs/example-layouts"
+    },
+    {
+      "path": "../../../../libs/chat"
+    }
+  ]
 }

--- a/cockpit/chat/debug/angular/tsconfig.app.json
+++ b/cockpit/chat/debug/angular/tsconfig.app.json
@@ -5,5 +5,19 @@
     "types": []
   },
   "files": ["src/main.ts"],
-  "include": ["src/**/*.d.ts", "src/**/*.ts"]
+  "include": ["src/**/*.d.ts", "src/**/*.ts"],
+  "references": [
+    {
+      "path": "../../../../libs/cockpit-telemetry"
+    },
+    {
+      "path": "../../../../libs/example-layouts"
+    },
+    {
+      "path": "../../../../libs/chat"
+    },
+    {
+      "path": "../../../../libs/langgraph"
+    }
+  ]
 }

--- a/cockpit/chat/generative-ui/angular/tsconfig.app.json
+++ b/cockpit/chat/generative-ui/angular/tsconfig.app.json
@@ -6,5 +6,22 @@
   },
   "files": ["src/main.ts"],
   "include": ["src/**/*.d.ts", "src/**/*.ts"],
-  "exclude": ["src/**/*.spec.ts"]
+  "exclude": ["src/**/*.spec.ts"],
+  "references": [
+    {
+      "path": "../../../../libs/cockpit-telemetry"
+    },
+    {
+      "path": "../../../../libs/render"
+    },
+    {
+      "path": "../../../../libs/example-layouts"
+    },
+    {
+      "path": "../../../../libs/chat"
+    },
+    {
+      "path": "../../../../libs/langgraph"
+    }
+  ]
 }

--- a/cockpit/chat/input/angular/tsconfig.app.json
+++ b/cockpit/chat/input/angular/tsconfig.app.json
@@ -5,5 +5,19 @@
     "types": []
   },
   "files": ["src/main.ts"],
-  "include": ["src/**/*.d.ts", "src/**/*.ts"]
+  "include": ["src/**/*.d.ts", "src/**/*.ts"],
+  "references": [
+    {
+      "path": "../../../../libs/cockpit-telemetry"
+    },
+    {
+      "path": "../../../../libs/example-layouts"
+    },
+    {
+      "path": "../../../../libs/chat"
+    },
+    {
+      "path": "../../../../libs/langgraph"
+    }
+  ]
 }

--- a/cockpit/chat/interrupts/angular/tsconfig.app.json
+++ b/cockpit/chat/interrupts/angular/tsconfig.app.json
@@ -5,5 +5,19 @@
     "types": []
   },
   "files": ["src/main.ts"],
-  "include": ["src/**/*.d.ts", "src/**/*.ts"]
+  "include": ["src/**/*.d.ts", "src/**/*.ts"],
+  "references": [
+    {
+      "path": "../../../../libs/cockpit-telemetry"
+    },
+    {
+      "path": "../../../../libs/example-layouts"
+    },
+    {
+      "path": "../../../../libs/chat"
+    },
+    {
+      "path": "../../../../libs/langgraph"
+    }
+  ]
 }

--- a/cockpit/chat/messages/angular/tsconfig.app.json
+++ b/cockpit/chat/messages/angular/tsconfig.app.json
@@ -5,5 +5,19 @@
     "types": []
   },
   "files": ["src/main.ts"],
-  "include": ["src/**/*.d.ts", "src/**/*.ts"]
+  "include": ["src/**/*.d.ts", "src/**/*.ts"],
+  "references": [
+    {
+      "path": "../../../../libs/cockpit-telemetry"
+    },
+    {
+      "path": "../../../../libs/example-layouts"
+    },
+    {
+      "path": "../../../../libs/chat"
+    },
+    {
+      "path": "../../../../libs/langgraph"
+    }
+  ]
 }

--- a/cockpit/chat/subagents/angular/tsconfig.app.json
+++ b/cockpit/chat/subagents/angular/tsconfig.app.json
@@ -5,5 +5,22 @@
     "types": []
   },
   "files": ["src/main.ts"],
-  "include": ["src/**/*.d.ts", "src/**/*.ts"]
+  "include": ["src/**/*.d.ts", "src/**/*.ts"],
+  "references": [
+    {
+      "path": "../../../../libs/cockpit-telemetry"
+    },
+    {
+      "path": "../../../../libs/example-layouts"
+    },
+    {
+      "path": "../../../../libs/chat"
+    },
+    {
+      "path": "../../../../libs/langgraph"
+    },
+    {
+      "path": "../../../../libs/internal/aimock-harness"
+    }
+  ]
 }

--- a/cockpit/chat/theming/angular/tsconfig.app.json
+++ b/cockpit/chat/theming/angular/tsconfig.app.json
@@ -5,5 +5,19 @@
     "types": []
   },
   "files": ["src/main.ts"],
-  "include": ["src/**/*.d.ts", "src/**/*.ts"]
+  "include": ["src/**/*.d.ts", "src/**/*.ts"],
+  "references": [
+    {
+      "path": "../../../../libs/cockpit-telemetry"
+    },
+    {
+      "path": "../../../../libs/example-layouts"
+    },
+    {
+      "path": "../../../../libs/chat"
+    },
+    {
+      "path": "../../../../libs/langgraph"
+    }
+  ]
 }

--- a/cockpit/chat/threads/angular/tsconfig.app.json
+++ b/cockpit/chat/threads/angular/tsconfig.app.json
@@ -5,5 +5,19 @@
     "types": []
   },
   "files": ["src/main.ts"],
-  "include": ["src/**/*.d.ts", "src/**/*.ts"]
+  "include": ["src/**/*.d.ts", "src/**/*.ts"],
+  "references": [
+    {
+      "path": "../../../../libs/cockpit-telemetry"
+    },
+    {
+      "path": "../../../../libs/example-layouts"
+    },
+    {
+      "path": "../../../../libs/chat"
+    },
+    {
+      "path": "../../../../libs/langgraph"
+    }
+  ]
 }

--- a/cockpit/chat/timeline/angular/tsconfig.app.json
+++ b/cockpit/chat/timeline/angular/tsconfig.app.json
@@ -5,5 +5,19 @@
     "types": []
   },
   "files": ["src/main.ts"],
-  "include": ["src/**/*.d.ts", "src/**/*.ts"]
+  "include": ["src/**/*.d.ts", "src/**/*.ts"],
+  "references": [
+    {
+      "path": "../../../../libs/cockpit-telemetry"
+    },
+    {
+      "path": "../../../../libs/example-layouts"
+    },
+    {
+      "path": "../../../../libs/chat"
+    },
+    {
+      "path": "../../../../libs/langgraph"
+    }
+  ]
 }

--- a/cockpit/chat/tool-calls/angular/tsconfig.app.json
+++ b/cockpit/chat/tool-calls/angular/tsconfig.app.json
@@ -5,5 +5,22 @@
     "types": []
   },
   "files": ["src/main.ts"],
-  "include": ["src/**/*.d.ts", "src/**/*.ts"]
+  "include": ["src/**/*.d.ts", "src/**/*.ts"],
+  "references": [
+    {
+      "path": "../../../../libs/cockpit-telemetry"
+    },
+    {
+      "path": "../../../../libs/example-layouts"
+    },
+    {
+      "path": "../../../../libs/chat"
+    },
+    {
+      "path": "../../../../libs/langgraph"
+    },
+    {
+      "path": "../../../../libs/internal/aimock-harness"
+    }
+  ]
 }

--- a/cockpit/deep-agents/filesystem/angular/tsconfig.app.json
+++ b/cockpit/deep-agents/filesystem/angular/tsconfig.app.json
@@ -7,5 +7,22 @@
     "emitDeclarationOnly": false
   },
   "files": ["src/main.ts"],
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "references": [
+    {
+      "path": "../../../../libs/cockpit-telemetry"
+    },
+    {
+      "path": "../../../../libs/example-layouts"
+    },
+    {
+      "path": "../../../../libs/render"
+    },
+    {
+      "path": "../../../../libs/chat"
+    },
+    {
+      "path": "../../../../libs/langgraph"
+    }
+  ]
 }

--- a/cockpit/deep-agents/memory/angular/tsconfig.app.json
+++ b/cockpit/deep-agents/memory/angular/tsconfig.app.json
@@ -7,5 +7,22 @@
     "emitDeclarationOnly": false
   },
   "files": ["src/main.ts"],
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "references": [
+    {
+      "path": "../../../../libs/cockpit-telemetry"
+    },
+    {
+      "path": "../../../../libs/example-layouts"
+    },
+    {
+      "path": "../../../../libs/render"
+    },
+    {
+      "path": "../../../../libs/chat"
+    },
+    {
+      "path": "../../../../libs/langgraph"
+    }
+  ]
 }

--- a/cockpit/deep-agents/planning/angular/tsconfig.app.json
+++ b/cockpit/deep-agents/planning/angular/tsconfig.app.json
@@ -7,5 +7,22 @@
     "emitDeclarationOnly": false
   },
   "files": ["src/main.ts"],
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "references": [
+    {
+      "path": "../../../../libs/cockpit-telemetry"
+    },
+    {
+      "path": "../../../../libs/example-layouts"
+    },
+    {
+      "path": "../../../../libs/render"
+    },
+    {
+      "path": "../../../../libs/chat"
+    },
+    {
+      "path": "../../../../libs/langgraph"
+    }
+  ]
 }

--- a/cockpit/deep-agents/sandboxes/angular/tsconfig.app.json
+++ b/cockpit/deep-agents/sandboxes/angular/tsconfig.app.json
@@ -7,5 +7,22 @@
     "emitDeclarationOnly": false
   },
   "files": ["src/main.ts"],
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "references": [
+    {
+      "path": "../../../../libs/cockpit-telemetry"
+    },
+    {
+      "path": "../../../../libs/example-layouts"
+    },
+    {
+      "path": "../../../../libs/render"
+    },
+    {
+      "path": "../../../../libs/chat"
+    },
+    {
+      "path": "../../../../libs/langgraph"
+    }
+  ]
 }

--- a/cockpit/deep-agents/skills/angular/tsconfig.app.json
+++ b/cockpit/deep-agents/skills/angular/tsconfig.app.json
@@ -7,5 +7,22 @@
     "emitDeclarationOnly": false
   },
   "files": ["src/main.ts"],
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "references": [
+    {
+      "path": "../../../../libs/cockpit-telemetry"
+    },
+    {
+      "path": "../../../../libs/example-layouts"
+    },
+    {
+      "path": "../../../../libs/render"
+    },
+    {
+      "path": "../../../../libs/chat"
+    },
+    {
+      "path": "../../../../libs/langgraph"
+    }
+  ]
 }

--- a/cockpit/deep-agents/subagents/angular/tsconfig.app.json
+++ b/cockpit/deep-agents/subagents/angular/tsconfig.app.json
@@ -7,5 +7,22 @@
     "emitDeclarationOnly": false
   },
   "files": ["src/main.ts"],
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "references": [
+    {
+      "path": "../../../../libs/cockpit-telemetry"
+    },
+    {
+      "path": "../../../../libs/example-layouts"
+    },
+    {
+      "path": "../../../../libs/render"
+    },
+    {
+      "path": "../../../../libs/chat"
+    },
+    {
+      "path": "../../../../libs/langgraph"
+    }
+  ]
 }

--- a/cockpit/langgraph/deployment-runtime/angular/tsconfig.app.json
+++ b/cockpit/langgraph/deployment-runtime/angular/tsconfig.app.json
@@ -7,5 +7,19 @@
     "emitDeclarationOnly": false
   },
   "files": ["src/main.ts"],
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "references": [
+    {
+      "path": "../../../../libs/cockpit-telemetry"
+    },
+    {
+      "path": "../../../../libs/example-layouts"
+    },
+    {
+      "path": "../../../../libs/chat"
+    },
+    {
+      "path": "../../../../libs/langgraph"
+    }
+  ]
 }

--- a/cockpit/langgraph/durable-execution/angular/tsconfig.app.json
+++ b/cockpit/langgraph/durable-execution/angular/tsconfig.app.json
@@ -7,5 +7,22 @@
     "emitDeclarationOnly": false
   },
   "files": ["src/main.ts"],
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "references": [
+    {
+      "path": "../../../../libs/cockpit-telemetry"
+    },
+    {
+      "path": "../../../../libs/example-layouts"
+    },
+    {
+      "path": "../../../../libs/render"
+    },
+    {
+      "path": "../../../../libs/chat"
+    },
+    {
+      "path": "../../../../libs/langgraph"
+    }
+  ]
 }

--- a/cockpit/langgraph/interrupts/angular/tsconfig.app.json
+++ b/cockpit/langgraph/interrupts/angular/tsconfig.app.json
@@ -7,5 +7,22 @@
     "emitDeclarationOnly": false
   },
   "files": ["src/main.ts"],
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "references": [
+    {
+      "path": "../../../../libs/cockpit-telemetry"
+    },
+    {
+      "path": "../../../../libs/render"
+    },
+    {
+      "path": "../../../../libs/example-layouts"
+    },
+    {
+      "path": "../../../../libs/chat"
+    },
+    {
+      "path": "../../../../libs/langgraph"
+    }
+  ]
 }

--- a/cockpit/langgraph/memory/angular/tsconfig.app.json
+++ b/cockpit/langgraph/memory/angular/tsconfig.app.json
@@ -7,5 +7,19 @@
     "emitDeclarationOnly": false
   },
   "files": ["src/main.ts"],
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "references": [
+    {
+      "path": "../../../../libs/cockpit-telemetry"
+    },
+    {
+      "path": "../../../../libs/example-layouts"
+    },
+    {
+      "path": "../../../../libs/chat"
+    },
+    {
+      "path": "../../../../libs/langgraph"
+    }
+  ]
 }

--- a/cockpit/langgraph/persistence/angular/tsconfig.app.json
+++ b/cockpit/langgraph/persistence/angular/tsconfig.app.json
@@ -7,5 +7,19 @@
     "emitDeclarationOnly": false
   },
   "files": ["src/main.ts"],
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "references": [
+    {
+      "path": "../../../../libs/cockpit-telemetry"
+    },
+    {
+      "path": "../../../../libs/example-layouts"
+    },
+    {
+      "path": "../../../../libs/chat"
+    },
+    {
+      "path": "../../../../libs/langgraph"
+    }
+  ]
 }

--- a/cockpit/langgraph/streaming/angular/tsconfig.app.json
+++ b/cockpit/langgraph/streaming/angular/tsconfig.app.json
@@ -7,5 +7,22 @@
     "emitDeclarationOnly": false
   },
   "files": ["src/main.ts"],
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "references": [
+    {
+      "path": "../../../../libs/cockpit-telemetry"
+    },
+    {
+      "path": "../../../../libs/example-layouts"
+    },
+    {
+      "path": "../../../../libs/chat"
+    },
+    {
+      "path": "../../../../libs/langgraph"
+    },
+    {
+      "path": "../../../../libs/internal/aimock-harness"
+    }
+  ]
 }

--- a/cockpit/langgraph/subgraphs/angular/tsconfig.app.json
+++ b/cockpit/langgraph/subgraphs/angular/tsconfig.app.json
@@ -7,5 +7,19 @@
     "emitDeclarationOnly": false
   },
   "files": ["src/main.ts"],
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "references": [
+    {
+      "path": "../../../../libs/cockpit-telemetry"
+    },
+    {
+      "path": "../../../../libs/example-layouts"
+    },
+    {
+      "path": "../../../../libs/chat"
+    },
+    {
+      "path": "../../../../libs/langgraph"
+    }
+  ]
 }

--- a/cockpit/langgraph/time-travel/angular/tsconfig.app.json
+++ b/cockpit/langgraph/time-travel/angular/tsconfig.app.json
@@ -7,5 +7,19 @@
     "emitDeclarationOnly": false
   },
   "files": ["src/main.ts"],
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "references": [
+    {
+      "path": "../../../../libs/cockpit-telemetry"
+    },
+    {
+      "path": "../../../../libs/example-layouts"
+    },
+    {
+      "path": "../../../../libs/chat"
+    },
+    {
+      "path": "../../../../libs/langgraph"
+    }
+  ]
 }

--- a/cockpit/render/computed-functions/angular/tsconfig.app.json
+++ b/cockpit/render/computed-functions/angular/tsconfig.app.json
@@ -5,5 +5,16 @@
     "types": []
   },
   "files": ["src/main.ts"],
-  "include": ["src/**/*.d.ts", "src/**/*.ts"]
+  "include": ["src/**/*.d.ts", "src/**/*.ts"],
+  "references": [
+    {
+      "path": "../../../../libs/cockpit-telemetry"
+    },
+    {
+      "path": "../../../../libs/example-layouts"
+    },
+    {
+      "path": "../../../../libs/render"
+    }
+  ]
 }

--- a/cockpit/render/element-rendering/angular/tsconfig.app.json
+++ b/cockpit/render/element-rendering/angular/tsconfig.app.json
@@ -5,5 +5,16 @@
     "types": []
   },
   "files": ["src/main.ts"],
-  "include": ["src/**/*.d.ts", "src/**/*.ts"]
+  "include": ["src/**/*.d.ts", "src/**/*.ts"],
+  "references": [
+    {
+      "path": "../../../../libs/cockpit-telemetry"
+    },
+    {
+      "path": "../../../../libs/example-layouts"
+    },
+    {
+      "path": "../../../../libs/render"
+    }
+  ]
 }

--- a/cockpit/render/registry/angular/tsconfig.app.json
+++ b/cockpit/render/registry/angular/tsconfig.app.json
@@ -5,5 +5,16 @@
     "types": []
   },
   "files": ["src/main.ts"],
-  "include": ["src/**/*.d.ts", "src/**/*.ts"]
+  "include": ["src/**/*.d.ts", "src/**/*.ts"],
+  "references": [
+    {
+      "path": "../../../../libs/cockpit-telemetry"
+    },
+    {
+      "path": "../../../../libs/example-layouts"
+    },
+    {
+      "path": "../../../../libs/render"
+    }
+  ]
 }

--- a/cockpit/render/repeat-loops/angular/tsconfig.app.json
+++ b/cockpit/render/repeat-loops/angular/tsconfig.app.json
@@ -5,5 +5,16 @@
     "types": []
   },
   "files": ["src/main.ts"],
-  "include": ["src/**/*.d.ts", "src/**/*.ts"]
+  "include": ["src/**/*.d.ts", "src/**/*.ts"],
+  "references": [
+    {
+      "path": "../../../../libs/cockpit-telemetry"
+    },
+    {
+      "path": "../../../../libs/example-layouts"
+    },
+    {
+      "path": "../../../../libs/render"
+    }
+  ]
 }

--- a/cockpit/render/spec-rendering/angular/tsconfig.app.json
+++ b/cockpit/render/spec-rendering/angular/tsconfig.app.json
@@ -5,5 +5,16 @@
     "types": []
   },
   "files": ["src/main.ts"],
-  "include": ["src/**/*.d.ts", "src/**/*.ts"]
+  "include": ["src/**/*.d.ts", "src/**/*.ts"],
+  "references": [
+    {
+      "path": "../../../../libs/cockpit-telemetry"
+    },
+    {
+      "path": "../../../../libs/example-layouts"
+    },
+    {
+      "path": "../../../../libs/render"
+    }
+  ]
 }

--- a/cockpit/render/state-management/angular/tsconfig.app.json
+++ b/cockpit/render/state-management/angular/tsconfig.app.json
@@ -5,5 +5,16 @@
     "types": []
   },
   "files": ["src/main.ts"],
-  "include": ["src/**/*.d.ts", "src/**/*.ts"]
+  "include": ["src/**/*.d.ts", "src/**/*.ts"],
+  "references": [
+    {
+      "path": "../../../../libs/cockpit-telemetry"
+    },
+    {
+      "path": "../../../../libs/example-layouts"
+    },
+    {
+      "path": "../../../../libs/render"
+    }
+  ]
 }

--- a/docs/gtm/messaging.md
+++ b/docs/gtm/messaging.md
@@ -49,7 +49,7 @@ Repeat across the site, comparison pages, and content.
 
 **Trust signal:** GitHub star count pill. No logo wall.
 
-**Fields:** email + free-text body. No stack dropdown, no company size, no "how did you hear."
+**Fields:** email (required) + name, company, message (all optional). No stack dropdown, no company size, no "how did you hear." Optional fields feed enterprise-qualification when present.
 
 Hidden attribution fields (populated by URL params + referrer): `source_page`, `track`, `cta_id`, `paper`, `referrer_host`.
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,4 +1,4 @@
-# Angular Agent Framework — Limitations vs React useStream()
+# Agent UI for Angular — Limitations vs React useStream()
 
 Features that are technically impossible or behaviorally degraded when
  porting LangGraph's React `useStream()` hook to Angular.

--- a/docs/superpowers/plans/gtm/2026-05-16-positioning-and-risks.md
+++ b/docs/superpowers/plans/gtm/2026-05-16-positioning-and-risks.md
@@ -1,0 +1,1647 @@
+# Spec 2 — Positioning & Risks Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the locked Direction-A hero, the `/contact` enterprise CTA destination, four risk-cleanup copy sweeps, and CTA tracking that makes the two-track funnel measurable in PostHog.
+
+**Architecture:** Drop-in rewrites of existing landing-surface React components plus new components for the contact route. `getGitHubStars()` uses Next.js ISR (24h) for the trust-signal pill. `/api/leads` validation loosens to email-only; Spec 1E's qualification gate stays in place. Three full-repo copy sweeps run per-file with `git grep -l` + targeted edits — never `replace_all`.
+
+**Tech Stack:** Next.js 16 (App Router); React server + client components; `@ngaf/design-tokens` for typography/colors; Vitest with jsdom for unit tests (`npx vitest run` from `apps/website/`); existing `track(...)` analytics wrapper in `apps/website/src/lib/analytics/client.ts`.
+
+---
+
+## Context for the implementer
+
+- **Spec:** `docs/superpowers/specs/gtm/2026-05-16-positioning-and-risks-design.md` — read §§3–9 before starting.
+- **Locked content lives in `docs/gtm/messaging.md`** — hero copy, contact-page copy. Render the literal words. If the layout crowds, reflow lines but don't rewrite.
+- **Substring-overlap rule** (per the repo's "Chat" memory note): never `replace_all` for the three sweeps. Use `git grep -l <phrase>` to enumerate files, then per-file review for each replacement. "Angular Agent Framework" is a unique phrase but the discipline matters.
+- **Sweep exclusions** (always skip):
+  - `CHANGELOG.md`, anything under `release-notes/`, anything under `docs/superpowers/specs/` and `docs/superpowers/plans/` (historical record / spec lock state)
+  - `docs/gtm/reports/` (weekly snapshots, immutable)
+- **Website has no `nx run website:test` target.** Run vitest directly: `cd apps/website && npx vitest run <path>`. The cockpit and telemetry projects have nx test targets and are unaffected by this spec.
+- **TDD discipline:** write test → run-see-fail → implement → run-see-pass → commit on every code-producing task. Sweep tasks are "git grep → per-file edit → verify build" instead.
+- **Commit format:** conventional commits, one task = one commit.
+- **Worktree branch:** `gtm-spec-2-positioning-and-risks` (already created from `origin/main`, currently at the spec commit `fe049849`).
+
+## File structure (locked)
+
+```
+NEW
+├── apps/website/src/app/contact/page.tsx                    # Phase 2
+├── apps/website/src/components/contact/ContactForm.tsx      # Phase 2 ('use client')
+├── apps/website/src/components/contact/GitHubStarsPill.tsx  # Phase 2 (server component)
+├── apps/website/src/components/contact/AltChannelRow.tsx    # Phase 2
+├── apps/website/src/components/contact/SlaCard.tsx          # Phase 2
+├── apps/website/src/components/pricing/CompatibilityMatrix.tsx  # Phase 3
+├── apps/website/src/lib/github.ts                            # Phase 2
+├── apps/website/src/lib/github.spec.ts                       # Phase 2
+├── apps/website/src/components/landing/Hero.spec.tsx        # Phase 1
+├── apps/website/src/components/contact/ContactForm.spec.tsx # Phase 2
+├── apps/website/src/components/contact/GitHubStarsPill.spec.tsx # Phase 2
+├── apps/website/src/components/pricing/CompatibilityMatrix.spec.tsx # Phase 3
+
+MODIFIED
+├── apps/website/src/lib/analytics/events.ts                 # Phase 1 — CtaId union + AnalyticsProperties.cta_id type
+├── apps/website/src/components/landing/Hero.tsx             # Phase 1 — full content + 'use client'
+├── apps/website/src/app/pricing/page.tsx                    # Phase 3 — replace "All Angular versions" with <CompatibilityMatrix />
+├── apps/website/src/app/api/leads/route.ts                  # Phase 4 — require email only
+├── apps/website/emails/lead-notification.ts                 # Phase 4 — handle missing name (subject + body)
+├── docs/gtm/messaging.md                                    # Phase 4 — Contact §Fields line
+├── ~10–20 files                                             # Phase 0 — three sweeps, per-file review
+```
+
+---
+
+## Phase 0 — Three risk-cleanup copy sweeps
+
+These are mechanical per-file edits. Use `git grep -l <phrase>` to enumerate. **Never `replace_all` — every file is reviewed individually.** Common exclusion patterns: `:!CHANGELOG.md :!release-notes/* :!docs/superpowers/specs/* :!docs/superpowers/plans/* :!docs/gtm/reports/*`.
+
+### Task 0.1: Category sweep — "Angular Agent Framework" → "Agent UI for Angular"
+
+**Approach:** find all files, classify each as (a) page copy/metadata sweep target, (b) skip (historical/spec/release), (c) edge case (component identifier, OG image). Edit per-file. Build verifies.
+
+- [ ] **Step 1: Enumerate occurrences (read-only)**
+
+```bash
+git grep -l "Angular Agent Framework" -- ':!CHANGELOG.md' ':!release-notes/*' ':!docs/superpowers/specs/*' ':!docs/superpowers/plans/*' ':!docs/gtm/reports/*'
+```
+
+Expected output: ~15-25 files across `apps/website/src`, `apps/website/content`, `apps/website/scripts`, `apps/website/emails`, `apps/website/public`, `apps/cockpit/src/app/layout.tsx`, `apps/cockpit/src/app/opengraph-image.tsx`, `libs/*/README.md`, `README.md`, `gtm.md`, and `apps/website/e2e/website.spec.ts`.
+
+- [ ] **Step 2: For each file, edit the human-readable copy occurrences**
+
+Replacement rules:
+- Page titles, metadata, OG alt text, headlines, descriptions: `"Angular Agent Framework"` → `"Agent UI for Angular"`.
+- Sentences where the phrase reads as a category/product name: same replacement.
+- Identifier / variable name occurrences (e.g., `AGENT_FRAMEWORK_PACKAGE_NAME`): **DO NOT change**. These are program identifiers, not copy. There are none in the current repo, but verify per-file.
+- `gtm.md` line 15 ("Do not use: 'Angular Agent Framework'") — leave the substring there because the surrounding text is documenting the don't-use list. If the framing reads oddly post-sweep, rephrase the line; don't excise the phrase.
+- `apps/website/e2e/website.spec.ts` — if the test asserts the phrase, update the assertion. PR #358 moved differentiator assertions to stable ids, but landing tests may still check page title text. Update assertions.
+
+- [ ] **Step 3: Verify builds**
+
+```bash
+npx nx run website:build
+npx nx run cockpit:build
+```
+
+Expected: green.
+
+- [ ] **Step 4: Verify the phrase is gone from the swept surfaces**
+
+```bash
+git grep "Angular Agent Framework" -- ':!CHANGELOG.md' ':!release-notes/*' ':!docs/superpowers/specs/*' ':!docs/superpowers/plans/*' ':!docs/gtm/reports/*'
+```
+
+Expected: zero matches OR only the documented don't-use mention in gtm.md (acceptable).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "$(cat <<'EOF'
+chore(gtm): category sweep — "Angular Agent Framework" → "Agent UI for Angular"
+
+Per-file review across page titles, OG metadata, hero eyebrow, email
+templates, README files, gtm.md, and llms.txt routes. CHANGELOG.md,
+release-notes, and superpowers spec/plan history excluded.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 0.2: A2UI v0.9 sweep — "A2UI v1" → "A2UI v0.9-compatible"
+
+- [ ] **Step 1: Enumerate**
+
+```bash
+git grep -l 'A2UI v1\b' -- ':!CHANGELOG.md' ':!release-notes/*' ':!docs/superpowers/specs/*' ':!docs/superpowers/plans/*' ':!docs/gtm/reports/*'
+```
+
+Known matches (from inspection): `apps/website/src/app/render/page.tsx` (3 occurrences), `apps/website/src/app/page.tsx` (1), `libs/chat/README.md` (1), `libs/render/README.md` (1+), `libs/chat/src/lib/compositions/chat/chat.component.ts` (1 — in a comment), `libs/chat/src/lib/streaming/content-classifier.spec.ts` (2 — in test descriptions referring to the protocol envelope keys).
+
+- [ ] **Step 2: Per-file review and replace**
+
+Replacement rules:
+- User-facing copy ("Google A2UI v1", "A2UI v1 protocol"): `"A2UI v1"` → `"A2UI v0.9-compatible"`.
+- Code comments documenting the protocol envelope (e.g., `// A2UI v1 envelope keys (canonical Google shape).`): change to `// A2UI v0.9 envelope keys (canonical Google shape).` — these reference the actual on-the-wire spec version, not the marketing claim.
+- Test descriptions ("parses A2UI v1 messages"): change to `"parses A2UI v0.9 messages"` for the same reason.
+- The bare token `"v1"` is too short for a safe global edit; only edit where it appears as `"A2UI v1"`.
+
+- [ ] **Step 3: Verify**
+
+```bash
+npx nx run website:build
+npx nx run-many -t test -p chat,render
+git grep 'A2UI v1\b' -- ':!CHANGELOG.md' ':!release-notes/*' ':!docs/superpowers/specs/*' ':!docs/superpowers/plans/*' ':!docs/gtm/reports/*'
+```
+
+Expected: builds green, tests green, zero `A2UI v1` matches.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "$(cat <<'EOF'
+chore(gtm): A2UI sweep — "A2UI v1" → "A2UI v0.9-compatible"
+
+Per-file review. User-facing copy uses "v0.9-compatible"; code comments
+and test descriptions referencing the on-the-wire envelope use plain
+"A2UI v0.9". Tightens claims until v1 is verified.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 0.3: Telemetry phrasing sweep — "No telemetry" → "App telemetry off by default"
+
+- [ ] **Step 1: Enumerate**
+
+```bash
+git grep -E -l "No telemetry|no telemetry" -- ':!CHANGELOG.md' ':!release-notes/*' ':!docs/superpowers/specs/*' ':!docs/superpowers/plans/*' ':!docs/gtm/reports/*' ':!libs/telemetry/*'
+```
+
+(The `libs/telemetry/*` exclusion is deliberate — the trust contract README and source comments use the canonical phrasing already; don't churn them.)
+
+Known surfaces likely to hit: hero proof row (current Hero.tsx still says "No telemetry" or similar), pricing page copy, footer, marketing collateral.
+
+- [ ] **Step 2: Per-file review and replace**
+
+Replacement rules:
+- Marketing copy bullets / pills: `"No telemetry"` → `"App telemetry off by default"`. When the surrounding context already says "no app/runtime telemetry", change to the canonical phrase.
+- When the sweep target is in a structured pill/list with a hyperlink slot, link to `libs/telemetry/README.md` (relative path) where possible.
+- Code comments that say `"No telemetry is emitted unless..."` describe a runtime behavior, not a marketing claim — leave them. Example: `libs/langgraph/src/lib/agent.types.ts:259`. Skip these.
+
+- [ ] **Step 3: Verify**
+
+```bash
+npx nx run website:build
+git grep -E "No telemetry|no telemetry" -- ':!CHANGELOG.md' ':!release-notes/*' ':!docs/superpowers/specs/*' ':!docs/superpowers/plans/*' ':!docs/gtm/reports/*' ':!libs/telemetry/*'
+```
+
+Expected: only the code-comment occurrences remain (acceptable).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "$(cat <<'EOF'
+chore(gtm): telemetry phrasing sweep — "App telemetry off by default"
+
+Replaces marketing claims of "No telemetry" with the precise phrasing
+from libs/telemetry/README.md trust contract. Code comments describing
+runtime behavior are left as-is (they correctly describe the silent
+default, not a marketing claim).
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 1 — Hero rewrite + CTA tracking
+
+### Task 1.1: Add `CtaId` union + tighten `AnalyticsProperties.cta_id`
+
+**File:** `apps/website/src/lib/analytics/events.ts`
+
+- [ ] **Step 1: Add the union below the existing types**
+
+Open `apps/website/src/lib/analytics/events.ts`. Find the existing `AnalyticsSurface` union (around line 24). Append after it:
+
+```typescript
+export type CtaId =
+  | 'hero_install'
+  | 'hero_talk_to_engineers';
+```
+
+- [ ] **Step 2: Tighten `AnalyticsProperties.cta_id`**
+
+In the same file, find the `AnalyticsProperties` type. Change:
+
+```typescript
+cta_id?: string;
+```
+
+to:
+
+```typescript
+cta_id?: CtaId;
+```
+
+If `cta_id?` is currently typed as `string` (no separate line — it's covered by the index signature `[key: string]: ...`), add an explicit `cta_id?: CtaId;` line before the index signature so it takes precedence.
+
+- [ ] **Step 3: Build to surface existing callers**
+
+```bash
+npx nx run website:build
+```
+
+If a callsite uses `cta_id` with a string literal not in the union, the build will fail. **Fix each callsite by either adding the literal to `CtaId` OR removing/fixing the call** — the goal is for every emitted `cta_id` to be a known, documented identifier.
+
+Expected callsites (verify with `grep -rn "cta_id:" apps/website/src --include="*.tsx" --include="*.ts" | grep -v ".spec."`): probably the `AnnouncementToast`, `Footer`, and `client.ts` `track(...)` wrappers if any of them stamp a cta_id. Add their literal values to `CtaId` if they're stable, or remove the property if not.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/website/src/lib/analytics/events.ts apps/website/src/components apps/website/src/lib
+git commit -m "$(cat <<'EOF'
+feat(website): typed CtaId union + tightened AnalyticsProperties.cta_id
+
+Locks the cta_id property to a known union so misspellings or
+inconsistent slicing in PostHog get caught at build time. Initial
+members: hero_install (developer track), hero_talk_to_engineers
+(enterprise track). Existing callers update to use union members.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 1.2: TDD — Hero.spec.tsx for both CTAs
+
+**File:** `apps/website/src/components/landing/Hero.spec.tsx` (NEW)
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// SPDX-License-Identifier: MIT
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+const trackMock = vi.hoisted(() => vi.fn());
+const writeTextMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
+vi.mock('../../lib/analytics/client', () => ({
+  track: trackMock,
+}));
+
+beforeEach(() => {
+  trackMock.mockClear();
+  writeTextMock.mockClear();
+  Object.assign(navigator, { clipboard: { writeText: writeTextMock } });
+});
+
+describe('Hero', () => {
+  it('renders the locked H1 and subhead', async () => {
+    const { Hero } = await import('./Hero');
+    render(<Hero />);
+    expect(screen.getByRole('heading', { level: 1 }).textContent)
+      .toMatch(/Ship production agent UIs in Angular\./);
+    expect(screen.getByText(/Signal-native chat, threads, interrupts/)).toBeTruthy();
+  });
+
+  it('primary CTA copies the install command and fires cta_id=hero_install', async () => {
+    const { Hero } = await import('./Hero');
+    render(<Hero />);
+    const btn = screen.getByRole('button', { name: /Install @ngaf\/chat/i });
+    fireEvent.click(btn);
+    expect(writeTextMock).toHaveBeenCalledWith('npm install @ngaf/chat');
+    expect(trackMock).toHaveBeenCalledWith('marketing:cta_click', expect.objectContaining({
+      cta_id: 'hero_install',
+      track: 'developer',
+      surface: 'home',
+    }));
+  });
+
+  it('secondary CTA links to /contact and fires cta_id=hero_talk_to_engineers', async () => {
+    const { Hero } = await import('./Hero');
+    render(<Hero />);
+    const link = screen.getByRole('link', { name: /Talk to our engineers/i });
+    expect(link.getAttribute('href')).toBe('/contact?source=home_hero&track=enterprise');
+    fireEvent.click(link);
+    expect(trackMock).toHaveBeenCalledWith('marketing:cta_click', expect.objectContaining({
+      cta_id: 'hero_talk_to_engineers',
+      track: 'enterprise',
+      surface: 'home',
+    }));
+  });
+});
+```
+
+- [ ] **Step 2: Run, see fail**
+
+```bash
+cd apps/website && npx vitest run src/components/landing/Hero.spec.tsx
+```
+
+Expected: fails (Hero still has the old copy + old CTAs).
+
+- [ ] **Step 3: NO COMMIT** — Task 1.3 implements.
+
+### Task 1.3: Implement Hero rewrite
+
+**File:** `apps/website/src/components/landing/Hero.tsx` (MODIFIED — full content replacement of the left column; right column collage unchanged)
+
+- [ ] **Step 1: Replace Hero.tsx**
+
+```typescript
+'use client';
+
+import { useCallback, useState } from 'react';
+import { tokens } from '@ngaf/design-tokens';
+import { Container } from '../ui/Container';
+import { Section } from '../ui/Section';
+import { Eyebrow } from '../ui/Eyebrow';
+import { Button } from '../ui/Button';
+import { BrowserFrame } from '../ui/BrowserFrame';
+import { Pill } from '../ui/Pill';
+import { track } from '../../lib/analytics/client';
+import { analyticsEvents } from '../../lib/analytics/events';
+
+const INSTALL_COMMAND = 'npm install @ngaf/chat';
+const COPY_FEEDBACK_MS = 1500;
+
+function PrimaryInstallButton() {
+  const [copied, setCopied] = useState(false);
+
+  const onClick = useCallback(async () => {
+    track(analyticsEvents.marketingCtaClick, {
+      cta_id: 'hero_install',
+      track: 'developer',
+      surface: 'home',
+    });
+    try {
+      await navigator.clipboard?.writeText(INSTALL_COMMAND);
+      setCopied(true);
+      setTimeout(() => setCopied(false), COPY_FEEDBACK_MS);
+    } catch {
+      // Silent fail. Event still fires; users can copy from the docs page.
+    }
+  }, []);
+
+  return (
+    <Button variant="primary" size="lg" onClick={onClick}>
+      {copied ? 'Copied ✓' : 'Install @ngaf/chat'}
+    </Button>
+  );
+}
+
+function SecondaryTalkButton() {
+  const onClick = useCallback(() => {
+    track(analyticsEvents.marketingCtaClick, {
+      cta_id: 'hero_talk_to_engineers',
+      track: 'enterprise',
+      surface: 'home',
+    });
+  }, []);
+
+  return (
+    <Button
+      variant="ghost"
+      size="lg"
+      href="/contact?source=home_hero&track=enterprise"
+      onClick={onClick}
+    >
+      Talk to our engineers
+    </Button>
+  );
+}
+
+export function Hero() {
+  return (
+    <Section surface="canvas" ariaLabelledBy="hero-heading">
+      <Container>
+        <div
+          className="hero-grid"
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'minmax(0, 1fr) minmax(0, 1fr)',
+            gap: 64,
+            alignItems: 'center',
+          }}
+        >
+          {/* Left column */}
+          <div>
+            <Eyebrow tone="accent" style={{ marginBottom: 16 }}>
+              Agent UI for Angular · MIT
+            </Eyebrow>
+            <h1
+              id="hero-heading"
+              style={{
+                fontFamily: tokens.typography.h1.family,
+                fontSize: tokens.typography.h1.size,
+                lineHeight: tokens.typography.h1.line,
+                fontWeight: 700,
+                color: tokens.colors.textPrimary,
+                margin: 0,
+                marginBottom: 24,
+                letterSpacing: '-0.02em',
+              }}
+            >
+              Ship production agent UIs in Angular.
+            </h1>
+            <p
+              style={{
+                fontFamily: tokens.typography.bodyLg.family,
+                fontSize: tokens.typography.bodyLg.size,
+                lineHeight: tokens.typography.bodyLg.line,
+                color: tokens.colors.textSecondary,
+                margin: 0,
+                marginBottom: 32,
+                maxWidth: '54ch',
+              }}
+            >
+              Signal-native chat, threads, interrupts, tool progress, and generative UI for LangGraph, AG-UI, and A2UI. MIT-licensed, self-hostable, app telemetry off by default, no React rewrite.
+            </p>
+            <div style={{ display: 'flex', gap: 12, marginBottom: 24, flexWrap: 'wrap' }}>
+              <PrimaryInstallButton />
+              <SecondaryTalkButton />
+            </div>
+            <div
+              style={{
+                display: 'flex',
+                gap: 8,
+                alignItems: 'center',
+                flexWrap: 'wrap',
+                marginBottom: 12,
+              }}
+            >
+              <Pill variant="accent">MIT</Pill>
+              <Pill variant="neutral">Angular-native Signals</Pill>
+              <Pill variant="neutral">LangGraph + AG-UI</Pill>
+              <Pill variant="neutral">A2UI-compatible</Pill>
+              <Pill variant="neutral">Self-hostable</Pill>
+              <Pill variant="neutral">App telemetry off by default</Pill>
+            </div>
+            <p
+              style={{
+                margin: 0,
+                fontFamily: tokens.typography.body.family,
+                fontSize: tokens.typography.body.size,
+                lineHeight: tokens.typography.body.line,
+                color: tokens.colors.textMuted,
+                fontStyle: 'italic',
+                maxWidth: '60ch',
+              }}
+            >
+              Not another backend agent runtime. Keep LangGraph, Genkit, Mastra, CrewAI, or your own service. Cacheplane solves the Angular UI layer.
+            </p>
+          </div>
+
+          {/* Right column — KEEP existing layered collage exactly as-is. Re-paste from
+              the prior version of this file (BrowserFrame x 2 with screenshots + code). */}
+          <div style={{ position: 'relative', minHeight: 420 }} aria-hidden="true">
+            {/* ...preserve the collage block from the prior Hero.tsx... */}
+          </div>
+        </div>
+      </Container>
+    </Section>
+  );
+}
+```
+
+**Important:** the right-column collage in the prior `Hero.tsx` is 70+ lines of `<BrowserFrame>` markup. Preserve it verbatim. Don't re-author it.
+
+- [ ] **Step 2: Run the spec from Task 1.2 — see pass**
+
+```bash
+cd apps/website && npx vitest run src/components/landing/Hero.spec.tsx
+```
+
+Expected: 3 tests passing.
+
+- [ ] **Step 3: Run the full landing test suite + build**
+
+```bash
+cd apps/website && npx vitest run src/components/landing
+npx nx run website:build
+```
+
+Expected: green. Pre-existing failures unrelated to Hero (e2e under wrong runner, open-in-cockpit JSX) may persist — not in scope.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/website/src/components/landing/Hero.tsx apps/website/src/components/landing/Hero.spec.tsx
+git commit -m "$(cat <<'EOF'
+feat(website): hero rewrite per Spec 2 — Direction A copy + tracked CTAs
+
+- H1: "Ship production agent UIs in Angular."
+- Subhead per docs/gtm/messaging.md
+- Primary CTA: copies "npm install @ngaf/chat", fires cta_id=hero_install
+  (track=developer)
+- Secondary CTA: links to /contact?source=home_hero&track=enterprise,
+  fires cta_id=hero_talk_to_engineers (track=enterprise)
+- Eyebrow updated to "Agent UI for Angular · MIT"
+- Proof pills + subline match the locked copy
+
+Three tests cover both CTAs (event payload + clipboard write + link href).
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 2 — `/contact` route + supporting components
+
+### Task 2.1: `getGitHubStars` helper + spec
+
+**Files:** `apps/website/src/lib/github.ts` (NEW), `apps/website/src/lib/github.spec.ts` (NEW)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/website/src/lib/github.spec.ts`:
+
+```typescript
+// SPDX-License-Identifier: MIT
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { getGitHubStars } from './github';
+
+const fetchMock = vi.hoisted(() => vi.fn());
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+describe('getGitHubStars', () => {
+  it('returns the stargazers_count on 2xx', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ stargazers_count: 1234 }),
+    });
+    const stars = await getGitHubStars('cacheplane/angular-agent-framework');
+    expect(stars).toBe(1234);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.github.com/repos/cacheplane/angular-agent-framework',
+      expect.objectContaining({
+        next: { revalidate: 86400 },
+      }),
+    );
+  });
+
+  it('returns null on non-2xx', async () => {
+    fetchMock.mockResolvedValue({ ok: false, json: async () => ({}) });
+    expect(await getGitHubStars('owner/repo')).toBeNull();
+  });
+
+  it('returns null when fetch throws', async () => {
+    fetchMock.mockRejectedValue(new Error('network'));
+    expect(await getGitHubStars('owner/repo')).toBeNull();
+  });
+
+  it('returns null when payload lacks stargazers_count', async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({}) });
+    expect(await getGitHubStars('owner/repo')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run, see fail**
+
+```bash
+cd apps/website && npx vitest run src/lib/github.spec.ts
+```
+
+Expected: fails (`Cannot find module './github'`).
+
+- [ ] **Step 3: Implement**
+
+Create `apps/website/src/lib/github.ts`:
+
+```typescript
+// SPDX-License-Identifier: MIT
+export async function getGitHubStars(
+  repo = 'cacheplane/angular-agent-framework',
+): Promise<number | null> {
+  try {
+    const res = await fetch(`https://api.github.com/repos/${repo}`, {
+      next: { revalidate: 86400 },
+      headers: { Accept: 'application/vnd.github+json' },
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { stargazers_count?: number };
+    return typeof data.stargazers_count === 'number' ? data.stargazers_count : null;
+  } catch {
+    return null;
+  }
+}
+```
+
+- [ ] **Step 4: Run, see pass**
+
+```bash
+cd apps/website && npx vitest run src/lib/github.spec.ts
+```
+
+Expected: 4 tests passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/website/src/lib/github.ts apps/website/src/lib/github.spec.ts
+git commit -m "$(cat <<'EOF'
+feat(website): getGitHubStars helper with ISR + silent-fail fallback
+
+Server-only helper that fetches repo stargazer count via Next.js fetch
+with 24h revalidate. Returns null on any failure (non-2xx, network
+error, missing field) so callers can render a graceful fallback.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 2.2: `GitHubStarsPill` component + spec
+
+**Files:** `apps/website/src/components/contact/GitHubStarsPill.tsx` (NEW), `apps/website/src/components/contact/GitHubStarsPill.spec.tsx` (NEW)
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// SPDX-License-Identifier: MIT
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('../../lib/github', () => ({
+  getGitHubStars: vi.fn(),
+}));
+
+import { getGitHubStars } from '../../lib/github';
+import { GitHubStarsPill } from './GitHubStarsPill';
+
+describe('GitHubStarsPill', () => {
+  it('renders with star count when fetch succeeds', async () => {
+    (getGitHubStars as ReturnType<typeof vi.fn>).mockResolvedValue(1234);
+    const el = await GitHubStarsPill();
+    const { container } = render(el);
+    expect(container.textContent).toMatch(/1,234/);
+    expect(container.querySelector('a')?.getAttribute('href'))
+      .toBe('https://github.com/cacheplane/angular-agent-framework');
+  });
+
+  it('renders fallback when fetch returns null', async () => {
+    (getGitHubStars as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const el = await GitHubStarsPill();
+    const { container } = render(el);
+    expect(container.textContent).toMatch(/GitHub/);
+    expect(container.textContent).not.toMatch(/\d/);
+  });
+});
+```
+
+- [ ] **Step 2: Run, see fail**
+
+```bash
+cd apps/website && npx vitest run src/components/contact/GitHubStarsPill.spec.tsx
+```
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// SPDX-License-Identifier: MIT
+import { Pill } from '../ui/Pill';
+import { getGitHubStars } from '../../lib/github';
+
+const REPO = 'cacheplane/angular-agent-framework';
+const REPO_URL = `https://github.com/${REPO}`;
+
+export async function GitHubStarsPill() {
+  const stars = await getGitHubStars(REPO);
+  const label = stars != null ? `★ ${stars.toLocaleString()} on GitHub` : 'GitHub';
+  return (
+    <a
+      href={REPO_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      style={{ textDecoration: 'none' }}
+    >
+      <Pill variant="neutral">{label}</Pill>
+    </a>
+  );
+}
+```
+
+- [ ] **Step 4: Run, see pass + commit**
+
+```bash
+cd apps/website && npx vitest run src/components/contact/GitHubStarsPill.spec.tsx
+```
+
+Expected: 2 tests passing.
+
+```bash
+git add apps/website/src/components/contact/GitHubStarsPill.tsx apps/website/src/components/contact/GitHubStarsPill.spec.tsx
+git commit -m "$(cat <<'EOF'
+feat(website): GitHubStarsPill server component with ISR-backed star count
+
+Renders "★ <n> on GitHub" when the fetch succeeds; falls back to a
+plain "GitHub" pill on null. Links to the repo regardless. ISR via
+the getGitHubStars helper means at most one fetch per 24h.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 2.3: `ContactForm` component + spec
+
+**Files:** `apps/website/src/components/contact/ContactForm.tsx` (NEW), `apps/website/src/components/contact/ContactForm.spec.tsx` (NEW)
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// SPDX-License-Identifier: MIT
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const trackMock = vi.hoisted(() => vi.fn());
+const fetchMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../../lib/analytics/client', () => ({ track: trackMock }));
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => new URLSearchParams('?source=home_hero&track=enterprise'),
+}));
+
+beforeEach(() => {
+  trackMock.mockClear();
+  fetchMock.mockReset();
+  vi.stubGlobal('fetch', fetchMock);
+  Object.defineProperty(document, 'referrer', {
+    value: 'https://cacheplane.ai/pricing',
+    configurable: true,
+  });
+});
+
+describe('ContactForm', () => {
+  it('submits with email only and fires lead_form_submit + lead_form_success', async () => {
+    fetchMock.mockResolvedValue({ ok: true });
+    const { ContactForm } = await import('./ContactForm');
+    render(<ContactForm />);
+
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'jane@acme.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.email).toBe('jane@acme.com');
+    expect(body.source_page).toBe('home_hero');
+    expect(body.track).toBe('enterprise');
+    expect(body.referrer_host).toBe('cacheplane.ai');
+
+    expect(trackMock).toHaveBeenCalledWith(
+      'marketing:lead_form_submit',
+      expect.objectContaining({ surface: 'contact' }),
+    );
+    expect(trackMock).toHaveBeenCalledWith(
+      'marketing:lead_form_success',
+      expect.objectContaining({ surface: 'contact' }),
+    );
+  });
+
+  it('submits with all optional fields populated', async () => {
+    fetchMock.mockResolvedValue({ ok: true });
+    const { ContactForm } = await import('./ContactForm');
+    render(<ContactForm />);
+
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'jane@acme.com' } });
+    fireEvent.change(screen.getByLabelText(/name/i), { target: { value: 'Jane Smith' } });
+    fireEvent.change(screen.getByLabelText(/company/i), { target: { value: 'Acme' } });
+    fireEvent.change(screen.getByLabelText(/message/i), { target: { value: 'Hi' } });
+    fireEvent.click(screen.getByRole('button', { name: /send/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body).toMatchObject({
+      email: 'jane@acme.com',
+      name: 'Jane Smith',
+      company: 'Acme',
+      message: 'Hi',
+    });
+  });
+
+  it('fires lead_form_fail on non-2xx', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500 });
+    const { ContactForm } = await import('./ContactForm');
+    render(<ContactForm />);
+
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'jane@acme.com' } });
+    fireEvent.click(screen.getByRole('button', { name: /send/i }));
+
+    await waitFor(() =>
+      expect(trackMock).toHaveBeenCalledWith(
+        'marketing:lead_form_fail',
+        expect.objectContaining({ surface: 'contact' }),
+      ),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run, see fail**
+
+```bash
+cd apps/website && npx vitest run src/components/contact/ContactForm.spec.tsx
+```
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// SPDX-License-Identifier: MIT
+'use client';
+
+import { useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { tokens } from '@ngaf/design-tokens';
+import { Button } from '../ui/Button';
+import { track } from '../../lib/analytics/client';
+import { analyticsEvents } from '../../lib/analytics/events';
+
+type Status = 'idle' | 'sending' | 'sent' | 'error';
+
+function sanitizeReferrerHost(): string | undefined {
+  if (typeof document === 'undefined' || !document.referrer) return undefined;
+  try {
+    return new URL(document.referrer).hostname;
+  } catch {
+    return undefined;
+  }
+}
+
+export function ContactForm() {
+  const params = useSearchParams();
+  const [status, setStatus] = useState<Status>('idle');
+  const [email, setEmail] = useState('');
+  const [name, setName] = useState('');
+  const [company, setCompany] = useState('');
+  const [message, setMessage] = useState('');
+
+  const sourcePage = params.get('source') ?? 'contact_direct';
+  const trackParam = (params.get('track') ?? 'enterprise') as string;
+  const ctaId = params.get('cta_id') ?? undefined;
+  const paper = params.get('paper') ?? undefined;
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (!email) return;
+    setStatus('sending');
+    track(analyticsEvents.marketingLeadFormSubmit, {
+      surface: 'contact',
+      source_section: 'contact-form',
+    });
+    try {
+      const res = await fetch('/api/leads', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email,
+          name: name || undefined,
+          company: company || undefined,
+          message: message || undefined,
+          source_page: sourcePage,
+          track: trackParam,
+          cta_id: ctaId,
+          paper,
+          referrer_host: sanitizeReferrerHost(),
+        }),
+      });
+      if (res.ok) {
+        track(analyticsEvents.marketingLeadFormSuccess, {
+          surface: 'contact',
+          source_section: 'contact-form',
+        });
+        setStatus('sent');
+      } else {
+        track(analyticsEvents.marketingLeadFormFail, {
+          surface: 'contact',
+          source_section: 'contact-form',
+          error_reason: 'api_error',
+        });
+        setStatus('error');
+      }
+    } catch {
+      track(analyticsEvents.marketingLeadFormFail, {
+        surface: 'contact',
+        source_section: 'contact-form',
+        error_reason: 'network_error',
+      });
+      setStatus('error');
+    }
+  }
+
+  if (status === 'sent') {
+    return (
+      <div role="status" style={{ color: tokens.colors.textPrimary, padding: 24 }}>
+        Thanks. We&apos;ll be in touch within one business day.
+      </div>
+    );
+  }
+
+  const inputStyle: React.CSSProperties = {
+    display: 'block',
+    width: '100%',
+    padding: '10px 12px',
+    fontSize: tokens.typography.body.size,
+    fontFamily: tokens.typography.body.family,
+    color: tokens.colors.textPrimary,
+    background: tokens.surfaces.surface,
+    border: `1px solid ${tokens.surfaces.border}`,
+    borderRadius: 6,
+    marginTop: 4,
+  };
+
+  return (
+    <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 16, maxWidth: 480 }}>
+      <label style={{ fontSize: tokens.typography.body.size, color: tokens.colors.textPrimary }}>
+        Email
+        <input
+          type="email"
+          required
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          style={inputStyle}
+        />
+      </label>
+      <label style={{ fontSize: tokens.typography.body.size, color: tokens.colors.textPrimary }}>
+        Name <span style={{ color: tokens.colors.textMuted }}>(optional)</span>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          style={inputStyle}
+        />
+      </label>
+      <label style={{ fontSize: tokens.typography.body.size, color: tokens.colors.textPrimary }}>
+        Company <span style={{ color: tokens.colors.textMuted }}>(optional)</span>
+        <input
+          type="text"
+          value={company}
+          onChange={(e) => setCompany(e.target.value)}
+          style={inputStyle}
+        />
+      </label>
+      <label style={{ fontSize: tokens.typography.body.size, color: tokens.colors.textPrimary }}>
+        Message <span style={{ color: tokens.colors.textMuted }}>(optional)</span>
+        <textarea
+          rows={5}
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          placeholder="What are you shipping?"
+          style={{ ...inputStyle, resize: 'vertical' }}
+        />
+      </label>
+      <Button variant="primary" size="lg" type="submit" disabled={status === 'sending'}>
+        {status === 'sending' ? 'Sending…' : 'Send'}
+      </Button>
+      {status === 'error' && (
+        <div role="alert" style={{ color: tokens.colors.danger ?? '#c00' }}>
+          Something went wrong. Please try again or email us directly.
+        </div>
+      )}
+    </form>
+  );
+}
+```
+
+- [ ] **Step 4: Run, see pass**
+
+```bash
+cd apps/website && npx vitest run src/components/contact/ContactForm.spec.tsx
+```
+
+Expected: 3 tests passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/website/src/components/contact/ContactForm.tsx apps/website/src/components/contact/ContactForm.spec.tsx
+git commit -m "$(cat <<'EOF'
+feat(website): ContactForm — email required, name/company/message optional
+
+POSTs to /api/leads with hidden attribution fields (source_page, track,
+cta_id, paper, referrer_host) populated from URL params + document
+.referrer. Fires marketing:lead_form_submit / _success / _fail with
+surface=contact. Inline success state; no redirect.
+
+Three unit tests cover email-only submit, full-fields submit, failure path.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 2.4: `SlaCard` + `AltChannelRow` static components
+
+**Files:** `apps/website/src/components/contact/SlaCard.tsx` (NEW), `apps/website/src/components/contact/AltChannelRow.tsx` (NEW)
+
+- [ ] **Step 1: Create SlaCard.tsx**
+
+```typescript
+// SPDX-License-Identifier: MIT
+import { tokens } from '@ngaf/design-tokens';
+import { Card } from '../ui/Card';
+
+export function SlaCard() {
+  return (
+    <Card style={{ padding: 20, maxWidth: 480 }}>
+      <p
+        style={{
+          margin: 0,
+          color: tokens.colors.textPrimary,
+          fontSize: tokens.typography.body.size,
+          fontFamily: tokens.typography.body.family,
+          lineHeight: tokens.typography.body.line,
+        }}
+      >
+        Brian or someone on the team replies personally — from a real inbox, not <code>noreply@</code>. We read every message.
+      </p>
+    </Card>
+  );
+}
+```
+
+If `Card` doesn't exist in `apps/website/src/components/ui/Card.tsx`, substitute a plain `<div>` styled with `border: 1px solid var(--border)` and a small radius. Check first.
+
+- [ ] **Step 2: Create AltChannelRow.tsx**
+
+```typescript
+// SPDX-License-Identifier: MIT
+import { tokens } from '@ngaf/design-tokens';
+
+const linkStyle: React.CSSProperties = {
+  color: tokens.colors.accent,
+  textDecoration: 'none',
+  fontSize: tokens.typography.body.size,
+  fontFamily: tokens.typography.body.family,
+};
+
+export function AltChannelRow() {
+  return (
+    <p style={{ display: 'flex', gap: 16, alignItems: 'center', flexWrap: 'wrap', margin: 0 }}>
+      <a href="/docs" style={linkStyle}>docs</a>
+      <span style={{ color: tokens.colors.textMuted }}>·</span>
+      <a href="https://github.com/cacheplane/angular-agent-framework/issues" style={linkStyle}>GitHub issues</a>
+      <span style={{ color: tokens.colors.textMuted }}>·</span>
+      <a href="https://discord.gg/cacheplane" style={linkStyle}>Discord</a>
+    </p>
+  );
+}
+```
+
+If the Discord URL is unknown, leave it as `https://discord.gg/cacheplane` and the operator can adjust post-merge.
+
+- [ ] **Step 3: Build to confirm**
+
+```bash
+npx nx run website:build
+```
+
+Expected: green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/website/src/components/contact/SlaCard.tsx apps/website/src/components/contact/AltChannelRow.tsx
+git commit -m "$(cat <<'EOF'
+feat(website): SlaCard + AltChannelRow static contact-page subcomponents
+
+Renders the "replies personally from a real inbox" promise and the
+docs / GitHub issues / Discord row below the contact form, per the
+locked Direction A.v2 spec.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 2.5: `/contact` page composition
+
+**File:** `apps/website/src/app/contact/page.tsx` (NEW)
+
+- [ ] **Step 1: Create the page**
+
+```typescript
+// SPDX-License-Identifier: MIT
+import type { Metadata } from 'next';
+import { Suspense } from 'react';
+import { tokens } from '@ngaf/design-tokens';
+import { Container } from '../../components/ui/Container';
+import { Section } from '../../components/ui/Section';
+import { Eyebrow } from '../../components/ui/Eyebrow';
+import { ContactForm } from '../../components/contact/ContactForm';
+import { GitHubStarsPill } from '../../components/contact/GitHubStarsPill';
+import { SlaCard } from '../../components/contact/SlaCard';
+import { AltChannelRow } from '../../components/contact/AltChannelRow';
+
+export const metadata: Metadata = {
+  title: 'Talk to an engineer — Cacheplane',
+  description: "Tell us what you're shipping. We'll reply within one business day — usually with code, not a calendar invite.",
+  openGraph: {
+    title: 'Talk to an engineer — Cacheplane',
+    description: "Tell us what you're shipping. We'll reply within one business day.",
+    type: 'website',
+  },
+};
+
+export default function ContactPage() {
+  return (
+    <Section surface="canvas" ariaLabelledBy="contact-heading">
+      <Container>
+        <div style={{ maxWidth: 720 }}>
+          <Eyebrow tone="accent" style={{ marginBottom: 16 }}>Contact</Eyebrow>
+          <h1
+            id="contact-heading"
+            style={{
+              fontFamily: tokens.typography.h1.family,
+              fontSize: tokens.typography.h1.size,
+              lineHeight: tokens.typography.h1.line,
+              fontWeight: 700,
+              color: tokens.colors.textPrimary,
+              margin: 0,
+              marginBottom: 16,
+              letterSpacing: '-0.02em',
+            }}
+          >
+            Talk to an engineer.
+          </h1>
+          <p
+            style={{
+              fontFamily: tokens.typography.bodyLg.family,
+              fontSize: tokens.typography.bodyLg.size,
+              lineHeight: tokens.typography.bodyLg.line,
+              color: tokens.colors.textSecondary,
+              margin: 0,
+              marginBottom: 24,
+              maxWidth: '60ch',
+            }}
+          >
+            Tell us what you&apos;re shipping. We&apos;ll reply within one business day — usually with code, not a calendar invite.
+          </p>
+          <div style={{ marginBottom: 24 }}>
+            <SlaCard />
+          </div>
+          <Suspense>
+            <ContactForm />
+          </Suspense>
+          <div style={{ marginTop: 32, display: 'flex', flexDirection: 'column', gap: 16 }}>
+            <GitHubStarsPill />
+            <AltChannelRow />
+          </div>
+        </div>
+      </Container>
+    </Section>
+  );
+}
+```
+
+The `<Suspense>` wrapper is required because `ContactForm` uses `useSearchParams()` which Next.js demands wrap in Suspense.
+
+- [ ] **Step 2: Verify build + manual smoke**
+
+```bash
+npx nx run website:build
+```
+
+Expected: green. Page reachable at `/contact` and `/contact?source=home_hero&track=enterprise`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/website/src/app/contact/page.tsx
+git commit -m "$(cat <<'EOF'
+feat(website): /contact route per Direction A.v2
+
+Server-rendered page composing ContactForm, SlaCard, GitHubStarsPill,
+and AltChannelRow. Headline + subhead from docs/gtm/messaging.md.
+ContactForm wrapped in Suspense for useSearchParams compatibility.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 3 — Pricing CompatibilityMatrix
+
+### Task 3.1: `CompatibilityMatrix` component + spec
+
+**Files:** `apps/website/src/components/pricing/CompatibilityMatrix.tsx` (NEW), `apps/website/src/components/pricing/CompatibilityMatrix.spec.tsx` (NEW)
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// SPDX-License-Identifier: MIT
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { CompatibilityMatrix } from './CompatibilityMatrix';
+
+describe('CompatibilityMatrix', () => {
+  it('renders four buckets with the conservative content', () => {
+    render(<CompatibilityMatrix />);
+    expect(screen.getByText(/Supported/)).toBeTruthy();
+    expect(screen.getByText(/Angular 20, 21/)).toBeTruthy();
+    expect(screen.getByText(/Experimental/)).toBeTruthy();
+    expect(screen.getByText(/Planned/)).toBeTruthy();
+    expect(screen.getByText(/Angular 22/)).toBeTruthy();
+    expect(screen.getByText(/Unsupported/)).toBeTruthy();
+    expect(screen.getByText(/≤19/)).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: Run, see fail**
+
+```bash
+cd apps/website && npx vitest run src/components/pricing/CompatibilityMatrix.spec.tsx
+```
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// SPDX-License-Identifier: MIT
+import { tokens } from '@ngaf/design-tokens';
+
+interface Row {
+  label: string;
+  versions: string;
+  tone: 'success' | 'warn' | 'info' | 'muted';
+}
+
+const ROWS: ReadonlyArray<Row> = [
+  { label: 'Supported',    versions: 'Angular 20, 21', tone: 'success' },
+  { label: 'Experimental', versions: '—',              tone: 'warn'    },
+  { label: 'Planned',      versions: 'Angular 22',     tone: 'info'    },
+  { label: 'Unsupported',  versions: 'Angular ≤19',    tone: 'muted'   },
+];
+
+const TONE_COLORS: Record<Row['tone'], string> = {
+  success: '#16a34a',
+  warn:    '#d97706',
+  info:    tokens.colors.accent,
+  muted:   tokens.colors.textMuted,
+};
+
+export function CompatibilityMatrix() {
+  return (
+    <div
+      style={{
+        border: `1px solid ${tokens.surfaces.border}`,
+        borderRadius: 8,
+        overflow: 'hidden',
+      }}
+    >
+      <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+        <thead>
+          <tr style={{ background: tokens.surfaces.surface }}>
+            <th
+              style={{
+                textAlign: 'left',
+                padding: '12px 16px',
+                fontWeight: 600,
+                color: tokens.colors.textPrimary,
+                fontSize: tokens.typography.body.size,
+                borderBottom: `1px solid ${tokens.surfaces.border}`,
+              }}
+            >
+              Status
+            </th>
+            <th
+              style={{
+                textAlign: 'left',
+                padding: '12px 16px',
+                fontWeight: 600,
+                color: tokens.colors.textPrimary,
+                fontSize: tokens.typography.body.size,
+                borderBottom: `1px solid ${tokens.surfaces.border}`,
+              }}
+            >
+              Angular versions
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {ROWS.map((row) => (
+            <tr key={row.label}>
+              <td
+                style={{
+                  padding: '12px 16px',
+                  fontSize: tokens.typography.body.size,
+                  color: TONE_COLORS[row.tone],
+                  fontWeight: 500,
+                  borderBottom: `1px solid ${tokens.surfaces.border}`,
+                }}
+              >
+                {row.label}
+              </td>
+              <td
+                style={{
+                  padding: '12px 16px',
+                  fontSize: tokens.typography.body.size,
+                  color: tokens.colors.textSecondary,
+                  fontFamily: tokens.typography.fontMono,
+                  borderBottom: `1px solid ${tokens.surfaces.border}`,
+                }}
+              >
+                {row.versions}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run, see pass + commit**
+
+```bash
+cd apps/website && npx vitest run src/components/pricing/CompatibilityMatrix.spec.tsx
+```
+
+Expected: 1 test passing.
+
+```bash
+git add apps/website/src/components/pricing/CompatibilityMatrix.tsx apps/website/src/components/pricing/CompatibilityMatrix.spec.tsx
+git commit -m "$(cat <<'EOF'
+feat(website): CompatibilityMatrix component
+
+Replaces the "All Angular versions" risk claim with a real
+supported/experimental/planned/unsupported matrix. Initial content
+matches the peer-deps reality: Angular 20, 21 supported; 22 planned;
+≤19 unsupported.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 3.2: Wire `CompatibilityMatrix` into `/pricing`
+
+**File:** `apps/website/src/app/pricing/page.tsx` (MODIFIED)
+
+- [ ] **Step 1: Locate the "All Angular versions" claim**
+
+```bash
+grep -n "All Angular\|Angular versions" apps/website/src/app/pricing/page.tsx apps/website/src/components/pricing/*.tsx 2>/dev/null
+```
+
+Likely match in either `page.tsx` directly or inside `CompareTable.tsx` / `PricingGrid.tsx`. Find the exact text.
+
+- [ ] **Step 2: Replace with `<CompatibilityMatrix />`**
+
+Add the import:
+
+```typescript
+import { CompatibilityMatrix } from '../../components/pricing/CompatibilityMatrix';
+```
+
+Replace the offending row/cell/paragraph with the matrix. If the claim sits inside a feature-row of a table cell that just says "All Angular versions", swap that cell content for "See compatibility matrix below" and render the matrix as its own labeled subsection above or below the `CompareTable`.
+
+A safe insertion location: a new `<Section>` block between `<CompareTable />` and `<LeadForm />` titled "Compatibility":
+
+```tsx
+<Section surface="canvas">
+  <Container>
+    <Eyebrow style={{ marginBottom: 12 }}>Compatibility</Eyebrow>
+    <h2
+      style={{
+        fontFamily: tokens.typography.h2.family,
+        fontSize: tokens.typography.h2.size,
+        margin: 0,
+        marginBottom: 16,
+        color: tokens.colors.textPrimary,
+      }}
+    >
+      Angular version support
+    </h2>
+    <p
+      style={{
+        margin: 0,
+        marginBottom: 24,
+        color: tokens.colors.textSecondary,
+        maxWidth: '60ch',
+      }}
+    >
+      We ship against the versions our CI tests. Other versions may work but aren&apos;t guaranteed.
+    </p>
+    <CompatibilityMatrix />
+  </Container>
+</Section>
+```
+
+- [ ] **Step 3: Build + commit**
+
+```bash
+npx nx run website:build
+git add apps/website/src/app/pricing/page.tsx
+git commit -m "$(cat <<'EOF'
+feat(website): wire CompatibilityMatrix into /pricing
+
+Replaces the "All Angular versions" claim with a real matrix. New
+"Compatibility" section sits between CompareTable and LeadForm.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 4 — Loosen `/api/leads` + Resend template + messaging.md
+
+### Task 4.1: Loosen `/api/leads` validation + adapt Resend subject
+
+**Files:** `apps/website/src/app/api/leads/route.ts` (MODIFIED), `apps/website/emails/lead-notification.ts` (MODIFIED)
+
+- [ ] **Step 1: Update validation**
+
+In `apps/website/src/app/api/leads/route.ts`, find the validation block:
+
+```typescript
+if (!name || !email) {
+  return NextResponse.json({ error: 'name and email required' }, { status: 400 });
+}
+```
+
+Replace with:
+
+```typescript
+if (!email) {
+  return NextResponse.json({ error: 'email required' }, { status: 400 });
+}
+```
+
+- [ ] **Step 2: Update the Resend subject construction**
+
+Find the line that builds the subject:
+
+```typescript
+subject: `New lead: ${name}${company ? ` at ${company}` : ''}`,
+```
+
+Replace with:
+
+```typescript
+subject: `New lead: ${name || email}${company ? ` at ${company}` : ''}`,
+```
+
+- [ ] **Step 3: Update `emails/lead-notification.ts` to handle missing name**
+
+Read the file. If it renders `<h1>${name}</h1>` or similar, replace with `<h1>${name || 'No name provided'}</h1>` — or surface the email as the fallback identity. The shape of this template varies; pattern-match the prior behavior and make name optional throughout.
+
+- [ ] **Step 4: Verify build**
+
+```bash
+npx nx run website:build
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/website/src/app/api/leads/route.ts apps/website/emails/lead-notification.ts
+git commit -m "$(cat <<'EOF'
+feat(website): loosen /api/leads validation to email-only
+
+Spec 2's /contact form collects email (required) + name, company,
+message (all optional). Pricing's LeadForm continues to send name.
+Resend notification subject falls back to email when name is missing.
+The lead-notification email template no longer requires name.
+
+Spec 1E's qualified-lead gate is unchanged — still requires non-personal
+email + non-empty company. Contact-form leads without a company fire
+marketing:lead_form_success but not marketing:lead_qualified, by design.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 4.2: Update `docs/gtm/messaging.md`
+
+**File:** `docs/gtm/messaging.md` (MODIFIED)
+
+- [ ] **Step 1: Update the Fields line in the Contact page section**
+
+Find:
+
+```
+**Fields:** email + free-text body. No stack dropdown, no company size, no "how did you hear."
+```
+
+Replace with:
+
+```
+**Fields:** email (required) + name, company, message (all optional). No stack dropdown, no company size, no "how did you hear." Optional fields feed enterprise-qualification when present.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/gtm/messaging.md
+git commit -m "$(cat <<'EOF'
+docs(gtm): update Contact page §Fields per Spec 2 implementation
+
+Direction A.v2 originally locked "email + free-text body." During Spec 2
+implementation we expanded to email (required) + name, company, message
+(all optional) so Spec 1E's captureLeadQualified gate (which requires
+company) still works for contact-form submissions.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 5 — Verification
+
+### Task 5.1: Final test + build sweep (no commit)
+
+- [ ] **Step 1: Run tests**
+
+```bash
+npx nx run-many -t test -p telemetry,cockpit
+cd apps/website && npx vitest run src/components/landing src/components/contact src/components/pricing src/lib/github.spec.ts src/lib/analytics/server.spec.ts
+```
+
+Expected: green. Pre-existing e2e + open-in-cockpit failures (unrelated) may persist.
+
+- [ ] **Step 2: Run builds**
+
+```bash
+npx nx run-many -t build -p website,cockpit,telemetry
+```
+
+Expected: green.
+
+- [ ] **Step 3: Drift guard sanity (no new events; the guard should still pass)**
+
+```bash
+npx nx run posthog-tools:test
+```
+
+Expected: green. (Spec 2 doesn't introduce new event names — only `cta_id` property values, which the drift guard doesn't scan.)
+
+- [ ] **Step 4: Manual smoke**
+
+Start the website locally:
+
+```bash
+nx run website:dev
+```
+
+Visit `http://localhost:3000/`:
+- Confirm hero shows "Ship production agent UIs in Angular." H1.
+- Click `Install @ngaf/chat` — button label flips to "Copied ✓" and clipboard contains `npm install @ngaf/chat`.
+- Click `Talk to our engineers` — navigates to `/contact?source=home_hero&track=enterprise`.
+
+Visit `/contact?source=home_hero&track=enterprise`:
+- Confirm headline "Talk to an engineer." renders.
+- SLA card present.
+- Form has 4 fields (email required, others optional).
+- GitHub stars pill renders (or fallback to plain "GitHub" pill).
+- Alt-channel row visible.
+
+Visit `/pricing`:
+- Confirm `<CompatibilityMatrix />` section renders with four rows.
+
+Submit a test lead via `/contact?...` with `email=jane@acme.com, company=Acme` and verify PostHog Live Events shows `marketing:lead_form_submit`, `marketing:lead_form_success`, AND `marketing:lead_qualified` (the last one from Spec 1E's gate passing).
+
+- [ ] **Step 5: Done**
+
+If all checks pass, Spec 2 is implementation-complete. Proceed to PR.
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+
+| Spec deliverable | Task |
+|---|---|
+| Hero rewrite with locked copy + two tracked CTAs + clipboard primary CTA | 1.2 + 1.3 |
+| `/contact` route with ContactForm (email required; name/company/message optional) | 2.5 + 2.3 |
+| GitHubStarsPill + getGitHubStars ISR + fetch-failure fallback | 2.1 + 2.2 |
+| CompatibilityMatrix on /pricing with conservative content | 3.1 + 3.2 |
+| Three full-repo sweeps: telemetry phrasing, A2UI v0.9, category sweep | 0.1, 0.2, 0.3 |
+| `CtaId` type union exported; `AnalyticsProperties.cta_id` tightened | 1.1 |
+| `/api/leads` validates email only | 4.1 |
+| Resend subject template handles missing name | 4.1 |
+| `docs/gtm/messaging.md` Contact page §Fields updated | 4.2 |
+| Hidden attribution fields populated from URL params + referrer | 2.3 (ContactForm impl) |
+| Alt-channel row (docs/GitHub issues/Discord) | 2.4 |
+| SLA card | 2.4 |
+| All affected projects' tests green | 5.1 |
+
+All deliverables covered.
+
+**2. Placeholder scan:** No "TBD", no "fill in details", no "similar to Task N" without showing code. ✓
+
+**3. Type consistency:**
+
+- `CtaId` union members `'hero_install' | 'hero_talk_to_engineers'` — defined in 1.1, used in 1.3 (`cta_id: 'hero_install'` / `'hero_talk_to_engineers'`). ✓
+- `track: 'developer' | 'enterprise'` — used in 1.3 (Hero CTAs), 2.3 (ContactForm default), 2.5 (page URL). ✓
+- `surface: 'home' | 'contact'` — `'home'` in Hero (1.3), `'contact'` in ContactForm (2.3). Both are members of the existing `AnalyticsSurface` union (`surface?: AnalyticsSurface`). ✓
+- `INSTALL_COMMAND = 'npm install @ngaf/chat'` — written in 1.3, asserted in test 1.2. ✓
+- `getGitHubStars` signature `(repo?: string) => Promise<number | null>` — same across 2.1 implementation and 2.2 consumer. ✓
+- `CompatibilityMatrix` content (Angular 20, 21 / — / 22 / ≤19) consistent across 3.1 spec, 3.1 implementation, and the spec doc §3. ✓

--- a/docs/superpowers/specs/gtm/2026-05-16-positioning-and-risks-design.md
+++ b/docs/superpowers/specs/gtm/2026-05-16-positioning-and-risks-design.md
@@ -1,0 +1,311 @@
+---
+workstream: positioning-and-risks
+status: approved
+owner: brian
+phase: 1
+spec: docs/superpowers/specs/gtm/2026-05-16-positioning-and-risks-design.md
+plan: docs/superpowers/plans/gtm/2026-05-16-positioning-and-risks.md
+parent: docs/superpowers/specs/gtm/2026-05-13-gtm-meta-design.md
+---
+
+# Spec 2 — Positioning & Risks (Design)
+
+> Replaces the homepage hero with the locked Direction-A copy, stands up the `/contact` enterprise CTA destination, applies four risk-cleanup copy changes, and wires the two CTA tracks so the developer/enterprise funnel split becomes measurable in PostHog.
+
+## 1. Goal
+
+Deliver Phase 1's developer-clarity foundation:
+
+1. Homepage hero communicates the durable category claim ("Agent UI for Angular") in 30 seconds with a working CTA fork (developer / enterprise).
+2. `/contact` exists as the enterprise CTA destination per the locked Direction A.v2 spec.
+3. The four risk-cleanup copy changes are deployed everywhere they appear: telemetry phrasing, real Angular compatibility matrix, A2UI v0.9, "Angular Agent Framework" → "Agent UI for Angular" category sweep.
+4. Both CTA tracks emit `marketing:cta_click` with a stable `cta_id` so the developer-funnel and enterprise-funnel dashboards from Spec 1A populate.
+
+## 2. Context
+
+- Parent: `docs/superpowers/specs/gtm/2026-05-13-gtm-meta-design.md` §6 (Phase 1 critical path: 0 → 1 → 2 → 3 → 4).
+- Locked content lives in `docs/gtm/messaging.md`:
+  - **Positioning statement** (durable).
+  - **Hero copy** (H1, subhead, primary CTA, secondary CTA, proof row, subline) — locked.
+  - **Contact page (Direction A.v2)** — locked.
+  - **Risk-cleanup copy changes (Spec 2)** — 4 items, locked.
+- The current Hero in `apps/website/src/components/landing/Hero.tsx` reads "Build fullstack agentic Angular apps" — superseded by the locked H1.
+- The `/contact` route does not exist. The existing `LeadForm` lives on `/pricing` and reuses the `/api/leads` route handler.
+- Spec 1E shipped `captureLeadQualified` server-side. `/api/leads` already calls it after `captureLeadConversion`. Spec 2's contact form will POST to the same endpoint.
+- The repo's "Chat" memory note (`feedback_chat_prefix_substring_overlap.md`) warns against blind `replace_all` on overlapping substrings; "Angular Agent Framework" is a longer unique phrase, so the same risk does not apply — but a per-file review remains the right discipline.
+
+### Deviation from messaging.md (call-out)
+
+`docs/gtm/messaging.md` Contact page §"Fields" locks: *"email + free-text body. No stack dropdown, no company size, no 'how did you hear.'"* This spec **expands** the field list to **email (required) + name, company, message (all optional)** so Spec 1E's `captureLeadQualified` gate (which requires `company` to fire) still works for contact-form submissions. The form remains a single short block — no progressive disclosure, no qualification dropdowns — but the optional fields, when filled, feed enterprise qualification. The messaging.md doc gets updated in this PR to reflect the new locked field set.
+
+## 3. Scope
+
+**In:**
+
+- **Hero rewrite** (`apps/website/src/components/landing/Hero.tsx`):
+  - Eyebrow: `Agent UI for Angular · MIT` (replaces `Angular Agent Framework · MIT`).
+  - H1: `Ship production agent UIs in Angular.`
+  - Subhead: `Signal-native chat, threads, interrupts, tool progress, and generative UI for LangGraph, AG-UI, and A2UI. MIT-licensed, self-hostable, app telemetry off by default, no React rewrite.`
+  - Primary CTA: button label `Install @ngaf/chat`; click copies `npm install @ngaf/chat` to clipboard and fires `marketing:cta_click` with `cta_id: 'hero_install'`, `track: 'developer'`, `surface: 'home'`. Brief visual confirmation on copy (existing `Pill`/toast pattern if available, otherwise a label flip for ~1.5s).
+  - Secondary CTA: button label `Talk to our engineers`; routes to `/contact?source=home_hero&track=enterprise` and fires `marketing:cta_click` with `cta_id: 'hero_talk_to_engineers'`, `track: 'enterprise'`, `surface: 'home'`.
+  - Proof row: `MIT · Angular-native Signals · LangGraph + AG-UI · A2UI-compatible · Self-hostable · App telemetry off by default`.
+  - Subline under proof row: `Not another backend agent runtime. Keep LangGraph, Genkit, Mastra, CrewAI, or your own service. Cacheplane solves the Angular UI layer.`
+
+- **New `/contact` route** (`apps/website/src/app/contact/page.tsx`):
+  - Server component. Page metadata (title, OG, twitter).
+  - Headline: `Talk to an engineer.`
+  - Subhead: `Tell us what you're shipping. We'll reply within one business day — usually with code, not a calendar invite.`
+  - SLA card: `Brian or someone on the team replies personally — from a real inbox, not noreply@. We read every message.`
+  - `<ContactForm />` (new client component): email (required) + name (optional) + company (optional) + message (optional, textarea) + hidden attribution fields populated from URL params + `document.referrer`. POSTs to `/api/leads`.
+  - `<GitHubStarsPill />` (new server component): fetches `https://api.github.com/repos/cacheplane/angular-agent-framework` once per build / 24h ISR; renders a pill with the star count + link. Graceful fallback to a "GitHub" pill (no count) on fetch failure.
+  - Alt-channel row below form: `docs · GitHub issues · Discord` (three links).
+  - On successful submit: inline success message; no redirect.
+
+- **Loosen `/api/leads` validation** (`apps/website/src/app/api/leads/route.ts`):
+  - Require email only. `name`, `company`, `message` all optional.
+  - Existing `LeadForm` on `/pricing` continues to send `name`; new contact form sends what users fill in.
+  - Resend notification body adapts: when `name` absent, subject becomes `New lead: <email>` instead of `New lead: <name> at <company>`. Body still shows whichever fields are present.
+
+- **Four risk-cleanup copy changes (full-repo sweep):**
+  - **Telemetry phrasing.** Sweep `apps/website` + `gtm.md` + `libs/*/README.md` for "No telemetry" (and close variants) → `App telemetry off by default` with a link to `libs/telemetry/README.md`. Per-file review, no blind replace.
+  - **Compatibility matrix.** Replace the "All Angular versions" claim on `/pricing` with a new `<CompatibilityMatrix />` component:
+    - Supported: Angular 20, 21 (matches `peerDependencies: "^20.0.0 || ^21.0.0"`)
+    - Experimental: (none — empty row labeled "—")
+    - Planned: Angular 22 (next major)
+    - Unsupported: Angular ≤19
+  - **A2UI v0.9 sweep.** "A2UI v1" → "A2UI v0.9-compatible" everywhere across the full repo. Includes website copy, MDX docs, READMEs, `gtm.md`, package descriptions.
+  - **Category sweep.** "Angular Agent Framework" → "Agent UI for Angular" across the full repo. Excludes CHANGELOG.md and release-note files (historical record). Excludes class/identifier names (none exist). Per-file review.
+
+- **`marketing:cta_click` `cta_id` typing:** export a `CtaId` string union from `apps/website/src/lib/analytics/events.ts` and tighten `AnalyticsProperties.cta_id` to that union. Initial members: `'hero_install' | 'hero_talk_to_engineers'`. Future CTAs extend this list.
+
+- **`docs/gtm/messaging.md` update:** the Contact page §"Fields" line gets updated from "email + free-text body" to "email (required) + name, company, message (all optional)". The locked status remains; the field set is the only revision.
+
+**Out:**
+
+- Comparison pages (Spec 3).
+- Cockpit activation recipes (Spec 4).
+- New events. The `cta_id` property does the slicing on the existing `marketing:cta_click`.
+- Adding a hero CTA tracking insight to PostHog. The dashboards-as-code pipeline (Spec 1A) handles tile-level work; this spec only ensures the underlying event property lands cleanly.
+- Replacing or styling other landing sections (proof rows below hero, differentiator section, etc.). Codex PR #352 polished those; we keep them.
+- Repo rename or README badge updates beyond the category-sweep text replacements already enumerated.
+
+## 4. Components
+
+### 4.1 Hero (`apps/website/src/components/landing/Hero.tsx`)
+
+Replace H1, subhead, eyebrow, both buttons, proof row, and add the subline. Layout, grid, and right-column collage from PR #352 stay intact.
+
+```tsx
+'use client';
+import { useCallback, useState } from 'react';
+import { track } from '../../lib/analytics/client';
+import { analyticsEvents } from '../../lib/analytics/events';
+// ...existing imports
+
+function PrimaryInstallButton() {
+  const [copied, setCopied] = useState(false);
+  const onClick = useCallback(async () => {
+    track(analyticsEvents.marketingCtaClick, {
+      cta_id: 'hero_install',
+      track: 'developer',
+      surface: 'home',
+    });
+    try {
+      await navigator.clipboard?.writeText('npm install @ngaf/chat');
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // silent fail — focus stays on event firing
+    }
+  }, []);
+  return (
+    <Button variant="primary" size="lg" onClick={onClick}>
+      {copied ? 'Copied ✓' : 'Install @ngaf/chat'}
+    </Button>
+  );
+}
+```
+
+Secondary CTA is a plain `<Button href="/contact?…">` with the same `track(...)` call.
+
+### 4.2 `/contact` route (`apps/website/src/app/contact/page.tsx`)
+
+Server component:
+
+```tsx
+import { ContactForm } from '../../components/contact/ContactForm';
+import { GitHubStarsPill } from '../../components/contact/GitHubStarsPill';
+
+export const metadata = {
+  title: 'Talk to an engineer — Cacheplane',
+  description: "Tell us what you're shipping. We'll reply within one business day.",
+};
+
+export default function ContactPage() {
+  return (
+    <Section surface="canvas">
+      <Container>
+        <h1>Talk to an engineer.</h1>
+        <p>Tell us what you're shipping. We'll reply within one business day — usually with code, not a calendar invite.</p>
+        <SlaCard>Brian or someone on the team replies personally — from a real inbox, not noreply@. We read every message.</SlaCard>
+        <ContactForm />
+        <GitHubStarsPill />
+        <AltChannelRow />
+      </Container>
+    </Section>
+  );
+}
+```
+
+### 4.3 `ContactForm` (`apps/website/src/components/contact/ContactForm.tsx`)
+
+Client component. Reads URL params via `useSearchParams()` and `document.referrer`. Posts JSON to `/api/leads`. Fields:
+
+- `email` — required, type=email
+- `name` — optional, type=text, placeholder "Optional"
+- `company` — optional, type=text, placeholder "Optional — helps us route your request"
+- `message` — optional, textarea, placeholder "What are you shipping?"
+
+Hidden attribution fields included in the POST body:
+- `source_page` (= `useSearchParams().get('source') ?? 'contact_direct'`)
+- `track` (= `useSearchParams().get('track') ?? 'enterprise'`)
+- `cta_id` (= `useSearchParams().get('cta_id') ?? null`)
+- `paper` (= `useSearchParams().get('paper') ?? null`)
+- `referrer_host` (= sanitized hostname from `document.referrer`)
+
+On submit, fire `marketing:lead_form_submit` then POST; on 2xx, fire `marketing:lead_form_success` and show inline success block. On non-2xx, fire `marketing:lead_form_fail` and show error.
+
+### 4.4 `GitHubStarsPill` (`apps/website/src/components/contact/GitHubStarsPill.tsx`)
+
+Server component (`async function`). Fetches via the helper `getGitHubStars()` (next §). Renders:
+
+- `<Pill>★ {count} on GitHub</Pill>` when count available.
+- `<Pill>GitHub</Pill>` (no number) on fetch failure.
+
+Both link to `https://github.com/cacheplane/angular-agent-framework`.
+
+### 4.5 `getGitHubStars` helper (`apps/website/src/lib/github.ts`)
+
+```typescript
+export async function getGitHubStars(repo = 'cacheplane/angular-agent-framework'): Promise<number | null> {
+  try {
+    const res = await fetch(`https://api.github.com/repos/${repo}`, {
+      next: { revalidate: 86400 }, // 24h ISR
+      headers: { Accept: 'application/vnd.github+json' },
+    });
+    if (!res.ok) return null;
+    const data = await res.json() as { stargazers_count?: number };
+    return typeof data.stargazers_count === 'number' ? data.stargazers_count : null;
+  } catch {
+    return null;
+  }
+}
+```
+
+### 4.6 `CompatibilityMatrix` (`apps/website/src/components/pricing/CompatibilityMatrix.tsx`)
+
+Pure-render component, no props (initial v1). Four-row table with the conservative content from Q1. Renders inside an Eyebrow-labeled card on `/pricing`, replacing the "All Angular versions" claim.
+
+### 4.7 `cta_id` typing (`apps/website/src/lib/analytics/events.ts`)
+
+Add:
+
+```typescript
+export type CtaId =
+  | 'hero_install'
+  | 'hero_talk_to_engineers';
+```
+
+Tighten `AnalyticsProperties.cta_id`:
+
+```typescript
+cta_id?: CtaId;
+```
+
+(Existing callers using bare strings will fail typecheck; the only caller today is the toast/footer/landing-CTA pattern — we update those to use the union or extend the union with their values.)
+
+### 4.8 `/api/leads` loosening
+
+Change the validation at the top of `POST`:
+
+```typescript
+// before
+if (!name || !email) {
+  return NextResponse.json({ error: 'name and email required' }, { status: 400 });
+}
+
+// after
+if (!email) {
+  return NextResponse.json({ error: 'email required' }, { status: 400 });
+}
+```
+
+Resend notification subject becomes `New lead: ${name || email}${company ? ` at ${company}` : ''}`. The email body template handles missing optional fields gracefully.
+
+## 5. Data flow
+
+Developer track:
+
+1. User on `/` clicks `Install @ngaf/chat` in the hero.
+2. `marketing:cta_click` fires with `{cta_id: 'hero_install', track: 'developer', surface: 'home'}`.
+3. `npm install @ngaf/chat` copies to clipboard; button label flips to "Copied ✓" for 1.5s.
+4. PostHog filters `marketing:cta_click` by `cta_id=hero_install` to count developer-track entries.
+
+Enterprise track:
+
+1. User on `/` clicks `Talk to our engineers`.
+2. `marketing:cta_click` fires with `{cta_id: 'hero_talk_to_engineers', track: 'enterprise', surface: 'home'}`.
+3. Browser navigates to `/contact?source=home_hero&track=enterprise`.
+4. `ContactForm` reads those params, includes them as hidden fields.
+5. User submits with `email=jane@acme.com, company=Acme`.
+6. POST `/api/leads` → existing pipeline (Resend, Loops, NDJSON) → `captureLeadConversion` fires `marketing:lead_form_success` → `captureLeadQualified` fires `marketing:lead_qualified` (Spec 1E, gate passes).
+7. Enterprise-funnel dashboard tile populates.
+
+## 6. Error handling
+
+- **Clipboard API absent or denied:** the event still fires; only the visual confirmation is skipped. The user can fall back to the docs page where the install command is also shown.
+- **GitHub stars fetch failure:** pill renders as "GitHub" (no count); build does not fail.
+- **Contact form submit failure:** form shows an inline error with a retry button; `marketing:lead_form_fail` fires with the HTTP status.
+- **Bot submissions:** the `/api/leads` route stays as-is; existing rate-limiting / abuse mitigations apply at the platform layer (Vercel) for v1.
+
+## 7. Testing
+
+- **Vitest unit tests:**
+  - `Hero.spec.tsx` — primary CTA fires the expected event + copies the install command (clipboard mocked); secondary CTA fires its event and the href matches.
+  - `ContactForm.spec.tsx` — happy-path submit (email-only minimum), full-fields submit (event payload includes hidden attribution fields), submit failure path (network error fires `marketing:lead_form_fail`).
+  - `getGitHubStars.spec.ts` — happy-path returns number; non-2xx returns null; thrown fetch returns null.
+  - `CompatibilityMatrix.spec.tsx` — renders four buckets with the conservative content.
+- **No new code → taxonomy drift** — `cta_id` is a property not an event; the drift guard (Spec 1E) doesn't need to know about it. The taxonomy.md "Shared properties" section already documents `cta_id` as a stable string; we tighten the type in code without changing taxonomy.
+- **No new dashboards.** The existing developer-funnel + enterprise-funnel dashboards from Spec 1A consume `marketing:cta_click` and `marketing:lead_qualified` — both already wired.
+- **Pre-existing e2e tests** on the landing page rely on stable section ids (PR #358 fix); copy changes don't break them.
+
+## 8. Risks
+
+- **Locked copy may need a tweak after seeing it in context.** The hero subhead is long; if it visually crowds the layout, accept a 1-line word reflow but preserve the literal words. Any actual copy change re-routes through messaging.md.
+- **Category sweep blast radius.** "Angular Agent Framework" appears in ~10–20 files. Per-file review is the discipline; `replace_all` is forbidden. Worst-case mistake: a sentence reads awkwardly post-replacement. Mitigated by reading each diff hunk.
+- **CHANGELOG / release notes** must NOT be swept (historical record). The grep step excludes `CHANGELOG.md` and `release-notes/`.
+- **`/api/leads` validation change** is API-breaking in the sense that callers expecting the 400-on-missing-name will see successes. The only known caller is the existing `LeadForm`, which always sends a name — so no behavioral change in practice.
+- **Spec 1E qualification gate still requires company.** Contact-form leads without a company will fire `marketing:lead_form_success` but NOT `marketing:lead_qualified`. That's the explicit trade-off (see §3 deviation call-out).
+
+## 9. Phases
+
+1. **Phase 0 — Sweeps.** Three commits, one per sweep theme (telemetry phrasing, A2UI v0.9, category rename). Mechanical, per-file review.
+2. **Phase 1 — Hero.** `cta_id` typing → new `Hero` content + clipboard CTA + tracking + unit tests (~4 commits).
+3. **Phase 2 — `/contact` route.** ContactForm + GitHubStarsPill + `getGitHubStars` helper + alt-channel row + page composition + unit tests (~5 commits).
+4. **Phase 3 — Pricing matrix.** `CompatibilityMatrix` + pricing-page edit + unit tests (~2 commits).
+5. **Phase 4 — `/api/leads` loosen + messaging.md update + verification.** Loosen validation, update Resend subject template, update messaging.md to reflect the new contact-form field set (~2 commits).
+6. **Phase 5 — Verification** (no commit). Full test sweep, manual smoke that both CTAs fire correctly via PostHog Live Events.
+
+## 10. Deliverables
+
+- ☐ Hero rewritten with locked copy + two tracked CTAs + clipboard primary CTA
+- ☐ `/contact` route live with ContactForm (email required; name, company, message optional) + hidden attribution fields
+- ☐ `GitHubStarsPill` + `getGitHubStars` with ISR + fetch-failure fallback
+- ☐ `CompatibilityMatrix` on `/pricing` with conservative content (20, 21 supported; 22 planned; ≤19 unsupported)
+- ☐ Three full-repo sweeps applied per-file: telemetry phrasing, A2UI v0.9, category sweep
+- ☐ `CtaId` type union exported; `AnalyticsProperties.cta_id` tightened
+- ☐ `/api/leads` validates email only
+- ☐ Resend subject template handles missing name
+- ☐ `docs/gtm/messaging.md` Contact page §Fields updated
+- ☐ All affected projects' tests green
+- ☐ Manual smoke: both hero CTAs fire `marketing:cta_click` with correct `cta_id` + `track` properties in PostHog Live Events

--- a/examples/chat/angular/src/app/shell/demo-shell.component.ts
+++ b/examples/chat/angular/src/app/shell/demo-shell.component.ts
@@ -260,7 +260,7 @@ export class DemoShell {
   ]);
 
   protected readonly genUiOptions = signal<readonly { value: string; label: string }[]>([
-    { value: 'a2ui',        label: 'A2UI v1' },
+    { value: 'a2ui',        label: 'A2UI v0.9-compatible' },
     { value: 'json-render', label: 'json-render' },
   ]);
 

--- a/examples/chat/angular/tsconfig.app.json
+++ b/examples/chat/angular/tsconfig.app.json
@@ -7,5 +7,16 @@
     "emitDeclarationOnly": false
   },
   "files": ["src/main.ts"],
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "references": [
+    {
+      "path": "../../../libs/langgraph"
+    },
+    {
+      "path": "../../../libs/chat"
+    },
+    {
+      "path": "../../../libs/telemetry/tsconfig.lib.json"
+    }
+  ]
 }

--- a/examples/chat/python/src/graph.py
+++ b/examples/chat/python/src/graph.py
@@ -399,7 +399,7 @@ async def generate(state: State, config: RunnableConfig) -> dict:
     # false. The envelope shape carries list[dict] for components/contents
     # (untyped inner objects), which strict mode rejects with a 400
     # ('additionalProperties is required to be supplied and to be false').
-    # Typing the inner shapes would over-couple this example to the A2UI v1
+    # Typing the inner shapes would over-couple this example to the A2UI v0.9
     # spec; instead we leave strict OFF and rely on the envelope-args
     # normalizer (Python: src/streaming/envelope_normalizer.py; TS:
     # libs/chat/src/lib/a2ui/envelope-normalizer.ts) to canonicalize the
@@ -408,11 +408,11 @@ async def generate(state: State, config: RunnableConfig) -> dict:
     llm = ChatOpenAI(**kwargs).bind_tools(
         [search_documents, request_approval, research, gen_ui_tool],
     )
-    # Append A2UI v1 schema to system prompt when in a2ui mode, so the parent
+    # Append A2UI v0.9 schema to system prompt when in a2ui mode, so the parent
     # LLM knows how to construct the envelopes directly.
     system = SYSTEM_PROMPT
     if gen_ui_mode == "a2ui":
-        system = SYSTEM_PROMPT + "\n\n--- A2UI v1 SCHEMA ---\n" + A2UI_V1_SCHEMA_PROMPT + (
+        system = SYSTEM_PROMPT + "\n\n--- A2UI v0.9 SCHEMA ---\n" + A2UI_V1_SCHEMA_PROMPT + (
             "\n\nWhen rendering UI in a2ui mode, emit envelopes in this order: "
             "surfaceUpdate FIRST, then beginRendering, then any dataModelUpdate "
             "entries. This lets the client mount the surface as early as possible."

--- a/examples/chat/python/src/schemas/a2ui_v1.py
+++ b/examples/chat/python/src/schemas/a2ui_v1.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
-"""A2UI v1 protocol schema documentation, used as the system prompt for
+"""A2UI v0.9 protocol schema documentation, used as the system prompt for
 the `generate_a2ui_schema` sub-LLM tool. Sourced verbatim from the
-L4 production reference (canonical Google A2UI v1 schema)."""
+L4 production reference (canonical Google A2UI v0.9 schema)."""
 
 A2UI_V1_SCHEMA_PROMPT = """
 Generate A2UI JSON.

--- a/examples/chat/python/src/streaming/envelope_tool.py
+++ b/examples/chat/python/src/streaming/envelope_tool.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-"""Parent-LLM-bound tool that emits A2UI v1 envelopes as structured tool
+"""Parent-LLM-bound tool that emits A2UI v0.9 envelopes as structured tool
 arguments. Replaces the old two-LLM `generate_a2ui_schema` flow (parent
 calls a sub-LLM that produces envelopes); the parent now emits envelopes
 directly so the natural token stream IS the surface-rendering stream.
@@ -41,7 +41,7 @@ class DataModelUpdate(BaseModel):
 
 
 class A2uiEnvelope(BaseModel):
-    """Single A2UI v1 envelope. Exactly one of the three discriminators
+    """Single A2UI v0.9 envelope. Exactly one of the three discriminators
     is set per envelope — the model_validator below enforces this so the
     parent LLM cannot emit ambiguous or empty envelopes."""
     surfaceUpdate: Optional[SurfaceUpdate] = None
@@ -64,7 +64,7 @@ class A2uiEnvelope(BaseModel):
 
 @tool
 def render_a2ui_surface(envelopes: list[A2uiEnvelope]) -> str:
-    """Render a UI surface using A2UI v1 envelopes. Emit:
+    """Render a UI surface using A2UI v0.9 envelopes. Emit:
       - exactly one `surfaceUpdate` (component tree),
       - exactly one `beginRendering` (root reference),
       - zero or more `dataModelUpdate` entries (initial state).

--- a/examples/chat/smoke/CHECKLIST.md
+++ b/examples/chat/smoke/CHECKLIST.md
@@ -272,14 +272,14 @@ renders correctly both during streaming and after completion.
 
 ### Gen UI mode dropdown
 
-- [ ] Palette "Gen UI" dropdown lists 2 options: `A2UI v1` and `json-render`
-- [ ] Default value is `A2UI v1` on first load
+- [ ] Palette "Gen UI" dropdown lists 2 options: `A2UI v0.9-compatible` and `json-render`
+- [ ] Default value is `A2UI v0.9-compatible` on first load
 - [ ] Selection persists across reload and mode switches
 - [ ] Server-side: `curl localhost:2024/threads/<id>/state` shows `values.gen_ui_mode` matches the palette selection
 
-### Dynamic dispatch — A2UI v1 mode
+### Dynamic dispatch — A2UI v0.9-compatible mode
 
-- [ ] With Gen UI = `A2UI v1`, click any GenUI welcome suggestion (e.g. "Demo: render a feedback form")
+- [ ] With Gen UI = `A2UI v0.9-compatible`, click any GenUI welcome suggestion (e.g. "Demo: render a feedback form")
 - [ ] **Single bubble** — exactly ONE assistant bubble per GenUI turn (no skeleton bubble followed by a separate surface bubble)
 - [ ] Parent LLM emits a tool_call to `render_a2ui_surface` (parent emits envelopes directly as typed args — there is no sub-LLM hop)
 - [ ] Final assistant AI message carries BOTH `tool_calls` AND `---a2ui_JSON---\n`-prefixed content (in-place replacement of the tool-call AI)
@@ -291,7 +291,7 @@ renders correctly both during streaming and after completion.
 
 ### Progressive A2UI streaming (per-component fallback transition)
 
-- [ ] DevTools Network → trigger any A2UI v1 GenUI prompt; the `/runs/stream` SSE response contains `event: custom` frames carrying `a2ui-partial` payloads (`{name: 'a2ui-partial', data: {tool_call_id, args_so_far}}`)
+- [ ] DevTools Network → trigger any A2UI v0.9-compatible GenUI prompt; the `/runs/stream` SSE response contains `event: custom` frames carrying `a2ui-partial` payloads (`{name: 'a2ui-partial', data: {tool_call_id, args_so_far}}`)
 - [ ] At least several `a2ui-partial` frames stream as the parent LLM emits tool-call argument tokens (not all-at-once)
 - [ ] During streaming: `<a2ui-surface>` mounts before all `dataModelUpdate` envelopes arrive — components show `<render-default-fallback>` (shimmer card with "Building UI…" label) until their bound state populates
 - [ ] As each `dataModelUpdate` envelope arrives, exactly one component flips from fallback → real
@@ -309,7 +309,7 @@ renders correctly both during streaming and after completion.
 
 ### Server-side wire format
 
-- [ ] In A2UI v1 mode: the final AI message content starts with `---a2ui_JSON---\n` followed by JSONL (one envelope per line); contains at minimum `surfaceUpdate` and `beginRendering` envelopes; envelopes are reordered so `beginRendering` follows the first `surfaceUpdate` regardless of LLM emission order
+- [ ] In A2UI v0.9-compatible mode: the final AI message content starts with `---a2ui_JSON---\n` followed by JSONL (one envelope per line); contains at minimum `surfaceUpdate` and `beginRendering` envelopes; envelopes are reordered so `beginRendering` follows the first `surfaceUpdate` regardless of LLM emission order
 - [ ] The same AI message carries `tool_calls` set (single-bubble invariant)
 - [ ] In json-render mode: final AI message content is a bare JSON object starting with `{`
 - [ ] `curl localhost:2024/threads/<id>/state` confirms the above for both modes

--- a/libs/ag-ui/README.md
+++ b/libs/ag-ui/README.md
@@ -2,7 +2,7 @@
 
 Adapter that wraps an [AG-UI](https://github.com/ag-ui-protocol/ag-ui) `AbstractAgent` into the runtime-neutral `Agent` contract from `@ngaf/chat`. Works with any AG-UI-compatible backend — LangGraph, CrewAI, Mastra, Microsoft Agent Framework, AG2, Pydantic AI, AWS Strands, CopilotKit runtime.
 
-Part of the [Angular Agent Framework](https://github.com/cacheplane/angular-agent-framework). MIT licensed.
+Part of [Agent UI for Angular](https://github.com/cacheplane/angular-agent-framework). MIT licensed.
 
 ## Install
 

--- a/libs/ag-ui/tsconfig.lib.json
+++ b/libs/ag-ui/tsconfig.lib.json
@@ -9,5 +9,10 @@
     "types": []
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"],
+  "references": [
+    {
+      "path": "../licensing/tsconfig.lib.json"
+    }
+  ]
 }

--- a/libs/chat/README.md
+++ b/libs/chat/README.md
@@ -2,7 +2,7 @@
 
 Drop-in agent chat UI for Angular 20+. Headless primitives that read from a runtime-neutral `Agent` contract, plus opinionated compositions (`<chat>`, `<chat-debug>`, GenUI surfaces) you can ship in days.
 
-Part of the [Angular Agent Framework](https://github.com/cacheplane/angular-agent-framework). MIT licensed.
+Part of [Agent UI for Angular](https://github.com/cacheplane/angular-agent-framework). MIT licensed.
 
 ## Runtime adapters
 

--- a/libs/chat/README.md
+++ b/libs/chat/README.md
@@ -70,7 +70,7 @@ The `CitationsResolverService` is provided to query citations in message-first o
 
 ### Agent-driven theming (v1 wire format)
 
-Agents control exactly two knobs per the canonical A2UI v1 spec, set via `beginRendering.styles`:
+Agents control exactly two knobs per the canonical A2UI v0.9-compatible spec, set via `beginRendering.styles`:
 
 - `font` — primary font family
 - `primaryColor` — hex `#RRGGBB`

--- a/libs/chat/src/lib/compositions/chat/chat.component.ts
+++ b/libs/chat/src/lib/compositions/chat/chat.component.ts
@@ -638,7 +638,7 @@ export class ChatComponent {
     // A2UI/json-render markers in the content string.
     const projectedContent = (m as { content?: unknown }).content;
     if (typeof projectedContent === 'string' && projectedContent.length > 0) {
-      // A2UI v1 envelope keys (canonical Google shape).
+      // A2UI v0.9 envelope keys (canonical Google shape).
       if (projectedContent.includes('"surfaceUpdate"')
           || projectedContent.includes('"beginRendering"')
           || projectedContent.includes('"dataModelUpdate"')) {

--- a/libs/chat/src/lib/streaming/content-classifier.spec.ts
+++ b/libs/chat/src/lib/streaming/content-classifier.spec.ts
@@ -179,7 +179,7 @@ describe('ContentClassifier', () => {
   });
 
   describe('a2ui JSONL parsing (v1)', () => {
-    it('parses A2UI v1 messages and exposes surfaces after beginRendering', () => {
+    it('parses A2UI v0.9 messages and exposes surfaces after beginRendering', () => {
       const c = setup();
       c.update(
         '---a2ui_JSON---' +
@@ -194,7 +194,7 @@ describe('ContentClassifier', () => {
       expect('Text' in comp.component).toBe(true);
     });
 
-    it('accumulates A2UI v1 messages across updates', () => {
+    it('accumulates A2UI v0.9 messages across updates', () => {
       const c = setup();
       // First update: surfaceUpdate + dataModelUpdate (no beginRendering yet — surface not visible)
       c.update(

--- a/libs/chat/tsconfig.lib.json
+++ b/libs/chat/tsconfig.lib.json
@@ -9,5 +9,13 @@
     "types": []
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"],
+  "references": [
+    {
+      "path": "../a2ui/tsconfig.lib.json"
+    },
+    {
+      "path": "../licensing/tsconfig.lib.json"
+    }
+  ]
 }

--- a/libs/example-layouts/tsconfig.lib.json
+++ b/libs/example-layouts/tsconfig.lib.json
@@ -9,5 +9,10 @@
     "types": []
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"],
+  "references": [
+    {
+      "path": "../design-tokens/tsconfig.lib.json"
+    }
+  ]
 }

--- a/libs/langgraph/README.md
+++ b/libs/langgraph/README.md
@@ -2,7 +2,7 @@
 
 Adapter that wraps a LangGraph agent into the runtime-neutral `Agent` contract from `@ngaf/chat`. The Angular equivalent of LangGraph's React `useStream()` hook — signal-driven access to messages, status, tool calls, interrupts, subagents, regenerate, and thread history.
 
-Part of the [Angular Agent Framework](https://github.com/cacheplane/angular-agent-framework). MIT licensed.
+Part of [Agent UI for Angular](https://github.com/cacheplane/angular-agent-framework). MIT licensed.
 
 ## Install
 

--- a/libs/langgraph/tsconfig.lib.json
+++ b/libs/langgraph/tsconfig.lib.json
@@ -9,5 +9,10 @@
     "types": []
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"],
+  "references": [
+    {
+      "path": "../licensing/tsconfig.lib.json"
+    }
+  ]
 }

--- a/libs/render/README.md
+++ b/libs/render/README.md
@@ -1,6 +1,6 @@
 # @ngaf/render
 
-Generative UI for Angular. Agents emit structured JSON specs; this library renders them into Angular components you already own. Supports the Vercel `json-render` and Google A2UI v1 protocols out of the box.
+Generative UI for Angular. Agents emit structured JSON specs; this library renders them into Angular components you already own. Supports the Vercel `json-render` and Google A2UI v0.9-compatible protocols out of the box.
 
 Part of [Agent UI for Angular](https://github.com/cacheplane/angular-agent-framework). MIT licensed.
 
@@ -13,7 +13,7 @@ npm install @ngaf/render
 ## What it does
 
 - **Spec-driven rendering** — agents return JSON; you map each node type to one of your Angular components via a registry
-- **Two protocols supported** — Vercel `json-render` and Google A2UI v1
+- **Two protocols supported** — Vercel `json-render` and Google A2UI v0.9-compatible
 - **Per-component fallback API** — when a spec node has no registered component, you control what renders (and surface it to your observability layer)
 - **Readiness gate** — holds renders until the surface is real, so users never see mystery partial UI
 - **Streaming partial renders** — works with `@cacheplane/partial-json` to render progressive JSON as it streams
@@ -23,7 +23,7 @@ npm install @ngaf/render
 - [Quickstart](https://cacheplane.ai/docs/render/getting-started/quickstart)
 - [Component registry](https://cacheplane.ai/docs/render/guides/registry)
 - [Fallback patterns](https://cacheplane.ai/docs/render/guides/fallback)
-- [A2UI v1 protocol](https://cacheplane.ai/docs/render/a2ui/overview)
+- [A2UI v0.9-compatible protocol](https://cacheplane.ai/docs/render/a2ui/overview)
 
 ## License
 

--- a/libs/render/README.md
+++ b/libs/render/README.md
@@ -2,7 +2,7 @@
 
 Generative UI for Angular. Agents emit structured JSON specs; this library renders them into Angular components you already own. Supports the Vercel `json-render` and Google A2UI v1 protocols out of the box.
 
-Part of the [Angular Agent Framework](https://github.com/cacheplane/angular-agent-framework). MIT licensed.
+Part of [Agent UI for Angular](https://github.com/cacheplane/angular-agent-framework). MIT licensed.
 
 ## Install
 

--- a/libs/render/tsconfig.lib.json
+++ b/libs/render/tsconfig.lib.json
@@ -9,5 +9,10 @@
     "types": []
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"],
+  "references": [
+    {
+      "path": "../licensing/tsconfig.lib.json"
+    }
+  ]
 }

--- a/libs/ui-react/tsconfig.lib.json
+++ b/libs/ui-react/tsconfig.lib.json
@@ -8,5 +8,10 @@
     }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
-  "exclude": ["src/**/*.spec.ts", "src/**/*.spec.tsx"]
+  "exclude": ["src/**/*.spec.ts", "src/**/*.spec.tsx"],
+  "references": [
+    {
+      "path": "../design-tokens/tsconfig.lib.json"
+    }
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,78 @@
   "references": [
     {
       "path": "./apps/website"
+    },
+    {
+      "path": "./cockpit/langgraph/deployment-runtime/python"
+    },
+    {
+      "path": "./cockpit/langgraph/durable-execution/python"
+    },
+    {
+      "path": "./cockpit/deep-agents/filesystem/python"
+    },
+    {
+      "path": "./cockpit/deep-agents/sandboxes/python"
+    },
+    {
+      "path": "./cockpit/deep-agents/subagents/python"
+    },
+    {
+      "path": "./cockpit/langgraph/persistence/python"
+    },
+    {
+      "path": "./cockpit/langgraph/time-travel/python"
+    },
+    {
+      "path": "./cockpit/deep-agents/planning/python"
+    },
+    {
+      "path": "./cockpit/langgraph/interrupts/python"
+    },
+    {
+      "path": "./cockpit/langgraph/streaming/python"
+    },
+    {
+      "path": "./cockpit/langgraph/subgraphs/python"
+    },
+    {
+      "path": "./cockpit/deep-agents/memory/python"
+    },
+    {
+      "path": "./cockpit/deep-agents/skills/python"
+    },
+    {
+      "path": "./cockpit/langgraph/memory/python"
+    },
+    {
+      "path": "./apps/minting-service"
+    },
+    {
+      "path": "./libs/design-tokens"
+    },
+    {
+      "path": "./libs/licensing"
+    },
+    {
+      "path": "./libs/telemetry"
+    },
+    {
+      "path": "./e2e/agent-e2e"
+    },
+    {
+      "path": "./tools/posthog"
+    },
+    {
+      "path": "./libs/ui-react"
+    },
+    {
+      "path": "./apps/cockpit"
+    },
+    {
+      "path": "./libs/a2ui"
+    },
+    {
+      "path": "./libs/db"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Spec 2 ships Phase-1 developer clarity: locked Direction-A hero, new \`/contact\` enterprise CTA destination, four risk-cleanup copy sweeps, and CTA tracking that makes the two-track funnel measurable.

**Hero** — H1 "Ship production agent UIs in Angular." with subhead from \`docs/gtm/messaging.md\`. Primary CTA \`Install @ngaf/chat\` copies the install command (clipboard) + fires \`marketing:cta_click {cta_id: hero_install, track: developer}\`. Secondary CTA \`Talk to our engineers\` routes to \`/contact?source=home_hero&track=enterprise\` + fires \`{cta_id: hero_talk_to_engineers, track: enterprise}\`. Six proof pills + italic subline.

**\`/contact\`** — Direction A.v2: "Talk to an engineer." H1, SLA card, GitHub stars pill (live build-time ISR fetch — verified live as "★ 2 on GitHub"), alt-channel row (docs · GitHub issues · Discord), form with email (required) + name, company, message (all optional), hidden attribution fields (\`source_page\`, \`track\`, \`cta_id\`, \`paper\`, \`referrer_host\`) auto-populated. Submits to the existing \`/api/leads\` pipeline — Spec 1E's qualification gate stamps \`marketing:lead_qualified\` when company + non-personal email.

**\`/pricing\`** — replaced "All Angular versions" with a real \`CompatibilityMatrix\` (Supported: 20, 21 / Experimental: — / Planned: 22 / Unsupported: ≤19).

**Three full-repo sweeps (per-file review, never \`replace_all\`):**
- "Angular Agent Framework" → "Agent UI for Angular" (40 files)
- "A2UI v1" → "A2UI v0.9-compatible" / "A2UI v0.9" in code comments (11 files)
- "No telemetry" — already canonical from prior Spec 1 work (no changes needed)

**Typed \`CtaId\` union** in \`apps/website/src/lib/analytics/events.ts\` so misspellings get caught at build time.

**\`/api/leads\`** validation loosened to email-only; Resend subject + email template handle missing name.

**\`docs/gtm/messaging.md\`** Contact page §Fields updated to reflect the expanded field set (deviation from the original locked spec — call-out in the design doc explains why).

## Spec & Plan

- Spec: \`docs/superpowers/specs/gtm/2026-05-16-positioning-and-risks-design.md\`
- Plan: \`docs/superpowers/plans/gtm/2026-05-16-positioning-and-risks.md\`

## Chrome MCP smoke (post-implementation)

End-to-end verified locally against \`http://localhost:3000\`:

- ✅ Hero renders locked copy + eyebrow + 6 proof pills + italic subline + right-column collage preserved
- ✅ Primary CTA click: clipboard receives \`npm install @ngaf/chat\`
- ✅ Secondary CTA: \`href="/contact?source=home_hero&track=enterprise"\`
- ✅ \`/contact\` H1 + SLA card + 4 form fields + GitHub pill (live count) + alt-channel row
- ✅ Form submit POSTed to \`/api/leads\` with full body including hidden attribution fields; success message displayed
- ✅ \`/pricing\` shows the 4-row CompatibilityMatrix; "All Angular versions" copy is gone; "See compatibility matrix below" is in CompareTable
- ✅ Page titles swept to "Agent UI for Angular"

## Test plan

- [x] \`nx run-many -t test -p telemetry,cockpit,posthog-tools\` — green
- [x] \`apps/website\` vitest unit tests — 18/18 pass (Hero, ContactForm, GitHubStarsPill, getGitHubStars, CompatibilityMatrix, server.spec.ts)
- [x] \`nx run website:build\` — green
- [x] Chrome MCP smoke (this PR description's verification list)
- [ ] Post-merge: confirm hero CTAs fire \`marketing:cta_click\` in PostHog Live Events with \`cta_id=hero_install\` (track=developer) and \`cta_id=hero_talk_to_engineers\` (track=enterprise)

🤖 Generated with [Claude Code](https://claude.com/claude-code)