### PR TITLE
fix(ci): give planning smoke enough time

### DIFF
--- a/apps/cockpit/src/lib/verify-shared-deployment.spec.ts
+++ b/apps/cockpit/src/lib/verify-shared-deployment.spec.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_SMOKE_ASSISTANT_STREAM_TIMEOUT_MS,
+  getSmokeAssistantStreamTimeoutMs,
+} from '../../../../scripts/verify-shared-deployment';
+
+describe('verify-shared-deployment', () => {
+  it('allows the two-pass planning graph more time than single-response smoke assistants', () => {
+    expect(getSmokeAssistantStreamTimeoutMs('planning')).toBe(90000);
+    expect(getSmokeAssistantStreamTimeoutMs('streaming')).toBe(
+      DEFAULT_SMOKE_ASSISTANT_STREAM_TIMEOUT_MS,
+    );
+  });
+});

--- a/scripts/verify-shared-deployment.ts
+++ b/scripts/verify-shared-deployment.ts
@@ -8,6 +8,7 @@
  */
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
+import { pathToFileURL } from 'url';
 
 type DeploymentUrls = Record<string, string>;
 
@@ -28,7 +29,23 @@ const SMOKE_ASSISTANT_IDS = [
   'chat',
 ] as const;
 
+type SmokeAssistantId = (typeof SMOKE_ASSISTANT_IDS)[number];
+
 const DEPLOYMENT_URLS_PATH = resolve(__dirname, '../deployment-urls.json');
+export const DEFAULT_SMOKE_ASSISTANT_STREAM_TIMEOUT_MS = 30000;
+
+const SMOKE_ASSISTANT_STREAM_TIMEOUT_MS: Partial<Record<SmokeAssistantId, number>> = {
+  // The planning graph intentionally performs two model calls: one to create
+  // structured plan state, then one to execute the plan and answer.
+  planning: 90000,
+};
+
+export function getSmokeAssistantStreamTimeoutMs(assistantId: SmokeAssistantId) {
+  return (
+    SMOKE_ASSISTANT_STREAM_TIMEOUT_MS[assistantId] ??
+    DEFAULT_SMOKE_ASSISTANT_STREAM_TIMEOUT_MS
+  );
+}
 
 function parseArgs(argv: string[]) {
   return {
@@ -128,8 +145,9 @@ async function createThread(url: string) {
   return threadId;
 }
 
-async function smokeAssistant(url: string, assistantId: string) {
+async function smokeAssistant(url: string, assistantId: SmokeAssistantId) {
   const threadId = await createThread(url);
+  const timeoutMs = getSmokeAssistantStreamTimeoutMs(assistantId);
   const runRes = await fetch(`${url}/threads/${threadId}/runs/stream`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', ...authHeaders() },
@@ -138,7 +156,7 @@ async function smokeAssistant(url: string, assistantId: string) {
       input: { messages: [{ role: 'human', content: 'hello' }] },
       stream_mode: ['values'],
     }),
-    signal: AbortSignal.timeout(30000),
+    signal: AbortSignal.timeout(timeoutMs),
   });
 
   const text = await runRes.text();
@@ -198,8 +216,10 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  const message = error instanceof Error ? error.message : String(error);
-  console.error(`❌ shared deployment verification failed — ${message}`);
-  process.exit(1);
-});
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`❌ shared deployment verification failed — ${message}`);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- give the shared LangGraph backend verifier a planning-specific stream timeout
- export the timeout policy so it can be covered without running the live verifier
- add cockpit unit coverage that keeps `planning` above the default smoke timeout

## Root Cause
`Production smoke` was failing before Playwright ran. The `Verify shared LangGraph backend` step consistently reported the shared deployment as healthy and passed six assistant probes, but `planning` aborted exactly at the verifier's fixed 30s stream timeout. That graph intentionally does two model calls: one to create structured plan state, then one to execute the plan and answer.

## Validation
- `node ../../node_modules/vitest/vitest.mjs run src/lib/verify-shared-deployment.spec.ts --config vite.config.mts --reporter=verbose` from `apps/cockpit`
- `node node_modules/.bin/tsx scripts/verify-shared-deployment.ts --dry-run`
- `NX_DAEMON=false node node_modules/.bin/nx test cockpit --skip-nx-cache --runInBand`
- `git diff --check`
