### PR TITLE
fix(cockpit): render docs markdown blocks

### DIFF
--- a/apps/cockpit/src/lib/render-markdown.spec.ts
+++ b/apps/cockpit/src/lib/render-markdown.spec.ts
@@ -51,6 +51,13 @@ describe('renderMarkdown', () => {
     expect(result.html).toContain('Build a streaming chat.');
   });
 
+  it('parses inline markdown inside Summary blocks', async () => {
+    const md = '# Test\n\n<Summary>\nUse `agent()` from [`@ngaf/langgraph`](/docs/langgraph).\n</Summary>';
+    const result = await renderMarkdown(md);
+    expect(result.html).toContain('<code>agent()</code>');
+    expect(result.html).toContain('<a href="/docs/langgraph">');
+  });
+
   it('renders Tip callout blocks', async () => {
     const md = '# Test\n\n<Tip>\nNo service layer needed.\n</Tip>';
     const result = await renderMarkdown(md);
@@ -87,6 +94,15 @@ describe('renderMarkdown', () => {
     expect(result.html).toContain('doc-prompt');
     expect(result.html).toContain('Add streaming to this component.');
     expect(result.html).toContain('data-copy-prompt');
+  });
+
+  it('renders Related blocks as markdown link lists', async () => {
+    const md = '# Test\n\n<Related>\n- [Chat Messages](/chat/core-capabilities/messages/overview/python) - Learn how messages render\n</Related>';
+    const result = await renderMarkdown(md);
+    expect(result.html).toContain('doc-related');
+    expect(result.html).toContain('<ul>');
+    expect(result.html).toContain('<a href="/chat/core-capabilities/messages/overview/python">Chat Messages</a>');
+    expect(result.html).not.toContain('- [Chat Messages]');
   });
 
   it('renders ApiTable blocks as styled tables', async () => {

--- a/apps/cockpit/src/lib/render-markdown.ts
+++ b/apps/cockpit/src/lib/render-markdown.ts
@@ -13,7 +13,7 @@ interface ExtractedBlock {
   attrs: Record<string, string>;
 }
 
-const COMPONENT_TAGS = ['Summary', 'Tip', 'Note', 'Warning', 'Prompt', 'ApiTable', 'Step', 'Steps'];
+const COMPONENT_TAGS = ['Summary', 'Tip', 'Note', 'Warning', 'Prompt', 'ApiTable', 'Related', 'Step', 'Steps'];
 
 function extractComponentTags(source: string): { cleaned: string; blocks: ExtractedBlock[] } {
   const blocks: ExtractedBlock[] = [];
@@ -41,14 +41,37 @@ function extractComponentTags(source: string): { cleaned: string; blocks: Extrac
   return { cleaned, blocks };
 }
 
-function renderSummary(content: string): string {
-  return `<div class="doc-summary">${content}</div>`;
+async function renderInlineMarkdown(content: string): Promise<string> {
+  return await marked.parseInline(content);
 }
 
-function renderCallout(type: 'tip' | 'note' | 'warning', content: string): string {
+async function renderSummary(content: string): Promise<string> {
+  const html = await renderInlineMarkdown(content);
+  return `<div class="doc-summary">${html}</div>`;
+}
+
+async function renderCallout(
+  type: 'tip' | 'note' | 'warning',
+  content: string,
+): Promise<string> {
+  const html = await renderInlineMarkdown(content);
   const icons = { tip: '💡', note: '⚠️', warning: '🚨' };
   const labels = { tip: 'Tip', note: 'Note', warning: 'Warning' };
-  return `<div class="doc-callout doc-callout--${type}"><div class="doc-callout__label">${icons[type]} ${labels[type]}</div><div class="doc-callout__content">${content}</div></div>`;
+  return `<div class="doc-callout doc-callout--${type}"><div class="doc-callout__label">${icons[type]} ${labels[type]}</div><div class="doc-callout__content">${html}</div></div>`;
+}
+
+async function renderPrompt(content: string): Promise<string> {
+  const html = await renderInlineMarkdown(content);
+  return `<div class="doc-prompt"><div class="doc-prompt__header"><span class="doc-prompt__label">🤖 Agentic Prompt</span><button class="doc-prompt__copy" data-copy-prompt>Copy prompt</button></div><div class="doc-prompt__content">${html}</div></div>`;
+}
+
+async function renderRelated(content: string): Promise<string> {
+  const html = await marked.parse(content);
+  return `<div class="doc-related">${html}</div>`;
+}
+
+function renderApiTable(content: string): string {
+  return `<div class="doc-api-table">${content}</div>`;
 }
 
 async function renderSteps(
@@ -98,14 +121,6 @@ async function parseStepContent(
   }
 
   return html;
-}
-
-function renderPrompt(content: string): string {
-  return `<div class="doc-prompt"><div class="doc-prompt__header"><span class="doc-prompt__label">🤖 Agentic Prompt</span><button class="doc-prompt__copy" data-copy-prompt>Copy prompt</button></div><div class="doc-prompt__content">${content}</div></div>`;
-}
-
-function renderApiTable(content: string): string {
-  return `<div class="doc-api-table">${content}</div>`;
 }
 
 function extractFilename(code: string): { filename: string | null; cleanedCode: string } {
@@ -166,13 +181,14 @@ export async function renderMarkdown(source: string): Promise<RenderedMarkdown> 
     if (!html.includes(block.placeholder)) continue;
     let rendered: string;
     switch (block.type) {
-      case 'Summary': rendered = renderSummary(block.content); break;
-      case 'Tip': rendered = renderCallout('tip', block.content); break;
-      case 'Note': rendered = renderCallout('note', block.content); break;
-      case 'Warning': rendered = renderCallout('warning', block.content); break;
+      case 'Summary': rendered = await renderSummary(block.content); break;
+      case 'Tip': rendered = await renderCallout('tip', block.content); break;
+      case 'Note': rendered = await renderCallout('note', block.content); break;
+      case 'Warning': rendered = await renderCallout('warning', block.content); break;
       case 'Steps': rendered = await renderSteps(block.content, blocks); break;
       case 'Step': rendered = ''; break;
-      case 'Prompt': rendered = renderPrompt(block.content); break;
+      case 'Prompt': rendered = await renderPrompt(block.content); break;
+      case 'Related': rendered = await renderRelated(block.content); break;
       case 'ApiTable': {
         const tableHtml = await marked.parse(block.content);
         rendered = renderApiTable(tableHtml);

--- a/apps/cockpit/src/lib/route-resolution.spec.ts
+++ b/apps/cockpit/src/lib/route-resolution.spec.ts
@@ -132,6 +132,24 @@ describe('getCapabilityPresentation', () => {
     });
   });
 
+  it('includes durable execution docs assets from the capability module', () => {
+    const entry = resolveCockpitEntry({
+      manifest: cockpitManifest,
+      product: 'langgraph',
+      section: 'core-capabilities',
+      topic: 'durable-execution',
+      page: 'overview',
+      language: 'python',
+    });
+    const presentation = getCapabilityPresentation(entry);
+
+    expect(presentation).toMatchObject({
+      kind: 'capability',
+      docsPath: '/docs/langgraph/core-capabilities/durable-execution/overview/python',
+      docsAssetPaths: ['cockpit/langgraph/durable-execution/python/docs/guide.md'],
+    });
+  });
+
   it('presents render capabilities with module-backed metadata', () => {
     const entry = resolveCockpitEntry({
       manifest: cockpitManifest,

--- a/apps/website/content/docs/chat/api/api-docs.json
+++ b/apps/website/content/docs/chat/api/api-docs.json
@@ -1132,7 +1132,7 @@
       },
       {
         "name": "surface",
-        "type": "InputSignal<A2uiSurface | undefined>",
+        "type": "InputSignal<any>",
         "description": "Wire-format surface (legacy path — kept for backwards compat).",
         "optional": false
       },
@@ -5332,118 +5332,6 @@
     "methods": []
   },
   {
-    "name": "A2uiAction",
-    "kind": "interface",
-    "description": "",
-    "properties": [
-      {
-        "name": "context",
-        "type": "A2uiActionContextEntry[]",
-        "description": "",
-        "optional": true
-      },
-      {
-        "name": "name",
-        "type": "string",
-        "description": "",
-        "optional": false
-      }
-    ],
-    "examples": []
-  },
-  {
-    "name": "A2uiActionContextEntry",
-    "kind": "interface",
-    "description": "",
-    "properties": [
-      {
-        "name": "key",
-        "type": "string",
-        "description": "",
-        "optional": false
-      },
-      {
-        "name": "value",
-        "type": "DynamicString | DynamicNumber | DynamicBoolean",
-        "description": "",
-        "optional": false
-      }
-    ],
-    "examples": []
-  },
-  {
-    "name": "A2uiActionMessage",
-    "kind": "interface",
-    "description": "",
-    "properties": [
-      {
-        "name": "action",
-        "type": "object",
-        "description": "",
-        "optional": false
-      },
-      {
-        "name": "metadata",
-        "type": "object",
-        "description": "",
-        "optional": true
-      },
-      {
-        "name": "version",
-        "type": "\"v0.9\"",
-        "description": "",
-        "optional": false
-      }
-    ],
-    "examples": []
-  },
-  {
-    "name": "A2uiClientDataModel",
-    "kind": "interface",
-    "description": "",
-    "properties": [
-      {
-        "name": "surfaces",
-        "type": "Record<string, Record<string, unknown>>",
-        "description": "",
-        "optional": false
-      },
-      {
-        "name": "version",
-        "type": "\"v0.9\"",
-        "description": "",
-        "optional": false
-      }
-    ],
-    "examples": []
-  },
-  {
-    "name": "A2uiComponent",
-    "kind": "interface",
-    "description": "",
-    "properties": [
-      {
-        "name": "component",
-        "type": "A2uiComponentDef",
-        "description": "",
-        "optional": false
-      },
-      {
-        "name": "id",
-        "type": "string",
-        "description": "",
-        "optional": false
-      },
-      {
-        "name": "weight",
-        "type": "number",
-        "description": "",
-        "optional": true
-      }
-    ],
-    "examples": []
-  },
-  {
     "name": "A2uiComponentView",
     "kind": "interface",
     "description": "Chat-internal projection of an A2UI component, materialized by the\nsurface store. Distinct from the wire-format `A2uiComponent` in\n`@ngaf/a2ui` (which carries the raw `component: A2uiComponentDef`\npayload) — this type adds the per-component readiness fields the\nprogressive renderer consumes.",
@@ -5483,56 +5371,6 @@
         "type": "string",
         "description": "The component type key — e.g. `'Button'`, `'TextField'` — matched\nagainst catalog `views` entries.",
         "optional": false
-      }
-    ],
-    "examples": []
-  },
-  {
-    "name": "A2uiSurface",
-    "kind": "interface",
-    "description": "",
-    "properties": [
-      {
-        "name": "catalogId",
-        "type": "string",
-        "description": "",
-        "optional": false
-      },
-      {
-        "name": "components",
-        "type": "Map<string, A2uiComponent>",
-        "description": "",
-        "optional": false
-      },
-      {
-        "name": "dataModel",
-        "type": "Record<string, unknown>",
-        "description": "",
-        "optional": false
-      },
-      {
-        "name": "sendDataModel",
-        "type": "boolean",
-        "description": "",
-        "optional": true
-      },
-      {
-        "name": "styles",
-        "type": "object",
-        "description": "Styles set by the agent via `beginRendering.styles`. The\ncanonical v1 spec defines exactly two fields: `font` (primary\nfont for the UI) and `primaryColor` (hex `#RRGGBB`). The renderer\napplies these as CSS custom properties on the surface root,\noverriding any consumer-set defaults for the duration of the\nsurface's life. Anything richer (typography scale, spacing,\nelevation, etc.) is the renderer's private vocabulary and not\ncommunicated through this field.",
-        "optional": true
-      },
-      {
-        "name": "surfaceId",
-        "type": "string",
-        "description": "",
-        "optional": false
-      },
-      {
-        "name": "theme",
-        "type": "A2uiTheme",
-        "description": "",
-        "optional": true
       }
     ],
     "examples": []
@@ -5603,32 +5441,6 @@
         "type": "unknown",
         "description": "",
         "optional": false
-      }
-    ],
-    "examples": []
-  },
-  {
-    "name": "A2uiTheme",
-    "kind": "interface",
-    "description": "",
-    "properties": [
-      {
-        "name": "agentDisplayName",
-        "type": "string",
-        "description": "",
-        "optional": true
-      },
-      {
-        "name": "iconUrl",
-        "type": "string",
-        "description": "",
-        "optional": true
-      },
-      {
-        "name": "primaryColor",
-        "type": "string",
-        "description": "",
-        "optional": true
       }
     ],
     "examples": []
@@ -6900,17 +6712,10 @@
     "examples": []
   },
   {
-    "name": "A2uiChildren",
+    "name": "A2uiActionMessage",
     "kind": "type",
     "description": "",
-    "signature": "object | object",
-    "examples": []
-  },
-  {
-    "name": "A2uiComponentDef",
-    "kind": "type",
-    "description": "",
-    "signature": "object | object | object | object | object | object | object | object | object | object | object | object | object | object | object | object | object | object",
+    "signature": "any",
     "examples": []
   },
   {
@@ -6995,27 +6800,6 @@
     "kind": "type",
     "description": "",
     "signature": "\"right\" | \"bottom\" | \"left\"",
-    "examples": []
-  },
-  {
-    "name": "DynamicBoolean",
-    "kind": "type",
-    "description": "",
-    "signature": "object | object",
-    "examples": []
-  },
-  {
-    "name": "DynamicNumber",
-    "kind": "type",
-    "description": "",
-    "signature": "object | object",
-    "examples": []
-  },
-  {
-    "name": "DynamicString",
-    "kind": "type",
-    "description": "",
-    "signature": "object | object",
     "examples": []
   },
   {
@@ -7308,82 +7092,6 @@
     ],
     "returns": {
       "type": "m is Message & { role: \"assistant\" }",
-      "description": ""
-    },
-    "examples": []
-  },
-  {
-    "name": "isLiteralBoolean",
-    "kind": "function",
-    "description": "",
-    "signature": "isLiteralBoolean(value: unknown): value is { literalBoolean: boolean }",
-    "params": [
-      {
-        "name": "value",
-        "type": "unknown",
-        "description": "",
-        "optional": false
-      }
-    ],
-    "returns": {
-      "type": "value is { literalBoolean: boolean }",
-      "description": ""
-    },
-    "examples": []
-  },
-  {
-    "name": "isLiteralNumber",
-    "kind": "function",
-    "description": "",
-    "signature": "isLiteralNumber(value: unknown): value is { literalNumber: number }",
-    "params": [
-      {
-        "name": "value",
-        "type": "unknown",
-        "description": "",
-        "optional": false
-      }
-    ],
-    "returns": {
-      "type": "value is { literalNumber: number }",
-      "description": ""
-    },
-    "examples": []
-  },
-  {
-    "name": "isLiteralString",
-    "kind": "function",
-    "description": "",
-    "signature": "isLiteralString(value: unknown): value is { literalString: string }",
-    "params": [
-      {
-        "name": "value",
-        "type": "unknown",
-        "description": "",
-        "optional": false
-      }
-    ],
-    "returns": {
-      "type": "value is { literalString: string }",
-      "description": ""
-    },
-    "examples": []
-  },
-  {
-    "name": "isPathRef",
-    "kind": "function",
-    "description": "",
-    "signature": "isPathRef(value: unknown): value is { path: string }",
-    "params": [
-      {
-        "name": "value",
-        "type": "unknown",
-        "description": "",
-        "optional": false
-      }
-    ],
-    "returns": {
-      "type": "value is { path: string }",
       "description": ""
     },
     "examples": []

--- a/cockpit/deep-agents/filesystem/python/docs/guide.md
+++ b/cockpit/deep-agents/filesystem/python/docs/guide.md
@@ -1,4 +1,4 @@
-# File Operations with angular
+# File Operations with Angular
 
 <Summary>
 Build a chat interface that shows real-time file operation logs using `agent()` from

--- a/cockpit/deep-agents/memory/python/docs/guide.md
+++ b/cockpit/deep-agents/memory/python/docs/guide.md
@@ -1,4 +1,4 @@
-# Persistent Agent Memory with angular
+# Persistent Agent Memory with Angular
 
 <Summary>
 Build a chat interface where the agent remembers facts about the user across turns using `agent()` from `@ngaf/langgraph`. The agent stores learned facts in `agent_memory` state, and the sidebar displays them in real time.

--- a/cockpit/deep-agents/planning/python/docs/guide.md
+++ b/cockpit/deep-agents/planning/python/docs/guide.md
@@ -1,4 +1,4 @@
-# Task Decomposition with angular
+# Task Decomposition with Angular
 
 <Summary>
 Build a chat interface that shows real-time task decomposition using `agent()` from

--- a/cockpit/deep-agents/sandboxes/python/docs/guide.md
+++ b/cockpit/deep-agents/sandboxes/python/docs/guide.md
@@ -1,4 +1,4 @@
-# Code Execution Sandbox with angular
+# Code Execution Sandbox with Angular
 
 <Summary>
 Build a chat interface that shows real-time code execution logs using `agent()` from

--- a/cockpit/deep-agents/skills/python/docs/guide.md
+++ b/cockpit/deep-agents/skills/python/docs/guide.md
@@ -1,4 +1,4 @@
-# Multi-Skill Agent with angular
+# Multi-Skill Agent with Angular
 
 <Summary>
 Build a chat interface that shows real-time skill invocations using `agent()` from

--- a/cockpit/deep-agents/subagents/python/docs/guide.md
+++ b/cockpit/deep-agents/subagents/python/docs/guide.md
@@ -1,4 +1,4 @@
-# Child Agent Delegation with angular
+# Child Agent Delegation with Angular
 
 <Summary>
 Build a chat interface that shows real-time subagent activity using `agent()` from

--- a/cockpit/langgraph/durable-execution/python/docs/guide.md
+++ b/cockpit/langgraph/durable-execution/python/docs/guide.md
@@ -1,4 +1,4 @@
-# Durable Execution with angular
+# Durable Execution with Angular
 
 <Summary>
 Build a fault-tolerant chat interface using `agent()` from

--- a/cockpit/langgraph/durable-execution/python/src/index.ts
+++ b/cockpit/langgraph/durable-execution/python/src/index.ts
@@ -2,7 +2,7 @@ export interface CockpitCapabilityModule {
   id: string;
   manifestIdentity: {
     product: 'langgraph';
-    section: 'fault-tolerance';
+    section: 'core-capabilities';
     topic: 'durable-execution';
     page: 'overview';
     language: 'python';
@@ -21,13 +21,13 @@ export const langgraphDurableExecutionPythonModule: CockpitCapabilityModule = {
   id: 'langgraph-durable-execution-python',
   manifestIdentity: {
     product: 'langgraph',
-    section: 'fault-tolerance',
+    section: 'core-capabilities',
     topic: 'durable-execution',
     page: 'overview',
     language: 'python',
   },
   title: 'LangGraph Durable Execution (Python)',
-  docsPath: '/docs/langgraph/fault-tolerance/durable-execution/overview/python',
+  docsPath: '/docs/langgraph/core-capabilities/durable-execution/overview/python',
   promptAssetPaths: ['cockpit/langgraph/durable-execution/python/prompts/durable-execution.md'],
   codeAssetPaths: [
     'cockpit/langgraph/durable-execution/angular/src/app/durable-execution.component.ts',

--- a/cockpit/langgraph/interrupts/python/docs/guide.md
+++ b/cockpit/langgraph/interrupts/python/docs/guide.md
@@ -1,4 +1,4 @@
-# Human-in-the-Loop Interrupts with angular
+# Human-in-the-Loop Interrupts with Angular
 
 <Summary>
 Build a chat interface with human-in-the-loop approval using `agent()` from

--- a/cockpit/langgraph/memory/python/docs/guide.md
+++ b/cockpit/langgraph/memory/python/docs/guide.md
@@ -1,4 +1,4 @@
-# Cross-Thread Persistent Memory with angular
+# Cross-Thread Persistent Memory with Angular
 
 <Summary>
 Build a chat interface where the agent actively learns and remembers facts about the user.

--- a/cockpit/langgraph/persistence/python/docs/guide.md
+++ b/cockpit/langgraph/persistence/python/docs/guide.md
@@ -1,4 +1,4 @@
-# Thread Persistence with angular
+# Thread Persistence with Angular
 
 <Summary>
 Build a chat interface with thread persistence using `agent()` from

--- a/cockpit/langgraph/streaming/python/docs/guide.md
+++ b/cockpit/langgraph/streaming/python/docs/guide.md
@@ -1,4 +1,4 @@
-# Streaming with angular
+# Streaming with Angular
 
 <Summary>
 Build a real-time streaming chat interface using `agent()` from

--- a/cockpit/langgraph/subgraphs/python/docs/guide.md
+++ b/cockpit/langgraph/subgraphs/python/docs/guide.md
@@ -1,4 +1,4 @@
-# Nested Agent Delegation with Subgraphs and angular
+# Nested Agent Delegation with Subgraphs and Angular
 
 <Summary>
 Build a chat interface that visualizes nested agent delegation using `agent()` from

--- a/cockpit/langgraph/time-travel/python/docs/guide.md
+++ b/cockpit/langgraph/time-travel/python/docs/guide.md
@@ -1,4 +1,4 @@
-# Time Travel with angular
+# Time Travel with Angular
 
 <Summary>
 Build a chat interface with time travel using `agent()` from


### PR DESCRIPTION
## Summary
- render markdown inside cockpit docs custom blocks so inline code and links display correctly
- support Related blocks as link lists
- fix durable execution cockpit docs module mapping and normalize Angular heading casing

## Verification
- npx nx test cockpit -- --run src/lib/route-resolution.spec.ts src/lib/render-markdown.spec.ts
- npx nx build cockpit --skip-nx-cache
- Chrome MCP visual sweep across 31 cockpit Docs routes: no missing article, raw markdown, code-block, or article-spacing issues after fixes