### PR TITLE
fix(ci): stabilize production smoke verifier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -590,11 +590,11 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
-      - run: npx playwright install --with-deps chromium
       - name: Verify shared LangGraph backend
         run: npx tsx scripts/verify-shared-deployment.ts
         env:
           LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
+      - run: npx playwright install --with-deps chromium
       - name: Run production smoke tests
         run: npx playwright test apps/cockpit/e2e/production-smoke.spec.ts --reporter=list
         env:

--- a/apps/cockpit/src/lib/verify-shared-deployment.spec.ts
+++ b/apps/cockpit/src/lib/verify-shared-deployment.spec.ts
@@ -12,4 +12,9 @@ describe('verify-shared-deployment', () => {
       DEFAULT_SMOKE_ASSISTANT_STREAM_TIMEOUT_MS,
     );
   });
+
+  it('allows UI-heavy smoke assistants more time than single-response smoke assistants', () => {
+    expect(getSmokeAssistantStreamTimeoutMs('c-generative-ui')).toBe(90000);
+    expect(getSmokeAssistantStreamTimeoutMs('c-a2ui')).toBe(90000);
+  });
 });

--- a/scripts/ci-workflow.spec.mjs
+++ b/scripts/ci-workflow.spec.mjs
@@ -48,4 +48,13 @@ describe('CI workflow', () => {
 
     assert.match(productionSmokeJob, /needs:\s*\[deploy,\s*demo-deploy\]/);
   });
+
+  it('verifies the shared backend before installing Playwright browsers', async () => {
+    const productionSmokeJob = await readProductionSmokeJob();
+
+    assert.ok(
+      productionSmokeJob.indexOf('Verify shared LangGraph backend') <
+        productionSmokeJob.indexOf('npx playwright install --with-deps chromium')
+    );
+  });
 });

--- a/scripts/verify-shared-deployment.ts
+++ b/scripts/verify-shared-deployment.ts
@@ -38,6 +38,10 @@ const SMOKE_ASSISTANT_STREAM_TIMEOUT_MS: Partial<Record<SmokeAssistantId, number
   // The planning graph intentionally performs two model calls: one to create
   // structured plan state, then one to execute the plan and answer.
   planning: 90000,
+  // UI graph assistants can include extra model/tool work before the first AI
+  // stream event, and CI has observed them occasionally crossing 30s.
+  'c-generative-ui': 90000,
+  'c-a2ui': 90000,
 };
 
 export function getSmokeAssistantStreamTimeoutMs(assistantId: SmokeAssistantId) {


### PR DESCRIPTION
## Summary
- give UI-heavy shared-backend smoke assistants the same 90s stream budget as the planning graph
- move Playwright browser installation after the shared-backend check so backend failures fail faster
- add workflow and timeout guard coverage

## Verification
- `node node_modules/vitest/vitest.mjs run src/lib/verify-shared-deployment.spec.ts --config vite.config.mts` from `apps/cockpit`
- `node --test scripts/ci-workflow.spec.mjs`
- `ruby -e "require 'psych'; Psych.load_file('.github/workflows/ci.yml'); puts 'ci.yml parses'"`
- `git diff --check`