### PR TITLE
fix(ci): extend a2ui production smoke timeout

### DIFF
--- a/apps/cockpit/e2e/production-smoke.spec.ts
+++ b/apps/cockpit/e2e/production-smoke.spec.ts
@@ -65,6 +65,9 @@ const RENDER_CAPABILITIES = [
   'render/computed-functions',
 ] as const;
 
+const SEND_RECEIVE_TIMEOUT_MS = 30_000;
+const A2UI_SEND_RECEIVE_TIMEOUT_MS = 90_000;
+
 test.describe('Production: Angular chat example apps load', () => {
   for (const cap of CHAT_CAPABILITIES) {
     test(`${cap} loads at examples URL`, async ({ page }) => {
@@ -113,6 +116,10 @@ test.describe('Production: send/receive smoke', () => {
 
   for (const cap of ['langgraph/streaming', 'deep-agents/planning', 'chat/a2ui'] as const) {
     test(`${cap} sends and receives a message`, async ({ page }) => {
+      const responseTimeout =
+        cap === 'chat/a2ui' ? A2UI_SEND_RECEIVE_TIMEOUT_MS : SEND_RECEIVE_TIMEOUT_MS;
+
+      test.setTimeout(responseTimeout + 15_000);
       await page.goto(`${EXAMPLES_URL}/${cap}/`, { timeout: 15_000 });
       await expect(page.locator('chat')).toBeVisible({ timeout: 10_000 });
 
@@ -120,12 +127,12 @@ test.describe('Production: send/receive smoke', () => {
       await page.getByRole('button', { name: /send message/i }).click();
 
       if (cap === 'chat/a2ui') {
-        await expect(page.locator('a2ui-surface')).toBeAttached({ timeout: 30_000 });
+        await expect(page.locator('a2ui-surface')).toBeAttached({ timeout: responseTimeout });
         return;
       }
 
       await expect(page.locator('chat-message[data-role="assistant"]').last()).toBeVisible({
-        timeout: 30_000,
+        timeout: responseTimeout,
       });
     });
   }


### PR DESCRIPTION
## Summary
- extend the production send/receive timeout budget for the `chat/a2ui` smoke
- keep the existing 30s response budget for the simpler streaming and planning smoke checks
- set the Playwright test timeout above the per-response wait so the assertion can use its full budget

## Root Cause
After #397 fixed the shared backend verifier timeout, the next production smoke step reached Playwright and failed only on `chat/a2ui`. That smoke uses the GPT-5 structured-output A2UI graph and timed out at Playwright's default 30s test limit while waiting for `a2ui-surface`. The assertion also had a 30s timeout, so the test-level timer could kill it before the A2UI surface had enough time to render.

## Validation
- `BASE_URL=https://cockpit.cacheplane.ai EXAMPLES_URL=https://examples.cacheplane.ai node_modules/.bin/playwright test apps/cockpit/e2e/production-smoke.spec.ts --reporter=list` locally: 32 passed, 3 skipped because local shell has no `OPENAI_API_KEY`
- `git diff --check`
