### PR TITLE
feat(c-interrupts): real interrupt() wiring via book_flight tool

### DIFF
--- a/cockpit/chat/interrupts/angular/src/app/interrupts.component.ts
+++ b/cockpit/chat/interrupts/angular/src/app/interrupts.component.ts
@@ -2,6 +2,7 @@
 import { Component, computed } from '@angular/core';
 import { JsonPipe } from '@angular/common';
 import { ChatComponent, ChatInterruptPanelComponent } from '@ngaf/chat';
+import type { InterruptAction } from '@ngaf/chat';
 import { ExampleChatLayoutComponent } from '@ngaf/example-layouts';
 import { agent } from '@ngaf/langgraph';
 import { environment } from '../environments/environment';
@@ -11,6 +12,10 @@ import { environment } from '../environments/environment';
  * using ChatComponent and ChatInterruptPanelComponent.
  *
  * Shows interrupt payload and action buttons in a sidebar panel.
+ * Maps the panel's UI actions to LangGraph resume payloads:
+ *   Accept  → resume('confirm')   — the book_flight tool returns Booked …
+ *   Ignore  → resume('cancel')    — the book_flight tool returns Booking cancelled.
+ * Edit / Respond are not wired for this demo's single-decision booking flow.
  */
 @Component({
   selector: 'app-interrupts',
@@ -22,7 +27,7 @@ import { environment } from '../environments/environment';
       <div sidebar class="p-4 space-y-4" style="background: var(--ngaf-chat-bg); color: var(--ngaf-chat-text);">
         <h3 class="text-xs font-semibold uppercase tracking-wide"
             style="color: var(--ngaf-chat-text-muted);">Interrupt Panel</h3>
-        <chat-interrupt-panel [agent]="agent" />
+        <chat-interrupt-panel [agent]="agent" (action)="onInterruptAction($event)" />
         <div class="mt-4">
           <h4 class="text-xs font-semibold uppercase tracking-wide mb-2"
               style="color: var(--ngaf-chat-text-muted);">Stream Status</h4>
@@ -39,4 +44,13 @@ export class InterruptsComponent {
   });
 
   protected readonly streamStatus = computed(() => this.agent.status());
+
+  protected onInterruptAction(action: InterruptAction): void {
+    if (action === 'accept') {
+      this.agent.submit({ resume: 'confirm' });
+    } else if (action === 'ignore') {
+      this.agent.submit({ resume: 'cancel' });
+    }
+    // 'edit' and 'respond' are intentionally unhandled for the booking flow.
+  }
 }

--- a/cockpit/chat/interrupts/python/prompts/interrupts.md
+++ b/cockpit/chat/interrupts/python/prompts/interrupts.md
@@ -9,14 +9,13 @@ BOS, ATL, DFW, SEA, MIA, DEN — and 4 airlines (American, United, Delta,
 JetBlue). For airports/airlines outside this list, you can still provide
 general aviation knowledge but acknowledge the data limit.
 
-## Interrupt behavior
+## Booking flow
 
-If the user wants to actually book a flight, ANY flight, pause and ask for
-explicit confirmation before proceeding. Phrase it like:
+If the user wants to book a flight, call the `book_flight` tool with the
+flight number (e.g., `AA123`). The tool pauses the conversation and surfaces
+a confirmation card in the UI; after the user responds, the tool returns
+either a confirmation or a cancellation message. Relay that result naturally
+in your reply.
 
-> "I can help you book that flight. Before I proceed, please confirm:
-> [airline] flight [number] from [origin] to [destination] for approximately
-> $[mock price]. Reply 'confirm' or 'cancel'."
-
-This pause demonstrates the chat-interrupts primitive's human-in-the-loop
-gate. Do not actually charge anything; this is a UI demo.
+If the user has not yet picked a specific flight number, use `find_routes`
+to list options first, then ask which one they want to book.

