### PR TITLE
[codex] Align cockpit e2e workflow targets

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,14 +15,30 @@ jobs:
           node-version: 22
           cache: npm
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.0.0
+        with:
+          python-version: "3.12"
+
       - name: Install npm dependencies
         run: npm ci
+
+      - name: Install Python dependencies
+        working-directory: cockpit/langgraph/streaming/python
+        run: uv sync
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 
-      - name: Run cockpit e2e tests
-        run: npx nx e2e cockpit --skip-nx-cache
+      - name: Run cockpit example aimock e2e suites
+        run: |
+          set -e
+          for proj in cockpit-langgraph-streaming-angular cockpit-chat-tool-calls-angular cockpit-chat-subagents-angular; do
+            echo "::group::nx e2e $proj"
+            npx nx e2e "$proj" --skip-nx-cache
+            echo "::endgroup::"
+            sleep 5
+          done
 
   e2e:
     runs-on: ubuntu-latest

--- a/cockpit/chat/subagents/angular/tsconfig.app.json
+++ b/cockpit/chat/subagents/angular/tsconfig.app.json
@@ -18,9 +18,6 @@
     },
     {
       "path": "../../../../libs/langgraph"
-    },
-    {
-      "path": "../../../../libs/internal/aimock-harness"
     }
   ]
 }

--- a/cockpit/chat/tool-calls/angular/tsconfig.app.json
+++ b/cockpit/chat/tool-calls/angular/tsconfig.app.json
@@ -18,9 +18,6 @@
     },
     {
       "path": "../../../../libs/langgraph"
-    },
-    {
-      "path": "../../../../libs/internal/aimock-harness"
     }
   ]
 }

--- a/cockpit/langgraph/streaming/angular/e2e/scripts/record-streaming.py
+++ b/cockpit/langgraph/streaming/angular/e2e/scripts/record-streaming.py
@@ -6,7 +6,7 @@ build_streaming_graph() setup: ChatOpenAI(gpt-5-mini, streaming=True)
 
 Run from repo root:
   OPENAI_API_KEY=sk-... uv run --project cockpit/langgraph/streaming/python \
-    python apps/cockpit/e2e/scripts/record-streaming.py
+    python cockpit/langgraph/streaming/angular/e2e/scripts/record-streaming.py
 """
 import json
 import os
@@ -52,7 +52,7 @@ fixture = {
     ]
 }
 
-out_path = Path("apps/cockpit/e2e/fixtures/streaming.json")
+out_path = Path("cockpit/langgraph/streaming/angular/e2e/fixtures/streaming.json")
 out_path.parent.mkdir(parents=True, exist_ok=True)
 out_path.write_text(json.dumps(fixture, indent=2) + "\n")
 print(f"\nWrote fixture to {out_path}")

--- a/cockpit/langgraph/streaming/angular/tsconfig.app.json
+++ b/cockpit/langgraph/streaming/angular/tsconfig.app.json
@@ -20,9 +20,6 @@
     },
     {
       "path": "../../../../libs/langgraph"
-    },
-    {
-      "path": "../../../../libs/internal/aimock-harness"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Replace the stale `nx e2e cockpit` workflow step with the actual cockpit e2e project targets.
- Install uv/Python dependencies in the e2e workflow so the LangGraph streaming cockpit can start locally in CI.
- Remove stale `libs/internal/aimock-harness` tsconfig project references and fix the streaming fixture recorder path docs/output.

## Local verification
- `uv sync` in `cockpit/langgraph/streaming/python`
- `npx playwright install chromium`
- `npx nx run-many -t build --projects=cockpit-langgraph-streaming-angular,cockpit-chat-tool-calls-angular,cockpit-chat-subagents-angular --skip-nx-cache`
- `npx nx e2e cockpit-langgraph-streaming-angular --skip-nx-cache`
- `npx nx e2e cockpit-chat-tool-calls-angular --skip-nx-cache`
- `npx nx e2e cockpit-chat-subagents-angular --skip-nx-cache`

e2e target results: streaming 1 passed, tool-calls 1 passed, subagents 3 passed.