### PR TITLE
feat(c-per-cap): standalone backends — nx serve + dev env cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,13 @@ jobs:
       - run: npm ci
       - working-directory: cockpit/langgraph/streaming/python
         run: uv sync
+      # Per-cap cleanup PR: each chat cap's e2e now starts its OWN
+      # standalone backend (not the umbrella). Pre-sync deps for the two
+      # caps with e2e suites.
+      - working-directory: cockpit/chat/tool-calls/python
+        run: uv sync
+      - working-directory: cockpit/chat/subagents/python
+        run: uv sync
       - run: npx playwright install --with-deps chromium
       # Explicit sequential loop (not `nx run-many --parallel=1`) so each
       # per-example e2e gets a fresh Playwright process and a clean port

--- a/apps/cockpit/scripts/capability-registry.ts
+++ b/apps/cockpit/scripts/capability-registry.ts
@@ -8,6 +8,7 @@ export interface Capability {
   topic: string;
   angularProject: string;
   port: number;
+  pythonPort?: number;
   pythonDir: string;
   graphName: string;
 }
@@ -35,17 +36,17 @@ export const capabilities: readonly Capability[] = [
   { id: 'repeat-loops', product: 'render', topic: 'repeat-loops', angularProject: 'cockpit-render-repeat-loops-angular', port: 4405, pythonDir: 'cockpit/render/repeat-loops/python', graphName: 'repeat-loops' },
   { id: 'computed-functions', product: 'render', topic: 'computed-functions', angularProject: 'cockpit-render-computed-functions-angular', port: 4406, pythonDir: 'cockpit/render/computed-functions/python', graphName: 'computed-functions' },
   // Chat capabilities
-  { id: 'c-messages', product: 'chat', topic: 'messages', angularProject: 'cockpit-chat-messages-angular', port: 4501, pythonDir: 'cockpit/langgraph/streaming/python', graphName: 'c-messages' },
-  { id: 'c-input', product: 'chat', topic: 'input', angularProject: 'cockpit-chat-input-angular', port: 4502, pythonDir: 'cockpit/langgraph/streaming/python', graphName: 'c-input' },
-  { id: 'c-interrupts', product: 'chat', topic: 'interrupts', angularProject: 'cockpit-chat-interrupts-angular', port: 4503, pythonDir: 'cockpit/langgraph/streaming/python', graphName: 'c-interrupts' },
-  { id: 'c-tool-calls', product: 'chat', topic: 'tool-calls', angularProject: 'cockpit-chat-tool-calls-angular', port: 4504, pythonDir: 'cockpit/langgraph/streaming/python', graphName: 'c-tool-calls' },
-  { id: 'c-subagents', product: 'chat', topic: 'subagents', angularProject: 'cockpit-chat-subagents-angular', port: 4505, pythonDir: 'cockpit/langgraph/streaming/python', graphName: 'c-subagents' },
-  { id: 'c-threads', product: 'chat', topic: 'threads', angularProject: 'cockpit-chat-threads-angular', port: 4506, pythonDir: 'cockpit/langgraph/streaming/python', graphName: 'c-threads' },
-  { id: 'c-timeline', product: 'chat', topic: 'timeline', angularProject: 'cockpit-chat-timeline-angular', port: 4507, pythonDir: 'cockpit/langgraph/streaming/python', graphName: 'c-timeline' },
-  { id: 'c-generative-ui', product: 'chat', topic: 'generative-ui', angularProject: 'cockpit-chat-generative-ui-angular', port: 4508, pythonDir: 'cockpit/langgraph/streaming/python', graphName: 'c-generative-ui' },
-  { id: 'c-debug', product: 'chat', topic: 'debug', angularProject: 'cockpit-chat-debug-angular', port: 4509, pythonDir: 'cockpit/langgraph/streaming/python', graphName: 'c-debug' },
-  { id: 'c-theming', product: 'chat', topic: 'theming', angularProject: 'cockpit-chat-theming-angular', port: 4510, pythonDir: 'cockpit/langgraph/streaming/python', graphName: 'c-theming' },
-  { id: 'c-a2ui', product: 'chat', topic: 'a2ui', angularProject: 'cockpit-chat-a2ui-angular', port: 4511, pythonDir: 'cockpit/langgraph/streaming/python', graphName: 'c-a2ui' },
+  { id: 'c-messages', product: 'chat', topic: 'messages', angularProject: 'cockpit-chat-messages-angular', port: 4501, pythonPort: 5501, pythonDir: 'cockpit/langgraph/streaming/python', graphName: 'c-messages' },
+  { id: 'c-input', product: 'chat', topic: 'input', angularProject: 'cockpit-chat-input-angular', port: 4502, pythonPort: 5502, pythonDir: 'cockpit/langgraph/streaming/python', graphName: 'c-input' },
+  { id: 'c-interrupts', product: 'chat', topic: 'interrupts', angularProject: 'cockpit-chat-interrupts-angular', port: 4503, pythonPort: 5503, pythonDir: 'cockpit/langgraph/streaming/python', graphName: 'c-interrupts' },
+  { id: 'c-tool-calls', product: 'chat', topic: 'tool-calls', angularProject: 'cockpit-chat-tool-calls-angular', port: 4504, pythonPort: 5504, pythonDir: 'cockpit/langgraph/streaming/python', graphName: 'c-tool-calls' },
+  { id: 'c-subagents', product: 'chat', topic: 'subagents', angularProject: 'cockpit-chat-subagents-angular', port: 4505, pythonPort: 5505, pythonDir: 'cockpit/langgraph/streaming/python', graphName: 'c-subagents' },
+  { id: 'c-threads', product: 'chat', topic: 'threads', angularProject: 'cockpit-chat-threads-angular', port: 4506, pythonPort: 5506, pythonDir: 'cockpit/langgraph/streaming/python', graphName: 'c-threads' },
+  { id: 'c-timeline', product: 'chat', topic: 'timeline', angularProject: 'cockpit-chat-timeline-angular', port: 4507, pythonPort: 5507, pythonDir: 'cockpit/langgraph/streaming/python', graphName: 'c-timeline' },
+  { id: 'c-generative-ui', product: 'chat', topic: 'generative-ui', angularProject: 'cockpit-chat-generative-ui-angular', port: 4508, pythonPort: 5508, pythonDir: 'cockpit/langgraph/streaming/python', graphName: 'c-generative-ui' },
+  { id: 'c-debug', product: 'chat', topic: 'debug', angularProject: 'cockpit-chat-debug-angular', port: 4509, pythonPort: 5509, pythonDir: 'cockpit/langgraph/streaming/python', graphName: 'c-debug' },
+  { id: 'c-theming', product: 'chat', topic: 'theming', angularProject: 'cockpit-chat-theming-angular', port: 4510, pythonPort: 5510, pythonDir: 'cockpit/langgraph/streaming/python', graphName: 'c-theming' },
+  { id: 'c-a2ui', product: 'chat', topic: 'a2ui', angularProject: 'cockpit-chat-a2ui-angular', port: 4511, pythonPort: 5511, pythonDir: 'cockpit/langgraph/streaming/python', graphName: 'c-a2ui' },
 ] as const;
 
 export function findCapability(id: string): Capability | undefined {

--- a/cockpit/chat/a2ui/angular/proxy.conf.json
+++ b/cockpit/chat/a2ui/angular/proxy.conf.json
@@ -1,6 +1,6 @@
 {
   "/api": {
-    "target": "http://localhost:8123",
+    "target": "http://localhost:5511",
     "secure": false,
     "changeOrigin": true,
     "pathRewrite": { "^/api": "" },

--- a/cockpit/chat/a2ui/angular/src/environments/environment.development.ts
+++ b/cockpit/chat/a2ui/angular/src/environments/environment.development.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: false,
-  langGraphApiUrl: 'http://localhost:4511/api',
-  a2uiAssistantId: 'a2ui_form',
+  langGraphApiUrl: '/api',
+  a2uiAssistantId: 'c-a2ui',
 };

--- a/cockpit/chat/a2ui/python/project.json
+++ b/cockpit/chat/a2ui/python/project.json
@@ -1,0 +1,24 @@
+{
+  "name": "cockpit-chat-a2ui-python",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "cockpit/chat/a2ui/python/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{workspaceRoot}/dist/cockpit/chat/a2ui/python"],
+      "options": {
+        "outputPath": "dist/cockpit/chat/a2ui/python",
+        "main": "cockpit/chat/a2ui/python/src/index.ts",
+        "tsConfig": "cockpit/chat/a2ui/python/tsconfig.json"
+      }
+    },
+    "serve": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "cockpit/chat/a2ui/python",
+        "command": "uv run langgraph dev --port 5511 --no-browser"
+      }
+    }
+  }
+}

--- a/cockpit/chat/a2ui/python/tsconfig.json
+++ b/cockpit/chat/a2ui/python/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/cockpit/chat/a2ui/python",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "target": "ES2022",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true
+  },
+  "include": ["src/**/*"]
+}

--- a/cockpit/chat/debug/angular/proxy.conf.json
+++ b/cockpit/chat/debug/angular/proxy.conf.json
@@ -1,6 +1,6 @@
 {
   "/api": {
-    "target": "http://localhost:8123",
+    "target": "http://localhost:5509",
     "secure": false,
     "changeOrigin": true,
     "pathRewrite": { "^/api": "" },

--- a/cockpit/chat/debug/angular/src/environments/environment.development.ts
+++ b/cockpit/chat/debug/angular/src/environments/environment.development.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: false,
-  langGraphApiUrl: 'http://localhost:4509/api',
+  langGraphApiUrl: '/api',
   streamingAssistantId: 'c-debug',
 };

--- a/cockpit/chat/debug/python/project.json
+++ b/cockpit/chat/debug/python/project.json
@@ -1,0 +1,24 @@
+{
+  "name": "cockpit-chat-debug-python",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "cockpit/chat/debug/python/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{workspaceRoot}/dist/cockpit/chat/debug/python"],
+      "options": {
+        "outputPath": "dist/cockpit/chat/debug/python",
+        "main": "cockpit/chat/debug/python/src/index.ts",
+        "tsConfig": "cockpit/chat/debug/python/tsconfig.json"
+      }
+    },
+    "serve": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "cockpit/chat/debug/python",
+        "command": "uv run langgraph dev --port 5509 --no-browser"
+      }
+    }
+  }
+}

--- a/cockpit/chat/debug/python/prompts/debug.md
+++ b/cockpit/chat/debug/python/prompts/debug.md
@@ -1,13 +1,10 @@
-# Chat Debug Assistant
+# Aviation Assistant — Debug Demo
 
-You are an assistant that demonstrates the ChatDebugComponent for
-development inspection.
+You are a friendly aviation assistant helping travelers with flights, airports,
+and trip questions. You're knowledgeable about commercial aviation and happy to
+discuss anything from flight planning to airport amenities.
 
-Your responses pass through a multi-step pipeline (generate -> process ->
-summarize), creating multiple state transitions that are visible in the
-debug panel. Each step produces different state data that developers can
-inspect using the timeline, state inspector, and diff viewer.
-
-Respond helpfully while noting that your response will be processed
-through multiple graph nodes, each creating a checkpoint visible in
-the debug panel.
+Note: this demo's mock dataset covers 10 US airports — LAX, JFK, SFO, ORD,
+BOS, ATL, DFW, SEA, MIA, DEN — and 4 airlines (American, United, Delta,
+JetBlue). For airports/airlines outside this list, you can still provide
+general aviation knowledge but acknowledge the data limit.

--- a/cockpit/chat/debug/python/tsconfig.json
+++ b/cockpit/chat/debug/python/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/cockpit/chat/debug/python",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "target": "ES2022",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true
+  },
+  "include": ["src/**/*"]
+}

--- a/cockpit/chat/generative-ui/angular/proxy.conf.json
+++ b/cockpit/chat/generative-ui/angular/proxy.conf.json
@@ -1,6 +1,6 @@
 {
   "/api": {
-    "target": "http://localhost:8123",
+    "target": "http://localhost:5508",
     "secure": false,
     "changeOrigin": true,
     "pathRewrite": { "^/api": "" },

--- a/cockpit/chat/generative-ui/angular/src/environments/environment.development.ts
+++ b/cockpit/chat/generative-ui/angular/src/environments/environment.development.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: false,
-  langGraphApiUrl: 'http://localhost:4310/api',
-  generativeUiAssistantId: 'generative_ui',
+  langGraphApiUrl: '/api',
+  generativeUiAssistantId: 'c-generative-ui',
 };

--- a/cockpit/chat/generative-ui/python/langgraph.json
+++ b/cockpit/chat/generative-ui/python/langgraph.json
@@ -1,6 +1,6 @@
 {
   "graphs": {
-    "generative_ui": "./src/graph.py:graph"
+    "c-generative-ui": "./src/graph.py:graph"
   },
   "dependencies": ["."],
   "python_version": "3.12",

--- a/cockpit/chat/generative-ui/python/project.json
+++ b/cockpit/chat/generative-ui/python/project.json
@@ -1,0 +1,24 @@
+{
+  "name": "cockpit-chat-generative-ui-python",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "cockpit/chat/generative-ui/python/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{workspaceRoot}/dist/cockpit/chat/generative-ui/python"],
+      "options": {
+        "outputPath": "dist/cockpit/chat/generative-ui/python",
+        "main": "cockpit/chat/generative-ui/python/src/index.ts",
+        "tsConfig": "cockpit/chat/generative-ui/python/tsconfig.json"
+      }
+    },
+    "serve": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "cockpit/chat/generative-ui/python",
+        "command": "uv run langgraph dev --port 5508 --no-browser"
+      }
+    }
+  }
+}

--- a/cockpit/chat/generative-ui/python/tsconfig.json
+++ b/cockpit/chat/generative-ui/python/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/cockpit/chat/generative-ui/python",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "target": "ES2022",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true
+  },
+  "include": ["src/**/*"]
+}

--- a/cockpit/chat/input/angular/proxy.conf.json
+++ b/cockpit/chat/input/angular/proxy.conf.json
@@ -1,6 +1,6 @@
 {
   "/api": {
-    "target": "http://localhost:8123",
+    "target": "http://localhost:5502",
     "secure": false,
     "changeOrigin": true,
     "pathRewrite": { "^/api": "" },

--- a/cockpit/chat/input/angular/src/environments/environment.development.ts
+++ b/cockpit/chat/input/angular/src/environments/environment.development.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: false,
-  langGraphApiUrl: 'http://localhost:4502/api',
+  langGraphApiUrl: '/api',
   streamingAssistantId: 'c-input',
 };

--- a/cockpit/chat/input/python/project.json
+++ b/cockpit/chat/input/python/project.json
@@ -1,0 +1,24 @@
+{
+  "name": "cockpit-chat-input-python",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "cockpit/chat/input/python/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{workspaceRoot}/dist/cockpit/chat/input/python"],
+      "options": {
+        "outputPath": "dist/cockpit/chat/input/python",
+        "main": "cockpit/chat/input/python/src/index.ts",
+        "tsConfig": "cockpit/chat/input/python/tsconfig.json"
+      }
+    },
+    "serve": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "cockpit/chat/input/python",
+        "command": "uv run langgraph dev --port 5502 --no-browser"
+      }
+    }
+  }
+}

--- a/cockpit/chat/input/python/prompts/input.md
+++ b/cockpit/chat/input/python/prompts/input.md
@@ -1,11 +1,10 @@
-# Chat Input Assistant
+# Aviation Assistant — Input Demo
 
-You are an assistant that demonstrates the ChatInputComponent from @ngaf/chat.
+You are a friendly aviation assistant helping travelers with flights, airports,
+and trip questions. You're knowledgeable about commercial aviation and happy to
+discuss anything from flight planning to airport amenities.
 
-Echo back what the user says, and explain the input features being demonstrated:
-- Custom placeholder text
-- Keyboard handling (Enter to send, Shift+Enter for newline)
-- Disabled state while the agent is responding
-- Loading indicator integration
-
-Keep responses concise to showcase the streaming and input state transitions.
+Note: this demo's mock dataset covers 10 US airports — LAX, JFK, SFO, ORD,
+BOS, ATL, DFW, SEA, MIA, DEN — and 4 airlines (American, United, Delta,
+JetBlue). For airports/airlines outside this list, you can still provide
+general aviation knowledge but acknowledge the data limit.

--- a/cockpit/chat/input/python/tsconfig.json
+++ b/cockpit/chat/input/python/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/cockpit/chat/input/python",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "target": "ES2022",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true
+  },
+  "include": ["src/**/*"]
+}

--- a/cockpit/chat/interrupts/angular/proxy.conf.json
+++ b/cockpit/chat/interrupts/angular/proxy.conf.json
@@ -1,6 +1,6 @@
 {
   "/api": {
-    "target": "http://localhost:8123",
+    "target": "http://localhost:5503",
     "secure": false,
     "changeOrigin": true,
     "pathRewrite": { "^/api": "" },

--- a/cockpit/chat/interrupts/angular/src/environments/environment.development.ts
+++ b/cockpit/chat/interrupts/angular/src/environments/environment.development.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: false,
-  langGraphApiUrl: 'http://localhost:4503/api',
+  langGraphApiUrl: '/api',
   streamingAssistantId: 'c-interrupts',
 };

--- a/cockpit/chat/interrupts/python/project.json
+++ b/cockpit/chat/interrupts/python/project.json
@@ -1,0 +1,24 @@
+{
+  "name": "cockpit-chat-interrupts-python",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "cockpit/chat/interrupts/python/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{workspaceRoot}/dist/cockpit/chat/interrupts/python"],
+      "options": {
+        "outputPath": "dist/cockpit/chat/interrupts/python",
+        "main": "cockpit/chat/interrupts/python/src/index.ts",
+        "tsConfig": "cockpit/chat/interrupts/python/tsconfig.json"
+      }
+    },
+    "serve": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "cockpit/chat/interrupts/python",
+        "command": "uv run langgraph dev --port 5503 --no-browser"
+      }
+    }
+  }
+}