--- a/cockpit/chat/interrupts/python/src/aviation_data.py
+++ b/cockpit/chat/interrupts/python/src/aviation_data.py
@@ -1,0 +1,207 @@
+"""Aviation mock dataset for c-* example demos.
+
+Hardcoded data for the c-tool-calls and c-subagents demos (and future c-*
+aviation-themed examples). Zero external API calls — everything is canned
+for deterministic demos and offline-friendly development.
+
+The dataset is small but cohesive: ~10 US airports, 4 major airlines,
+~30 flights criss-crossing those airports. Each airport has a static
+"current weather" entry that doesn't change between calls (for
+repeatability in screencasts and snapshot tests).
+"""
+
+# ── Airports ────────────────────────────────────────────────────────────────
+
+AIRPORTS = {
+    "LAX": {"code": "LAX", "name": "Los Angeles International", "city": "Los Angeles", "country": "USA",
+            "weather": {"temp_f": 72, "conditions": "Partly Cloudy"}, "terminals": 9, "runways": 4},
+    "JFK": {"code": "JFK", "name": "John F. Kennedy International", "city": "New York", "country": "USA",
+            "weather": {"temp_f": 58, "conditions": "Clear"}, "terminals": 6, "runways": 4},
+    "SFO": {"code": "SFO", "name": "San Francisco International", "city": "San Francisco", "country": "USA",
+            "weather": {"temp_f": 64, "conditions": "Foggy"}, "terminals": 4, "runways": 4},
+    "ORD": {"code": "ORD", "name": "O'Hare International", "city": "Chicago", "country": "USA",
+            "weather": {"temp_f": 48, "conditions": "Light Rain"}, "terminals": 4, "runways": 8},
+    "BOS": {"code": "BOS", "name": "Logan International", "city": "Boston", "country": "USA",
+            "weather": {"temp_f": 52, "conditions": "Overcast"}, "terminals": 4, "runways": 6},
+    "ATL": {"code": "ATL", "name": "Hartsfield-Jackson Atlanta International", "city": "Atlanta", "country": "USA",
+            "weather": {"temp_f": 68, "conditions": "Sunny"}, "terminals": 2, "runways": 5},
+    "DFW": {"code": "DFW", "name": "Dallas/Fort Worth International", "city": "Dallas", "country": "USA",
+            "weather": {"temp_f": 76, "conditions": "Sunny"}, "terminals": 5, "runways": 7},
+    "SEA": {"code": "SEA", "name": "Seattle-Tacoma International", "city": "Seattle", "country": "USA",
+            "weather": {"temp_f": 55, "conditions": "Drizzle"}, "terminals": 3, "runways": 3},
+    "MIA": {"code": "MIA", "name": "Miami International", "city": "Miami", "country": "USA",
+            "weather": {"temp_f": 82, "conditions": "Humid, Sunny"}, "terminals": 3, "runways": 4},
+    "DEN": {"code": "DEN", "name": "Denver International", "city": "Denver", "country": "USA",
+            "weather": {"temp_f": 60, "conditions": "Clear, Windy"}, "terminals": 1, "runways": 6},
+}
+
+# ── Airlines ────────────────────────────────────────────────────────────────
+
+AIRLINES = {
+    "AA": {"code": "AA", "name": "American Airlines", "hub": "DFW"},
+    "UA": {"code": "UA", "name": "United Airlines", "hub": "ORD"},
+    "DL": {"code": "DL", "name": "Delta Air Lines", "hub": "ATL"},
+    "B6": {"code": "B6", "name": "JetBlue Airways", "hub": "JFK"},
+}
+
+# ── Flights ─────────────────────────────────────────────────────────────────
+
+FLIGHTS = [
+    # United transcontinental
+    {"flight_number": "UA123", "airline": "UA", "from": "LAX", "to": "JFK",
+     "depart_local": "08:00", "arrive_local": "16:30", "duration_min": 330,
+     "status": "on_time", "gate": "B14", "aircraft": "Boeing 787"},
+    {"flight_number": "UA456", "airline": "UA", "from": "JFK", "to": "LAX",
+     "depart_local": "10:00", "arrive_local": "13:15", "duration_min": 375,
+     "status": "delayed", "gate": "T7-12", "aircraft": "Boeing 757"},
+    {"flight_number": "UA789", "airline": "UA", "from": "ORD", "to": "SFO",
+     "depart_local": "09:30", "arrive_local": "12:00", "duration_min": 270,
+     "status": "on_time", "gate": "C15", "aircraft": "Airbus A320"},
+
+    # American out of DFW hub
+    {"flight_number": "AA101", "airline": "AA", "from": "DFW", "to": "LAX",
+     "depart_local": "07:15", "arrive_local": "08:45", "duration_min": 210,
+     "status": "on_time", "gate": "A23", "aircraft": "Boeing 737"},
+    {"flight_number": "AA202", "airline": "AA", "from": "DFW", "to": "JFK",
+     "depart_local": "11:00", "arrive_local": "15:30", "duration_min": 210,
+     "status": "on_time", "gate": "D8", "aircraft": "Boeing 737"},
+    {"flight_number": "AA303", "airline": "AA", "from": "DFW", "to": "MIA",
+     "depart_local": "13:45", "arrive_local": "17:30", "duration_min": 165,
+     "status": "on_time", "gate": "C11", "aircraft": "Airbus A321"},
+    {"flight_number": "AA404", "airline": "AA", "from": "BOS", "to": "DFW",
+     "depart_local": "06:30", "arrive_local": "10:00", "duration_min": 270,
+     "status": "cancelled", "gate": "B5", "aircraft": "Boeing 737"},
+
+    # Delta hub-and-spoke from ATL
+    {"flight_number": "DL501", "airline": "DL", "from": "ATL", "to": "LAX",
+     "depart_local": "10:00", "arrive_local": "11:45", "duration_min": 285,
+     "status": "on_time", "gate": "F20", "aircraft": "Boeing 757"},
+    {"flight_number": "DL502", "airline": "DL", "from": "ATL", "to": "JFK",
+     "depart_local": "14:20", "arrive_local": "16:50", "duration_min": 150,
+     "status": "on_time", "gate": "B9", "aircraft": "Boeing 737"},
+    {"flight_number": "DL503", "airline": "DL", "from": "ATL", "to": "SEA",
+     "depart_local": "09:15", "arrive_local": "11:35", "duration_min": 320,
+     "status": "delayed", "gate": "A17", "aircraft": "Airbus A330"},
+    {"flight_number": "DL504", "airline": "DL", "from": "ATL", "to": "MIA",
+     "depart_local": "16:00", "arrive_local": "17:50", "duration_min": 110,
+     "status": "on_time", "gate": "T2", "aircraft": "Boeing 717"},
+
+    # JetBlue from JFK
+    {"flight_number": "B6601", "airline": "B6", "from": "JFK", "to": "LAX",
+     "depart_local": "07:30", "arrive_local": "10:55", "duration_min": 385,
+     "status": "on_time", "gate": "T5-12", "aircraft": "Airbus A321"},
+    {"flight_number": "B6602", "airline": "B6", "from": "JFK", "to": "BOS",
+     "depart_local": "12:15", "arrive_local": "13:30", "duration_min": 75,
+     "status": "on_time", "gate": "T5-9", "aircraft": "Embraer 190"},
+    {"flight_number": "B6603", "airline": "B6", "from": "JFK", "to": "MIA",
+     "depart_local": "15:45", "arrive_local": "18:55", "duration_min": 190,
+     "status": "on_time", "gate": "T5-15", "aircraft": "Airbus A320"},
+    {"flight_number": "B6604", "airline": "B6", "from": "BOS", "to": "MIA",
+     "depart_local": "09:00", "arrive_local": "12:35", "duration_min": 215,
+     "status": "on_time", "gate": "C42", "aircraft": "Airbus A320"},
+
+    # Denver hub (United secondary)
+    {"flight_number": "UA850", "airline": "UA", "from": "DEN", "to": "LAX",
+     "depart_local": "08:45", "arrive_local": "10:00", "duration_min": 135,
+     "status": "on_time", "gate": "B33", "aircraft": "Boeing 737"},
+    {"flight_number": "UA851", "airline": "UA", "from": "DEN", "to": "ORD",
+     "depart_local": "11:30", "arrive_local": "14:55", "duration_min": 145,
+     "status": "on_time", "gate": "B41", "aircraft": "Airbus A319"},
+    {"flight_number": "UA852", "airline": "UA", "from": "SFO", "to": "DEN",
+     "depart_local": "06:00", "arrive_local": "09:25", "duration_min": 145,
+     "status": "on_time", "gate": "F8", "aircraft": "Boeing 737"},
+
+    # Seattle (United + Delta)
+    {"flight_number": "UA901", "airline": "UA", "from": "SEA", "to": "ORD",
+     "depart_local": "07:00", "arrive_local": "12:55", "duration_min": 235,
+     "status": "on_time", "gate": "S2", "aircraft": "Boeing 737"},
+    {"flight_number": "DL902", "airline": "DL", "from": "SEA", "to": "ATL",
+     "depart_local": "14:30", "arrive_local": "22:05", "duration_min": 275,
+     "status": "on_time", "gate": "B12", "aircraft": "Boeing 757"},
+
+    # SFO-LAX shuttle
+    {"flight_number": "UA1001", "airline": "UA", "from": "SFO", "to": "LAX",
+     "depart_local": "06:00", "arrive_local": "07:25", "duration_min": 85,
+     "status": "on_time", "gate": "F3", "aircraft": "Airbus A320"},
+    {"flight_number": "UA1002", "airline": "UA", "from": "SFO", "to": "LAX",
+     "depart_local": "09:30", "arrive_local": "10:55", "duration_min": 85,
+     "status": "on_time", "gate": "F5", "aircraft": "Airbus A320"},
+    {"flight_number": "UA1003", "airline": "UA", "from": "LAX", "to": "SFO",
+     "depart_local": "08:00", "arrive_local": "09:25", "duration_min": 85,
+     "status": "on_time", "gate": "B22", "aircraft": "Airbus A320"},
+    {"flight_number": "UA1004", "airline": "UA", "from": "LAX", "to": "SFO",
+     "depart_local": "12:15", "arrive_local": "13:40", "duration_min": 85,
+     "status": "delayed", "gate": "B26", "aircraft": "Airbus A320"},
+
+    # Chicago hub (United + American)
+    {"flight_number": "UA710", "airline": "UA", "from": "ORD", "to": "BOS",
+     "depart_local": "06:30", "arrive_local": "09:45", "duration_min": 135,
+     "status": "on_time", "gate": "C12", "aircraft": "Boeing 737"},
+    {"flight_number": "AA711", "airline": "AA", "from": "ORD", "to": "DFW",
+     "depart_local": "07:15", "arrive_local": "09:50", "duration_min": 155,
+     "status": "on_time", "gate": "K8", "aircraft": "Boeing 737"},
+    {"flight_number": "UA712", "airline": "UA", "from": "ORD", "to": "DEN",
+     "depart_local": "10:00", "arrive_local": "11:30", "duration_min": 150,
+     "status": "on_time", "gate": "C20", "aircraft": "Embraer 175"},
+
+    # MIA southbound
+    {"flight_number": "AA801", "airline": "AA", "from": "MIA", "to": "JFK",
+     "depart_local": "08:00", "arrive_local": "11:00", "duration_min": 180,
+     "status": "on_time", "gate": "D40", "aircraft": "Boeing 737"},
+    {"flight_number": "DL802", "airline": "DL", "from": "MIA", "to": "ATL",
+     "depart_local": "12:30", "arrive_local": "14:20", "duration_min": 110,
+     "status": "on_time", "gate": "H5", "aircraft": "Boeing 717"},
+
+    # BOS additional
+    {"flight_number": "B6605", "airline": "B6", "from": "BOS", "to": "SFO",
+     "depart_local": "07:45", "arrive_local": "11:30", "duration_min": 405,
+     "status": "on_time", "gate": "C40", "aircraft": "Airbus A321"},
+]
+
+# ── Dashboard analytics (PR 3: c-generative-ui aviation KPIs) ───────────────
+
+KPI_SNAPSHOT = {
+    "on_time_pct": 84.2,
+    "on_time_delta": "+1.4%",
+    "flights_today": 312,
+    "flights_today_delta": "+8",
+    "avg_delay_min": 12,
+    "avg_delay_delta": "-2 min",
+    "load_factor_pct": 78.5,
+    "load_factor_delta": "+0.6%",
+}
+
+ON_TIME_TREND = [
+    {"month": "2025-05", "on_time_pct": 82.4},
+    {"month": "2025-06", "on_time_pct": 81.1},
+    {"month": "2025-07", "on_time_pct": 79.8},
+    {"month": "2025-08", "on_time_pct": 80.5},
+    {"month": "2025-09", "on_time_pct": 83.2},
+    {"month": "2025-10", "on_time_pct": 84.0},
+    {"month": "2025-11", "on_time_pct": 82.6},
+    {"month": "2025-12", "on_time_pct": 78.9},
+    {"month": "2026-01", "on_time_pct": 80.2},
+    {"month": "2026-02", "on_time_pct": 81.7},
+    {"month": "2026-03", "on_time_pct": 82.8},
+    {"month": "2026-04", "on_time_pct": 84.2},
+]
+
+FLIGHTS_BY_AIRLINE = [
+    {"airline": "American", "count": 87},
+    {"airline": "United",   "count": 92},
+    {"airline": "Delta",    "count": 78},
+    {"airline": "JetBlue",  "count": 55},
+]
+
+RECENT_DISRUPTIONS = [
+    {"flight_number": "UA123", "type": "delayed",   "minutes": 45, "route": "LAX→JFK", "date": "2026-05-14"},
+    {"flight_number": "AA456", "type": "cancelled", "minutes": 0,  "route": "JFK→LAX", "date": "2026-05-14"},
+    {"flight_number": "DL789", "type": "delayed",   "minutes": 22, "route": "ATL→ORD", "date": "2026-05-13"},
+    {"flight_number": "B6101", "type": "delayed",   "minutes": 68, "route": "BOS→MIA", "date": "2026-05-13"},
+    {"flight_number": "UA204", "type": "cancelled", "minutes": 0,  "route": "SFO→SEA", "date": "2026-05-12"},
+    {"flight_number": "AA318", "type": "delayed",   "minutes": 15, "route": "DFW→DEN", "date": "2026-05-12"},
+    {"flight_number": "DL552", "type": "delayed",   "minutes": 35, "route": "ATL→MIA", "date": "2026-05-11"},
+    {"flight_number": "B6217", "type": "delayed",   "minutes": 80, "route": "JFK→BOS", "date": "2026-05-11"},
+    {"flight_number": "UA640", "type": "cancelled", "minutes": 0,  "route": "ORD→DEN", "date": "2026-05-10"},
+    {"flight_number": "AA871", "type": "delayed",   "minutes": 25, "route": "LAX→DFW", "date": "2026-05-10"},
+]

