### PR TITLE
ci: derive pull request scope from project metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,22 +33,17 @@ jobs:
       - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
+      - name: Test CI scope classifier
+        run: node --test scripts/ci-scope.spec.mjs
       - name: Detect changed CI surfaces
         id: scope
         run: |
           set -euo pipefail
 
-          keys="library website cockpit cockpit_examples cockpit_smoke cockpit_secret cockpit_deploy_smoke examples_chat cockpit_e2e website_e2e posthog"
-
-          mark_all() {
-            for key in $keys; do
-              printf '%s=true\n' "$key" >> "$GITHUB_OUTPUT"
-            done
-          }
-
           if [ "${{ github.event_name }}" = "push" ]; then
-            mark_all
-            echo "::notice::Push to main runs the full CI suite."
+            node scripts/ci-scope.mjs \
+              --event push \
+              --output "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -60,93 +55,11 @@ jobs:
             head_sha="$(git rev-parse HEAD^2)"
           fi
 
-          changed_files="$(git diff --name-only "$base_sha" "$head_sha")"
-          printf '%s\n' "$changed_files"
-
-          library=false
-          website=false
-          cockpit=false
-          cockpit_examples=false
-          cockpit_smoke=false
-          cockpit_secret=false
-          cockpit_deploy_smoke=false
-          examples_chat=false
-          cockpit_e2e=false
-          website_e2e=false
-          posthog=false
-
-          if printf '%s\n' "$changed_files" | grep -E '^(\.github/workflows/ci\.yml|package(-lock)?\.json|nx\.json|tsconfig(\.base)?\.json|eslint\.config\.mjs)$' >/dev/null; then
-            library=true
-            website=true
-            cockpit=true
-            cockpit_examples=true
-            cockpit_smoke=true
-            cockpit_secret=true
-            cockpit_deploy_smoke=true
-            examples_chat=true
-            cockpit_e2e=true
-            website_e2e=true
-            posthog=true
-          fi
-
-          if printf '%s\n' "$changed_files" | grep -E '^libs/(chat|langgraph|ag-ui|render|a2ui|licensing|telemetry)/' >/dev/null; then
-            library=true
-            website=true
-            cockpit=true
-            cockpit_examples=true
-            cockpit_smoke=true
-            cockpit_secret=true
-            cockpit_deploy_smoke=true
-            examples_chat=true
-            cockpit_e2e=true
-            website_e2e=true
-          fi
-
-          if printf '%s\n' "$changed_files" | grep -E '^(apps/website/|vercel\.json$)' >/dev/null; then
-            website=true
-            website_e2e=true
-          fi
-
-          if printf '%s\n' "$changed_files" | grep -E '^(apps/cockpit/|vercel\.cockpit\.json$|libs/(cockpit-|design-tokens|ui-react|e2e-harness|example-layouts))' >/dev/null; then
-            cockpit=true
-            cockpit_examples=true
-            cockpit_deploy_smoke=true
-            cockpit_e2e=true
-          fi
-
-          if printf '%s\n' "$changed_files" | grep -E '^(cockpit/.*/angular/|scripts/assemble-examples\.ts$|vercel\.examples\.json$)' >/dev/null; then
-            cockpit_examples=true
-          fi
-
-          if printf '%s\n' "$changed_files" | grep -E '^cockpit/.*/python/' >/dev/null; then
-            cockpit_smoke=true
-          fi
-
-          if printf '%s\n' "$changed_files" | grep -E '^cockpit/langgraph/deployment-runtime/python/' >/dev/null; then
-            cockpit_secret=true
-          fi
-
-          if printf '%s\n' "$changed_files" | grep -E '^(apps/cockpit/scripts/deploy-smoke\.ts|scripts/deploy-smoke\.ts)$' >/dev/null; then
-            cockpit_deploy_smoke=true
-          fi
-
-          if printf '%s\n' "$changed_files" | grep -E '^(cockpit/langgraph/streaming/|cockpit/chat/(tool-calls|subagents)/|libs/(cockpit-testing|e2e-harness)/)' >/dev/null; then
-            cockpit_e2e=true
-          fi
-
-          if printf '%s\n' "$changed_files" | grep -E '^(examples/chat/|vercel\.demo\.json$|scripts/(assemble-demo|demo-middleware|langgraph-proxy|rate-limit)\.ts$)' >/dev/null; then
-            examples_chat=true
-          fi
-
-          if printf '%s\n' "$changed_files" | grep -E '^tools/posthog/' >/dev/null; then
-            posthog=true
-          fi
-
-          for key in $keys; do
-            value="$(eval "printf '%s' \"\$$key\"")"
-            printf '%s=%s\n' "$key" "$value" >> "$GITHUB_OUTPUT"
-            echo "$key=$value"
-          done
+          node scripts/ci-scope.mjs \
+            --event pull_request \
+            --base "$base_sha" \
+            --head "$head_sha" \
+            --output "$GITHUB_OUTPUT"
       - name: Validate CI workflow guards
         run: node --test scripts/ci-workflow.spec.mjs
 