--- a/cockpit/chat/interrupts/python/prompts/interrupts.md
+++ b/cockpit/chat/interrupts/python/prompts/interrupts.md
@@ -1,12 +1,22 @@
-# Chat Interrupts Assistant
+# Aviation Assistant — Interrupts Demo
 
-You are an assistant that demonstrates human-in-the-loop approval gates
-using LangGraph interrupts.
+You are a friendly aviation assistant helping travelers with flights, airports,
+and trip questions. You're knowledgeable about commercial aviation and happy to
+discuss anything from flight planning to airport amenities.
 
-Every response you generate will be paused at an approval gate before
-being finalized. This demonstrates the interrupt() primitive that enables
-human oversight of AI actions.
+Note: this demo's mock dataset covers 10 US airports — LAX, JFK, SFO, ORD,
+BOS, ATL, DFW, SEA, MIA, DEN — and 4 airlines (American, United, Delta,
+JetBlue). For airports/airlines outside this list, you can still provide
+general aviation knowledge but acknowledge the data limit.
 
-Explain to the user that after you draft a response, they will see an
-approval panel where they can approve or reject the response before it
-is committed to the conversation.
+## Interrupt behavior
+
+If the user wants to actually book a flight, ANY flight, pause and ask for
+explicit confirmation before proceeding. Phrase it like:
+
+> "I can help you book that flight. Before I proceed, please confirm:
+> [airline] flight [number] from [origin] to [destination] for approximately
+> $[mock price]. Reply 'confirm' or 'cancel'."
+
+This pause demonstrates the chat-interrupts primitive's human-in-the-loop
+gate. Do not actually charge anything; this is a UI demo.

--- a/cockpit/chat/interrupts/python/tsconfig.json
+++ b/cockpit/chat/interrupts/python/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/cockpit/chat/interrupts/python",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "target": "ES2022",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true
+  },
+  "include": ["src/**/*"]
+}

--- a/cockpit/chat/messages/angular/proxy.conf.json
+++ b/cockpit/chat/messages/angular/proxy.conf.json
@@ -1,6 +1,6 @@
 {
   "/api": {
-    "target": "http://localhost:8123",
+    "target": "http://localhost:5501",
     "secure": false,
     "changeOrigin": true,
     "pathRewrite": { "^/api": "" },

--- a/cockpit/chat/messages/angular/src/environments/environment.development.ts
+++ b/cockpit/chat/messages/angular/src/environments/environment.development.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: false,
-  langGraphApiUrl: 'http://localhost:4501/api',
+  langGraphApiUrl: '/api',
   streamingAssistantId: 'c-messages',
 };

--- a/cockpit/chat/messages/python/project.json
+++ b/cockpit/chat/messages/python/project.json
@@ -1,0 +1,24 @@
+{
+  "name": "cockpit-chat-messages-python",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "cockpit/chat/messages/python/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{workspaceRoot}/dist/cockpit/chat/messages/python"],
+      "options": {
+        "outputPath": "dist/cockpit/chat/messages/python",
+        "main": "cockpit/chat/messages/python/src/index.ts",
+        "tsConfig": "cockpit/chat/messages/python/tsconfig.json"
+      }
+    },
+    "serve": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "cockpit/chat/messages/python",
+        "command": "uv run langgraph dev --port 5501 --no-browser"
+      }
+    }
+  }
+}

--- a/cockpit/chat/messages/python/prompts/messages.md
+++ b/cockpit/chat/messages/python/prompts/messages.md
@@ -1,12 +1,10 @@
-# Chat Messages Assistant
+# Aviation Assistant — Messages Demo
 
-You are an assistant that demonstrates the chat message primitives from @ngaf/chat.
+You are a friendly aviation assistant helping travelers with flights, airports,
+and trip questions. You're knowledgeable about commercial aviation and happy to
+discuss anything from flight planning to airport amenities.
 
-Your role is to showcase different message types and rendering styles.
-Use varied response formats including short answers, longer explanations,
-bulleted lists, and code snippets to demonstrate how ChatMessageListComponent
-renders different content.
-
-When greeting the user, explain that this demo showcases ChatMessageListComponent,
-ChatInputComponent, and ChatTypingIndicatorComponent working together as
-individual primitives rather than the composed ChatComponent.
+Note: this demo's mock dataset covers 10 US airports — LAX, JFK, SFO, ORD,
+BOS, ATL, DFW, SEA, MIA, DEN — and 4 airlines (American, United, Delta,
+JetBlue). For airports/airlines outside this list, you can still provide
+general aviation knowledge but acknowledge the data limit.

--- a/cockpit/chat/messages/python/tsconfig.json
+++ b/cockpit/chat/messages/python/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/cockpit/chat/messages/python",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "target": "ES2022",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true
+  },
+  "include": ["src/**/*"]
+}

--- a/cockpit/chat/subagents/angular/e2e/global-setup-impl.ts
+++ b/cockpit/chat/subagents/angular/e2e/global-setup-impl.ts
@@ -3,12 +3,11 @@ import { resolve } from 'node:path';
 import { createGlobalSetup } from '../../../../../libs/e2e-harness/src';
 
 export default createGlobalSetup({
-  langgraphCwd: 'cockpit/langgraph/streaming/python',
-  // Each cockpit example pins its OWN langgraph port to avoid TIME_WAIT
-  // collisions when a sequential CI loop runs multiple per-example e2es
-  // back-to-back. Streaming uses 8123; tool-calls 8124; subagents 8125.
-  // The Angular proxy.conf.json target must match.
-  langgraphPort: 8125,
+  // Per-cap cleanup PR: each chat cap runs its OWN standalone backend
+  // (cockpit/chat/<name>/python) on `<angular_port> + 1000`. The
+  // proxy.conf.json target matches.
+  langgraphCwd: 'cockpit/chat/subagents/python',
+  langgraphPort: 5505,
   angularProject: 'cockpit-chat-subagents-angular',
   angularPort: 4505,
   fixturesDir: resolve(__dirname, 'fixtures'),

--- a/cockpit/chat/subagents/angular/proxy.conf.json
+++ b/cockpit/chat/subagents/angular/proxy.conf.json
@@ -1,6 +1,6 @@
 {
   "/api": {
-    "target": "http://localhost:8125",
+    "target": "http://localhost:5505",
     "secure": false,
     "changeOrigin": true,
     "pathRewrite": { "^/api": "" },

--- a/cockpit/chat/subagents/angular/src/environments/environment.development.ts
+++ b/cockpit/chat/subagents/angular/src/environments/environment.development.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: false,
-  langGraphApiUrl: 'http://localhost:4505/api',
+  langGraphApiUrl: '/api',
   streamingAssistantId: 'c-subagents',
 };

--- a/cockpit/chat/subagents/python/project.json
+++ b/cockpit/chat/subagents/python/project.json
@@ -1,0 +1,24 @@
+{
+  "name": "cockpit-chat-subagents-python",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "cockpit/chat/subagents/python/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{workspaceRoot}/dist/cockpit/chat/subagents/python"],
+      "options": {
+        "outputPath": "dist/cockpit/chat/subagents/python",
+        "main": "cockpit/chat/subagents/python/src/index.ts",
+        "tsConfig": "cockpit/chat/subagents/python/tsconfig.json"
+      }
+    },
+    "serve": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "cockpit/chat/subagents/python",
+        "command": "uv run langgraph dev --port 5505 --no-browser"
+      }
+    }
+  }
+}

--- a/cockpit/chat/subagents/python/prompts/subagents.md
+++ b/cockpit/chat/subagents/python/prompts/subagents.md
@@ -1,12 +1,23 @@
-# Chat Subagents Orchestrator
+# Trip Planner Orchestrator
 
-You are the orchestrator in a multi-agent system. You coordinate specialized
-subagents to handle user requests:
+You coordinate three specialized subagents to plan a trip. You delegate work
+by calling the `task` tool with a `role` and `task_description`.
 
-- **Research Agent**: Gathers background information and context
-- **Analysis Agent**: Analyzes findings and identifies patterns
-- **Summary Agent**: Produces a concise summary of results
+The three roles, in the order you should always call them:
 
-When the user asks a question, acknowledge their request and explain that
-you are delegating work to your specialized subagents. Each subagent will
-process the task in sequence and their progress will be visible in the UI.
+1. `task(role="research", ...)` — gathers destination intel (airports, weather, conditions)
+2. `task(role="booking", ...)` — finds flight options between origin and destination
+3. `task(role="itinerary", ...)` — synthesizes a final trip plan combining research + bookings
+
+When the user asks about a trip (e.g., "plan a trip from LAX to Tokyo" or
+"I want to fly from Boston to Miami next week"), call task() three times in
+that order, then summarize the final plan in 1-2 sentences. Each subagent
+will process its task and its output will be visible in the chat-subagents UI.
+
+If the user's request is ambiguous (e.g., they don't mention airports), ask
+a clarifying question before delegating. Once you have origin + destination,
+delegate to all three subagents.
+
+Note: the dataset is limited to 10 US airports (LAX, JFK, SFO, ORD, BOS,
+ATL, DFW, SEA, MIA, DEN). If the user asks about an airport not in this
+list, the research subagent will note it; suggest a nearby supported airport.

--- a/cockpit/chat/subagents/python/src/aviation_data.py
+++ b/cockpit/chat/subagents/python/src/aviation_data.py
@@ -1,0 +1,207 @@
+"""Aviation mock dataset for c-* example demos.
+
+Hardcoded data for the c-tool-calls and c-subagents demos (and future c-*
+aviation-themed examples). Zero external API calls — everything is canned
+for deterministic demos and offline-friendly development.
+
+The dataset is small but cohesive: ~10 US airports, 4 major airlines,
+~30 flights criss-crossing those airports. Each airport has a static
+"current weather" entry that doesn't change between calls (for
+repeatability in screencasts and snapshot tests).
+"""
+
+# ── Airports ────────────────────────────────────────────────────────────────
+
+AIRPORTS = {
+    "LAX": {"code": "LAX", "name": "Los Angeles International", "city": "Los Angeles", "country": "USA",
+            "weather": {"temp_f": 72, "conditions": "Partly Cloudy"}, "terminals": 9, "runways": 4},
+    "JFK": {"code": "JFK", "name": "John F. Kennedy International", "city": "New York", "country": "USA",
+            "weather": {"temp_f": 58, "conditions": "Clear"}, "terminals": 6, "runways": 4},
+    "SFO": {"code": "SFO", "name": "San Francisco International", "city": "San Francisco", "country": "USA",
+            "weather": {"temp_f": 64, "conditions": "Foggy"}, "terminals": 4, "runways": 4},
+    "ORD": {"code": "ORD", "name": "O'Hare International", "city": "Chicago", "country": "USA",
+            "weather": {"temp_f": 48, "conditions": "Light Rain"}, "terminals": 4, "runways": 8},
+    "BOS": {"code": "BOS", "name": "Logan International", "city": "Boston", "country": "USA",
+            "weather": {"temp_f": 52, "conditions": "Overcast"}, "terminals": 4, "runways": 6},
+    "ATL": {"code": "ATL", "name": "Hartsfield-Jackson Atlanta International", "city": "Atlanta", "country": "USA",
+            "weather": {"temp_f": 68, "conditions": "Sunny"}, "terminals": 2, "runways": 5},
+    "DFW": {"code": "DFW", "name": "Dallas/Fort Worth International", "city": "Dallas", "country": "USA",
+            "weather": {"temp_f": 76, "conditions": "Sunny"}, "terminals": 5, "runways": 7},
+    "SEA": {"code": "SEA", "name": "Seattle-Tacoma International", "city": "Seattle", "country": "USA",
+            "weather": {"temp_f": 55, "conditions": "Drizzle"}, "terminals": 3, "runways": 3},
+    "MIA": {"code": "MIA", "name": "Miami International", "city": "Miami", "country": "USA",
+            "weather": {"temp_f": 82, "conditions": "Humid, Sunny"}, "terminals": 3, "runways": 4},
+    "DEN": {"code": "DEN", "name": "Denver International", "city": "Denver", "country": "USA",
+            "weather": {"temp_f": 60, "conditions": "Clear, Windy"}, "terminals": 1, "runways": 6},
+}
+
+# ── Airlines ────────────────────────────────────────────────────────────────
+
+AIRLINES = {
+    "AA": {"code": "AA", "name": "American Airlines", "hub": "DFW"},
+    "UA": {"code": "UA", "name": "United Airlines", "hub": "ORD"},
+    "DL": {"code": "DL", "name": "Delta Air Lines", "hub": "ATL"},
+    "B6": {"code": "B6", "name": "JetBlue Airways", "hub": "JFK"},
+}
+
+# ── Flights ─────────────────────────────────────────────────────────────────
+
+FLIGHTS = [
+    # United transcontinental
+    {"flight_number": "UA123", "airline": "UA", "from": "LAX", "to": "JFK",
+     "depart_local": "08:00", "arrive_local": "16:30", "duration_min": 330,
+     "status": "on_time", "gate": "B14", "aircraft": "Boeing 787"},
+    {"flight_number": "UA456", "airline": "UA", "from": "JFK", "to": "LAX",
+     "depart_local": "10:00", "arrive_local": "13:15", "duration_min": 375,
+     "status": "delayed", "gate": "T7-12", "aircraft": "Boeing 757"},
+    {"flight_number": "UA789", "airline": "UA", "from": "ORD", "to": "SFO",
+     "depart_local": "09:30", "arrive_local": "12:00", "duration_min": 270,
+     "status": "on_time", "gate": "C15", "aircraft": "Airbus A320"},
+
+    # American out of DFW hub
+    {"flight_number": "AA101", "airline": "AA", "from": "DFW", "to": "LAX",
+     "depart_local": "07:15", "arrive_local": "08:45", "duration_min": 210,
+     "status": "on_time", "gate": "A23", "aircraft": "Boeing 737"},
+    {"flight_number": "AA202", "airline": "AA", "from": "DFW", "to": "JFK",
+     "depart_local": "11:00", "arrive_local": "15:30", "duration_min": 210,
+     "status": "on_time", "gate": "D8", "aircraft": "Boeing 737"},
+    {"flight_number": "AA303", "airline": "AA", "from": "DFW", "to": "MIA",
+     "depart_local": "13:45", "arrive_local": "17:30", "duration_min": 165,
+     "status": "on_time", "gate": "C11", "aircraft": "Airbus A321"},
+    {"flight_number": "AA404", "airline": "AA", "from": "BOS", "to": "DFW",
+     "depart_local": "06:30", "arrive_local": "10:00", "duration_min": 270,
+     "status": "cancelled", "gate": "B5", "aircraft": "Boeing 737"},
+
+    # Delta hub-and-spoke from ATL
+    {"flight_number": "DL501", "airline": "DL", "from": "ATL", "to": "LAX",
+     "depart_local": "10:00", "arrive_local": "11:45", "duration_min": 285,
+     "status": "on_time", "gate": "F20", "aircraft": "Boeing 757"},
+    {"flight_number": "DL502", "airline": "DL", "from": "ATL", "to": "JFK",
+     "depart_local": "14:20", "arrive_local": "16:50", "duration_min": 150,
+     "status": "on_time", "gate": "B9", "aircraft": "Boeing 737"},
+    {"flight_number": "DL503", "airline": "DL", "from": "ATL", "to": "SEA",
+     "depart_local": "09:15", "arrive_local": "11:35", "duration_min": 320,
+     "status": "delayed", "gate": "A17", "aircraft": "Airbus A330"},
+    {"flight_number": "DL504", "airline": "DL", "from": "ATL", "to": "MIA",
+     "depart_local": "16:00", "arrive_local": "17:50", "duration_min": 110,
+     "status": "on_time", "gate": "T2", "aircraft": "Boeing 717"},
+
+    # JetBlue from JFK
+    {"flight_number": "B6601", "airline": "B6", "from": "JFK", "to": "LAX",
+     "depart_local": "07:30", "arrive_local": "10:55", "duration_min": 385,
+     "status": "on_time", "gate": "T5-12", "aircraft": "Airbus A321"},
+    {"flight_number": "B6602", "airline": "B6", "from": "JFK", "to": "BOS",
+     "depart_local": "12:15", "arrive_local": "13:30", "duration_min": 75,
+     "status": "on_time", "gate": "T5-9", "aircraft": "Embraer 190"},
+    {"flight_number": "B6603", "airline": "B6", "from": "JFK", "to": "MIA",
+     "depart_local": "15:45", "arrive_local": "18:55", "duration_min": 190,
+     "status": "on_time", "gate": "T5-15", "aircraft": "Airbus A320"},
+    {"flight_number": "B6604", "airline": "B6", "from": "BOS", "to": "MIA",
+     "depart_local": "09:00", "arrive_local": "12:35", "duration_min": 215,
+     "status": "on_time", "gate": "C42", "aircraft": "Airbus A320"},
+
+    # Denver hub (United secondary)
+    {"flight_number": "UA850", "airline": "UA", "from": "DEN", "to": "LAX",
+     "depart_local": "08:45", "arrive_local": "10:00", "duration_min": 135,
+     "status": "on_time", "gate": "B33", "aircraft": "Boeing 737"},
+    {"flight_number": "UA851", "airline": "UA", "from": "DEN", "to": "ORD",
+     "depart_local": "11:30", "arrive_local": "14:55", "duration_min": 145,
+     "status": "on_time", "gate": "B41", "aircraft": "Airbus A319"},
+    {"flight_number": "UA852", "airline": "UA", "from": "SFO", "to": "DEN",
+     "depart_local": "06:00", "arrive_local": "09:25", "duration_min": 145,
+     "status": "on_time", "gate": "F8", "aircraft": "Boeing 737"},
+
+    # Seattle (United + Delta)
+    {"flight_number": "UA901", "airline": "UA", "from": "SEA", "to": "ORD",
+     "depart_local": "07:00", "arrive_local": "12:55", "duration_min": 235,
+     "status": "on_time", "gate": "S2", "aircraft": "Boeing 737"},
+    {"flight_number": "DL902", "airline": "DL", "from": "SEA", "to": "ATL",
+     "depart_local": "14:30", "arrive_local": "22:05", "duration_min": 275,
+     "status": "on_time", "gate": "B12", "aircraft": "Boeing 757"},
+
+    # SFO-LAX shuttle
+    {"flight_number": "UA1001", "airline": "UA", "from": "SFO", "to": "LAX",
+     "depart_local": "06:00", "arrive_local": "07:25", "duration_min": 85,
+     "status": "on_time", "gate": "F3", "aircraft": "Airbus A320"},
+    {"flight_number": "UA1002", "airline": "UA", "from": "SFO", "to": "LAX",
+     "depart_local": "09:30", "arrive_local": "10:55", "duration_min": 85,
+     "status": "on_time", "gate": "F5", "aircraft": "Airbus A320"},
+    {"flight_number": "UA1003", "airline": "UA", "from": "LAX", "to": "SFO",
+     "depart_local": "08:00", "arrive_local": "09:25", "duration_min": 85,
+     "status": "on_time", "gate": "B22", "aircraft": "Airbus A320"},
+    {"flight_number": "UA1004", "airline": "UA", "from": "LAX", "to": "SFO",
+     "depart_local": "12:15", "arrive_local": "13:40", "duration_min": 85,
+     "status": "delayed", "gate": "B26", "aircraft": "Airbus A320"},
+
+    # Chicago hub (United + American)
+    {"flight_number": "UA710", "airline": "UA", "from": "ORD", "to": "BOS",
+     "depart_local": "06:30", "arrive_local": "09:45", "duration_min": 135,
+     "status": "on_time", "gate": "C12", "aircraft": "Boeing 737"},
+    {"flight_number": "AA711", "airline": "AA", "from": "ORD", "to": "DFW",
+     "depart_local": "07:15", "arrive_local": "09:50", "duration_min": 155,
+     "status": "on_time", "gate": "K8", "aircraft": "Boeing 737"},
+    {"flight_number": "UA712", "airline": "UA", "from": "ORD", "to": "DEN",
+     "depart_local": "10:00", "arrive_local": "11:30", "duration_min": 150,
+     "status": "on_time", "gate": "C20", "aircraft": "Embraer 175"},
+
+    # MIA southbound
+    {"flight_number": "AA801", "airline": "AA", "from": "MIA", "to": "JFK",
+     "depart_local": "08:00", "arrive_local": "11:00", "duration_min": 180,
+     "status": "on_time", "gate": "D40", "aircraft": "Boeing 737"},
+    {"flight_number": "DL802", "airline": "DL", "from": "MIA", "to": "ATL",
+     "depart_local": "12:30", "arrive_local": "14:20", "duration_min": 110,
+     "status": "on_time", "gate": "H5", "aircraft": "Boeing 717"},
+
+    # BOS additional
+    {"flight_number": "B6605", "airline": "B6", "from": "BOS", "to": "SFO",
+     "depart_local": "07:45", "arrive_local": "11:30", "duration_min": 405,
+     "status": "on_time", "gate": "C40", "aircraft": "Airbus A321"},
+]
+
+# ── Dashboard analytics (PR 3: c-generative-ui aviation KPIs) ───────────────
+
+KPI_SNAPSHOT = {
+    "on_time_pct": 84.2,
+    "on_time_delta": "+1.4%",
+    "flights_today": 312,
+    "flights_today_delta": "+8",
+    "avg_delay_min": 12,
+    "avg_delay_delta": "-2 min",
+    "load_factor_pct": 78.5,
+    "load_factor_delta": "+0.6%",
+}
+
+ON_TIME_TREND = [
+    {"month": "2025-05", "on_time_pct": 82.4},
+    {"month": "2025-06", "on_time_pct": 81.1},
+    {"month": "2025-07", "on_time_pct": 79.8},
+    {"month": "2025-08", "on_time_pct": 80.5},
+    {"month": "2025-09", "on_time_pct": 83.2},
+    {"month": "2025-10", "on_time_pct": 84.0},
+    {"month": "2025-11", "on_time_pct": 82.6},
+    {"month": "2025-12", "on_time_pct": 78.9},
+    {"month": "2026-01", "on_time_pct": 80.2},
+    {"month": "2026-02", "on_time_pct": 81.7},
+    {"month": "2026-03", "on_time_pct": 82.8},
+    {"month": "2026-04", "on_time_pct": 84.2},
+]
+
+FLIGHTS_BY_AIRLINE = [
+    {"airline": "American", "count": 87},
+    {"airline": "United",   "count": 92},
+    {"airline": "Delta",    "count": 78},
+    {"airline": "JetBlue",  "count": 55},
+]
+
+RECENT_DISRUPTIONS = [
+    {"flight_number": "UA123", "type": "delayed",   "minutes": 45, "route": "LAX→JFK", "date": "2026-05-14"},
+    {"flight_number": "AA456", "type": "cancelled", "minutes": 0,  "route": "JFK→LAX", "date": "2026-05-14"},
+    {"flight_number": "DL789", "type": "delayed",   "minutes": 22, "route": "ATL→ORD", "date": "2026-05-13"},
+    {"flight_number": "B6101", "type": "delayed",   "minutes": 68, "route": "BOS→MIA", "date": "2026-05-13"},
+    {"flight_number": "UA204", "type": "cancelled", "minutes": 0,  "route": "SFO→SEA", "date": "2026-05-12"},
+    {"flight_number": "AA318", "type": "delayed",   "minutes": 15, "route": "DFW→DEN", "date": "2026-05-12"},
+    {"flight_number": "DL552", "type": "delayed",   "minutes": 35, "route": "ATL→MIA", "date": "2026-05-11"},
+    {"flight_number": "B6217", "type": "delayed",   "minutes": 80, "route": "JFK→BOS", "date": "2026-05-11"},
+    {"flight_number": "UA640", "type": "cancelled", "minutes": 0,  "route": "ORD→DEN", "date": "2026-05-10"},
+    {"flight_number": "AA871", "type": "delayed",   "minutes": 25, "route": "LAX→DFW", "date": "2026-05-10"},
+]