--- a/cockpit/chat/interrupts/python/src/aviation_tools.py
+++ b/cockpit/chat/interrupts/python/src/aviation_tools.py
@@ -1,0 +1,90 @@
+"""LangChain @tool wrappers around the aviation mock dataset.
+
+Each tool's docstring is what the LLM sees for tool-selection — keep them
+informative and example-laden.
+"""
+
+from langchain_core.tools import tool
+from src.aviation_data import AIRPORTS, AIRLINES, FLIGHTS
+
+
+@tool
+async def lookup_flight(flight_number: str) -> dict:
+    """Look up the status, route, and gate for a specific flight number.
+
+    Use this when the user asks about a specific flight (e.g., "what's the
+    status of UA123?", "is AA404 on time?", "what gate is DL501 leaving from?").
+
+    Args:
+        flight_number: Flight number like 'UA123' or 'AA456'. Case-insensitive.
+
+    Returns:
+        dict with keys: flight_number, airline, from, to, depart_local,
+        arrive_local, status (on_time/delayed/cancelled), gate, aircraft,
+        duration_min.
+
+    Returns {"error": "Flight not found"} if the flight number is not in
+    the dataset.
+    """
+    fn = flight_number.upper().strip()
+    for f in FLIGHTS:
+        if f["flight_number"] == fn:
+            return f
+    return {"error": f"Flight {fn} not found in dataset"}
+
+
+@tool
+async def get_airport_info(airport_code: str) -> dict:
+    """Get details about an airport: name, city, current weather, terminals, runways.
+
+    Use this when the user asks about an airport (e.g., "what's the weather
+    at LAX?", "tell me about JFK", "how many runways does ORD have?").
+
+    Args:
+        airport_code: 3-letter IATA code like 'LAX' or 'JFK'. Case-insensitive.
+
+    Returns:
+        dict with keys: code, name, city, country, weather (with temp_f and
+        conditions), terminals, runways.
+
+    Returns {"error": "Airport not found"} if the code is not in the dataset.
+    """
+    code = airport_code.upper().strip()
+    if code in AIRPORTS:
+        return AIRPORTS[code]
+    return {"error": f"Airport {code} not in dataset. Available: {sorted(AIRPORTS.keys())}"}
+
+
+@tool
+async def find_routes(from_code: str, to_code: str, date_offset_days: int = 0) -> dict:
+    """Find available flights between two airports.
+
+    Use this when the user asks about flight options (e.g., "what flights
+    are there from LAX to JFK?", "find me a flight from Boston to Miami
+    tomorrow").
+
+    Args:
+        from_code: 3-letter IATA code for departure airport.
+        to_code: 3-letter IATA code for arrival airport.
+        date_offset_days: 0 = today, 1 = tomorrow, etc. Note: mock data is
+            the same regardless of date; the LLM can still reason about
+            the date in its response.
+
+    Returns:
+        dict with keys:
+          - "flights": list of flight dicts (same shape as lookup_flight)
+            sorted by depart_local, OR empty list if no routes.
+          - "from": echoed from_code
+          - "to": echoed to_code
+          - "date_offset_days": echoed
+    """
+    fc = from_code.upper().strip()
+    tc = to_code.upper().strip()
+    flights = sorted(
+        [f for f in FLIGHTS if f["from"] == fc and f["to"] == tc],
+        key=lambda f: f["depart_local"],
+    )
+    return {"from": fc, "to": tc, "date_offset_days": date_offset_days, "flights": flights}
+
+
+ALL_TOOLS = [lookup_flight, get_airport_info, find_routes]

