### PR TITLE
fix(a2ui): version label v0.9 → v1 to match canonical protocol

### DIFF
--- a/apps/website/content/docs/a2ui/api/api-docs.json
+++ b/apps/website/content/docs/a2ui/api/api-docs.json
@@ -58,7 +58,7 @@
       },
       {
         "name": "version",
-        "type": "\"v0.9\"",
+        "type": "\"v1\"",
         "description": "",
         "optional": false
       }
@@ -196,7 +196,7 @@
       },
       {
         "name": "version",
-        "type": "\"v0.9\"",
+        "type": "\"v1\"",
         "description": "",
         "optional": false
       }

--- a/cockpit/chat/a2ui/python/prompts/a2ui.md
+++ b/cockpit/chat/a2ui/python/prompts/a2ui.md
@@ -4,7 +4,7 @@ You are an assistant that builds interactive UIs using the A2UI (Agent-to-UI) pr
 
 When the user asks you to create a form, dashboard, or any interactive UI, respond with A2UI JSONL — newline-delimited JSON messages prefixed with `---a2ui_JSON---`.
 
-When the user sends a JSON message with `"version": "v0.9"` and an `"action"` field, that is a form submission event. Read the `action.context` object to see the submitted values and respond conversationally (in plain text/markdown, not A2UI).
+When the user sends a JSON message with `"version": "v1"` and an `"action"` field, that is a form submission event. Read the `action.context` object to see the submitted values and respond conversationally (in plain text/markdown, not A2UI).
 
 ## Response Format
 
@@ -142,4 +142,4 @@ Compose with `and`, `or`, `not`:
 4. Every component referenced in `children` must have a matching `id` in the components array.
 5. The root component must have `id: "root"`.
 6. Do NOT include `_bindings` in component definitions.
-7. When responding to a form submission (v0.9 action message), respond in plain markdown — do NOT emit A2UI JSONL.
+7. When responding to a form submission (v1 action message), respond in plain markdown — do NOT emit A2UI JSONL.

