### PR TITLE
fix(ci): stabilize production primitive smoke

### DIFF
--- a/apps/cockpit/e2e/production-smoke.spec.ts
+++ b/apps/cockpit/e2e/production-smoke.spec.ts
@@ -49,6 +49,13 @@ const CHAT_PRIMITIVE_CAPABILITIES = [
   'chat/debug',
 ] as const;
 
+const CHAT_PRIMITIVE_READY_SELECTORS: Record<(typeof CHAT_PRIMITIVE_CAPABILITIES)[number], string> = {
+  'chat/messages': 'chat-message-list',
+  'chat/input': 'chat-input',
+  'chat/interrupts': 'chat-interrupt-panel',
+  'chat/debug': 'chat-debug',
+};
+
 const RENDER_CAPABILITIES = [
   'render/spec-rendering',
   'render/element-rendering',
@@ -73,7 +80,9 @@ test.describe('Production: Angular chat primitive apps load', () => {
     test(`${cap} loads at examples URL`, async ({ page }) => {
       const response = await page.goto(`${EXAMPLES_URL}/${cap}/`, { timeout: 15_000 });
       expect(response?.status()).toBe(200);
-      await expect(page.locator('body')).not.toBeEmpty({ timeout: 10_000 });
+      await expect(page.locator(CHAT_PRIMITIVE_READY_SELECTORS[cap])).toBeAttached({
+        timeout: 10_000,
+      });
     });
   }
 });


### PR DESCRIPTION
## Summary
- Replaces the primitive production smoke body-text check with route-specific component readiness selectors.
- Treats primitive shells as loaded when their expected Angular component is attached, which covers intentionally textless or initially hidden primitive states.

## Root cause
`chat/debug` was rendering correctly in production, but the smoke test used `expect(body).not.toBeEmpty()`. Playwright evaluates that through text content, and the debug route renders a valid textless custom-element shell until the launcher is opened.

## Verification
- `BASE_URL=https://cockpit.cacheplane.ai EXAMPLES_URL=https://examples.cacheplane.ai node_modules/.bin/playwright test apps/cockpit/e2e/production-smoke.spec.ts -g "chat/debug loads at examples URL" --reporter=list`
- `BASE_URL=https://cockpit.cacheplane.ai EXAMPLES_URL=https://examples.cacheplane.ai node_modules/.bin/playwright test apps/cockpit/e2e/production-smoke.spec.ts --reporter=list` (32 passed, 3 skipped locally because `OPENAI_API_KEY` is not set)
- `NX_DAEMON=false node_modules/.bin/nx test cockpit --skip-nx-cache`
- `git diff --check`

## Local note
`NX_DAEMON=false node_modules/.bin/nx build cockpit --skip-nx-cache` is blocked locally by Turbopack failing to resolve the Darwin `lightningcss` native binding from this workstation install. CI should be the build authority for the Linux environment.
