### PR TITLE
fix(licensing): remove token tamper flake

### DIFF
--- a/libs/licensing/src/lib/run-license-check.spec.ts
+++ b/libs/licensing/src/lib/run-license-check.spec.ts
@@ -14,6 +14,13 @@ const BASE: LicenseClaims = {
   seats: 1,
 };
 
+function mutateSignature(token: string): string {
+  const [payload, signature] = token.split('.');
+  if (!payload || !signature) throw new Error('expected compact license token');
+  const replacement = signature.startsWith('x') ? 'y' : 'x';
+  return `${payload}.${replacement}${signature.slice(1)}`;
+}
+
 describe('runLicenseCheck', () => {
   let kp: DevKeyPair;
   let validToken: string;
@@ -77,7 +84,8 @@ describe('runLicenseCheck', () => {
   });
 
   it('re-runs when token changes (e.g., after key rotation in the host)', async () => {
-    const tamperedToken = `${validToken.slice(0, -1)}x`;
+    const tamperedToken = mutateSignature(validToken);
+    expect(tamperedToken).not.toBe(validToken);
     const first = await runLicenseCheck({
       package: '@ngaf/langgraph',
       token: validToken,


### PR DESCRIPTION
## Summary

Fixes the flaky `licensing:test` by making the tampered-token fixture deterministic.

## Root Cause

`run-license-check.spec.ts` generated a tampered token with `validToken.slice(0, -1) + 'x'`. Because the token is random base64url, that sometimes left the token unchanged or changed only unused trailing base64 bits in the unpadded signature segment. In those cases the decoded signature remained valid, so `runLicenseCheck()` correctly returned `licensed` instead of `tampered`.

## Change

Mutate the first character of the signature segment instead, where every bit affects the decoded signature, and assert that the generated tampered token differs from the original.

## Verification

- Reproduced the original flake locally in 8 direct Vitest runs.
- `20x` direct `licensing` Vitest coverage runs passed after the fix.
- `nx test licensing --coverage --skip-nx-cache` passed.
- `nx run-many -t test --projects=chat,langgraph,ag-ui,render,a2ui,licensing,telemetry --coverage --skip-nx-cache` passed.