--- a/cockpit/chat/subagents/python/src/aviation_tools.py
+++ b/cockpit/chat/subagents/python/src/aviation_tools.py
@@ -1,0 +1,90 @@
+"""LangChain @tool wrappers around the aviation mock dataset.
+
+Each tool's docstring is what the LLM sees for tool-selection — keep them
+informative and example-laden.
+"""
+
+from langchain_core.tools import tool
+from src.aviation_data import AIRPORTS, AIRLINES, FLIGHTS
+
+
+@tool
+async def lookup_flight(flight_number: str) -> dict:
+    """Look up the status, route, and gate for a specific flight number.
+
+    Use this when the user asks about a specific flight (e.g., "what's the
+    status of UA123?", "is AA404 on time?", "what gate is DL501 leaving from?").
+
+    Args:
+        flight_number: Flight number like 'UA123' or 'AA456'. Case-insensitive.
+
+    Returns:
+        dict with keys: flight_number, airline, from, to, depart_local,
+        arrive_local, status (on_time/delayed/cancelled), gate, aircraft,
+        duration_min.
+
+    Returns {"error": "Flight not found"} if the flight number is not in
+    the dataset.
+    """
+    fn = flight_number.upper().strip()
+    for f in FLIGHTS:
+        if f["flight_number"] == fn:
+            return f
+    return {"error": f"Flight {fn} not found in dataset"}
+
+
+@tool
+async def get_airport_info(airport_code: str) -> dict:
+    """Get details about an airport: name, city, current weather, terminals, runways.
+
+    Use this when the user asks about an airport (e.g., "what's the weather
+    at LAX?", "tell me about JFK", "how many runways does ORD have?").
+
+    Args:
+        airport_code: 3-letter IATA code like 'LAX' or 'JFK'. Case-insensitive.
+
+    Returns:
+        dict with keys: code, name, city, country, weather (with temp_f and
+        conditions), terminals, runways.
+
+    Returns {"error": "Airport not found"} if the code is not in the dataset.
+    """
+    code = airport_code.upper().strip()
+    if code in AIRPORTS:
+        return AIRPORTS[code]
+    return {"error": f"Airport {code} not in dataset. Available: {sorted(AIRPORTS.keys())}"}
+
+
+@tool
+async def find_routes(from_code: str, to_code: str, date_offset_days: int = 0) -> dict:
+    """Find available flights between two airports.
+
+    Use this when the user asks about flight options (e.g., "what flights
+    are there from LAX to JFK?", "find me a flight from Boston to Miami
+    tomorrow").
+
+    Args:
+        from_code: 3-letter IATA code for departure airport.
+        to_code: 3-letter IATA code for arrival airport.
+        date_offset_days: 0 = today, 1 = tomorrow, etc. Note: mock data is
+            the same regardless of date; the LLM can still reason about
+            the date in its response.
+
+    Returns:
+        dict with keys:
+          - "flights": list of flight dicts (same shape as lookup_flight)
+            sorted by depart_local, OR empty list if no routes.
+          - "from": echoed from_code
+          - "to": echoed to_code
+          - "date_offset_days": echoed
+    """
+    fc = from_code.upper().strip()
+    tc = to_code.upper().strip()
+    flights = sorted(
+        [f for f in FLIGHTS if f["from"] == fc and f["to"] == tc],
+        key=lambda f: f["depart_local"],
+    )
+    return {"from": fc, "to": tc, "date_offset_days": date_offset_days, "flights": flights}
+
+
+ALL_TOOLS = [lookup_flight, get_airport_info, find_routes]

--- a/cockpit/chat/subagents/python/src/graph.py
+++ b/cockpit/chat/subagents/python/src/graph.py
@@ -1,25 +1,114 @@
-"""
-Chat Subagents Graph
+"""Chat Subagents Graph — orchestrator LLM with a single `task` tool that
+dispatches to specialized aviation subagents (research/booking/itinerary).
 