--- a/cockpit/chat/interrupts/python/src/graph.py
+++ b/cockpit/chat/interrupts/python/src/graph.py
@@ -1,49 +1,91 @@
-"""
-Chat Interrupts Graph
+"""Chat Interrupts Graph — agent ↔ ToolNode loop with book_flight (interrupt).
 
-A LangGraph StateGraph that demonstrates human-in-the-loop approval gates
-using the interrupt() primitive. The graph generates a response, then pauses
-for user approval before proceeding.
+Self-contained: aviation_tools + aviation_data copied into this module.
+The book_flight tool raises interrupt({...}) before completing the booking,
+so the chat-interrupt-panel renders and the user can Accept or Ignore.
 """
 
 from pathlib import Path
 from langgraph.graph import StateGraph, MessagesState, END
+from langgraph.prebuilt import ToolNode
 from langgraph.types import interrupt
 from langchain_openai import ChatOpenAI
-from langchain_core.messages import SystemMessage, AIMessage
+from langchain_core.messages import SystemMessage
+from langchain_core.tools import tool
+
+from src.aviation_tools import (
+    get_airport_info,
+    find_routes,
+    lookup_flight,
+)
 
 PROMPTS_DIR = Path(__file__).parent.parent / "prompts"
+MODEL = "gpt-5-mini"
+
+
+@tool
+async def book_flight(flight_number: str) -> str:
+    """Book a flight by flight number. Pauses for human confirmation.
+
+    Use this tool when the user explicitly asks to book a specific flight.
+    The tool raises a LangGraph interrupt so the UI can render an
+    approval card; on resume, it returns a confirmation or cancellation
+    message.
+
+    Args:
+        flight_number: Flight number like 'AA123' or 'UA456'.
+
+    Returns:
+        A short booking confirmation or cancellation message.
+    """
+    flight = await lookup_flight.ainvoke({"flight_number": flight_number})
+    if "error" in flight:
+        return f"Cannot book {flight_number}: {flight['error']}."
+
+    summary = (
+        f"Book {flight['airline']} {flight['flight_number']} from "
+        f"{flight['from']} to {flight['to']} "
+        f"(departs {flight['depart_local']}, {flight['aircraft']})?"
+    )
+    response = interrupt({
+        "type": "approval_request",
+        "summary": summary,
+        "flight": flight,
+    })
+
+    decision = str(response).strip().lower()
+    if decision.startswith("confirm"):
+        return (
+            f"Booked {flight['airline']} {flight['flight_number']} from "
+            f"{flight['from']} to {flight['to']} "
+            f"(departs {flight['depart_local']})."
+        )
+    return "Booking cancelled."
 
 
 def build_interrupts_graph():
-    """
-    Constructs a graph with an approval gate that interrupts execution
-    and waits for human approval before continuing.
-    """
-    llm = ChatOpenAI(model="gpt-5-mini", streaming=True)
+    """Agent ↔ ToolNode loop with aviation read tools + book_flight (interrupt)."""
+    tools = [book_flight, find_routes, lookup_flight, get_airport_info]
+    llm = ChatOpenAI(model=MODEL, streaming=True).bind_tools(tools)
 
-    async def generate(state: MessagesState) -> dict:
+    async def agent(state: MessagesState) -> dict:
         system_prompt = (PROMPTS_DIR / "interrupts.md").read_text()
         messages = [SystemMessage(content=system_prompt)] + state["messages"]
         response = await llm.ainvoke(messages)
         return {"messages": [response]}
 
-    async def approval_gate(state: MessagesState) -> dict:
-        last_message = state["messages"][-1]
-        result = interrupt({
-            "type": "approval",
-            "message": "The assistant wants to proceed. Do you approve?",
-            "draft": last_message.content,
-        })
-        return {"messages": [AIMessage(content=f"Approved. Proceeding with: {last_message.content}")]}
+    def should_continue(state: MessagesState) -> str:
+        last = state["messages"][-1]
+        if hasattr(last, "tool_calls") and last.tool_calls:
+            return "tools"
+        return END
 
     graph = StateGraph(MessagesState)
-    graph.add_node("generate", generate)
-    graph.add_node("approval_gate", approval_gate)
-    graph.set_entry_point("generate")
-    graph.add_edge("generate", "approval_gate")
-    graph.add_edge("approval_gate", END)
-
+    graph.add_node("agent", agent)
+    graph.add_node("tools", ToolNode(tools))
+    graph.set_entry_point("agent")
+    graph.add_conditional_edges("agent", should_continue, {"tools": "tools", END: END})
+    graph.add_edge("tools", "agent")
     return graph.compile()
 
 


### PR DESCRIPTION
## Summary

Add real `interrupt()` wiring to the c-interrupts cockpit demo, now targeting
the per-cap **standalone backend** at `cockpit/chat/interrupts/python/` that
landed on main via PR #396 (`feat(c-per-cap): standalone backends`).

Previously the c-interrupts standalone shipped an unconditional approval-gate
graph (`{type:'approval', message, draft}`) that paused on every turn and had
no UI follow-through. This PR replaces it with an aviation-themed booking
flow that mirrors the rest of the cockpit chat demos:

- New `book_flight(flight_number)` tool inside the standalone graph raises
  `interrupt({type:'approval_request', summary, flight})` so the
  `chat-interrupt-panel` renders an Accept / Ignore card.
- Agent ↔ ToolNode loop binds `[book_flight, find_routes, lookup_flight,
  get_airport_info]`. Aviation data + read tools are **copied** into the
  standalone (per-cap convention: copy, don't share). The umbrella streaming
  backend is no longer touched.
- Prompt rewritten to direct the LLM to call `book_flight` instead of
  emitting a free-text "reply confirm/cancel".
- `interrupts.component.ts` maps panel actions to LangGraph resume payloads:
  - Accept → `submit({ resume: 'confirm' })` → tool returns "Booked …"
  - Ignore → `submit({ resume: 'cancel' })`  → tool returns "Booking cancelled."

## Files changed

- `cockpit/chat/interrupts/python/src/graph.py` — rewritten as agent ↔ ToolNode loop
- `cockpit/chat/interrupts/python/src/aviation_tools.py` — copied from umbrella
- `cockpit/chat/interrupts/python/src/aviation_data.py` — copied from umbrella
- `cockpit/chat/interrupts/python/prompts/interrupts.md` — booking-flow rewrite
- `cockpit/chat/interrupts/angular/src/app/interrupts.component.ts` — panel → resume wiring

The umbrella `cockpit/langgraph/streaming/python/src/chat_graphs.py` is **not**
touched on this branch — its `c_interrupts` registration is now functionally
dead for this demo and can be removed in a follow-up cleanup PR.

## Test plan

- [x] `uv sync` resolves in `cockpit/chat/interrupts/python/`
- [x] `from src.graph import graph` returns a `CompiledStateGraph`
- [x] `langgraph dev --port 5503` boots without traceback and registers `c-interrupts`
- [ ] Chrome MCP manual check: "Book me on UA123." → Accept → confirmation reply
- [ ] Chrome MCP manual check: "Actually, book me on AA404 instead." → Ignore → cancellation reply

🤖 Generated with [Claude Code](https://claude.com/claude-code)