--- a/scripts/ci-scope.mjs
+++ b/scripts/ci-scope.mjs
@@ -1,0 +1,321 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+import { appendFileSync, existsSync, readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const SCOPE_KEYS = [
+  'library',
+  'website',
+  'cockpit',
+  'cockpit_examples',
+  'cockpit_smoke',
+  'cockpit_secret',
+  'cockpit_deploy_smoke',
+  'examples_chat',
+  'cockpit_e2e',
+  'website_e2e',
+  'posthog',
+];
+
+const PROJECT_SKIP_DIRS = new Set([
+  '.git',
+  '.next',
+  '.nx',
+  'coverage',
+  'dist',
+  'node_modules',
+]);
+
+export function emptyScope() {
+  return Object.fromEntries(SCOPE_KEYS.map((key) => [key, false]));
+}
+
+export function fullScope() {
+  return Object.fromEntries(SCOPE_KEYS.map((key) => [key, true]));
+}
+
+export function classifyChangedFiles(changedFiles, workspace) {
+  const scope = emptyScope();
+  const projects = workspace.projects ?? [];
+  const publishableProjects = new Set(workspace.publishableProjects ?? []);
+
+  for (const changedFile of changedFiles.map(normalizePath).filter(Boolean)) {
+    if (isGlobalCiFile(changedFile)) {
+      return fullScope();
+    }
+
+    const owningProjects = projects.filter((project) => ownsPath(project, changedFile));
+
+    for (const project of owningProjects) {
+      applyProjectScope(scope, project, publishableProjects);
+    }
+
+    applyFallbackPathScope(scope, changedFile);
+  }
+
+  return scope;
+}
+
+export function loadWorkspaceMetadata(workspaceRoot) {
+  return {
+    projects: discoverProjects(workspaceRoot),
+    publishableProjects: loadPublishableProjects(workspaceRoot),
+  };
+}
+
+export function discoverProjects(workspaceRoot) {
+  const projects = [];
+
+  walk(workspaceRoot, (absolutePath) => {
+    const projectJson = path.join(absolutePath, 'project.json');
+    if (!existsSync(projectJson)) {
+      return;
+    }
+
+    const project = JSON.parse(readFileSync(projectJson, 'utf8'));
+    const root = normalizePath(path.relative(workspaceRoot, absolutePath));
+    projects.push({
+      ...project,
+      root,
+      sourceRoot: normalizePath(project.sourceRoot ?? root),
+      tags: Array.isArray(project.tags) ? project.tags : [],
+      targets: project.targets ?? {},
+    });
+  });
+
+  return projects.sort((a, b) => b.root.length - a.root.length);
+}
+
+function walk(directory, visit) {
+  visit(directory);
+
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    if (!entry.isDirectory() || PROJECT_SKIP_DIRS.has(entry.name)) {
+      continue;
+    }
+
+    walk(path.join(directory, entry.name), visit);
+  }
+}
+
+function loadPublishableProjects(workspaceRoot) {
+  const nxJsonPath = path.join(workspaceRoot, 'nx.json');
+  if (!existsSync(nxJsonPath)) {
+    return [];
+  }
+
+  const nxJson = JSON.parse(readFileSync(nxJsonPath, 'utf8'));
+  return nxJson.release?.groups?.publishable?.projects ?? [];
+}
+
+function applyProjectScope(scope, project, publishableProjects) {
+  const tags = new Set(project.tags ?? []);
+  const targets = project.targets ?? {};
+  const root = project.root ?? '';
+  const name = project.name ?? '';
+
+  if (publishableProjects.has(name)) {
+    scope.library = true;
+    scope.website = true;
+    scope.website_e2e = true;
+    scope.cockpit = true;
+    scope.cockpit_examples = true;
+    scope.cockpit_smoke = true;
+    scope.cockpit_secret = true;
+    scope.cockpit_deploy_smoke = true;
+    scope.examples_chat = true;
+    scope.cockpit_e2e = true;
+  }
+
+  if (tags.has('scope:website') || name === 'website' || root === 'apps/website') {
+    scope.website = true;
+    scope.website_e2e = true;
+  }
+
+  if (tags.has('scope:cockpit') || name === 'cockpit' || root === 'apps/cockpit') {
+    scope.cockpit = true;
+    scope.cockpit_examples = true;
+    scope.cockpit_deploy_smoke = true;
+    scope.cockpit_e2e = true;
+  }
+
+  if (tags.has('scope:examples') || root === 'examples/chat' || root.startsWith('examples/chat/')) {
+    scope.examples_chat = true;
+  }
+
+  if (tags.has('scope:gtm') || name === 'posthog-tools' || root === 'tools/posthog') {
+    scope.posthog = true;
+  }
+
+  if (root.startsWith('cockpit/')) {
+    if (root.includes('/angular') || project.projectType === 'application') {
+      scope.cockpit_examples = true;
+    }
+
+    if (targets.smoke && root.includes('/python')) {
+      scope.cockpit_smoke = true;
+    }
+
+    if (targets.integration) {
+      scope.cockpit_secret = true;
+    }
+
+    if (targets.e2e) {
+      scope.cockpit_e2e = true;
+    }
+  }
+
+  if (
+    root.startsWith('libs/cockpit-') ||
+    root === 'libs/design-tokens' ||
+    root === 'libs/ui-react' ||
+    root === 'libs/example-layouts' ||
+    root === 'libs/e2e-harness'
+  ) {
+    scope.cockpit = true;
+    scope.cockpit_examples = true;
+    scope.cockpit_deploy_smoke = true;
+    scope.cockpit_e2e = true;
+  }
+
+  if (root === 'libs/e2e-harness' || root === 'libs/cockpit-testing') {
+    scope.cockpit_e2e = true;
+  }
+}
+
+function applyFallbackPathScope(scope, changedFile) {
+  if (changedFile === 'vercel.json') {
+    scope.website = true;
+    scope.website_e2e = true;
+  }
+
+  if (changedFile === 'vercel.cockpit.json') {
+    scope.cockpit = true;
+    scope.cockpit_deploy_smoke = true;
+  }
+
+  if (changedFile === 'vercel.examples.json' || changedFile === 'scripts/assemble-examples.ts') {
+    scope.cockpit_examples = true;
+  }
+
+  if (changedFile === 'apps/cockpit/scripts/deploy-smoke.ts' || changedFile === 'scripts/deploy-smoke.ts') {
+    scope.cockpit_deploy_smoke = true;
+  }
+
+  if (
+    changedFile === 'vercel.demo.json' ||
+    changedFile === 'scripts/assemble-demo.ts' ||
+    changedFile === 'scripts/demo-middleware.ts' ||
+    changedFile === 'scripts/langgraph-proxy.ts' ||
+    changedFile === 'scripts/rate-limit.ts'
+  ) {
+    scope.examples_chat = true;
+  }
+
+  if (changedFile.startsWith('tools/posthog/')) {
+    scope.posthog = true;
+  }
+}
+
+function isGlobalCiFile(changedFile) {
+  return (
+    changedFile === '.github/workflows/ci.yml' ||
+    changedFile === 'package.json' ||
+    changedFile === 'package-lock.json' ||
+    changedFile === 'nx.json' ||
+    changedFile === 'tsconfig.json' ||
+    changedFile === 'tsconfig.base.json' ||
+    changedFile === 'eslint.config.mjs'
+  );
+}
+
+function ownsPath(project, changedFile) {
+  const root = normalizePath(project.root);
+  const sourceRoot = normalizePath(project.sourceRoot);
+
+  return (
+    changedFile === `${root}/project.json` ||
+    changedFile === root ||
+    changedFile.startsWith(`${root}/`) ||
+    changedFile === sourceRoot ||
+    changedFile.startsWith(`${sourceRoot}/`)
+  );
+}
+
+function normalizePath(value) {
+  return String(value ?? '').replaceAll(path.sep, '/').replace(/^\.\//, '').replace(/\/+$/, '');
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg.startsWith('--')) {
+      continue;
+    }
+
+    args[arg.slice(2)] = argv[index + 1];
+    index += 1;
+  }
+  return args;
+}
+
+function changedFilesBetween(baseSha, headSha, workspaceRoot) {
+  return execFileSync('git', ['diff', '--name-only', baseSha, headSha], {
+    cwd: workspaceRoot,
+    encoding: 'utf8',
+  })
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function writeOutputs(scope, outputPath) {
+  const lines = SCOPE_KEYS.map((key) => `${key}=${scope[key] ? 'true' : 'false'}`);
+
+  if (outputPath) {
+    appendFileSync(outputPath, `${lines.join('\n')}\n`);
+  }
+
+  for (const line of lines) {
+    console.log(line);
+  }
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const workspaceRoot = process.cwd();
+
+  if (args.event === 'push') {
+    writeOutputs(fullScope(), args.output);
+    console.log('Push to main runs the full CI suite.');
+    return;
+  }
+
+  const base = args.base;
+  const head = args.head;
+  if (!base || !head) {
+    throw new Error('Expected --base and --head for pull request scope detection.');
+  }
+
+  const changedFiles = changedFilesBetween(base, head, workspaceRoot);
+  const workspace = loadWorkspaceMetadata(workspaceRoot);
+  const scope = classifyChangedFiles(changedFiles, workspace);
+
+  console.log('Changed files:');
+  for (const changedFile of changedFiles) {
+    console.log(`  ${changedFile}`);
+  }
+
+  writeOutputs(scope, args.output);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`::error::${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  }
+}

--- a/scripts/ci-scope.spec.mjs
+++ b/scripts/ci-scope.spec.mjs
@@ -1,0 +1,121 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { classifyChangedFiles } from './ci-scope.mjs';
+
+const projects = [
+  {
+    name: 'chat',
+    root: 'libs/chat',
+    sourceRoot: 'libs/chat/src',
+    projectType: 'library',
+    tags: [],
+    targets: { build: {}, lint: {}, test: {} },
+  },
+  {
+    name: 'website',
+    root: 'apps/website',
+    sourceRoot: 'apps/website/src',
+    projectType: 'application',
+    tags: ['scope:website', 'type:app'],
+    targets: { build: {}, e2e: {}, lint: {} },
+  },
+  {
+    name: 'cockpit-new-cap-angular',
+    root: 'cockpit/new/cap/angular',
+    sourceRoot: 'cockpit/new/cap/angular/src',
+    projectType: 'application',
+    tags: [],
+    targets: { build: {}, e2e: {}, smoke: {} },
+  },
+  {
+    name: 'cockpit-new-cap-python',
+    root: 'cockpit/new/cap/python',
+    sourceRoot: 'cockpit/new/cap/python/src',
+    projectType: 'library',
+    tags: [],
+    targets: { build: {}, smoke: {}, integration: {} },
+  },
+  {
+    name: 'posthog-tools',
+    root: 'tools/posthog',
+    sourceRoot: 'tools/posthog',
+    projectType: 'library',
+    tags: ['scope:gtm', 'type:tool'],
+    targets: { 'sync:plan': {}, 'quality:live': {} },
+  },
+  {
+    name: 'e2e-harness',
+    root: 'libs/e2e-harness',
+    sourceRoot: 'libs/e2e-harness/src',
+    projectType: 'library',
+    tags: [],
+    targets: { build: {} },
+  },
+];
+
+const workspace = {
+  projects,
+  publishableProjects: ['chat'],
+};
+
+test('publishable library changes fan out to dependent product checks', () => {
+  const scope = classifyChangedFiles(['libs/chat/src/public-api.ts'], workspace);
+
+  assert.equal(scope.library, true);
+  assert.equal(scope.website, true);
+  assert.equal(scope.website_e2e, true);
+  assert.equal(scope.cockpit, true);
+  assert.equal(scope.cockpit_examples, true);
+  assert.equal(scope.cockpit_smoke, true);
+  assert.equal(scope.cockpit_secret, true);
+  assert.equal(scope.cockpit_deploy_smoke, true);
+  assert.equal(scope.examples_chat, true);
+  assert.equal(scope.cockpit_e2e, true);
+  assert.equal(scope.posthog, false);
+});
+
+test('cockpit angular project metadata drives examples and e2e scope', () => {
+  const scope = classifyChangedFiles(['cockpit/new/cap/angular/src/app/app.ts'], workspace);
+
+  assert.equal(scope.cockpit_examples, true);
+  assert.equal(scope.cockpit_e2e, true);
+  assert.equal(scope.cockpit_smoke, false);
+});
+
+test('cockpit python project targets drive smoke and secret integration scope', () => {
+  const scope = classifyChangedFiles(['cockpit/new/cap/python/src/index.ts'], workspace);
+
+  assert.equal(scope.cockpit_smoke, true);
+  assert.equal(scope.cockpit_secret, true);
+  assert.equal(scope.cockpit_examples, false);
+});
+
+test('PostHog project metadata drives PostHog scope', () => {
+  const scope = classifyChangedFiles(['tools/posthog/live-quality.ts'], workspace);
+
+  assert.equal(scope.posthog, true);
+  assert.equal(scope.library, false);
+  assert.equal(scope.website, false);
+});
+
+test('shared cockpit support libraries preserve conservative cockpit coverage', () => {
+  const scope = classifyChangedFiles(['libs/e2e-harness/src/index.ts'], workspace);
+
+  assert.equal(scope.cockpit, true);
+  assert.equal(scope.cockpit_examples, true);
+  assert.equal(scope.cockpit_deploy_smoke, true);
+  assert.equal(scope.cockpit_e2e, true);
+});
+
+test('global CI config changes keep full PR coverage', () => {
+  const scope = classifyChangedFiles(['.github/workflows/ci.yml'], workspace);
+
+  assert.deepEqual(Object.values(scope), Object.values(scope).map(() => true));
+});
+
+test('unowned docs changes do not trigger heavy CI jobs', () => {
+  const scope = classifyChangedFiles(['docs/notes.md'], workspace);
+
+  assert.deepEqual(Object.values(scope), Object.values(scope).map(() => false));
+});


### PR DESCRIPTION
## Summary
- replace the inline PR CI scope shell classifier with `scripts/ci-scope.mjs`
- derive scope from Nx project metadata: `project.json` roots/tags/targets plus the publishable release group in `nx.json`
- add `node --test` coverage for publishable libs, cockpit angular/python projects, shared cockpit support libs, PostHog tooling, global CI config, and unrelated docs

## Validation
- `/Applications/Codex.app/Contents/Resources/node --test scripts/ci-scope.spec.mjs`
- `ruby -e "require 'psych'; Psych.load_file('.github/workflows/ci.yml'); puts 'ci.yml parses'"`
- `/Applications/Codex.app/Contents/Resources/node --input-type=module ...` representative real-path classifier smoke
- `git diff --check`