-A LangGraph StateGraph demonstrating an orchestrator pattern with
-subagent delegation. The orchestrator routes tasks to specialized
-subagent nodes that simulate domain-specific processing.
+Mirrors umbrella's c-subagents. Self-contained: aviation_tools + aviation_data
+copied into this module.
 """
 
 from pathlib import Path
-from langgraph.graph import StateGraph, MessagesState, END
+from typing import Literal
+
+from langchain_core.messages import SystemMessage, HumanMessage
+from langchain_core.tools import tool
 from langchain_openai import ChatOpenAI
-from langchain_core.messages import SystemMessage, AIMessage
+from langgraph.graph import StateGraph, MessagesState, END
+from langgraph.prebuilt import ToolNode
+
+from src.aviation_tools import (
+    get_airport_info,
+    find_routes,
+    lookup_flight,
+)
 
 PROMPTS_DIR = Path(__file__).parent.parent / "prompts"
 
 
-def build_subagents_graph():
-    """
-    Constructs an orchestrator graph that delegates to specialized subagents.
-    Demonstrates the subagent pattern with research, analysis, and summary nodes.
-    """
+_RESEARCH_PROMPT = """You are a Research Agent for trip planning. Your job is to gather
+destination intel about airports the traveler is considering. Use the
+get_airport_info tool to look up airport details (city, weather, terminals,
+runways) for any airport codes mentioned in the task description.
+
+Return a concise 2-4 sentence summary of what you found. If a code isn't
+recognized, say so."""
+
+_BOOKING_PROMPT = """You are a Booking Agent for trip planning. Your job is to find
+flight options between the origin and destination airports in the task
+description. Use find_routes to list available flights, and lookup_flight
+if the user mentioned a specific flight number.
+
+Return a concise summary listing 2-3 best flight options with airline,
+flight number, times, and price-or-aircraft info. If no flights are found,
+say so and suggest alternatives."""
+
+_ITINERARY_PROMPT = """You are an Itinerary Agent for trip planning. Your job is to
+synthesize a final trip plan from research + booking outputs you receive in
+the task description.
+
+Return a clean 3-5 sentence itinerary summarizing the recommended flight
+choice, what to expect on arrival (weather), and any practical tips
+(e.g., delays, terminal info). Be helpful and concise."""
+
+
+async def _run_subagent(role: str, task_description: str, system_prompt: str, tools: list):
+    """Run a single subagent: LLM bound with role-specific tools, single tool loop."""
     llm = ChatOpenAI(model="gpt-5-mini", streaming=True)
+    if tools:
+        llm = llm.bind_tools(tools)
+    messages = [
+        SystemMessage(content=system_prompt),
+        HumanMessage(content=task_description),
+    ]
+    # Allow up to 3 tool-loop iterations
+    for _ in range(3):
+        response = await llm.ainvoke(messages)
+        messages.append(response)
+        tool_calls = getattr(response, "tool_calls", None)
+        if not tool_calls:
+            return response.content
+        # Execute tool calls inline
+        for tc in tool_calls:
+            tool_name = tc["name"]
+            tool_args = tc["args"]
+            target = next((t for t in tools if t.name == tool_name), None)
+            if target is None:
+                tool_result = f"Tool {tool_name} not available"
+            else:
+                tool_result = await target.ainvoke(tool_args)
+            from langchain_core.messages import ToolMessage
+            messages.append(ToolMessage(content=str(tool_result), tool_call_id=tc["id"]))
+    return response.content
+
+
+@tool
+async def task(role: Literal["research", "booking", "itinerary"], task_description: str) -> str:
+    """Delegate a subtask to a specialized subagent.
+
+    Roles:
+      - research: gathers destination intel (airports, weather, conditions)
+      - booking: finds flight options between origin and destination
+      - itinerary: synthesizes a final trip plan combining research + bookings
+
+    Args:
+        role: One of "research", "booking", "itinerary".
+        task_description: Plain-English description of what the subagent
+            should do (e.g., "Gather info on LAX and JFK airports", or
+            "Find morning flights from LAX to JFK").
+
+    Returns:
+        The subagent's final answer as a string.
+    """
+    if role == "research":
+        return await _run_subagent(role, task_description, _RESEARCH_PROMPT, [get_airport_info])
+    if role == "booking":
+        return await _run_subagent(role, task_description, _BOOKING_PROMPT, [find_routes, lookup_flight])
+    if role == "itinerary":
+        return await _run_subagent(role, task_description, _ITINERARY_PROMPT, [])
+    return f"Unknown role: {role}"
+
+
+def build_subagents_graph():
+    """Orchestrator LLM with a single `task` tool that dispatches to subagent functions."""
+    llm = ChatOpenAI(model="gpt-5-mini", streaming=True).bind_tools([task])
 
     async def orchestrator(state: MessagesState) -> dict:
         system_prompt = (PROMPTS_DIR / "subagents.md").read_text()
@@ -27,36 +116,18 @@ def build_subagents_graph():
         response = await llm.ainvoke(messages)
         return {"messages": [response]}
 
-    async def research_agent(state: MessagesState) -> dict:
-        last = state["messages"][-1].content
-        response = AIMessage(
-            content=f"[Research Agent] Gathered background information on: {last[:100]}"
-        )
-        return {"messages": [response]}
-
-    async def analysis_agent(state: MessagesState) -> dict:
-        last = state["messages"][-1].content
-        response = AIMessage(
-            content=f"[Analysis Agent] Analyzed findings and identified key patterns."
-        )
-        return {"messages": [response]}
-
-    async def summary_agent(state: MessagesState) -> dict:
-        messages = [SystemMessage(content="Summarize the conversation so far in a concise paragraph.")] + state["messages"]
-        response = await llm.ainvoke(messages)
-        return {"messages": [response]}
+    def should_continue(state: MessagesState) -> str:
+        last = state["messages"][-1]
+        if hasattr(last, "tool_calls") and last.tool_calls:
+            return "tools"
+        return END
 
     graph = StateGraph(MessagesState)
     graph.add_node("orchestrator", orchestrator)
-    graph.add_node("research_agent", research_agent)
-    graph.add_node("analysis_agent", analysis_agent)
-    graph.add_node("summary_agent", summary_agent)
+    graph.add_node("tools", ToolNode([task]))
     graph.set_entry_point("orchestrator")
-    graph.add_edge("orchestrator", "research_agent")
-    graph.add_edge("research_agent", "analysis_agent")
-    graph.add_edge("analysis_agent", "summary_agent")
-    graph.add_edge("summary_agent", END)
-
+    graph.add_conditional_edges("orchestrator", should_continue, {"tools": "tools", END: END})
+    graph.add_edge("tools", "orchestrator")
     return graph.compile()
 
 

--- a/cockpit/chat/subagents/python/tsconfig.json
+++ b/cockpit/chat/subagents/python/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/cockpit/chat/subagents/python",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "target": "ES2022",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true
+  },
+  "include": ["src/**/*"]
+}

--- a/cockpit/chat/theming/angular/proxy.conf.json
+++ b/cockpit/chat/theming/angular/proxy.conf.json
@@ -1,6 +1,6 @@
 {
   "/api": {
-    "target": "http://localhost:8123",
+    "target": "http://localhost:5510",
     "secure": false,
     "changeOrigin": true,
     "pathRewrite": { "^/api": "" },

--- a/cockpit/chat/theming/angular/src/environments/environment.development.ts
+++ b/cockpit/chat/theming/angular/src/environments/environment.development.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: false,
-  langGraphApiUrl: 'http://localhost:4510/api',
+  langGraphApiUrl: '/api',
   streamingAssistantId: 'c-theming',
 };

--- a/cockpit/chat/theming/python/project.json
+++ b/cockpit/chat/theming/python/project.json
@@ -1,0 +1,24 @@
+{
+  "name": "cockpit-chat-theming-python",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "cockpit/chat/theming/python/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{workspaceRoot}/dist/cockpit/chat/theming/python"],
+      "options": {
+        "outputPath": "dist/cockpit/chat/theming/python",
+        "main": "cockpit/chat/theming/python/src/index.ts",
+        "tsConfig": "cockpit/chat/theming/python/tsconfig.json"
+      }
+    },
+    "serve": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "cockpit/chat/theming/python",
+        "command": "uv run langgraph dev --port 5510 --no-browser"
+      }
+    }
+  }
+}

--- a/cockpit/chat/theming/python/prompts/theming.md
+++ b/cockpit/chat/theming/python/prompts/theming.md
@@ -1,13 +1,10 @@
-# Chat Theming Assistant
+# Aviation Assistant — Theming Demo
 
-You are an assistant that demonstrates chat theming and CSS custom
-property customization in @ngaf/chat.
+You are a friendly aviation assistant helping travelers with flights, airports,
+and trip questions. You're knowledgeable about commercial aviation and happy to
+discuss anything from flight planning to airport amenities.
 
-The chat UI supports extensive theming via CSS custom properties like
-`--ngaf-chat-bg`, `--ngaf-chat-text`, `--ngaf-chat-accent`,
-`--ngaf-chat-surface-alt`, and more. These can be swapped at runtime by
-setting CSS variables on a parent element.
-
-Explain the theming system when asked, and demonstrate how different
-themes change the appearance of the chat interface. The sidebar contains
-theme picker buttons that swap themes in real time.
+Note: this demo's mock dataset covers 10 US airports — LAX, JFK, SFO, ORD,
+BOS, ATL, DFW, SEA, MIA, DEN — and 4 airlines (American, United, Delta,
+JetBlue). For airports/airlines outside this list, you can still provide
+general aviation knowledge but acknowledge the data limit.

--- a/cockpit/chat/theming/python/tsconfig.json
+++ b/cockpit/chat/theming/python/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/cockpit/chat/theming/python",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "target": "ES2022",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true
+  },
+  "include": ["src/**/*"]
+}

--- a/cockpit/chat/threads/angular/proxy.conf.json
+++ b/cockpit/chat/threads/angular/proxy.conf.json
@@ -1,6 +1,6 @@
 {
   "/api": {
-    "target": "http://localhost:8123",
+    "target": "http://localhost:5506",
     "secure": false,
     "changeOrigin": true,
     "pathRewrite": { "^/api": "" },

--- a/cockpit/chat/threads/angular/src/environments/environment.development.ts
+++ b/cockpit/chat/threads/angular/src/environments/environment.development.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: false,
-  langGraphApiUrl: 'http://localhost:4506/api',
+  langGraphApiUrl: '/api',
   streamingAssistantId: 'c-threads',
 };

--- a/cockpit/chat/threads/python/project.json
+++ b/cockpit/chat/threads/python/project.json
@@ -1,0 +1,24 @@
+{
+  "name": "cockpit-chat-threads-python",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "cockpit/chat/threads/python/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{workspaceRoot}/dist/cockpit/chat/threads/python"],
+      "options": {
+        "outputPath": "dist/cockpit/chat/threads/python",
+        "main": "cockpit/chat/threads/python/src/index.ts",
+        "tsConfig": "cockpit/chat/threads/python/tsconfig.json"
+      }
+    },
+    "serve": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "cockpit/chat/threads/python",
+        "command": "uv run langgraph dev --port 5506 --no-browser"
+      }
+    }
+  }
+}

--- a/cockpit/chat/threads/python/prompts/threads.md
+++ b/cockpit/chat/threads/python/prompts/threads.md
@@ -1,11 +1,18 @@
-# Chat Threads Assistant
+# Aviation Assistant — Threads Demo
 
-You are an assistant that demonstrates multi-thread conversation management.
+You are a friendly aviation assistant helping travelers with flights, airports,
+and trip questions. You're knowledgeable about commercial aviation and happy to
+discuss anything from flight planning to airport amenities.
 
-Each conversation thread maintains its own isolated message history.
-Users can create new threads, switch between existing threads, and
-each thread preserves its full conversation context independently.
+Note: this demo's mock dataset covers 10 US airports — LAX, JFK, SFO, ORD,
+BOS, ATL, DFW, SEA, MIA, DEN — and 4 airlines (American, United, Delta,
+JetBlue). For airports/airlines outside this list, you can still provide
+general aviation knowledge but acknowledge the data limit.
 
-When the user starts a conversation, acknowledge the current thread
-and explain that they can create new threads or switch between them
-using the thread list in the sidebar.
+## Thread context
+
+This demo showcases multiple parallel conversation threads (e.g., a "Tokyo
+trip" thread and a "London trip" thread). Keep responses focused on the
+specific destination/topic the user has been discussing in the current
+thread. Don't reference details from other threads unless the user
+explicitly mentions them.

--- a/cockpit/chat/threads/python/tsconfig.json
+++ b/cockpit/chat/threads/python/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/cockpit/chat/threads/python",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "target": "ES2022",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true
+  },
+  "include": ["src/**/*"]
+}

--- a/cockpit/chat/timeline/angular/proxy.conf.json
+++ b/cockpit/chat/timeline/angular/proxy.conf.json
@@ -1,6 +1,6 @@
 {
   "/api": {
-    "target": "http://localhost:8123",
+    "target": "http://localhost:5507",
     "secure": false,
     "changeOrigin": true,
     "pathRewrite": { "^/api": "" },

--- a/cockpit/chat/timeline/angular/src/environments/environment.development.ts
+++ b/cockpit/chat/timeline/angular/src/environments/environment.development.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: false,
-  langGraphApiUrl: 'http://localhost:4507/api',
+  langGraphApiUrl: '/api',
   streamingAssistantId: 'c-timeline',
 };

--- a/cockpit/chat/timeline/python/project.json
+++ b/cockpit/chat/timeline/python/project.json
@@ -1,0 +1,24 @@
+{
+  "name": "cockpit-chat-timeline-python",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "cockpit/chat/timeline/python/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{workspaceRoot}/dist/cockpit/chat/timeline/python"],
+      "options": {
+        "outputPath": "dist/cockpit/chat/timeline/python",
+        "main": "cockpit/chat/timeline/python/src/index.ts",
+        "tsConfig": "cockpit/chat/timeline/python/tsconfig.json"
+      }
+    },
+    "serve": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "cockpit/chat/timeline/python",
+        "command": "uv run langgraph dev --port 5507 --no-browser"
+      }
+    }
+  }
+}

--- a/cockpit/chat/timeline/python/prompts/timeline.md
+++ b/cockpit/chat/timeline/python/prompts/timeline.md
@@ -1,11 +1,18 @@
-# Chat Timeline Assistant
+# Aviation Assistant — Timeline Demo
 
-You are an assistant that demonstrates conversation timeline and
-checkpoint navigation using the Angular agent() ref.
+You are a friendly aviation assistant helping travelers with flights, airports,
+and trip questions. You're knowledgeable about commercial aviation and happy to
+discuss anything from flight planning to airport amenities.
 
-Each message exchange creates a checkpoint in the conversation timeline.
-Users can navigate backward and forward through these checkpoints using
-the timeline slider, and even branch from a previous checkpoint to
-explore alternative conversation paths.
+Note: this demo's mock dataset covers 10 US airports — LAX, JFK, SFO, ORD,
+BOS, ATL, DFW, SEA, MIA, DEN — and 4 airlines (American, United, Delta,
+JetBlue). For airports/airlines outside this list, you can still provide
+general aviation knowledge but acknowledge the data limit.
 
-Respond helpfully to demonstrate how checkpoints accumulate over time.
+## Timeline context
+
+This demo showcases the chat-timeline primitive — users can scrub backwards
+through conversation history and branch from any checkpoint. Multi-turn
+trip planning is ideal: the user can ask "what about flying from BOS
+instead?" or rewind and try a different destination. Keep your answers
+relatively short (2-3 sentences) so each checkpoint is a clean unit.

--- a/cockpit/chat/timeline/python/tsconfig.json
+++ b/cockpit/chat/timeline/python/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/cockpit/chat/timeline/python",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "target": "ES2022",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true
+  },
+  "include": ["src/**/*"]
+}

--- a/cockpit/chat/tool-calls/angular/e2e/global-setup-impl.ts
+++ b/cockpit/chat/tool-calls/angular/e2e/global-setup-impl.ts
@@ -3,13 +3,11 @@ import { resolve } from 'node:path';
 import { createGlobalSetup } from '../../../../../libs/e2e-harness/src';
 
 export default createGlobalSetup({
-  langgraphCwd: 'cockpit/langgraph/streaming/python',
-  // Each cockpit example pins its OWN langgraph port to avoid TIME_WAIT
-  // collisions when a sequential CI loop runs multiple per-example e2es
-  // back-to-back. The streaming pilot keeps the historical 8123 default;
-  // tool-calls offsets to 8124. Future examples pick the next unused port.
-  // The Angular proxy.conf.json target must match.
-  langgraphPort: 8124,
+  // Per-cap cleanup PR: each chat cap runs its OWN standalone backend
+  // (cockpit/chat/<name>/python) on `<angular_port> + 1000`. The
+  // proxy.conf.json target matches.
+  langgraphCwd: 'cockpit/chat/tool-calls/python',
+  langgraphPort: 5504,
   angularProject: 'cockpit-chat-tool-calls-angular',
   angularPort: 4504,
   fixturesDir: resolve(__dirname, 'fixtures'),

--- a/cockpit/chat/tool-calls/angular/proxy.conf.json
+++ b/cockpit/chat/tool-calls/angular/proxy.conf.json
@@ -1,6 +1,6 @@
 {
   "/api": {
-    "target": "http://localhost:8124",
+    "target": "http://localhost:5504",
     "secure": false,
     "changeOrigin": true,
     "pathRewrite": { "^/api": "" },

--- a/cockpit/chat/tool-calls/angular/src/environments/environment.development.ts
+++ b/cockpit/chat/tool-calls/angular/src/environments/environment.development.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: false,
-  langGraphApiUrl: 'http://localhost:4504/api',
+  langGraphApiUrl: '/api',
   streamingAssistantId: 'c-tool-calls',
 };

--- a/cockpit/chat/tool-calls/python/project.json
+++ b/cockpit/chat/tool-calls/python/project.json
@@ -1,0 +1,24 @@
+{
+  "name": "cockpit-chat-tool-calls-python",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "cockpit/chat/tool-calls/python/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{workspaceRoot}/dist/cockpit/chat/tool-calls/python"],
+      "options": {
+        "outputPath": "dist/cockpit/chat/tool-calls/python",
+        "main": "cockpit/chat/tool-calls/python/src/index.ts",
+        "tsConfig": "cockpit/chat/tool-calls/python/tsconfig.json"
+      }
+    },
+    "serve": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "cockpit/chat/tool-calls/python",
+        "command": "uv run langgraph dev --port 5504 --no-browser"
+      }
+    }
+  }
+}

--- a/cockpit/chat/tool-calls/python/prompts/tool-calls.md
+++ b/cockpit/chat/tool-calls/python/prompts/tool-calls.md
@@ -1,13 +1,16 @@
-# Chat Tool Calls Assistant
+# Aviation Assistant — Tool Calls Demo
 
-You are an assistant with access to search, calculator, and weather tools.
-Use these tools proactively to answer user questions.
+You are a helpful aviation assistant with access to flight and airport data
+through three tools:
 
-Available tools:
-- **search**: Search the web for information on any topic
-- **calculator**: Evaluate mathematical expressions
-- **weather**: Get current weather for any city
+- **lookup_flight(flight_number)** — status, route, and gate for a specific flight
+- **get_airport_info(airport_code)** — airport name, city, weather, terminals, runways
+- **find_routes(from_code, to_code, date_offset_days)** — available flights between two airports
 
-When the user asks a question, use the appropriate tool(s) to gather
-information before responding. Combine results from multiple tools
-when needed. Always explain which tools you used and why.
+Use these tools whenever the user asks about flights, airports, or routes.
+Combine multiple calls when helpful (e.g., "compare LAX and JFK" → call
+get_airport_info twice). Always cite which tools you used and summarize
+the results clearly.
+
+If a flight number or airport code isn't recognized, say so and suggest
+alternatives from the dataset (LAX, JFK, SFO, ORD, BOS, ATL, DFW, SEA, MIA, DEN).

--- a/cockpit/chat/tool-calls/python/src/aviation_data.py
+++ b/cockpit/chat/tool-calls/python/src/aviation_data.py
@@ -1,0 +1,207 @@
+"""Aviation mock dataset for c-* example demos.
+
+Hardcoded data for the c-tool-calls and c-subagents demos (and future c-*
+aviation-themed examples). Zero external API calls — everything is canned
+for deterministic demos and offline-friendly development.
+
+The dataset is small but cohesive: ~10 US airports, 4 major airlines,
+~30 flights criss-crossing those airports. Each airport has a static
+"current weather" entry that doesn't change between calls (for
+repeatability in screencasts and snapshot tests).
+"""
+
+# ── Airports ────────────────────────────────────────────────────────────────
+
+AIRPORTS = {
+    "LAX": {"code": "LAX", "name": "Los Angeles International", "city": "Los Angeles", "country": "USA",
+            "weather": {"temp_f": 72, "conditions": "Partly Cloudy"}, "terminals": 9, "runways": 4},
+    "JFK": {"code": "JFK", "name": "John F. Kennedy International", "city": "New York", "country": "USA",
+            "weather": {"temp_f": 58, "conditions": "Clear"}, "terminals": 6, "runways": 4},
+    "SFO": {"code": "SFO", "name": "San Francisco International", "city": "San Francisco", "country": "USA",
+            "weather": {"temp_f": 64, "conditions": "Foggy"}, "terminals": 4, "runways": 4},
+    "ORD": {"code": "ORD", "name": "O'Hare International", "city": "Chicago", "country": "USA",
+            "weather": {"temp_f": 48, "conditions": "Light Rain"}, "terminals": 4, "runways": 8},
+    "BOS": {"code": "BOS", "name": "Logan International", "city": "Boston", "country": "USA",
+            "weather": {"temp_f": 52, "conditions": "Overcast"}, "terminals": 4, "runways": 6},
+    "ATL": {"code": "ATL", "name": "Hartsfield-Jackson Atlanta International", "city": "Atlanta", "country": "USA",
+            "weather": {"temp_f": 68, "conditions": "Sunny"}, "terminals": 2, "runways": 5},
+    "DFW": {"code": "DFW", "name": "Dallas/Fort Worth International", "city": "Dallas", "country": "USA",
+            "weather": {"temp_f": 76, "conditions": "Sunny"}, "terminals": 5, "runways": 7},
+    "SEA": {"code": "SEA", "name": "Seattle-Tacoma International", "city": "Seattle", "country": "USA",
+            "weather": {"temp_f": 55, "conditions": "Drizzle"}, "terminals": 3, "runways": 3},
+    "MIA": {"code": "MIA", "name": "Miami International", "city": "Miami", "country": "USA",
+            "weather": {"temp_f": 82, "conditions": "Humid, Sunny"}, "terminals": 3, "runways": 4},
+    "DEN": {"code": "DEN", "name": "Denver International", "city": "Denver", "country": "USA",
+            "weather": {"temp_f": 60, "conditions": "Clear, Windy"}, "terminals": 1, "runways": 6},
+}
+
+# ── Airlines ────────────────────────────────────────────────────────────────
+
+AIRLINES = {
+    "AA": {"code": "AA", "name": "American Airlines", "hub": "DFW"},
+    "UA": {"code": "UA", "name": "United Airlines", "hub": "ORD"},
+    "DL": {"code": "DL", "name": "Delta Air Lines", "hub": "ATL"},
+    "B6": {"code": "B6", "name": "JetBlue Airways", "hub": "JFK"},
+}
+
+# ── Flights ─────────────────────────────────────────────────────────────────
+
+FLIGHTS = [
+    # United transcontinental
+    {"flight_number": "UA123", "airline": "UA", "from": "LAX", "to": "JFK",
+     "depart_local": "08:00", "arrive_local": "16:30", "duration_min": 330,
+     "status": "on_time", "gate": "B14", "aircraft": "Boeing 787"},
+    {"flight_number": "UA456", "airline": "UA", "from": "JFK", "to": "LAX",
+     "depart_local": "10:00", "arrive_local": "13:15", "duration_min": 375,
+     "status": "delayed", "gate": "T7-12", "aircraft": "Boeing 757"},
+    {"flight_number": "UA789", "airline": "UA", "from": "ORD", "to": "SFO",
+     "depart_local": "09:30", "arrive_local": "12:00", "duration_min": 270,
+     "status": "on_time", "gate": "C15", "aircraft": "Airbus A320"},
+
+    # American out of DFW hub
+    {"flight_number": "AA101", "airline": "AA", "from": "DFW", "to": "LAX",
+     "depart_local": "07:15", "arrive_local": "08:45", "duration_min": 210,
+     "status": "on_time", "gate": "A23", "aircraft": "Boeing 737"},
+    {"flight_number": "AA202", "airline": "AA", "from": "DFW", "to": "JFK",
+     "depart_local": "11:00", "arrive_local": "15:30", "duration_min": 210,
+     "status": "on_time", "gate": "D8", "aircraft": "Boeing 737"},
+    {"flight_number": "AA303", "airline": "AA", "from": "DFW", "to": "MIA",
+     "depart_local": "13:45", "arrive_local": "17:30", "duration_min": 165,
+     "status": "on_time", "gate": "C11", "aircraft": "Airbus A321"},
+    {"flight_number": "AA404", "airline": "AA", "from": "BOS", "to": "DFW",
+     "depart_local": "06:30", "arrive_local": "10:00", "duration_min": 270,
+     "status": "cancelled", "gate": "B5", "aircraft": "Boeing 737"},
+
+    # Delta hub-and-spoke from ATL
+    {"flight_number": "DL501", "airline": "DL", "from": "ATL", "to": "LAX",
+     "depart_local": "10:00", "arrive_local": "11:45", "duration_min": 285,
+     "status": "on_time", "gate": "F20", "aircraft": "Boeing 757"},
+    {"flight_number": "DL502", "airline": "DL", "from": "ATL", "to": "JFK",
+     "depart_local": "14:20", "arrive_local": "16:50", "duration_min": 150,
+     "status": "on_time", "gate": "B9", "aircraft": "Boeing 737"},
+    {"flight_number": "DL503", "airline": "DL", "from": "ATL", "to": "SEA",
+     "depart_local": "09:15", "arrive_local": "11:35", "duration_min": 320,
+     "status": "delayed", "gate": "A17", "aircraft": "Airbus A330"},
+    {"flight_number": "DL504", "airline": "DL", "from": "ATL", "to": "MIA",
+     "depart_local": "16:00", "arrive_local": "17:50", "duration_min": 110,
+     "status": "on_time", "gate": "T2", "aircraft": "Boeing 717"},
+
+    # JetBlue from JFK
+    {"flight_number": "B6601", "airline": "B6", "from": "JFK", "to": "LAX",
+     "depart_local": "07:30", "arrive_local": "10:55", "duration_min": 385,
+     "status": "on_time", "gate": "T5-12", "aircraft": "Airbus A321"},
+    {"flight_number": "B6602", "airline": "B6", "from": "JFK", "to": "BOS",
+     "depart_local": "12:15", "arrive_local": "13:30", "duration_min": 75,
+     "status": "on_time", "gate": "T5-9", "aircraft": "Embraer 190"},
+    {"flight_number": "B6603", "airline": "B6", "from": "JFK", "to": "MIA",
+     "depart_local": "15:45", "arrive_local": "18:55", "duration_min": 190,
+     "status": "on_time", "gate": "T5-15", "aircraft": "Airbus A320"},
+    {"flight_number": "B6604", "airline": "B6", "from": "BOS", "to": "MIA",
+     "depart_local": "09:00", "arrive_local": "12:35", "duration_min": 215,
+     "status": "on_time", "gate": "C42", "aircraft": "Airbus A320"},
+
+    # Denver hub (United secondary)
+    {"flight_number": "UA850", "airline": "UA", "from": "DEN", "to": "LAX",
+     "depart_local": "08:45", "arrive_local": "10:00", "duration_min": 135,
+     "status": "on_time", "gate": "B33", "aircraft": "Boeing 737"},
+    {"flight_number": "UA851", "airline": "UA", "from": "DEN", "to": "ORD",
+     "depart_local": "11:30", "arrive_local": "14:55", "duration_min": 145,
+     "status": "on_time", "gate": "B41", "aircraft": "Airbus A319"},
+    {"flight_number": "UA852", "airline": "UA", "from": "SFO", "to": "DEN",
+     "depart_local": "06:00", "arrive_local": "09:25", "duration_min": 145,
+     "status": "on_time", "gate": "F8", "aircraft": "Boeing 737"},
+
+    # Seattle (United + Delta)
+    {"flight_number": "UA901", "airline": "UA", "from": "SEA", "to": "ORD",
+     "depart_local": "07:00", "arrive_local": "12:55", "duration_min": 235,
+     "status": "on_time", "gate": "S2", "aircraft": "Boeing 737"},
+    {"flight_number": "DL902", "airline": "DL", "from": "SEA", "to": "ATL",
+     "depart_local": "14:30", "arrive_local": "22:05", "duration_min": 275,
+     "status": "on_time", "gate": "B12", "aircraft": "Boeing 757"},
+
+    # SFO-LAX shuttle
+    {"flight_number": "UA1001", "airline": "UA", "from": "SFO", "to": "LAX",
+     "depart_local": "06:00", "arrive_local": "07:25", "duration_min": 85,
+     "status": "on_time", "gate": "F3", "aircraft": "Airbus A320"},
+    {"flight_number": "UA1002", "airline": "UA", "from": "SFO", "to": "LAX",
+     "depart_local": "09:30", "arrive_local": "10:55", "duration_min": 85,
+     "status": "on_time", "gate": "F5", "aircraft": "Airbus A320"},
+    {"flight_number": "UA1003", "airline": "UA", "from": "LAX", "to": "SFO",
+     "depart_local": "08:00", "arrive_local": "09:25", "duration_min": 85,
+     "status": "on_time", "gate": "B22", "aircraft": "Airbus A320"},
+    {"flight_number": "UA1004", "airline": "UA", "from": "LAX", "to": "SFO",
+     "depart_local": "12:15", "arrive_local": "13:40", "duration_min": 85,
+     "status": "delayed", "gate": "B26", "aircraft": "Airbus A320"},
+
+    # Chicago hub (United + American)
+    {"flight_number": "UA710", "airline": "UA", "from": "ORD", "to": "BOS",
+     "depart_local": "06:30", "arrive_local": "09:45", "duration_min": 135,
+     "status": "on_time", "gate": "C12", "aircraft": "Boeing 737"},
+    {"flight_number": "AA711", "airline": "AA", "from": "ORD", "to": "DFW",
+     "depart_local": "07:15", "arrive_local": "09:50", "duration_min": 155,
+     "status": "on_time", "gate": "K8", "aircraft": "Boeing 737"},
+    {"flight_number": "UA712", "airline": "UA", "from": "ORD", "to": "DEN",
+     "depart_local": "10:00", "arrive_local": "11:30", "duration_min": 150,
+     "status": "on_time", "gate": "C20", "aircraft": "Embraer 175"},
+
+    # MIA southbound
+    {"flight_number": "AA801", "airline": "AA", "from": "MIA", "to": "JFK",
+     "depart_local": "08:00", "arrive_local": "11:00", "duration_min": 180,
+     "status": "on_time", "gate": "D40", "aircraft": "Boeing 737"},
+    {"flight_number": "DL802", "airline": "DL", "from": "MIA", "to": "ATL",
+     "depart_local": "12:30", "arrive_local": "14:20", "duration_min": 110,
+     "status": "on_time", "gate": "H5", "aircraft": "Boeing 717"},
+
+    # BOS additional
+    {"flight_number": "B6605", "airline": "B6", "from": "BOS", "to": "SFO",
+     "depart_local": "07:45", "arrive_local": "11:30", "duration_min": 405,
+     "status": "on_time", "gate": "C40", "aircraft": "Airbus A321"},
+]
+
+# ── Dashboard analytics (PR 3: c-generative-ui aviation KPIs) ───────────────
+
+KPI_SNAPSHOT = {
+    "on_time_pct": 84.2,
+    "on_time_delta": "+1.4%",
+    "flights_today": 312,
+    "flights_today_delta": "+8",
+    "avg_delay_min": 12,
+    "avg_delay_delta": "-2 min",
+    "load_factor_pct": 78.5,
+    "load_factor_delta": "+0.6%",
+}
+
+ON_TIME_TREND = [
+    {"month": "2025-05", "on_time_pct": 82.4},
+    {"month": "2025-06", "on_time_pct": 81.1},
+    {"month": "2025-07", "on_time_pct": 79.8},
+    {"month": "2025-08", "on_time_pct": 80.5},
+    {"month": "2025-09", "on_time_pct": 83.2},
+    {"month": "2025-10", "on_time_pct": 84.0},
+    {"month": "2025-11", "on_time_pct": 82.6},
+    {"month": "2025-12", "on_time_pct": 78.9},
+    {"month": "2026-01", "on_time_pct": 80.2},
+    {"month": "2026-02", "on_time_pct": 81.7},
+    {"month": "2026-03", "on_time_pct": 82.8},
+    {"month": "2026-04", "on_time_pct": 84.2},
+]
+
+FLIGHTS_BY_AIRLINE = [
+    {"airline": "American", "count": 87},
+    {"airline": "United",   "count": 92},
+    {"airline": "Delta",    "count": 78},
+    {"airline": "JetBlue",  "count": 55},
+]
+
+RECENT_DISRUPTIONS = [
+    {"flight_number": "UA123", "type": "delayed",   "minutes": 45, "route": "LAX→JFK", "date": "2026-05-14"},
+    {"flight_number": "AA456", "type": "cancelled", "minutes": 0,  "route": "JFK→LAX", "date": "2026-05-14"},
+    {"flight_number": "DL789", "type": "delayed",   "minutes": 22, "route": "ATL→ORD", "date": "2026-05-13"},
+    {"flight_number": "B6101", "type": "delayed",   "minutes": 68, "route": "BOS→MIA", "date": "2026-05-13"},
+    {"flight_number": "UA204", "type": "cancelled", "minutes": 0,  "route": "SFO→SEA", "date": "2026-05-12"},
+    {"flight_number": "AA318", "type": "delayed",   "minutes": 15, "route": "DFW→DEN", "date": "2026-05-12"},
+    {"flight_number": "DL552", "type": "delayed",   "minutes": 35, "route": "ATL→MIA", "date": "2026-05-11"},
+    {"flight_number": "B6217", "type": "delayed",   "minutes": 80, "route": "JFK→BOS", "date": "2026-05-11"},
+    {"flight_number": "UA640", "type": "cancelled", "minutes": 0,  "route": "ORD→DEN", "date": "2026-05-10"},
+    {"flight_number": "AA871", "type": "delayed",   "minutes": 25, "route": "LAX→DFW", "date": "2026-05-10"},
+]

--- a/cockpit/chat/tool-calls/python/src/aviation_tools.py
+++ b/cockpit/chat/tool-calls/python/src/aviation_tools.py
@@ -1,0 +1,90 @@
+"""LangChain @tool wrappers around the aviation mock dataset.
+
+Each tool's docstring is what the LLM sees for tool-selection — keep them
+informative and example-laden.
+"""
+
+from langchain_core.tools import tool
+from src.aviation_data import AIRPORTS, AIRLINES, FLIGHTS
+
+
+@tool
+async def lookup_flight(flight_number: str) -> dict:
+    """Look up the status, route, and gate for a specific flight number.
+
+    Use this when the user asks about a specific flight (e.g., "what's the
+    status of UA123?", "is AA404 on time?", "what gate is DL501 leaving from?").
+
+    Args:
+        flight_number: Flight number like 'UA123' or 'AA456'. Case-insensitive.
+
+    Returns:
+        dict with keys: flight_number, airline, from, to, depart_local,
+        arrive_local, status (on_time/delayed/cancelled), gate, aircraft,
+        duration_min.
+
+    Returns {"error": "Flight not found"} if the flight number is not in
+    the dataset.
+    """
+    fn = flight_number.upper().strip()
+    for f in FLIGHTS:
+        if f["flight_number"] == fn:
+            return f
+    return {"error": f"Flight {fn} not found in dataset"}
+
+
+@tool
+async def get_airport_info(airport_code: str) -> dict:
+    """Get details about an airport: name, city, current weather, terminals, runways.
+
+    Use this when the user asks about an airport (e.g., "what's the weather
+    at LAX?", "tell me about JFK", "how many runways does ORD have?").
+
+    Args:
+        airport_code: 3-letter IATA code like 'LAX' or 'JFK'. Case-insensitive.
+
+    Returns:
+        dict with keys: code, name, city, country, weather (with temp_f and
+        conditions), terminals, runways.
+
+    Returns {"error": "Airport not found"} if the code is not in the dataset.
+    """
+    code = airport_code.upper().strip()
+    if code in AIRPORTS:
+        return AIRPORTS[code]
+    return {"error": f"Airport {code} not in dataset. Available: {sorted(AIRPORTS.keys())}"}
+
+
+@tool
+async def find_routes(from_code: str, to_code: str, date_offset_days: int = 0) -> dict:
+    """Find available flights between two airports.
+
+    Use this when the user asks about flight options (e.g., "what flights
+    are there from LAX to JFK?", "find me a flight from Boston to Miami
+    tomorrow").
+
+    Args:
+        from_code: 3-letter IATA code for departure airport.
+        to_code: 3-letter IATA code for arrival airport.
+        date_offset_days: 0 = today, 1 = tomorrow, etc. Note: mock data is
+            the same regardless of date; the LLM can still reason about
+            the date in its response.
+
+    Returns:
+        dict with keys:
+          - "flights": list of flight dicts (same shape as lookup_flight)
+            sorted by depart_local, OR empty list if no routes.
+          - "from": echoed from_code
+          - "to": echoed to_code
+          - "date_offset_days": echoed
+    """
+    fc = from_code.upper().strip()
+    tc = to_code.upper().strip()
+    flights = sorted(
+        [f for f in FLIGHTS if f["from"] == fc and f["to"] == tc],
+        key=lambda f: f["depart_local"],
+    )
+    return {"from": fc, "to": tc, "date_offset_days": date_offset_days, "flights": flights}
+
+
+ALL_TOOLS = [lookup_flight, get_airport_info, find_routes]

--- a/cockpit/chat/tool-calls/python/src/graph.py
+++ b/cockpit/chat/tool-calls/python/src/graph.py
@@ -1,73 +1,43 @@
-"""
-Chat Tool Calls Graph
+"""Chat Tool-Calls Graph — canonical agent ↔ ToolNode loop with aviation tools.
 
-A LangGraph StateGraph that demonstrates tool calling with search,
-calculator, and weather tools. The agent uses tools proactively
-and the frontend renders tool call cards.
+Mirrors umbrella's c-tool-calls. Self-contained: aviation_tools + aviation_data
+copied into this module.
 """
 
 from pathlib import Path
+
+from langchain_core.messages import SystemMessage
+from langchain_openai import ChatOpenAI
 from langgraph.graph import StateGraph, MessagesState, END
 from langgraph.prebuilt import ToolNode
-from langchain_openai import ChatOpenAI
-from langchain_core.messages import SystemMessage
-from langchain_core.tools import tool
+
+from src.aviation_tools import ALL_TOOLS as AVIATION_TOOLS
 
 PROMPTS_DIR = Path(__file__).parent.parent / "prompts"
 
 
-@tool
-def search(query: str) -> str:
-    """Search the web for information."""
-    return f"Search results for '{query}': Found 3 relevant articles about {query}."
-
-
-@tool
-def calculator(expression: str) -> str:
-    """Evaluate a mathematical expression."""
-    try:
-        result = eval(expression, {"__builtins__": {}}, {})
-        return f"Result: {result}"
-    except Exception as e:
-        return f"Error: {str(e)}"
-
-
-@tool
-def weather(city: str) -> str:
-    """Get current weather for a city."""
-    return f"Weather in {city}: 72F, partly cloudy, humidity 45%."
-
-
-tools = [search, calculator, weather]
-
-
 def build_tool_calls_graph():
-    """
-    Constructs a tool-calling agent with search, calculator, and weather tools.
-    Uses conditional edges to route between generation and tool execution.
-    """
-    llm = ChatOpenAI(model="gpt-5-mini", streaming=True).bind_tools(tools)
+    """Canonical agent ↔ ToolNode loop with aviation tools bound."""
+    llm = ChatOpenAI(model="gpt-5-mini", streaming=True).bind_tools(AVIATION_TOOLS)
 
-    async def generate(state: MessagesState) -> dict:
+    async def agent(state: MessagesState) -> dict:
         system_prompt = (PROMPTS_DIR / "tool-calls.md").read_text()
         messages = [SystemMessage(content=system_prompt)] + state["messages"]
         response = await llm.ainvoke(messages)
         return {"messages": [response]}
 
     def should_continue(state: MessagesState) -> str:
-        last_message = state["messages"][-1]
-        if hasattr(last_message, "tool_calls") and last_message.tool_calls:
+        last = state["messages"][-1]
+        if hasattr(last, "tool_calls") and last.tool_calls:
             return "tools"
         return END
 
-    tool_node = ToolNode(tools)
-
     graph = StateGraph(MessagesState)
-    graph.add_node("generate", generate)
-    graph.add_node("tools", tool_node)
-    graph.set_entry_point("generate")
-    graph.add_conditional_edges("generate", should_continue)
-    graph.add_edge("tools", "generate")
+    graph.add_node("agent", agent)
+    graph.add_node("tools", ToolNode(AVIATION_TOOLS))
+    graph.set_entry_point("agent")
+    graph.add_conditional_edges("agent", should_continue, {"tools": "tools", END: END})
+    graph.add_edge("tools", "agent")
 
     return graph.compile()
 

--- a/cockpit/chat/tool-calls/python/tsconfig.json
+++ b/cockpit/chat/tool-calls/python/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/cockpit/chat/tool-calls/python",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "target": "ES2022",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true
+  },
+  "include": ["src/**/*"]
+}

--- a/docs/superpowers/plans/2026-05-16-c-per-cap-backend-cleanup.md
+++ b/docs/superpowers/plans/2026-05-16-c-per-cap-backend-cleanup.md
@@ -1,0 +1,864 @@
+# c-* Per-Capability Backend Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every `cockpit/chat/<name>/python/` runnable via `nx serve` on `port+1000`, fix dev env wiring so Angular dev hits the per-cap backend through the proxy, and sync per-cap python content to match umbrella's `c-<topic>` emission. Production deploy stays unchanged.
+
+**Architecture:** Per-cap python/ stays as a self-contained copy (no umbrella imports). Each gets its own `project.json` with `serve` (`uv run langgraph dev --port 55XX --no-browser`) and `build`. Angular dev env points at `/api` which the proxy forwards to `localhost:55XX`. The `pythonPort` field added to `capability-registry.ts` is dev-only — production deploy still aggregates umbrella code through the existing manifest generator.
+
+**Tech Stack:** Python 3.12, LangGraph, langgraph-cli, langchain-openai (`gpt-5-mini` for prompt-only caps, `gpt-5` reasoning_effort="minimal" for c-subagents planner), uv, Nx 21, Angular 21.
+
+---
+
+## Audit (read once, before tasks)
+
+Today's state (verified via grep):
+
+| Cap | graph.py shape | langgraph.json name | env URL | env assistantId | proxy port | prompt drifted? |
+|---|---|---|---|---|---|---|
+| messages | `_build_prompt_graph`-equivalent, gpt-5-mini | `c-messages` ✓ | `localhost:4501/api` (dead) | `c-messages` ✓ | 8123 (umbrella) | YES — pre-aviation |
+| input | same | `c-input` ✓ | `localhost:4502/api` | `c-input` ✓ | 8123 | YES |
+| interrupts | same | `c-interrupts` ✓ | `localhost:4503/api` | `c-interrupts` ✓ | 8123 | YES |
+| tool-calls | stub | `c-tool-calls` ✓ | `localhost:4504/api` | `c-tool-calls` ✓ | **8124** ⚠ | n/a — graph replaced |
+| subagents | stub | `c-subagents` ✓ | `localhost:4505/api` | `c-subagents` ✓ | **8125** ⚠ | n/a — graph replaced |
+| threads | same | `c-threads` ✓ | `localhost:4506/api` | `c-threads` ✓ | 8123 | YES |
+| timeline | same | `c-timeline` ✓ | `localhost:4507/api` | `c-timeline` ✓ | 8123 | YES |
+| generative-ui | dashboard graph (PR3+A+E synced) | **`generative_ui`** ⚠ | `localhost:4310/api` ⚠ | **`generative_ui`** ⚠ | 8123 | n/a — graph + prompt file `dashboard.md` (NOT generative-ui.md) |
+| debug | same as prompt-only | `c-debug` ✓ | `localhost:4509/api` | `c-debug` ✓ | 8123 | YES |
+| theming | same | `c-theming` ✓ | `localhost:4510/api` | `c-theming` ✓ | 8123 | YES |
+| a2ui | a2ui_graph (PR4 synced) | **`a2ui_form`** ⚠ | `localhost:4511/api` | **`a2ui_form`** ⚠ | 8123 | n/a |
+
+After this PR: every cap's graph name = `c-<topic>`, env URL = `/api`, env assistantId value = `c-<topic>`, proxy target = `localhost:55XX` (per-cap pythonPort), nx serve target exists, prompts and code in per-cap python match what umbrella emits for that cap today.
+
+---
+
+## Task 1: Add `pythonPort` to capability-registry
+
+**Files:**
+- Modify: `apps/cockpit/scripts/capability-registry.ts` (only the 11 chat cap entries; type def too if needed)
+
+- [ ] **Step 1: Add the field to each chat cap entry**
+
+For each of the 11 chat cap entries in `apps/cockpit/scripts/capability-registry.ts`, add a `pythonPort` field equal to `port + 1000`. The chat caps and resulting values:
+
+| id | port | pythonPort |
+|---|---|---|
+| c-messages | 4501 | 5501 |
+| c-input | 4502 | 5502 |
+| c-interrupts | 4503 | 5503 |
+| c-tool-calls | 4504 | 5504 |
+| c-subagents | 4505 | 5505 |
+| c-threads | 4506 | 5506 |
+| c-timeline | 4507 | 5507 |
+| c-generative-ui | 4508 | 5508 |
+| c-debug | 4509 | 5509 |
+| c-theming | 4510 | 5510 |
+| c-a2ui | 4511 | 5511 |
+
+For each cap, change the line from:
+```ts
+{ id: 'c-messages', product: 'chat', topic: 'messages', angularProject: 'cockpit-chat-messages-angular', port: 4501, pythonDir: 'cockpit/langgraph/streaming/python', graphName: 'c-messages' },
+```
+to:
+```ts
+{ id: 'c-messages', product: 'chat', topic: 'messages', angularProject: 'cockpit-chat-messages-angular', port: 4501, pythonPort: 5501, pythonDir: 'cockpit/langgraph/streaming/python', graphName: 'c-messages' },
+```
+
+If the `Capability` type declaration in the same file enumerates explicit fields, add `pythonPort?: number;`. If it's inferred from `as const` literal, the field shows up automatically.
+
+- [ ] **Step 2: Verify generation script still works**
+
+Run: `npx tsx scripts/generate-shared-deployment-config.ts`
+Expected: no error; `deployments/shared-dev/langgraph.json` regenerated. Verify the chat graph names in the output still resolve to `cockpit/langgraph/streaming/python/...` paths (production deploy source unchanged).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/cockpit/scripts/capability-registry.ts deployments/shared-dev/langgraph.json
+git commit -m "feat(registry): add pythonPort (port+1000) to each chat capability"
+```
+
+---
+
+## Task 2: Fix the 2 langgraph.json outliers
+
+**Files:**
+- Modify: `cockpit/chat/generative-ui/python/langgraph.json`
+- Modify: `cockpit/chat/a2ui/python/langgraph.json`
+
+- [ ] **Step 1: Rename graph in generative-ui standalone**
+
+Replace `cockpit/chat/generative-ui/python/langgraph.json` with:
+
+```json
+{
+  "graphs": {
+    "c-generative-ui": "./src/graph.py:graph"
+  },
+  "dependencies": ["."],
+  "python_version": "3.12",
+  "env": ".env"
+}
+```
+
+- [ ] **Step 2: Rename graph in a2ui standalone**
+
+Replace `cockpit/chat/a2ui/python/langgraph.json` with:
+
+```json
+{
+  "graphs": {
+    "c-a2ui": "./src/graph.py:graph"
+  },
+  "dependencies": ["."],
+  "python_version": "3.12",
+  "env": ".env"
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cockpit/chat/generative-ui/python/langgraph.json cockpit/chat/a2ui/python/langgraph.json
+git commit -m "fix(c-per-cap): rename langgraph.json graphs to c-<topic> (generative-ui, a2ui)"
+```
+
+---
+
+## Task 3: Create `project.json` for each per-cap python (11 caps)
+
+**Files (CREATE):**
+- `cockpit/chat/messages/python/project.json` … `cockpit/chat/a2ui/python/project.json` (11 total)
+
+- [ ] **Step 1: Create a project.json per cap**
+
+Use this template per cap, substituting `<name>` (kebab) and `<port>` (the pythonPort from Task 1):
+
+```json
+{
+  "name": "cockpit-chat-<name>-python",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "cockpit/chat/<name>/python/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{workspaceRoot}/dist/cockpit/chat/<name>/python"],
+      "options": {
+        "outputPath": "dist/cockpit/chat/<name>/python",
+        "main": "cockpit/chat/<name>/python/src/index.ts",
+        "tsConfig": "cockpit/chat/<name>/python/tsconfig.json"
+      }
+    },
+    "serve": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "cockpit/chat/<name>/python",
+        "command": "uv run langgraph dev --port <port> --no-browser"
+      }
+    }
+  }
+}
+```
+
+Concrete `<name>` / `<port>` pairs (write all 11):
+- messages / 5501
+- input / 5502
+- interrupts / 5503
+- tool-calls / 5504
+- subagents / 5505
+- threads / 5506
+- timeline / 5507
+- generative-ui / 5508
+- debug / 5509
+- theming / 5510
+- a2ui / 5511
+
+- [ ] **Step 2: Add tsconfig.json where missing**
+
+Some per-cap dirs already have `tsconfig.json` (mirroring umbrella's pattern), some don't. For each cap, check `cockpit/chat/<name>/python/tsconfig.json` — if missing, create it as:
+
+```json
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/cockpit/chat/<name>/python",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "target": "ES2022",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true
+  },
+  "include": ["src/**/*"]
+}
+```
+
+- [ ] **Step 3: Verify nx discovers projects**
+
+Run: `pnpm nx show projects | grep cockpit-chat-.*-python | sort`
+Expected: 11 lines, one per cap (`cockpit-chat-messages-python`, etc.)
+
+- [ ] **Step 4: Verify builds**
+
+Run: `pnpm nx run-many -t build --projects='cockpit-chat-*-python'`
+Expected: 11 builds green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cockpit/chat/*/python/project.json cockpit/chat/*/python/tsconfig.json
+git commit -m "feat(c-per-cap): add nx project.json (build+serve) per chat capability"
+```
+
+---
+
+## Task 4: Fix all 11 `environment.development.ts`
+
+**Files:**
+- Modify: `cockpit/chat/<name>/angular/src/environments/environment.development.ts` × 11
+
+- [ ] **Step 1: Replace each file**
+
+For each cap, the file becomes (keep the existing field NAME, only change values):
+
+**Pattern A — most caps use `streamingAssistantId`:**
+
+`cockpit/chat/messages/angular/src/environments/environment.development.ts`:
+```ts
+export const environment = {
+  production: false,
+  langGraphApiUrl: '/api',
+  streamingAssistantId: 'c-messages',
+};
+```
+
+Same shape for: `input` (`c-input`), `interrupts` (`c-interrupts`), `tool-calls` (`c-tool-calls`), `subagents` (`c-subagents`), `threads` (`c-threads`), `timeline` (`c-timeline`), `debug` (`c-debug`), `theming` (`c-theming`). 9 files using `streamingAssistantId`.
+
+**Pattern B — generative-ui uses `generativeUiAssistantId`:**
+
+`cockpit/chat/generative-ui/angular/src/environments/environment.development.ts`:
+```ts
+export const environment = {
+  production: false,
+  langGraphApiUrl: '/api',
+  generativeUiAssistantId: 'c-generative-ui',
+};
+```
+
+**Pattern C — a2ui uses `a2uiAssistantId`:**
+
+`cockpit/chat/a2ui/angular/src/environments/environment.development.ts`:
+```ts
+export const environment = {
+  production: false,
+  langGraphApiUrl: '/api',
+  a2uiAssistantId: 'c-a2ui',
+};
+```
+
+- [ ] **Step 2: Verify each Angular project still builds**
+
+Run: `pnpm nx run-many -t build --projects='cockpit-chat-*-angular'`
+Expected: 11 builds green (no TS errors from field rename — we kept the field names).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cockpit/chat/*/angular/src/environments/environment.development.ts
+git commit -m "fix(c-per-cap): point dev env at /api proxy with c-<topic> assistant ids"
+```
+
+---
+
+## Task 5: Fix all 11 `proxy.conf.json`
+
+**Files:**
+- Modify: `cockpit/chat/<name>/angular/proxy.conf.json` × 11
+
+- [ ] **Step 1: Replace each file**
+
+Use the cap's pythonPort (5501-5511):
+
+```json
+{
+  "/api": {
+    "target": "http://localhost:<port>",
+    "secure": false,
+    "changeOrigin": true,
+    "pathRewrite": { "^/api": "" },
+    "ws": true
+  }
+}
+```
+
+Pairs: messages/5501, input/5502, interrupts/5503, tool-calls/5504, subagents/5505, threads/5506, timeline/5507, generative-ui/5508, debug/5509, theming/5510, a2ui/5511.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add cockpit/chat/*/angular/proxy.conf.json
+git commit -m "fix(c-per-cap): proxy /api to per-cap python backend (port+1000)"
+```
+
+---
+
+## Task 6: Sync the 7 prompt-only caps' `prompts/<name>.md` from umbrella
+
+**Files:**
+- Modify: `cockpit/chat/<name>/python/prompts/<name>.md` × 7 (messages, input, interrupts, threads, timeline, debug, theming)
+
+- [ ] **Step 1: Copy from umbrella**
+
+For each of the 7 prompt-only caps, copy the umbrella's aviation-themed prompt into the per-cap dir:
+
+```bash
+for cap in messages input interrupts threads timeline debug theming; do
+  cp "cockpit/langgraph/streaming/python/prompts/${cap}.md" \
+     "cockpit/chat/${cap}/python/prompts/${cap}.md"
+done
+```
+
+- [ ] **Step 2: Verify the diff is now empty for those 7**
+
+```bash
+for cap in messages input interrupts threads timeline debug theming; do
+  diff -q "cockpit/langgraph/streaming/python/prompts/${cap}.md" \
+          "cockpit/chat/${cap}/python/prompts/${cap}.md"
+done
+```
+Expected: no output (all files identical).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cockpit/chat/*/python/prompts/*.md
+git commit -m "fix(c-per-cap): sync prompt-only prompts to umbrella aviation rewrites (PR 2)"
+```
+
+---
+
+## Task 7: Verify the 7 prompt-only caps' `graph.py` structure (no changes expected)
+
+**Files:**
+- Read-only: `cockpit/chat/<name>/python/src/graph.py` × 7
+
+- [ ] **Step 1: Verify the existing single-node pattern**
+
+For each cap (messages, input, interrupts, threads, timeline, debug, theming), the existing `graph.py` should already match the pattern: single async node, `ChatOpenAI(model="gpt-5-mini", streaming=True)`, reads `prompts/<name>.md` via `Path(__file__).parent.parent / "prompts" / "<name>.md"`. Confirm via:
+
+```bash
+for cap in messages input interrupts threads timeline debug theming; do
+  echo "=== $cap ==="
+  grep -E "ChatOpenAI|read_text|model=" "cockpit/chat/${cap}/python/src/graph.py"
+done
+```
+Expected output for each: `ChatOpenAI(model="gpt-5-mini", streaming=True)` and a `.read_text()` call.
+
+- [ ] **Step 2: If any cap deviates, replace with the canonical pattern**
+
+If any cap shows a deviation (different model, different prompt path, multi-node graph), replace its `graph.py` with this template (substituting `<name>` and `<NAME>`):
+
+```python
+"""Chat <NAME> Graph — single-node prompt LLM."""
+
+from pathlib import Path
+from langgraph.graph import StateGraph, MessagesState, END
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import SystemMessage
+
+PROMPTS_DIR = Path(__file__).parent.parent / "prompts"
+
+
+def build_<name>_graph():
+    llm = ChatOpenAI(model="gpt-5-mini", streaming=True)
+
+    async def generate(state: MessagesState) -> dict:
+        system_prompt = (PROMPTS_DIR / "<name>.md").read_text()
+        messages = [SystemMessage(content=system_prompt)] + state["messages"]
+        response = await llm.ainvoke(messages)
+        return {"messages": [response]}
+
+    graph = StateGraph(MessagesState)
+    graph.add_node("generate", generate)
+    graph.set_entry_point("generate")
+    graph.add_edge("generate", END)
+
+    return graph.compile()
+
+
+graph = build_<name>_graph()
+```
+
+- [ ] **Step 3: Commit (or skip if no changes)**
+
+```bash
+git add cockpit/chat/*/python/src/graph.py 2>/dev/null && \
+  git commit -m "fix(c-per-cap): align prompt-only graph.py to canonical single-node pattern" || \
+  echo "No graph.py changes needed"
+```
+
+---
+
+## Task 8: Rewrite c-tool-calls per-cap to match umbrella
+
+**Files:**
+- Modify: `cockpit/chat/tool-calls/python/src/graph.py`
+- Create: `cockpit/chat/tool-calls/python/src/aviation_tools.py` (inlined; matches PR 1 pattern)
+
+- [ ] **Step 1: Create inlined aviation_tools.py**
+
+Replace or create `cockpit/chat/tool-calls/python/src/aviation_tools.py` with the 3 tools (lookup_flight, get_airport_info, find_routes) and a minimal hardcoded dataset (10 airports, 4 airlines, ~30 flights). Copy the file verbatim from `cockpit/langgraph/streaming/python/src/aviation_tools.py` (umbrella), then change the import line at the top to be self-contained:
+
+```bash
+# After the cp, edit the import to NOT depend on aviation_data.py
+cp cockpit/langgraph/streaming/python/src/aviation_tools.py cockpit/chat/tool-calls/python/src/aviation_tools.py
+```
+
+If the umbrella aviation_tools.py imports from `aviation_data.py`, also copy `aviation_data.py` into the same dir:
+
+```bash
+cp cockpit/langgraph/streaming/python/src/aviation_data.py cockpit/chat/tool-calls/python/src/aviation_data.py
+```
+
+(The umbrella copies are the canonical source. Standalone holds duplicates per the "full copy" policy.)
+
+- [ ] **Step 2: Replace graph.py with the umbrella's tool-calls implementation**
+
+Read `cockpit/langgraph/streaming/python/src/chat_graphs.py` and find the `_build_tool_calls_graph()` function plus its prompt file reference. Create `cockpit/chat/tool-calls/python/src/graph.py`:
+
+```python
+"""Chat Tool-Calls Graph — canonical agent ↔ ToolNode loop with aviation tools.
+
+Mirrors umbrella's c-tool-calls. Self-contained: aviation_tools + aviation_data
+copied into this module.
+"""
+
+from pathlib import Path
+from typing import Literal
+
+from langchain_core.messages import SystemMessage
+from langchain_openai import ChatOpenAI
+from langgraph.graph import StateGraph, MessagesState, END
+from langgraph.prebuilt import ToolNode
+
+from src.aviation_tools import ALL_TOOLS as AVIATION_TOOLS
+
+PROMPTS_DIR = Path(__file__).parent.parent / "prompts"
+
+
+def build_tool_calls_graph():
+    """Canonical agent ↔ ToolNode loop with aviation tools bound."""
+    llm = ChatOpenAI(model="gpt-5-mini", streaming=True).bind_tools(AVIATION_TOOLS)
+    system_prompt = (PROMPTS_DIR / "tool-calls.md").read_text()
+
+    async def agent(state: MessagesState) -> dict:
+        messages = [SystemMessage(content=system_prompt)] + state["messages"]
+        response = await llm.ainvoke(messages)
+        return {"messages": [response]}
+
+    def should_continue(state: MessagesState) -> Literal["tools", "__end__"]:
+        last = state["messages"][-1]
+        if hasattr(last, "tool_calls") and last.tool_calls:
+            return "tools"
+        return "__end__"
+
+    g = StateGraph(MessagesState)
+    g.add_node("agent", agent)
+    g.add_node("tools", ToolNode(AVIATION_TOOLS))
+    g.set_entry_point("agent")
+    g.add_conditional_edges("agent", should_continue)
+    g.add_edge("tools", "agent")
+
+    return g.compile()
+
+
+graph = build_tool_calls_graph()
+```
+
+- [ ] **Step 3: Verify it imports + the prompt file already exists**
+
+Run:
+```bash
+ls cockpit/chat/tool-calls/python/prompts/tool-calls.md
+cd cockpit/chat/tool-calls/python && uv run python -c "from src.graph import graph; print(type(graph).__name__)"
+```
+Expected: file exists; printed `CompiledStateGraph`.
+
+If the prompt file content differs from umbrella's, also copy that:
+```bash
+cp cockpit/langgraph/streaming/python/prompts/tool-calls.md cockpit/chat/tool-calls/python/prompts/tool-calls.md
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cockpit/chat/tool-calls/python/src/graph.py cockpit/chat/tool-calls/python/src/aviation_tools.py cockpit/chat/tool-calls/python/src/aviation_data.py cockpit/chat/tool-calls/python/prompts/tool-calls.md
+git commit -m "feat(c-tool-calls standalone): full graph + inlined aviation tools (matches PR 1)"
+```
+
+---
+
+## Task 9: Rewrite c-subagents per-cap to match umbrella
+
+**Files:**
+- Modify: `cockpit/chat/subagents/python/src/graph.py`
+- Create: `cockpit/chat/subagents/python/src/aviation_tools.py` + `aviation_data.py` (inlined)
+- Modify (if drifted): `cockpit/chat/subagents/python/prompts/subagents.md`
+
+- [ ] **Step 1: Inline aviation tools + data**
+
+```bash
+cp cockpit/langgraph/streaming/python/src/aviation_tools.py cockpit/chat/subagents/python/src/aviation_tools.py
+cp cockpit/langgraph/streaming/python/src/aviation_data.py cockpit/chat/subagents/python/src/aviation_data.py
+```
+
+- [ ] **Step 2: Copy umbrella subagent code into per-cap graph.py**
+
+Read `cockpit/langgraph/streaming/python/src/chat_graphs.py`. Find `_RESEARCH_PROMPT`, `_BOOKING_PROMPT`, `_ITINERARY_PROMPT`, the `_run_subagent()` helper, the `@tool task(...)` definition, and `_build_subagents_graph()`. Build `cockpit/chat/subagents/python/src/graph.py` with the equivalent self-contained module:
+
+```python
+"""Chat Subagents Graph — orchestrator LLM with a single `task` tool that
+dispatches to specialized aviation subagents (research/booking/itinerary).
+
+Mirrors umbrella's c-subagents. Self-contained: aviation_tools + aviation_data
+copied into this module.
+"""
+
+from pathlib import Path
+from typing import Literal
+
+from langchain_core.messages import HumanMessage, SystemMessage
+from langchain_core.tools import tool
+from langchain_openai import ChatOpenAI
+from langgraph.graph import StateGraph, MessagesState, END
+from langgraph.prebuilt import ToolNode
+
+from src.aviation_tools import get_airport_info, find_routes, lookup_flight
+
+PROMPTS_DIR = Path(__file__).parent.parent / "prompts"
+
+
+_RESEARCH_PROMPT = """You research a destination airport. Given a city or
+airport code, call get_airport_info to fetch its details and return a brief
+paragraph summarizing terminals, weather, and any notable facts."""
+
+_BOOKING_PROMPT = """You find a flight. Given an origin/destination pair,
+call find_routes and (optionally) lookup_flight on the most promising option.
+Return a single recommended flight with airline, depart/arrive times, and price."""
+
+_ITINERARY_PROMPT = """You assemble a trip itinerary. Given the research and
+booking notes from prior subagents, synthesize a 3-bullet trip plan: flight,
+arrival, suggested first activity. No tools — synthesis only."""
+
+
+async def _run_subagent(prompt: str, task_description: str, tools: list) -> str:
+    llm = ChatOpenAI(model="gpt-5-mini", streaming=True)
+    bound = llm.bind_tools(tools) if tools else llm
+    messages = [
+        SystemMessage(content=prompt),
+        HumanMessage(content=task_description),
+    ]
+    for _ in range(3):
+        response = await bound.ainvoke(messages)
+        messages.append(response)
+        if not getattr(response, "tool_calls", None):
+            return response.content if isinstance(response.content, str) else str(response.content)
+        for tool_call in response.tool_calls:
+            chosen = next((t for t in tools if t.name == tool_call["name"]), None)
+            if chosen is None:
+                continue
+            result = await chosen.ainvoke(tool_call["args"])
+            messages.append(
+                HumanMessage(content=f"Tool {chosen.name} returned: {result}")
+            )
+    return "Subagent reached max iterations."
+
+
+@tool
+async def task(role: Literal["research", "booking", "itinerary"], task_description: str) -> str:
+    """Delegate a subtask to a specialized aviation subagent."""
+    if role == "research":
+        return await _run_subagent(_RESEARCH_PROMPT, task_description, [get_airport_info])
+    if role == "booking":
+        return await _run_subagent(_BOOKING_PROMPT, task_description, [find_routes, lookup_flight])
+    return await _run_subagent(_ITINERARY_PROMPT, task_description, [])
+
+
+def build_subagents_graph():
+    """Orchestrator LLM with a single `task` tool dispatching to subagent fns."""
+    llm = ChatOpenAI(model="gpt-5-mini", streaming=True).bind_tools([task])
+    system_prompt = (PROMPTS_DIR / "subagents.md").read_text()
+
+    async def orchestrator(state: MessagesState) -> dict:
+        messages = [SystemMessage(content=system_prompt)] + state["messages"]
+        response = await llm.ainvoke(messages)
+        return {"messages": [response]}
+
+    def should_continue(state: MessagesState) -> Literal["tools", "__end__"]:
+        last = state["messages"][-1]
+        if hasattr(last, "tool_calls") and last.tool_calls:
+            return "tools"
+        return "__end__"
+
+    g = StateGraph(MessagesState)
+    g.add_node("orchestrator", orchestrator)
+    g.add_node("tools", ToolNode([task]))
+    g.set_entry_point("orchestrator")
+    g.add_conditional_edges("orchestrator", should_continue)
+    g.add_edge("tools", "orchestrator")
+
+    return g.compile()
+
+
+graph = build_subagents_graph()
+```
+
+If the umbrella's actual `_run_subagent`, prompts, or `task` tool implementation differ in details (model name, prompt body, iteration count), substitute the umbrella values. The umbrella file is at `cockpit/langgraph/streaming/python/src/chat_graphs.py`.
+
+- [ ] **Step 3: Sync the prompt file**
+
+```bash
+cp cockpit/langgraph/streaming/python/prompts/subagents.md cockpit/chat/subagents/python/prompts/subagents.md
+```
+
+- [ ] **Step 4: Verify it imports**
+
+```bash
+cd cockpit/chat/subagents/python && uv run python -c "from src.graph import graph; print(type(graph).__name__)"
+```
+Expected: `CompiledStateGraph`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cockpit/chat/subagents/python/src/graph.py cockpit/chat/subagents/python/src/aviation_tools.py cockpit/chat/subagents/python/src/aviation_data.py cockpit/chat/subagents/python/prompts/subagents.md
+git commit -m "feat(c-subagents standalone): full orchestrator+task graph + inlined aviation tools (matches PR 1)"
+```
+
+---
+
+## Task 10: Verify generative-ui + a2ui per-cap copies in sync
+
+**Files:**
+- Read-only: `cockpit/chat/generative-ui/python/src/*.py`, `cockpit/chat/a2ui/python/src/*.py`
+
+- [ ] **Step 1: Diff structure vs umbrella**
+
+```bash
+echo "--- generative-ui graph.py vs umbrella dashboard_graph.py ---"
+diff -q cockpit/chat/generative-ui/python/src/graph.py cockpit/langgraph/streaming/python/src/dashboard_graph.py || echo "(differences expected — different import roots)"
+
+echo "--- a2ui graph.py vs umbrella a2ui_graph.py ---"
+diff cockpit/chat/a2ui/python/src/graph.py cockpit/langgraph/streaming/python/src/a2ui_graph.py | head -20
+```
+
+Both files were synced in PRs 3, 4, and the bug-fix PRs A/E. The diff should show only the import-substitution block (per-cap inlines `_FLIGHTS` and friends instead of `from src.aviation_tools import find_routes`). If a non-trivial logic divergence appears, port the umbrella version into the per-cap, preserving the per-cap's inlined data-tools block.
+
+- [ ] **Step 2: Smoke import**
+
+```bash
+cd cockpit/chat/generative-ui/python && uv run python -c "from src.graph import graph; print(type(graph).__name__)"
+cd cockpit/chat/a2ui/python && uv run python -c "from src.graph import graph; print(type(graph).__name__)"
+```
+Expected: both print `CompiledStateGraph`.
+
+- [ ] **Step 3: Commit (only if changes)**
+
+If no changes: skip. Otherwise:
+```bash
+git add cockpit/chat/generative-ui/python/src/graph.py cockpit/chat/a2ui/python/src/graph.py
+git commit -m "chore(c-per-cap): re-sync generative-ui + a2ui standalone with umbrella"
+```
+
+---
+
+## Task 11: Build verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Build every chat python**
+
+Run: `pnpm nx run-many -t build --projects='cockpit-chat-*-python'`
+Expected: 11 builds green.
+
+- [ ] **Step 2: Build every chat angular**
+
+Run: `pnpm nx run-many -t build --projects='cockpit-chat-*-angular'`
+Expected: 11 builds green.
+
+- [ ] **Step 3: Verify production deploy manifest unchanged**
+
+```bash
+git stash push -m "wip" -- cockpit chat/* 2>/dev/null || true
+npx tsx scripts/generate-shared-deployment-config.ts
+git diff deployments/shared-dev/langgraph.json
+```
+Expected: empty diff (manifest unchanged because production deploy still uses umbrella `pythonDir`).
+
+If diff is non-empty, the production-deploy script picked up our pythonPort field where it shouldn't. Re-read Task 1's notes.
+
+```bash
+git stash pop 2>/dev/null || true
+```
+
+- [ ] **Step 4: No commit (verification only)**
+
+---
+
+## Task 12: Boot smoke — every per-cap backend starts cleanly
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Ensure no stale 55XX backends listening**
+
+```bash
+for p in 5501 5502 5503 5504 5505 5506 5507 5508 5509 5510 5511; do
+  pid=$(lsof -nP -iTCP:$p -sTCP:LISTEN -t 2>/dev/null | head -1)
+  [ -n "$pid" ] && kill "$pid" 2>/dev/null
+done
+sleep 2
+```
+
+- [ ] **Step 2: Boot each backend in sequence, confirm /ok, kill**
+
+Run this script from the repo root:
+
+```bash
+set -a; source .env; set +a
+for cap_port in "messages:5501" "input:5502" "interrupts:5503" "tool-calls:5504" "subagents:5505" "threads:5506" "timeline:5507" "generative-ui:5508" "debug:5509" "theming:5510" "a2ui:5511"; do
+  cap=${cap_port%%:*}
+  port=${cap_port##*:}
+  echo "=== booting $cap on $port ==="
+  pnpm nx run cockpit-chat-${cap}-python:serve > /tmp/boot-${cap}.log 2>&1 &
+  pid=$!
+  for _ in $(seq 1 60); do
+    grep -q "Application started up" /tmp/boot-${cap}.log 2>/dev/null && break
+    sleep 1
+  done
+  if grep -q "Application started up" /tmp/boot-${cap}.log; then
+    echo "  ✓ $cap up"
+  else
+    echo "  ✗ $cap FAILED — log tail:"
+    tail -15 /tmp/boot-${cap}.log
+  fi
+  kill $pid 2>/dev/null
+  sleep 2
+done
+```
+
+Expected output: 11 lines all reading `✓ <cap> up`.
+
+If any cap fails, inspect `/tmp/boot-<cap>.log` for the import error, fix the relevant earlier task's code, restart the smoke loop for that cap.
+
+- [ ] **Step 3: No commit (verification only)**
+
+---
+
+## Task 13: Manual chrome MCP smoke — 3 spot checks
+
+**Files:** none (verification only). Requires `OPENAI_API_KEY` in repo-root `.env`.
+
+The user requested chrome MCP verification. Spot-check 3 representative caps: `messages` (simplest), `tool-calls` (LLM + tools), `a2ui` (most complex).
+
+For each of the 3, perform this sequence:
+
+- [ ] **Step 1: For `c-messages` (simple prompt LLM)**
+
+1. Start backend: `pnpm nx run cockpit-chat-messages-python:serve` (background)
+2. Start frontend: `pnpm nx serve cockpit-chat-messages-angular --port 4501` (background)
+3. Wait for both ready (grep logs for `Application started up` and `Local:`)
+4. Chrome MCP: navigate to `http://localhost:4501/`, JS-inject `"Hello"` into the textarea and press Enter (use the same JS pattern from PR 4 / PR 3 chrome tests)
+5. Wait 15s, screenshot — expect a conversational AI reply on screen
+6. Kill both processes
+
+- [ ] **Step 2: For `c-tool-calls`**
+
+1. Start backend `cockpit-chat-tool-calls-python:serve` on 5504
+2. Start frontend `cockpit-chat-tool-calls-angular --port 4504`
+3. Chrome MCP: navigate to `http://localhost:4504/`, send `"What is UA123?"`
+4. Wait 25s, screenshot — expect: tool-call card for `lookup_flight` + an AI response mentioning UA123 / LAX→JFK / 16:30 arrival
+5. Kill both processes
+
+- [ ] **Step 3: For `c-a2ui`**
+
+1. Start backend `cockpit-chat-a2ui-python:serve` on 5511
+2. Start frontend `cockpit-chat-a2ui-angular --port 4511`
+3. Chrome MCP: navigate to `http://localhost:4511/`, send `"I want to fly from LAX to JFK"`
+4. Wait 30s, screenshot — expect the aviation booking form with Origin/Destination/Date/Passengers/Fare class/Search flights
+5. Kill both processes
+
+- [ ] **Step 4: No commit (verification only)**
+
+If any spot check fails, debug per-cap (likely wrong prompt path or stale graph code), fix the earlier task, re-run.
+
+---
+
+## Task 14: Open PR, watch CI, merge on green
+
+- [ ] **Step 1: Push branch**
+
+```bash
+git push -u origin HEAD
+```
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create --title "feat(c-per-cap): standalone backends — nx serve + dev env cleanup" --body "$(cat <<'EOF'
+## Summary
+- Make every cockpit/chat/<name>/python/ a runnable per-cap example backend:
+  - New nx serve target (\`uv run langgraph dev --port <pythonPort>\`)
+  - pythonPort = angular port + 1000 (5501-5511), captured in capability-registry.ts
+- Fix the dev-loop wiring so Angular dev actually hits the per-cap backend (instead of bypassing to ECONNREFUSED on dead ports):
+  - dev env URL → /api (proxied)
+  - dev env assistantId value → c-<topic> consistently
+  - proxy.conf target → localhost:<pythonPort>
+- Fix 2 inconsistency outliers: standalone langgraph.json names (\`generative_ui\` → \`c-generative-ui\`, \`a2ui_form\` → \`c-a2ui\`)
+- Sync per-cap python content to match umbrella's c-<topic> emission today:
+  - 7 prompt-only caps: aviation prompts from PR 2 copied in
+  - c-tool-calls: full PR 1 implementation + inlined aviation_tools
+  - c-subagents: full PR 1 implementation + inlined aviation_tools
+  - c-generative-ui, c-a2ui: verified in sync (synced inline during PR 3/4)
+- Production deploy unchanged: shared LangGraph Cloud manifest (deployments/shared-dev/langgraph.json) regenerates byte-identically; pythonDir in capability-registry.ts still points at umbrella.
+
+## Test plan
+- [x] \`pnpm nx run-many -t build --projects='cockpit-chat-*-python'\` — green
+- [x] \`pnpm nx run-many -t build --projects='cockpit-chat-*-angular'\` — green
+- [x] \`npx tsx scripts/generate-shared-deployment-config.ts\` — diff of deployments/shared-dev/langgraph.json is empty
+- [x] Boot smoke: every per-cap backend (5501-5511) starts cleanly via nx serve, returns Application-started log
+- [x] Chrome MCP smoke (3 caps): c-messages, c-tool-calls, c-a2ui — each renders correctly against its own per-cap backend
+- [ ] CI
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Watch CI**
+
+`gh pr checks <PR_NUMBER> --watch`
+
+- [ ] **Step 4: Squash-merge on green**
+
+`gh pr merge <PR_NUMBER> --squash`
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Decision 1 (production source unchanged) → Task 11 Step 3 asserts ✓
+- Decision 2 (full copies, no umbrella imports) → Tasks 8/9 inline aviation_tools+data ✓
+- Decision 3 (port+1000 in registry) → Task 1 ✓
+- Decision 4 (nx serve target) → Task 3 ✓
+- Decision 5 (content sync) → Tasks 6-10 ✓
+- Port table → Tasks 1, 3, 5 all use the same numbers ✓
+- Wiring fixes (1: project.json, 2: langgraph.json outliers, 3: env files, 4: proxy.conf, 5: registry) → Tasks 3, 2, 4, 5, 1 respectively ✓
+- Boot smoke → Task 12 ✓
+- Chrome MCP smoke (3 caps) → Task 13 ✓
+- Production deploy unchanged → Task 11 Step 3 ✓
+
+**Placeholder scan:** No TBDs. Task 7 Step 2 has a conditional "if any cap deviates, replace with template" — that's an audit step with a complete fix template; acceptable. Task 9 Step 2 says "if the umbrella's actual prompts differ in details, substitute the umbrella values" — acceptable because we explicitly point at the source-of-truth file path.
+
+**Type consistency:** Port numbers (5501-5511) appear identically in Tasks 1, 3, 5, 12. Field names (`pythonPort`, `streamingAssistantId`, etc.) are stable across tasks. Cap order (messages, input, interrupts, tool-calls, subagents, threads, timeline, generative-ui, debug, theming, a2ui) used consistently.

--- a/docs/superpowers/specs/2026-05-16-c-per-cap-backend-cleanup-design.md
+++ b/docs/superpowers/specs/2026-05-16-c-per-cap-backend-cleanup-design.md
@@ -1,0 +1,215 @@
+# c-* Per-Capability Backend Cleanup — Design
+
+**Date:** 2026-05-16
+**Status:** Spec — pending implementation plan
+
+## Goal
+
+Make every `cockpit/chat/<name>/python/` a real, runnable, self-contained example backend that:
+
+1. Starts via `nx serve cockpit-chat-<name>-python` on a predictable per-cap port
+2. Is the actual dev-loop target for the matching `cockpit-chat-<name>-angular`
+3. Serves as documentation of "minimal single-capability LangGraph backend"
+4. Currently matches what umbrella's `c-<topic>` graph emits in production
+
+**Production deploy stays unchanged.** Umbrella (`cockpit/langgraph/streaming/python/`) remains the canonical source for the shared LangGraph Cloud deployment `cockpit-dev` (built by `scripts/generate-shared-deployment-config.ts` from `capability-registry.ts`). Per-cap copies are intentionally maintained parallel artifacts — dev-loop convenience + standalone examples.
+
+Out of scope:
+- Refactoring per-cap copies into shared-package imports (explicitly rejected: user prefers full copies for example clarity)
+- Production deploy changes
+- Frontend (Angular) graph code changes — only env + proxy files touched
+- New nx serve target for umbrella
+
+## Decisions
+
+| # | Decision | Choice |
+|---|---|---|
+| 1 | Production source | Unchanged — umbrella drives the shared deploy. Per-cap copies are dev-only. |
+| 2 | Code sharing | Each per-cap python/ keeps its **own full copy** of graph code + tools (no umbrella imports). Drift maintenance accepted. |
+| 3 | Port scheme | Each per-cap python backend runs on `<angular_port> + 1000`. Captured as `pythonPort` field in `capability-registry.ts`. |
+| 4 | nx serve | Each per-cap python/ gets a `project.json` with `serve` (runs `langgraph dev --port`) + `build` targets. |
+| 5 | Content drift | In-scope — per-cap python/graph.py audited and synced to match what umbrella's `c-<topic>` emits today (post-PR1-2-3-4). |
+
+## Port assignments
+
+Source of truth: `apps/cockpit/scripts/capability-registry.ts` extended with `pythonPort` per cap.
+
+| Cap | Angular `port` | New `pythonPort` |
+|---|---|---|
+| c-messages | 4501 | 5501 |
+| c-input | 4502 | 5502 |
+| c-interrupts | 4503 | 5503 |
+| c-tool-calls | 4504 | 5504 |
+| c-subagents | 4505 | 5505 |
+| c-threads | 4506 | 5506 |
+| c-timeline | 4507 | 5507 |
+| c-generative-ui | 4508 | 5508 |
+| c-debug | 4509 | 5509 |
+| c-theming | 4510 | 5510 |
+| c-a2ui | 4511 | 5511 |
+
+Note: generative-ui's `environment.development.ts` currently says `4310`; registry says `4508`. Registry is canonical — env gets fixed to `/api`.
+
+## Wiring fixes (every cap, 4 files each)
+
+### 1. `cockpit/chat/<name>/python/project.json` (NEW for all 11)
+
+```json
+{
+  "name": "cockpit-chat-<name>-python",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "cockpit/chat/<name>/python/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{workspaceRoot}/dist/cockpit/chat/<name>/python"],
+      "options": {
+        "outputPath": "dist/cockpit/chat/<name>/python",
+        "main": "cockpit/chat/<name>/python/src/index.ts",
+        "tsConfig": "cockpit/chat/<name>/python/tsconfig.json"
+      }
+    },
+    "serve": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "cockpit/chat/<name>/python",
+        "command": "uv run langgraph dev --port 55<XX> --no-browser"
+      }
+    }
+  }
+}
+```
+
+Some per-cap dirs may already have a `tsconfig.json`; if not, add a minimal one. The `build` target mirrors umbrella's `cockpit/langgraph/streaming/python` pattern so that the TS module export (`src/index.ts`) compiles cleanly. `serve` uses `langgraph dev` exclusively for the Python graph runtime.
+
+### 2. `cockpit/chat/<name>/python/langgraph.json` outliers
+
+```diff
+- "generative_ui": "./src/graph.py:graph"
++ "c-generative-ui": "./src/graph.py:graph"
+```
+```diff
+- "a2ui_form": "./src/graph.py:graph"
++ "c-a2ui": "./src/graph.py:graph"
+```
+All other 9 caps already use `c-<topic>` — no change needed.
+
+### 3. `cockpit/chat/<name>/angular/src/environments/environment.development.ts`
+
+All 11 caps — replace `http://localhost:4XXX/api` with `/api`, ensure `*AssistantId` value is `c-<topic>`:
+
+```ts
+export const environment = {
+  production: false,
+  langGraphApiUrl: '/api',
+  <fieldName>AssistantId: 'c-<topic>',
+};
+```
+
+Field name (`streamingAssistantId` / `generativeUiAssistantId` / `a2uiAssistantId`) stays as-is per cap because the matching Angular component reads that specific property. Only the value (`c-<topic>`) is what we standardize.
+
+### 4. `cockpit/chat/<name>/angular/proxy.conf.json`
+
+```json
+{
+  "/api": {
+    "target": "http://localhost:55<XX>",
+    "secure": false,
+    "changeOrigin": true,
+    "pathRewrite": { "^/api": "" },
+    "ws": true
+  }
+}
+```
+
+All 11 caps — target = per-cap pythonPort. Fixes the 2 outliers (subagents was `8125`, tool-calls was `8124`) and the 9 that all targeted `8123`.
+
+### 5. `apps/cockpit/scripts/capability-registry.ts`
+
+Add `pythonPort: <port> + 1000` to each chat cap entry. Type update:
+
+```ts
+type Capability = {
+  // ...existing fields...
+  port: number;        // Angular dev server
+  pythonPort?: number; // Per-cap langgraph dev server (chat caps only)
+  pythonDir: string;
+  graphName: string;
+};
+```
+
+Verify generative-ui port in the registry is `4508` (it is) and that the dev env stops drifting to `4310`. Production deploy script (`scripts/generate-shared-deployment-config.ts`) does NOT use `pythonPort` — it still uses `pythonDir` which still points at umbrella. So the registry change is additive.
+
+## Content sync (per-cap graph.py)
+
+Each per-cap python/graph.py and prompts/<name>.md should match what umbrella's `c-<topic>` graph emits today. Audit + sync per the table below.
+
+| Cap | Current size | Expected source pattern | Action |
+|---|---|---|---|
+| messages, input, debug, interrupts, theming, threads, timeline (7 caps) | 37-57 lines each | Single-node `system_prompt + LLM` via `_build_prompt_graph(prompt_file)` factory (PR 2 pattern) | Verify graph.py matches umbrella's factory output; verify prompt files match PR 2 aviation prompts. Fix if drifted. |
+| tool-calls | 75 lines | Real LLM bound with `[lookup_flight, get_airport_info, find_routes]` (PR 1 aviation tools); standard ToolNode agent loop | Replace stub with full PR 1 implementation. Inline `aviation_tools` module (same pattern as a2ui standalone). |
+| subagents | 63 lines | Orchestrator LLM with `task(role, task_description)` tool dispatching to 3 internal subagent functions (research/booking/itinerary) (PR 1) | Replace stub with full PR 1 implementation. Inline `aviation_tools`. |
+| generative-ui | 176 lines (PR 3 dashboard) | Match `dashboard_graph.py` from umbrella post-PR3 + post-PR-A (get_stream_writer fix) + post-PR-E (gpt-5 planner) | Verify; expected in sync (was already synced in PR 3 + bug-fix PRs touched both copies). |
+| a2ui | 505 lines (PR 4) | Match umbrella's a2ui_graph.py post-PR4 | Verify; expected in sync (PR 4 mirrored at every step). |
+
+**Inlining policy.** When a per-cap graph needs tools or data fixtures, inline them directly into `python/src/` (e.g. `python/src/aviation_tools.py`, inline `_FLIGHTS` list) instead of importing from umbrella. This keeps each per-cap a true self-contained example — exactly the pattern PR 4 used for a2ui and PR 3 used for generative-ui standalone.
+
+## Frontend changes — NONE
+
+The Angular apps' component code (e.g. `MessagesComponent`, `A2uiComponent`) read `environment.<fieldName>AssistantId` directly. Field NAMES stay; only values + the URL get fixed. No template changes.
+
+## Files modified summary
+
+| Type | Count | Notes |
+|---|---|---|
+| NEW `cockpit/chat/<name>/python/project.json` | 11 | One per cap |
+| Modified `cockpit/chat/<name>/python/langgraph.json` | 2 | generative-ui, a2ui outlier graph names |
+| Modified `cockpit/chat/<name>/python/src/graph.py` | up to 11 | After content audit; expected 9 (skip generative-ui + a2ui if verified in sync) |
+| Modified `cockpit/chat/<name>/python/prompts/<name>.md` | up to 7 | Only the 7 prompt-only caps; only if drifted from PR 2 prompts |
+| NEW `cockpit/chat/<name>/python/src/aviation_tools.py` | 2 | tool-calls + subagents need inlined aviation tools (matches a2ui's inline FLIGHTS pattern) |
+| Modified `cockpit/chat/<name>/angular/src/environments/environment.development.ts` | 11 | URL + assistantId value |
+| Modified `cockpit/chat/<name>/angular/proxy.conf.json` | 11 | Target = pythonPort |
+| Modified `apps/cockpit/scripts/capability-registry.ts` | 1 | Add `pythonPort` field per chat cap |
+| (Optional) NEW `cockpit/chat/<name>/python/tsconfig.json` | up to 11 | Add if missing; mirror umbrella's |
+
+## Testing
+
+**Build:**
+- `pnpm nx run-many -t build --projects='cockpit-chat-*-python'` — every per-cap python build is green
+- `pnpm nx run-many -t build --projects='cockpit-chat-*-angular'` — every Angular build is green
+
+**Boot smoke (automated):**
+For each cap, in a temporary scripted loop:
+1. `nx serve cockpit-chat-<name>-python` in background
+2. Wait for `Application started up` in log (or 60s timeout)
+3. `curl -fs http://localhost:55XX/ok` — backend healthy
+4. Kill backend, continue
+
+This confirms every per-cap backend boots without import errors and listens on its assigned port. Failure = the per-cap graph.py has a bug (missing import, syntax error, missing prompt file).
+
+**Manual chrome MCP smoke (3 spot checks):**
+- `c-messages` — simplest prompt-only cap
+- `c-tool-calls` — verifies the full aviation tools graph in a per-cap context
+- `c-a2ui` — verifies the most complex per-cap graph still works against its own backend (rather than the umbrella we've been using)
+
+For each: start matched `nx serve` pair, exercise via chrome MCP, capture screenshot.
+
+**Production deploy unaffected:**
+- `npx tsx scripts/generate-shared-deployment-config.ts` runs clean
+- Generated `deployments/shared-dev/langgraph.json` is byte-identical to current main (umbrella source unchanged)
+
+## Risks and mitigations
+
+- **PR is broad** (~33-44 small file edits). Mitigation: structured into wiring tasks (Tasks 1-5 of the plan) and content-sync tasks (Tasks 6-12 of the plan). Reviewer can spot-check by category.
+- **Stale prompts in per-cap caps.** If a prompt drifted from PR 2's aviation rewrite, audit catches it. Mitigation: explicit per-cap audit task in the plan.
+- **uv/langgraph dev port conflicts when running batch boot smoke.** Mitigation: kill the previous before starting the next; never run more than one at a time during the boot smoke.
+- **The `pythonDir` field still points at umbrella for production.** This is intentional — production source of truth doesn't change. Mitigation: explicit assertion in plan + spec.
+- **chrome MCP hydration race.** Already known; use JS-injected input as in PR 4.
+
+## Out-of-scope follow-ups
+
+- Refactor to shared-package imports (rejected for this round — full copies preferred for example clarity)
+- Add CI check that prevents per-cap copies from drifting (could be a future automated diff/snapshot test)
+- Document the per-cap example pattern in the cockpit docs (separate doc PR)
+- Add nx serve target for umbrella (currently has only build + smoke; not blocking since per-cap covers dev needs after this PR)


### PR DESCRIPTION
## Summary
Make every `cockpit/chat/<name>/python/` a runnable per-cap example backend with consistent wiring across all 11 chat capabilities.

**Wiring fixes:**
- New `nx serve` target per cap that runs `uv run langgraph dev --port <pythonPort>` (5501-5511)
- `pythonPort = angularPort + 1000`, captured in `apps/cockpit/scripts/capability-registry.ts`
- All 11 dev env files: `langGraphApiUrl: '/api'` (proxied) + assistantId value = `c-<topic>` consistently
- All 11 `proxy.conf.json`: target = `localhost:<pythonPort>`
- 2 outlier `langgraph.json` graph names fixed: `generative_ui` → `c-generative-ui`, `a2ui_form` → `c-a2ui`

**Content sync (per-cap python matches umbrella's c-<topic> emission today):**
- 7 prompt-only caps (messages/input/debug/interrupts/theming/threads/timeline): aviation prompts from PR 2 copied in; graph.py structure already matched
- c-tool-calls: full PR 1 implementation + inlined `aviation_tools.py` + `aviation_data.py`
- c-subagents: full PR 1 orchestrator+task implementation + inlined aviation tools
- c-generative-ui, c-a2ui: verified in sync (synced inline during PR 3/4)

**Production deploy unchanged.** `capability-registry.ts.pythonDir` still points at the umbrella; `scripts/generate-shared-deployment-config.ts` produces a byte-identical `deployments/shared-dev/langgraph.json`. Per-cap copies are dev/example artifacts maintained in parallel.

## Test plan
- [x] `pnpm nx run-many -t build --projects='cockpit-chat-*-python'` — 11 green
- [x] `pnpm nx run-many -t build --projects='cockpit-chat-*-angular'` — 11 green
- [x] `npx tsx scripts/generate-shared-deployment-config.ts` → `git diff deployments/shared-dev/langgraph.json` is empty (production manifest unchanged)
- [x] **Boot smoke for all 11 backends** — each `nx run cockpit-chat-<name>-python:serve` boots cleanly on the assigned port, reports "Application started up" within 90s
- [x] End-to-end smoke (curl against per-cap backend on `localhost:55XX`):
  - `c-messages` (5501) → aviation-themed conversational reply
  - `c-tool-calls` (5504) → `lookup_flight` tool fires for "UA123", returns LAX→JFK / on_time / gate B14
  - `c-a2ui` (5511) → full v0.9 envelope sequence (`surfaceUpdate`/`dataModelUpdate`/`beginRendering`), 3 MultipleChoice + 2 TextField components, "Book a flight" + "Search flights" labels
- [ ] CI

## Files
- `apps/cockpit/scripts/capability-registry.ts` — `pythonPort` field added to 11 chat cap entries
- `cockpit/chat/<name>/python/project.json` — NEW (11 files), `build` + `serve` targets
- `cockpit/chat/<name>/python/langgraph.json` — 2 outlier graph names fixed
- `cockpit/chat/<name>/python/src/graph.py` — c-tool-calls + c-subagents rewritten (matches umbrella PR 1)
- `cockpit/chat/{tool-calls,subagents}/python/src/aviation_tools.py` + `aviation_data.py` — NEW (inlined per-cap)
- `cockpit/chat/<name>/python/prompts/<name>.md` — 7 prompt-only caps synced to umbrella's aviation rewrite
- `cockpit/chat/<name>/angular/src/environments/environment.development.ts` — 11 files: URL + assistantId
- `cockpit/chat/<name>/angular/proxy.conf.json` — 11 files: target = per-cap pythonPort

## Out-of-scope follow-ups
- CI snapshot test that prevents per-cap copies from drifting from umbrella
- Cockpit docs explaining the per-cap example pattern
- Add `serve` target to umbrella (currently has only `build` + `smoke`; per-cap covers dev needs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)