### PR TITLE
Smoke canonical demo runtime telemetry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -667,7 +667,7 @@ jobs:
 
   production-smoke:
     name: Production smoke
-    needs: [deploy]
+    needs: [deploy, demo-deploy]
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     steps:

--- a/apps/cockpit/e2e/production-smoke.spec.ts
+++ b/apps/cockpit/e2e/production-smoke.spec.ts
@@ -16,7 +16,9 @@ import { expect, test } from '@playwright/test';
  */
 
 const COCKPIT_URL = process.env['BASE_URL'] ?? 'https://cockpit.cacheplane.ai';
-const EXAMPLES_URL = process.env['EXAMPLES_URL'] ?? 'https://examples.cacheplane.ai';
+const EXAMPLES_URL =
+  process.env['EXAMPLES_URL'] ?? 'https://examples.cacheplane.ai';
+const DEMO_URL = process.env['DEMO_URL'] ?? 'https://demo.cacheplane.ai';
 
 const CHAT_CAPABILITIES = [
   'langgraph/streaming',
@@ -49,7 +51,10 @@ const CHAT_PRIMITIVE_CAPABILITIES = [
   'chat/debug',
 ] as const;
 
-const CHAT_PRIMITIVE_READY_SELECTORS: Record<(typeof CHAT_PRIMITIVE_CAPABILITIES)[number], string> = {
+const CHAT_PRIMITIVE_READY_SELECTORS: Record<
+  (typeof CHAT_PRIMITIVE_CAPABILITIES)[number],
+  string
+> = {
   'chat/messages': 'chat-message-list',
   'chat/input': 'chat-input',
   'chat/interrupts': 'chat-interrupt-panel',
@@ -71,7 +76,9 @@ const A2UI_SEND_RECEIVE_TIMEOUT_MS = 90_000;
 test.describe('Production: Angular chat example apps load', () => {
   for (const cap of CHAT_CAPABILITIES) {
     test(`${cap} loads at examples URL`, async ({ page }) => {
-      const response = await page.goto(`${EXAMPLES_URL}/${cap}/`, { timeout: 15_000 });
+      const response = await page.goto(`${EXAMPLES_URL}/${cap}/`, {
+        timeout: 15_000,
+      });
       expect(response?.status()).toBe(200);
       await expect(page.locator('chat')).toBeVisible({ timeout: 10_000 });
     });
@@ -81,9 +88,13 @@ test.describe('Production: Angular chat example apps load', () => {
 test.describe('Production: Angular chat primitive apps load', () => {
   for (const cap of CHAT_PRIMITIVE_CAPABILITIES) {
     test(`${cap} loads at examples URL`, async ({ page }) => {
-      const response = await page.goto(`${EXAMPLES_URL}/${cap}/`, { timeout: 15_000 });
+      const response = await page.goto(`${EXAMPLES_URL}/${cap}/`, {
+        timeout: 15_000,
+      });
       expect(response?.status()).toBe(200);
-      await expect(page.locator(CHAT_PRIMITIVE_READY_SELECTORS[cap])).toBeAttached({
+      await expect(
+        page.locator(CHAT_PRIMITIVE_READY_SELECTORS[cap])
+      ).toBeAttached({
         timeout: 10_000,
       });
     });
@@ -93,7 +104,9 @@ test.describe('Production: Angular chat primitive apps load', () => {
 test.describe('Production: render example apps load', () => {
   for (const cap of RENDER_CAPABILITIES) {
     test(`${cap} loads at examples URL`, async ({ page }) => {
-      const response = await page.goto(`${EXAMPLES_URL}/${cap}/`, { timeout: 15_000 });
+      const response = await page.goto(`${EXAMPLES_URL}/${cap}/`, {
+        timeout: 15_000,
+      });
       expect(response?.status()).toBe(200);
       await expect(page.locator('body')).not.toBeEmpty({ timeout: 10_000 });
     });
@@ -103,21 +116,93 @@ test.describe('Production: render example apps load', () => {
 test.describe('Production: cockpit shell loads', () => {
   test('cockpit loads with sidebar navigation', async ({ page }) => {
     await page.goto(COCKPIT_URL, { timeout: 15_000 });
-    await expect(page.getByRole('navigation', { name: 'Cockpit navigation' })).toBeVisible();
+    await expect(
+      page.getByRole('navigation', { name: 'Cockpit navigation' })
+    ).toBeVisible();
 
     const links = await page.locator('nav a').allTextContents();
-    const overviewLinks = links.filter((text) => text.toLowerCase().includes('overview'));
+    const overviewLinks = links.filter((text) =>
+      text.toLowerCase().includes('overview')
+    );
     expect(overviewLinks).toHaveLength(0);
+  });
+});
+
+test.describe('Production: canonical demo sends runtime telemetry', () => {
+  test.skip(() => !process.env['OPENAI_API_KEY'], 'Requires OPENAI_API_KEY');
+
+  test('demo chat sends and receives a message with runtime lifecycle telemetry', async ({
+    page,
+  }) => {
+    test.setTimeout(75_000);
+    const telemetryPayloads: Array<{ event?: unknown; properties?: unknown }> =
+      [];
+    page.on('request', (request) => {
+      const url = request.url();
+      if (!url.includes('/api/ingest')) return;
+      const body = request.postData();
+      if (!body) return;
+      try {
+        telemetryPayloads.push(JSON.parse(body));
+      } catch {
+        // Ignore malformed non-JSON requests; assertions below require valid telemetry payloads.
+      }
+    });
+
+    await page.goto(`${DEMO_URL}/embed`, { timeout: 15_000 });
+    await expect(page.locator('chat')).toBeVisible({ timeout: 10_000 });
+
+    await page.locator('textarea[name="messageText"]').fill('hello');
+    await page.getByRole('button', { name: /send message/i }).click();
+
+    await expect(
+      page.locator('chat-message[data-role="assistant"]').last()
+    ).toBeVisible({
+      timeout: SEND_RECEIVE_TIMEOUT_MS,
+    });
+
+    for (const event of [
+      'ngaf:runtime_request_created',
+      'ngaf:stream_started',
+      'ngaf:stream_ended',
+    ]) {
+      await expect
+        .poll(
+          () =>
+            telemetryPayloads.some(
+              (payload) =>
+                payload.event === event &&
+                typeof payload.properties === 'object' &&
+                payload.properties !== null &&
+                (payload.properties as Record<string, unknown>)['transport'] ===
+                  'langgraph' &&
+                (payload.properties as Record<string, unknown>)['surface'] ===
+                  'canonical_demo'
+            ),
+          { timeout: 10_000 }
+        )
+        .toBe(true);
+    }
+
+    expect(JSON.stringify(telemetryPayloads)).not.toMatch(
+      /messages|threadId|assistantId|apiUrl/
+    );
   });
 });
 
 test.describe('Production: send/receive smoke', () => {
   test.skip(() => !process.env['OPENAI_API_KEY'], 'Requires OPENAI_API_KEY');
 
-  for (const cap of ['langgraph/streaming', 'deep-agents/planning', 'chat/a2ui'] as const) {
+  for (const cap of [
+    'langgraph/streaming',
+    'deep-agents/planning',
+    'chat/a2ui',
+  ] as const) {
     test(`${cap} sends and receives a message`, async ({ page }) => {
       const responseTimeout =
-        cap === 'chat/a2ui' ? A2UI_SEND_RECEIVE_TIMEOUT_MS : SEND_RECEIVE_TIMEOUT_MS;
+        cap === 'chat/a2ui'
+          ? A2UI_SEND_RECEIVE_TIMEOUT_MS
+          : SEND_RECEIVE_TIMEOUT_MS;
 
       test.setTimeout(responseTimeout + 15_000);
       await page.goto(`${EXAMPLES_URL}/${cap}/`, { timeout: 15_000 });
@@ -127,11 +212,15 @@ test.describe('Production: send/receive smoke', () => {
       await page.getByRole('button', { name: /send message/i }).click();
 
       if (cap === 'chat/a2ui') {
-        await expect(page.locator('a2ui-surface')).toBeAttached({ timeout: responseTimeout });
+        await expect(page.locator('a2ui-surface')).toBeAttached({
+          timeout: responseTimeout,
+        });
         return;
       }
 
-      await expect(page.locator('chat-message[data-role="assistant"]').last()).toBeVisible({
+      await expect(
+        page.locator('chat-message[data-role="assistant"]').last()
+      ).toBeVisible({
         timeout: responseTimeout,
       });
     });

--- a/scripts/ci-workflow.spec.mjs
+++ b/scripts/ci-workflow.spec.mjs
@@ -11,12 +11,23 @@ describe('CI workflow', () => {
     );
   }
 
+  async function readProductionSmokeJob() {
+    const workflow = await readFile('.github/workflows/ci.yml', 'utf8');
+    return workflow.slice(
+      workflow.indexOf('  production-smoke:'),
+      workflow.indexOf('  posthog-sync-plan:')
+    );
+  }
+
   it('treats nested library files as deploy-relevant changes', async () => {
     const deployJob = await readDeployJob();
 
     const pattern = deployJob.match(/grep -E '([^']+)' >\/dev\/null/);
 
-    assert.match('libs/chat/src/lib/styles/chat-sidenav.styles.ts', new RegExp(pattern?.[1] ?? ''));
+    assert.match(
+      'libs/chat/src/lib/styles/chat-sidenav.styles.ts',
+      new RegExp(pattern?.[1] ?? '')
+    );
   });
 
   it('installs dependencies before assembling changed Angular examples', async () => {
@@ -30,5 +41,11 @@ describe('CI workflow', () => {
       dependencyInstall?.[1] ?? '',
       /steps\.examples_changed\.outputs\.changed == 'true'/
     );
+  });
+
+  it('runs production smoke after the canonical demo deploy', async () => {
+    const productionSmokeJob = await readProductionSmokeJob();
+
+    assert.match(productionSmokeJob, /needs:\s*\[deploy,\s*demo-deploy\]/);
   });
 });


### PR DESCRIPTION
## Summary
- make production smoke wait for the canonical demo deploy before running
- add a production demo chat smoke that observes real `/api/ingest` lifecycle telemetry requests
- assert runtime request/stream telemetry is emitted without content-bearing fields

## Verification
- `PATH=/tmp/codex-node-v24/bin:$PATH npx tsx --test scripts/ci-workflow.spec.mjs`
- `set -a; source /Users/blove/repos/angular-agent-framework/.env; set +a; PATH=/tmp/codex-node-v24/bin:$PATH npx playwright test apps/cockpit/e2e/production-smoke.spec.ts --grep "canonical demo" --reporter=list`
- `set -a; source /Users/blove/repos/angular-agent-framework/.env; set +a; PATH=/tmp/codex-node-v24/bin:$PATH npx nx run posthog-tools:quality:live -- --days 7 --limit-per-event 25 --require-critical-coverage`
- `PATH=/tmp/codex-node-v24/bin:$PATH npx prettier --check .github/workflows/ci.yml apps/cockpit/e2e/production-smoke.spec.ts scripts/ci-workflow.spec.mjs`
- `git diff --check`

## Notes
- `npx nx lint cockpit` is not available because the `cockpit` project has no lint target.