--- a/cockpit/chat/a2ui/python/src/graph.py
+++ b/cockpit/chat/a2ui/python/src/graph.py
@@ -83,7 +83,7 @@ ALLOWED_COMPONENTS = frozenset({
 # ── Pydantic schemas ────────────────────────────────────────────────────────
 
 class A2uiComponent(BaseModel):
-    """Single A2UI v0.9 updateComponents entry.
+    """Single A2UI v1 updateComponents entry.
 
     Format (from libs/chat/src/lib/a2ui/surface-to-spec.ts):
         {id: "name_field",
@@ -164,7 +164,7 @@ def _to_data_model_contents(model: dict[str, Any]) -> list[dict[str, Any]]:
 
 
 def _wrap_envelopes(spec: _SurfaceSpec, root_id: str = "root") -> str:
-    """Wrap a validated SurfaceSpec into A2UI v0.9 JSONL.
+    """Wrap a validated SurfaceSpec into A2UI v1 JSONL.
 
     Order matters: dataModelUpdate first (so bindings resolve), then
     surfaceUpdate (components), then beginRendering (mount + root id).
@@ -252,7 +252,7 @@ async def _emit_with_retry(
 _AIRPORT_OPTIONS = [{"label": c, "value": c} for c in AIRPORT_CODES]
 _FARE_OPTIONS = [{"label": c, "value": c} for c in FARE_CLASSES]
 
-_BUILD_FORM_SYSTEM = f"""You are an aviation booking-form designer. Emit an A2UI v0.9 booking form using the structured output schema.
+_BUILD_FORM_SYSTEM = f"""You are an aviation booking-form designer. Emit an A2UI v1 booking form using the structured output schema.
 
 A2UI FORMAT (CRITICAL): each component is `{{"id": "...", "component": {{"<ComponentName>": {{<props>}}}}}}`. The component name is the SINGLE KEY of the inner dict. ComponentName must be one of:
   Column, Row, Card, Text, TextField, MultipleChoice, DateTimeInput, CheckBox, Button, Divider, List, Image, Icon, Modal, Slider, Tabs
@@ -352,7 +352,7 @@ _SEARCH_FLIGHTS_SYSTEM = """You just received a booking submission. The find_rou
 
 Form data (for context): {form_json}
 
-Emit an A2UI v0.9 results surface using the FlightResultsSpec schema.
+Emit an A2UI v1 results surface using the FlightResultsSpec schema.
 
 A2UI format (CRITICAL): every component is `{{"id": "...", "component": {{"<ComponentName>": {{<props>}}}}}}`. The component name is the SINGLE KEY of the inner dict.
 
@@ -409,7 +409,7 @@ _SENTINEL_RESULTS = FlightResultsSpec(
 
 
 def _unwrap_literal(v: Any) -> Any:
-    """Unwrap a v0.9 literal wrapper ({literalString|literalNumber|literalBoolean: <v>})."""
+    """Unwrap a v1 literal wrapper ({literalString|literalNumber|literalBoolean: <v>})."""
     if isinstance(v, dict):
         for k in ("literalString", "literalNumber", "literalBoolean"):
             if k in v:
@@ -418,10 +418,10 @@ def _unwrap_literal(v: Any) -> Any:
 
 
 def _parse_submit_payload(content: str) -> dict[str, Any] | None:
-    """Extract the form-data dict from a v0.9 A2uiActionMessage content.
+    """Extract the form-data dict from a v1 A2uiActionMessage content.
 
     Chat-lib sends:
-      {"version":"v0.9","action":{"name":"...","surfaceId":"...",
+      {"version":"v1","action":{"name":"...","surfaceId":"...",
         "sourceComponentId":"...","timestamp":"...",
         "context":{"formId":{"literalString":"booking"},
                    "origin":{"literalString":"LAX"}, ...}}}
@@ -472,7 +472,7 @@ async def search_flights(state: MessagesState) -> dict:
 # ── Routing + compile ───────────────────────────────────────────────────────
 
 def _is_submit_event(content: str) -> bool:
-    """True iff the content is a v0.9 A2uiActionMessage named bookingSubmit."""
+    """True iff the content is a v1 A2uiActionMessage named bookingSubmit."""
     try:
         payload = json.loads(content)
     except (json.JSONDecodeError, TypeError):

--- a/cockpit/langgraph/streaming/python/src/a2ui_graph.py
+++ b/cockpit/langgraph/streaming/python/src/a2ui_graph.py
@@ -50,7 +50,7 @@ ALLOWED_COMPONENTS = frozenset({
 # ── Pydantic schemas ────────────────────────────────────────────────────────
 
 class A2uiComponent(BaseModel):
-    """Single A2UI v0.9 updateComponents entry.
+    """Single A2UI v1 updateComponents entry.
 
     Format (from libs/chat/src/lib/a2ui/surface-to-spec.ts):
         {id: "name_field",
@@ -131,7 +131,7 @@ def _to_data_model_contents(model: dict[str, Any]) -> list[dict[str, Any]]:
 
 
 def _wrap_envelopes(spec: _SurfaceSpec, root_id: str = "root") -> str:
-    """Wrap a validated SurfaceSpec into A2UI v0.9 JSONL.
+    """Wrap a validated SurfaceSpec into A2UI v1 JSONL.
 
     Order matters: dataModelUpdate first (so bindings resolve), then
     surfaceUpdate (components), then beginRendering (mount + root id).
@@ -219,7 +219,7 @@ async def _emit_with_retry(
 _AIRPORT_OPTIONS = [{"label": c, "value": c} for c in AIRPORT_CODES]
 _FARE_OPTIONS = [{"label": c, "value": c} for c in FARE_CLASSES]
 
-_BUILD_FORM_SYSTEM = f"""You are an aviation booking-form designer. Emit an A2UI v0.9 booking form using the structured output schema.
+_BUILD_FORM_SYSTEM = f"""You are an aviation booking-form designer. Emit an A2UI v1 booking form using the structured output schema.
 
 A2UI FORMAT (CRITICAL): each component is `{{"id": "...", "component": {{"<ComponentName>": {{<props>}}}}}}`. The component name is the SINGLE KEY of the inner dict. ComponentName must be one of:
   Column, Row, Card, Text, TextField, MultipleChoice, DateTimeInput, CheckBox, Button, Divider, List, Image, Icon, Modal, Slider, Tabs
@@ -319,7 +319,7 @@ _SEARCH_FLIGHTS_SYSTEM = """You just received a booking submission. The find_rou
 
 Form data (for context): {form_json}
 
-Emit an A2UI v0.9 results surface using the FlightResultsSpec schema.
+Emit an A2UI v1 results surface using the FlightResultsSpec schema.
 
 A2UI format (CRITICAL): every component is `{{"id": "...", "component": {{"<ComponentName>": {{<props>}}}}}}`. The component name is the SINGLE KEY of the inner dict.
 
@@ -376,7 +376,7 @@ _SENTINEL_RESULTS = FlightResultsSpec(
 
 
 def _unwrap_literal(v: Any) -> Any:
-    """Unwrap a v0.9 literal wrapper ({literalString|literalNumber|literalBoolean: <v>})."""
+    """Unwrap a v1 literal wrapper ({literalString|literalNumber|literalBoolean: <v>})."""
     if isinstance(v, dict):
         for k in ("literalString", "literalNumber", "literalBoolean"):
             if k in v:
@@ -385,10 +385,10 @@ def _unwrap_literal(v: Any) -> Any:
 
 
 def _parse_submit_payload(content: str) -> dict[str, Any] | None:
-    """Extract the form-data dict from a v0.9 A2uiActionMessage content.
+    """Extract the form-data dict from a v1 A2uiActionMessage content.
 
     Chat-lib sends:
-      {"version":"v0.9","action":{"name":"...","surfaceId":"...",
+      {"version":"v1","action":{"name":"...","surfaceId":"...",
         "sourceComponentId":"...","timestamp":"...",
         "context":{"formId":{"literalString":"booking"},
                    "origin":{"literalString":"LAX"}, ...}}}
@@ -439,7 +439,7 @@ async def search_flights(state: MessagesState) -> dict:
 # ── Routing + compile ───────────────────────────────────────────────────────
 
 def _is_submit_event(content: str) -> bool:
-    """True iff the content is a v0.9 A2uiActionMessage named bookingSubmit."""
+    """True iff the content is a v1 A2uiActionMessage named bookingSubmit."""
     try:
         payload = json.loads(content)
     except (json.JSONDecodeError, TypeError):

--- a/examples/chat/angular/src/app/shell/demo-shell.component.ts
+++ b/examples/chat/angular/src/app/shell/demo-shell.component.ts
@@ -260,7 +260,7 @@ export class DemoShell {
   ]);
 
   protected readonly genUiOptions = signal<readonly { value: string; label: string }[]>([
-    { value: 'a2ui',        label: 'A2UI v0.9-compatible' },
+    { value: 'a2ui',        label: 'A2UI v1-compatible' },
     { value: 'json-render', label: 'json-render' },
   ]);
 

--- a/examples/chat/python/src/graph.py
+++ b/examples/chat/python/src/graph.py
@@ -399,7 +399,7 @@ async def generate(state: State, config: RunnableConfig) -> dict:
     # false. The envelope shape carries list[dict] for components/contents
     # (untyped inner objects), which strict mode rejects with a 400
     # ('additionalProperties is required to be supplied and to be false').
-    # Typing the inner shapes would over-couple this example to the A2UI v0.9
+    # Typing the inner shapes would over-couple this example to the A2UI v1
     # spec; instead we leave strict OFF and rely on the envelope-args
     # normalizer (Python: src/streaming/envelope_normalizer.py; TS:
     # libs/chat/src/lib/a2ui/envelope-normalizer.ts) to canonicalize the
@@ -408,11 +408,11 @@ async def generate(state: State, config: RunnableConfig) -> dict:
     llm = ChatOpenAI(**kwargs).bind_tools(
         [search_documents, request_approval, research, gen_ui_tool],
     )
-    # Append A2UI v0.9 schema to system prompt when in a2ui mode, so the parent
+    # Append A2UI v1 schema to system prompt when in a2ui mode, so the parent
     # LLM knows how to construct the envelopes directly.
     system = SYSTEM_PROMPT
     if gen_ui_mode == "a2ui":
-        system = SYSTEM_PROMPT + "\n\n--- A2UI v0.9 SCHEMA ---\n" + A2UI_V1_SCHEMA_PROMPT + (
+        system = SYSTEM_PROMPT + "\n\n--- A2UI v1 SCHEMA ---\n" + A2UI_V1_SCHEMA_PROMPT + (
             "\n\nWhen rendering UI in a2ui mode, emit envelopes in this order: "
             "surfaceUpdate FIRST, then beginRendering, then any dataModelUpdate "
             "entries. This lets the client mount the surface as early as possible."

--- a/examples/chat/python/src/schemas/a2ui_v1.py
+++ b/examples/chat/python/src/schemas/a2ui_v1.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
-"""A2UI v0.9 protocol schema documentation, used as the system prompt for
+"""A2UI v1 protocol schema documentation, used as the system prompt for
 the `generate_a2ui_schema` sub-LLM tool. Sourced verbatim from the
-L4 production reference (canonical Google A2UI v0.9 schema)."""
+L4 production reference (canonical Google A2UI v1 schema)."""
 
 A2UI_V1_SCHEMA_PROMPT = """
 Generate A2UI JSON.

--- a/examples/chat/python/src/streaming/envelope_tool.py
+++ b/examples/chat/python/src/streaming/envelope_tool.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-"""Parent-LLM-bound tool that emits A2UI v0.9 envelopes as structured tool
+"""Parent-LLM-bound tool that emits A2UI v1 envelopes as structured tool
 arguments. Replaces the old two-LLM `generate_a2ui_schema` flow (parent
 calls a sub-LLM that produces envelopes); the parent now emits envelopes
 directly so the natural token stream IS the surface-rendering stream.
@@ -41,7 +41,7 @@ class DataModelUpdate(BaseModel):
 
 
 class A2uiEnvelope(BaseModel):
-    """Single A2UI v0.9 envelope. Exactly one of the three discriminators
+    """Single A2UI v1 envelope. Exactly one of the three discriminators
     is set per envelope — the model_validator below enforces this so the
     parent LLM cannot emit ambiguous or empty envelopes."""
     surfaceUpdate: Optional[SurfaceUpdate] = None
@@ -64,7 +64,7 @@ class A2uiEnvelope(BaseModel):
 
 @tool
 def render_a2ui_surface(envelopes: list[A2uiEnvelope]) -> str:
-    """Render a UI surface using A2UI v0.9 envelopes. Emit:
+    """Render a UI surface using A2UI v1 envelopes. Emit:
       - exactly one `surfaceUpdate` (component tree),
       - exactly one `beginRendering` (root reference),
       - zero or more `dataModelUpdate` entries (initial state).

--- a/examples/chat/smoke/CHECKLIST.md
+++ b/examples/chat/smoke/CHECKLIST.md
@@ -272,14 +272,14 @@ renders correctly both during streaming and after completion.
 
 ### Gen UI mode dropdown
 
-- [ ] Palette "Gen UI" dropdown lists 2 options: `A2UI v0.9-compatible` and `json-render`
-- [ ] Default value is `A2UI v0.9-compatible` on first load
+- [ ] Palette "Gen UI" dropdown lists 2 options: `A2UI v1-compatible` and `json-render`
+- [ ] Default value is `A2UI v1-compatible` on first load
 - [ ] Selection persists across reload and mode switches
 - [ ] Server-side: `curl localhost:2024/threads/<id>/state` shows `values.gen_ui_mode` matches the palette selection
 
-### Dynamic dispatch — A2UI v0.9-compatible mode
+### Dynamic dispatch — A2UI v1-compatible mode
 
-- [ ] With Gen UI = `A2UI v0.9-compatible`, click any GenUI welcome suggestion (e.g. "Demo: render a feedback form")
+- [ ] With Gen UI = `A2UI v1-compatible`, click any GenUI welcome suggestion (e.g. "Demo: render a feedback form")
 - [ ] **Single bubble** — exactly ONE assistant bubble per GenUI turn (no skeleton bubble followed by a separate surface bubble)
 - [ ] Parent LLM emits a tool_call to `render_a2ui_surface` (parent emits envelopes directly as typed args — there is no sub-LLM hop)
 - [ ] Final assistant AI message carries BOTH `tool_calls` AND `---a2ui_JSON---\n`-prefixed content (in-place replacement of the tool-call AI)
@@ -291,7 +291,7 @@ renders correctly both during streaming and after completion.
 
 ### Progressive A2UI streaming (per-component fallback transition)
 
-- [ ] DevTools Network → trigger any A2UI v0.9-compatible GenUI prompt; the `/runs/stream` SSE response contains `event: custom` frames carrying `a2ui-partial` payloads (`{name: 'a2ui-partial', data: {tool_call_id, args_so_far}}`)
+- [ ] DevTools Network → trigger any A2UI v1-compatible GenUI prompt; the `/runs/stream` SSE response contains `event: custom` frames carrying `a2ui-partial` payloads (`{name: 'a2ui-partial', data: {tool_call_id, args_so_far}}`)
 - [ ] At least several `a2ui-partial` frames stream as the parent LLM emits tool-call argument tokens (not all-at-once)
 - [ ] During streaming: `<a2ui-surface>` mounts before all `dataModelUpdate` envelopes arrive — components show `<render-default-fallback>` (shimmer card with "Building UI…" label) until their bound state populates
 - [ ] As each `dataModelUpdate` envelope arrives, exactly one component flips from fallback → real
@@ -309,7 +309,7 @@ renders correctly both during streaming and after completion.
 
 ### Server-side wire format
 
-- [ ] In A2UI v0.9-compatible mode: the final AI message content starts with `---a2ui_JSON---\n` followed by JSONL (one envelope per line); contains at minimum `surfaceUpdate` and `beginRendering` envelopes; envelopes are reordered so `beginRendering` follows the first `surfaceUpdate` regardless of LLM emission order
+- [ ] In A2UI v1-compatible mode: the final AI message content starts with `---a2ui_JSON---\n` followed by JSONL (one envelope per line); contains at minimum `surfaceUpdate` and `beginRendering` envelopes; envelopes are reordered so `beginRendering` follows the first `surfaceUpdate` regardless of LLM emission order
 - [ ] The same AI message carries `tool_calls` set (single-bubble invariant)
 - [ ] In json-render mode: final AI message content is a bare JSON object starting with `{`
 - [ ] `curl localhost:2024/threads/<id>/state` confirms the above for both modes

--- a/libs/a2ui/src/lib/types.ts
+++ b/libs/a2ui/src/lib/types.ts
@@ -245,12 +245,12 @@ export interface A2uiSurface {
 // --- Outbound shapes ---
 
 export interface A2uiClientDataModel {
-  version: 'v0.9';
+  version: 'v1';
   surfaces: Record<string, Record<string, unknown>>;
 }
 
 export interface A2uiActionMessage {
-  version: 'v0.9';
+  version: 'v1';
   action: {
     name: string;
     surfaceId: string;

--- a/libs/chat/README.md
+++ b/libs/chat/README.md
@@ -70,7 +70,7 @@ The `CitationsResolverService` is provided to query citations in message-first o
 
 ### Agent-driven theming (v1 wire format)
 
-Agents control exactly two knobs per the canonical A2UI v0.9-compatible spec, set via `beginRendering.styles`:
+Agents control exactly two knobs per the canonical A2UI v1-compatible spec, set via `beginRendering.styles`:
 
 - `font` — primary font family
 - `primaryColor` — hex `#RRGGBB`

--- a/libs/chat/src/lib/a2ui/build-action-message.spec.ts
+++ b/libs/chat/src/lib/a2ui/build-action-message.spec.ts
@@ -27,7 +27,7 @@ describe('buildA2uiActionMessage (v1)', () => {
       context: {},
     };
     const msg = buildA2uiActionMessage(params, surface);
-    expect(msg.version).toBe('v0.9');
+    expect(msg.version).toBe('v1');
     expect(msg.action.name).toBe('formSubmit');
     expect(msg.action.surfaceId).toBe('s1');
     expect(msg.action.sourceComponentId).toBe('submit-btn');
@@ -80,7 +80,7 @@ describe('buildA2uiActionMessage (v1)', () => {
     const params = { surfaceId: 's1', sourceComponentId: 'btn', name: 'submit', context: {} };
     const msg = buildA2uiActionMessage(params, surface);
     expect(msg.metadata).toBeDefined();
-    expect(msg.metadata!.a2uiClientDataModel.version).toBe('v0.9');
+    expect(msg.metadata!.a2uiClientDataModel.version).toBe('v1');
     expect(msg.metadata!.a2uiClientDataModel.surfaces['s1']).toEqual({ name: 'Alice', email: 'alice@co.com' });
   });
 

--- a/libs/chat/src/lib/a2ui/build-action-message.ts
+++ b/libs/chat/src/lib/a2ui/build-action-message.ts
@@ -21,7 +21,7 @@ export function buildA2uiActionMessage(
   }
 
   const message: A2uiActionMessage = {
-    version: 'v0.9',
+    version: 'v1',
     action: {
       name: params['name'] as string,
       surfaceId: surface.surfaceId,
@@ -33,7 +33,7 @@ export function buildA2uiActionMessage(
   if (surface.sendDataModel) {
     message.metadata = {
       a2uiClientDataModel: {
-        version: 'v0.9',
+        version: 'v1',
         surfaces: { [surface.surfaceId]: surface.dataModel },
       },
     };

--- a/libs/chat/src/lib/compositions/chat/chat.component.ts
+++ b/libs/chat/src/lib/compositions/chat/chat.component.ts
@@ -653,7 +653,7 @@ export class ChatComponent {
     // A2UI/json-render markers in the content string.
     const projectedContent = (m as { content?: unknown }).content;
     if (typeof projectedContent === 'string' && projectedContent.length > 0) {
-      // A2UI v0.9 envelope keys (canonical Google shape).
+      // A2UI v1 envelope keys (canonical Google shape).
       if (projectedContent.includes('"surfaceUpdate"')
           || projectedContent.includes('"beginRendering"')
           || projectedContent.includes('"dataModelUpdate"')) {

--- a/libs/chat/src/lib/streaming/content-classifier.spec.ts
+++ b/libs/chat/src/lib/streaming/content-classifier.spec.ts
@@ -179,7 +179,7 @@ describe('ContentClassifier', () => {
   });
 
   describe('a2ui JSONL parsing (v1)', () => {
-    it('parses A2UI v0.9 messages and exposes surfaces after beginRendering', () => {
+    it('parses A2UI v1 messages and exposes surfaces after beginRendering', () => {
       const c = setup();
       c.update(
         '---a2ui_JSON---' +
@@ -194,7 +194,7 @@ describe('ContentClassifier', () => {
       expect('Text' in comp.component).toBe(true);
     });
 
-    it('accumulates A2UI v0.9 messages across updates', () => {
+    it('accumulates A2UI v1 messages across updates', () => {
       const c = setup();
       // First update: surfaceUpdate + dataModelUpdate (no beginRendering yet — surface not visible)
       c.update(

--- a/libs/render/README.md
+++ b/libs/render/README.md
@@ -1,6 +1,6 @@
 # @ngaf/render
 
-Generative UI for Angular. Agents emit structured JSON specs; this library renders them into Angular components you already own. Supports the Vercel `json-render` and Google A2UI v0.9-compatible protocols out of the box.
+Generative UI for Angular. Agents emit structured JSON specs; this library renders them into Angular components you already own. Supports the Vercel `json-render` and Google A2UI v1-compatible protocols out of the box.
 
 Part of [Agent UI for Angular](https://github.com/cacheplane/angular-agent-framework). MIT licensed.
 
@@ -13,7 +13,7 @@ npm install @ngaf/render
 ## What it does
 
 - **Spec-driven rendering** — agents return JSON; you map each node type to one of your Angular components via a registry
-- **Two protocols supported** — Vercel `json-render` and Google A2UI v0.9-compatible
+- **Two protocols supported** — Vercel `json-render` and Google A2UI v1-compatible
 - **Per-component fallback API** — when a spec node has no registered component, you control what renders (and surface it to your observability layer)
 - **Readiness gate** — holds renders until the surface is real, so users never see mystery partial UI
 - **Streaming partial renders** — works with `@cacheplane/partial-json` to render progressive JSON as it streams
@@ -23,7 +23,7 @@ npm install @ngaf/render
 - [Quickstart](https://cacheplane.ai/docs/render/getting-started/quickstart)
 - [Component registry](https://cacheplane.ai/docs/render/guides/registry)
 - [Fallback patterns](https://cacheplane.ai/docs/render/guides/fallback)
-- [A2UI v0.9-compatible protocol](https://cacheplane.ai/docs/render/a2ui/overview)
+- [A2UI v1-compatible protocol](https://cacheplane.ai/docs/render/a2ui/overview)
 
 ## License
 


### PR DESCRIPTION
## Summary
The A2UI protocol migrated to **v1** back in PR #228 (envelope keys `surfaceUpdate`/`dataModelUpdate`/`beginRendering`, nested ComponentDef wrapper `{TextField: {...}}`, typed `A2uiDataModelEntry` shapes, `DynamicValue` wrappers). But the literal `version` string field on outbound `A2uiClientDataModel` + `A2uiActionMessage` was never updated — client→agent submit payloads still claimed `"version": "v0.9"` despite shipping v1 wire format.

This PR corrects the label. No protocol or behavior change; just truth-in-advertising.

## Functional changes (4 edits)
- `libs/a2ui/src/lib/types.ts` — `version: 'v0.9'` → `version: 'v1'` on `A2uiClientDataModel` and `A2uiActionMessage`
- `libs/chat/src/lib/a2ui/build-action-message.ts` — both outbound construction sites emit `v1`
- `libs/chat/src/lib/a2ui/build-action-message.spec.ts` — assertions match new value

## Doc/comment sweep (cosmetic)
Keeps explanatory text accurate to current reality:
- `libs/chat/README.md`, `libs/render/README.md`
- `libs/chat/src/lib/compositions/chat/chat.component.ts` envelope comment
- `libs/chat/src/lib/streaming/content-classifier.spec.ts` test descriptions
- `cockpit/{langgraph/streaming,chat/a2ui}/python` — graph docstrings + LLM prompts in both umbrella + standalone
- `cockpit/chat/a2ui/python/prompts/a2ui.md`
- `examples/chat/smoke/CHECKLIST.md`, `examples/chat/python/src/graph.py`, `schemas/a2ui_v1.py`, `streaming/envelope_tool.py`
- `examples/chat/angular/src/app/shell/demo-shell.component.ts` Gen UI option label

## Cockpit agent code is unaffected at runtime
The cockpit a2ui agent (`_is_submit_event` / `_parse_submit_payload`) routes on `action.name` and reads `action.context`. It does **not** check the `version` string field. So the label fix is purely truth-in-advertising — the per-cap PR's standalone backend (#396) continues to work without changes.

## Test plan
- [x] `pnpm nx test a2ui` — green
- [x] `pnpm nx test chat` — green
- [x] `pnpm nx run-many -t build --projects=a2ui,chat` — green
- [x] `git grep -n "v0\.9"` returns no remaining references in tracked code
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)