### PR TITLE
Sidenav button treatment: monochrome alignment with chat-input

### DIFF
--- a/docs/superpowers/plans/2026-05-17-sidenav-button-treatment.md
+++ b/docs/superpowers/plans/2026-05-17-sidenav-button-treatment.md
@@ -1,0 +1,328 @@
+# Sidenav Button Treatment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Pull the sidenav's "New chat" and "New project" buttons into the chat-input monochrome button system so the sidenav and chat surface read as one product.
+
+**Architecture:** CSS-only changes inside @ngaf/chat — two style modules, two new CSS-string unit specs. No template changes, no consumer-API changes.
+
+**Tech Stack:** TypeScript template literals carrying CSS, vitest for CSS-string assertions, Angular 20+ standalone component styles.
+
+**Branch:** `claude/sidenav-button-treatment` (already created off `eb419da9`; spec committed).
+
+**Spec:** `docs/superpowers/specs/2026-05-17-sidenav-button-treatment-design.md`
+
+---
+
+## File map
+
+| File | Change |
+|---|---|
+| `libs/chat/src/lib/styles/chat-sidenav.styles.ts` | Update both `.chat-sidenav__action--new` rule blocks for monochrome fill + new padding |
+| `libs/chat/src/lib/styles/chat-project-list.styles.ts` | Update `.chat-project-list__new` for solid surface-alt fill, no border, new padding |
+| `libs/chat/src/lib/styles/chat-sidenav.styles.spec.ts` | NEW — assert the new CSS values |
+| `libs/chat/src/lib/styles/chat-project-list.styles.spec.ts` | NEW — assert the new CSS values |
+| `libs/chat/package.json` + 6 sibling libs | Bump 0.0.36 → 0.0.37 (uniform publishable release group) |
+
+---
+
+## Task 1: Restyle New chat as the text-color CTA pill
+
+**Files:**
+- Modify: `libs/chat/src/lib/styles/chat-sidenav.styles.ts:102-122, 178-189`
+- Create: `libs/chat/src/lib/styles/chat-sidenav.styles.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `libs/chat/src/lib/styles/chat-sidenav.styles.spec.ts` with:
+
+```ts
+// SPDX-License-Identifier: MIT
+import { describe, it, expect } from 'vitest';
+import { CHAT_SIDENAV_STYLES } from './chat-sidenav.styles';
+
+describe('CHAT_SIDENAV_STYLES — New chat button', () => {
+  const normalized = CHAT_SIDENAV_STYLES.replace(/\s+/g, ' ');
+
+  it('uses --ngaf-chat-text as the late-cascade fill (monochrome CTA, not brand-primary)', () => {
+    expect(normalized).toMatch(
+      /\.chat-sidenav__action\.chat-sidenav__action--new\s*\{[^}]*background:\s*var\(--ngaf-chat-text\)\s*;/,
+    );
+  });
+
+  it('uses --ngaf-chat-bg as the late-cascade text color (inverse for contrast)', () => {
+    expect(normalized).toMatch(
+      /\.chat-sidenav__action\.chat-sidenav__action--new\s*\{[^}]*color:\s*var\(--ngaf-chat-bg\)\s*;/,
+    );
+  });
+
+  it('uses 12px / 18px padding for a slightly larger CTA presence', () => {
+    expect(normalized).toMatch(
+      /\.chat-sidenav__action\.chat-sidenav__action--new\s*\{[^}]*padding:\s*12px\s+18px\s*;/,
+    );
+  });
+
+  it('uses brightness(0.92) on hover (subtle darken on the light fill)', () => {
+    expect(normalized).toMatch(
+      /\.chat-sidenav__action\.chat-sidenav__action--new:hover\s*\{[^}]*filter:\s*brightness\(0\.92\)\s*;/,
+    );
+  });
+
+  it('keeps the primary-color focus ring (a11y affordance, not chrome)', () => {
+    expect(normalized).toMatch(
+      /\.chat-sidenav__action--new:focus-visible\s*\{[^}]*outline:\s*2px\s+solid\s+var\(--ngaf-chat-primary\)\s*;/,
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm nx test chat -- --runTestsByPath libs/chat/src/lib/styles/chat-sidenav.styles.spec.ts`
+Expected: FAIL — current values are `var(--ngaf-chat-primary)` fill, `10px 16px` padding, `brightness(1.1)` hover.
+
+- [ ] **Step 3: Update the early `.chat-sidenav__action--new` block**
+
+In `libs/chat/src/lib/styles/chat-sidenav.styles.ts`, replace the block at lines 102-122:
+
+```css
+  .chat-sidenav__action--new {
+    background: var(--ngaf-chat-primary);
+    color: var(--ngaf-chat-on-primary);
+    border: 0;
+    padding: 10px 16px;
+    border-radius: 9999px;
+    font-size: 13px;
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    width: 100%;
+  }
+  .chat-sidenav__action--new:hover {
+    filter: brightness(1.1);
+  }
+  .chat-sidenav__action--new:focus-visible {
+    outline: 2px solid var(--ngaf-chat-primary);
+    outline-offset: 2px;
+  }
+```
+
+with (note: fill + text color removed from this block; they're set by the late-cascade block below):
+
+```css
+  .chat-sidenav__action--new {
+    /* Geometry only — fill/color set by the late-cascade
+       .chat-sidenav__action.chat-sidenav__action--new block. */
+    border: 0;
+    padding: 12px 18px;
+    border-radius: 9999px;
+    font-size: 13px;
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    width: 100%;
+  }
+  .chat-sidenav__action--new:focus-visible {
+    outline: 2px solid var(--ngaf-chat-primary);
+    outline-offset: 2px;
+  }
+```
+
+- [ ] **Step 4: Update the late-cascade `.chat-sidenav__action.chat-sidenav__action--new` block**
+
+In the same file, replace the block at lines 178-189:
+
+```css
+  .chat-sidenav__action.chat-sidenav__action--new {
+    background: var(--ngaf-chat-primary);
+    color: var(--ngaf-chat-on-primary);
+    border-radius: 9999px;
+    padding: 10px 16px;
+    font-weight: 600;
+    font-size: 13px;
+  }
+  .chat-sidenav__action.chat-sidenav__action--new:hover {
+    background: var(--ngaf-chat-primary);
+    filter: brightness(1.1);
+  }
+```
+
+with:
+
+```css
+  .chat-sidenav__action.chat-sidenav__action--new {
+    background: var(--ngaf-chat-text);
+    color: var(--ngaf-chat-bg);
+    border-radius: 9999px;
+    padding: 12px 18px;
+    font-weight: 600;
+    font-size: 13px;
+  }
+  .chat-sidenav__action.chat-sidenav__action--new:hover {
+    background: var(--ngaf-chat-text);
+    filter: brightness(0.92);
+  }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pnpm nx test chat -- --runTestsByPath libs/chat/src/lib/styles/chat-sidenav.styles.spec.ts`
+Expected: all 5 PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add libs/chat/src/lib/styles/chat-sidenav.styles.ts \
+        libs/chat/src/lib/styles/chat-sidenav.styles.spec.ts
+git commit -m "feat(chat): restyle New chat as monochrome text-color CTA"
+```
+
+---
+
+## Task 2: Restyle New project as a borderless surface-alt pill
+
+**Files:**
+- Modify: `libs/chat/src/lib/styles/chat-project-list.styles.ts:77-93`
+- Create: `libs/chat/src/lib/styles/chat-project-list.styles.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `libs/chat/src/lib/styles/chat-project-list.styles.spec.ts`:
+
+```ts
+// SPDX-License-Identifier: MIT
+import { describe, it, expect } from 'vitest';
+import { CHAT_PROJECT_LIST_STYLES } from './chat-project-list.styles';
+
+describe('CHAT_PROJECT_LIST_STYLES — New project button', () => {
+  const normalized = CHAT_PROJECT_LIST_STYLES.replace(/\s+/g, ' ');
+
+  it('uses --ngaf-chat-surface-alt fill (solid secondary, not outlined)', () => {
+    expect(normalized).toMatch(
+      /\.chat-project-list__new\s*\{[^}]*background:\s*var\(--ngaf-chat-surface-alt\)\s*;/,
+    );
+  });
+
+  it('uses --ngaf-chat-text color (full strength, not muted)', () => {
+    expect(normalized).toMatch(
+      /\.chat-project-list__new\s*\{[^}]*color:\s*var\(--ngaf-chat-text\)\s*;/,
+    );
+  });
+
+  it('removes the separator border', () => {
+    expect(normalized).toMatch(
+      /\.chat-project-list__new\s*\{[^}]*border:\s*0\s*;/,
+    );
+  });
+
+  it('uses 10px / 16px padding for more presence', () => {
+    expect(normalized).toMatch(
+      /\.chat-project-list__new\s*\{[^}]*padding:\s*10px\s+16px\s*;/,
+    );
+  });
+
+  it('lifts hover via color-mix on top of surface-alt', () => {
+    expect(normalized).toMatch(
+      /\.chat-project-list__new:hover\s*\{[^}]*background:\s*color-mix\(in srgb,\s*var\(--ngaf-chat-text\)\s*8%,\s*var\(--ngaf-chat-surface-alt\)\)\s*;/,
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm nx test chat -- --runTestsByPath libs/chat/src/lib/styles/chat-project-list.styles.spec.ts`
+Expected: FAIL — current values are `var(--ngaf-chat-surface)` fill, `1px solid var(--ngaf-chat-separator)` border, `8px 14px` padding.
+
+- [ ] **Step 3: Update `.chat-project-list__new`**
+
+In `libs/chat/src/lib/styles/chat-project-list.styles.ts`, replace lines 77-93:
+
+```css
+  .chat-project-list__new {
+    background: var(--ngaf-chat-surface);
+    color: var(--ngaf-chat-text-muted);
+    border: 1px solid var(--ngaf-chat-separator);
+    padding: 8px 14px;
+    border-radius: 9999px;
+    font-size: 12px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    width: 100%;
+  }
+  .chat-project-list__new:hover {
+    background: var(--ngaf-chat-surface-alt);
+    color: var(--ngaf-chat-text);
+  }
+```
+
+with:
+
+```css
+  .chat-project-list__new {
+    background: var(--ngaf-chat-surface-alt);
+    color: var(--ngaf-chat-text);
+    border: 0;
+    padding: 10px 16px;
+    border-radius: 9999px;
+    font-size: 12px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    width: 100%;
+  }
+  .chat-project-list__new:hover {
+    background: color-mix(in srgb, var(--ngaf-chat-text) 8%, var(--ngaf-chat-surface-alt));
+    color: var(--ngaf-chat-text);
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm nx test chat -- --runTestsByPath libs/chat/src/lib/styles/chat-project-list.styles.spec.ts`
+Expected: all 5 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add libs/chat/src/lib/styles/chat-project-list.styles.ts \
+        libs/chat/src/lib/styles/chat-project-list.styles.spec.ts
+git commit -m "feat(chat): restyle New project as borderless surface-alt pill"
+```
+
+---
+
+## Task 3: Bump publishable libs to 0.0.37
+
+**Files:**
+- Modify: `libs/{a2ui,ag-ui,chat,langgraph,licensing,render,telemetry}/package.json` (version field, all 7)
+
+- [ ] **Step 1: Bump all seven publishable libs**
+
+For each of `libs/a2ui/package.json`, `libs/ag-ui/package.json`, `libs/chat/package.json`, `libs/langgraph/package.json`, `libs/licensing/package.json`, `libs/render/package.json`, `libs/telemetry/package.json`, change `"version": "0.0.36"` → `"version": "0.0.37"`.
+
+- [ ] **Step 2: Verify all seven match**
+
+Run: `grep '"version"' libs/a2ui/package.json libs/ag-ui/package.json libs/chat/package.json libs/langgraph/package.json libs/licensing/package.json libs/render/package.json libs/telemetry/package.json`
+Expected: all seven show `"version": "0.0.37"`.
+
+- [ ] **Step 3: Run full chat lib test suite**
+
+Run: `pnpm nx test chat`
+Expected: all pass, including the two new style specs.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add libs/a2ui/package.json libs/ag-ui/package.json libs/chat/package.json \
+        libs/langgraph/package.json libs/licensing/package.json \
+        libs/render/package.json libs/telemetry/package.json
+git commit -m "chore(release): bump publishable libs to 0.0.37"
+```

--- a/docs/superpowers/specs/2026-05-17-sidenav-button-treatment-design.md
+++ b/docs/superpowers/specs/2026-05-17-sidenav-button-treatment-design.md
@@ -1,0 +1,151 @@
+# Sidenav button treatment — Design
+
+**Status:** Approved
+**Date:** 2026-05-17
+**Goal:** Pull the sidenav's two buttons — "New chat" (primary CTA) and "New project" (secondary action) — into the chat-input button system so the sidenav reads as part of the same product surface as the chat.
+
+## Why now
+
+Final sub-project (C) of the demo UX polish pass. Sub-project A (sidenav layout) shipped in PR #399 and B (chat-surface polish) shipped in PR #409. With those two in place, the remaining mismatch is visual: the sidenav uses a brand-primary purple CTA and a thin-bordered secondary pill, while the chat-input area is a monochrome high-contrast system anchored on `--ngaf-chat-text` and `--ngaf-chat-surface-alt`. The two surfaces sit next to each other and shouldn't look like different products.
+
+## Decisions locked during brainstorming
+
+| Button | Current | Target |
+|---|---|---|
+| New chat (`.chat-sidenav__action--new`) | `--ngaf-chat-primary` fill, `--ngaf-chat-on-primary` text, padding `10px 16px` | `--ngaf-chat-text` fill, `--ngaf-chat-bg` text, padding `12px 18px` |
+| New project (`.chat-project-list__new`) | `--ngaf-chat-surface` fill, 1px `--ngaf-chat-separator` border, `--ngaf-chat-text-muted` text, padding `8px 14px` | `--ngaf-chat-surface-alt` fill, **no border**, `--ngaf-chat-text` text, padding `10px 16px` |
+| Anchor button | Chat-input send (`.chat-input__send`): solid `--ngaf-chat-text` fill on `--ngaf-chat-bg`, monochrome, no brand color | unchanged — this is the reference |
+
+The shared design rule: **buttons in chrome around the chat are monochrome, scaled by importance (text-color fill for the biggest CTA, surface-alt fill for secondary, transparent for tertiary).** No brand-primary color in button fills inside this surface.
+
+## Architecture
+
+### New chat — `.chat-sidenav__action--new`
+
+In `libs/chat/src/lib/styles/chat-sidenav.styles.ts`, both the early `.chat-sidenav__action--new` block and the later-cascade `.chat-sidenav__action.chat-sidenav__action--new` block carry the primary-color fill today. Both must change. The later block is the effective one (defined after the generic `.chat-sidenav__action` rule with equal specificity, so it wins the cascade) — that's where the new fill lives. The earlier block stays only to anchor the `:host([data-mode="collapsed"]) .chat-sidenav__action--new` override (which uses higher specificity and continues to work).
+
+Specifically:
+- `background: var(--ngaf-chat-text)` — same fill as the input send button
+- `color: var(--ngaf-chat-bg)` — inverse for contrast
+- `padding: 12px 18px` — bumped from `10px 16px` for a bit more presence
+- `font-weight: 600` — unchanged
+- `border-radius: 9999px` — pill, unchanged
+- Hover: `filter: brightness(0.92)` (subtle darken on light fill instead of brighten) — replacing the current `brightness(1.1)` which was tuned for the brand color
+- Focus: `outline: 2px solid var(--ngaf-chat-primary); outline-offset: 2px` — unchanged (the primary color stays for focus rings; this is an a11y affordance, not chrome)
+- Collapsed mode (32×32 square at 10px radius): inherits the new fill via cascade. No change needed beyond removing the duplicate `background: var(--ngaf-chat-primary)` line in the earlier block.
+
+### New project — `.chat-project-list__new`
+
+In `libs/chat/src/lib/styles/chat-project-list.styles.ts`:
+- `background: var(--ngaf-chat-surface-alt)` — solid fill, no longer outlined
+- `color: var(--ngaf-chat-text)` — full strength (was muted)
+- `border: 0` — removed
+- `padding: 10px 16px` — bumped from `8px 14px`
+- `font-size: 12px` — unchanged
+- `border-radius: 9999px` — pill, unchanged
+- Hover: `background: color-mix(in srgb, var(--ngaf-chat-text) 8%, var(--ngaf-chat-surface-alt))` — small lift on top of surface-alt (the existing rule's "surface-alt as hover from surface" no longer makes sense once the default is surface-alt)
+
+## Files touched
+
+### Library
+- `libs/chat/src/lib/styles/chat-sidenav.styles.ts` — update both `.chat-sidenav__action--new` rules (the early block: remove redundant `background`/`color`; the late-cascade block: new fill, color, padding, hover)
+- `libs/chat/src/lib/styles/chat-project-list.styles.ts` — `.chat-project-list__new`: new fill, color, border:0, padding, hover
+
+### Tests
+- `libs/chat/src/lib/styles/chat-sidenav.styles.spec.ts` — NEW: CSS-string assertions on the late-cascade `.chat-sidenav__action.chat-sidenav__action--new` rule (background, color, padding)
+- `libs/chat/src/lib/styles/chat-project-list.styles.spec.ts` — NEW: CSS-string assertions on `.chat-project-list__new` (background, border:0, padding)
+
+### Out of scope
+- Touching `.chat-input__send` (it's the anchor — leave it alone)
+- Focus ring color (still `--ngaf-chat-primary` — a11y, not chrome)
+- Collapsed-mode New chat geometry (still 32×32 square at 10px radius, just with the new fill)
+- The generic `.chat-sidenav__action` baseline (Search, etc. — they stay as transparent hover-only items, which already matches the "tertiary" tier of the monochrome system)
+- Other buttons in the sidenav header/footer slots (consumer-controlled)
+
+## Visual treatment
+
+### chat-sidenav.styles.ts (relevant rules after the change)
+
+```css
+.chat-sidenav__action--new {
+  /* Geometry only — the early block exists to anchor the collapsed-mode
+     :host overrides below. Fill + text color are set by the late-cascade
+     .chat-sidenav__action.chat-sidenav__action--new block. */
+  border: 0;
+  padding: 12px 18px;
+  border-radius: 9999px;
+  font-size: 13px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  width: 100%;
+}
+.chat-sidenav__action--new:focus-visible {
+  outline: 2px solid var(--ngaf-chat-primary);
+  outline-offset: 2px;
+}
+:host([data-mode="collapsed"]) .chat-sidenav__action--new {
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border-radius: 10px;
+  justify-content: center;
+}
+
+/* Late-cascade — wins over the generic .chat-sidenav__action below. */
+.chat-sidenav__action.chat-sidenav__action--new {
+  background: var(--ngaf-chat-text);
+  color: var(--ngaf-chat-bg);
+  border-radius: 9999px;
+  padding: 12px 18px;
+  font-weight: 600;
+  font-size: 13px;
+}
+.chat-sidenav__action.chat-sidenav__action--new:hover {
+  background: var(--ngaf-chat-text);
+  filter: brightness(0.92);
+}
+```
+
+### chat-project-list.styles.ts (relevant rule after the change)
+
+```css
+.chat-project-list__new {
+  background: var(--ngaf-chat-surface-alt);
+  color: var(--ngaf-chat-text);
+  border: 0;
+  padding: 10px 16px;
+  border-radius: 9999px;
+  font-size: 12px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  width: 100%;
+}
+.chat-project-list__new:hover {
+  background: color-mix(in srgb, var(--ngaf-chat-text) 8%, var(--ngaf-chat-surface-alt));
+  color: var(--ngaf-chat-text);
+}
+```
+
+## Testing
+
+### Unit
+- `chat-sidenav.styles.spec.ts` — assert the late-cascade rule contains `background: var(--ngaf-chat-text)`, `color: var(--ngaf-chat-bg)`, and `padding: 12px 18px`. Use whitespace-normalized regex matching, same pattern as `chat-message-actions.styles.spec.ts` from sub-project B.
+- `chat-project-list.styles.spec.ts` — assert `.chat-project-list__new` contains `background: var(--ngaf-chat-surface-alt)`, `border: 0`, and `padding: 10px 16px`.
+
+### Manual smoke
+- Local demo: `/embed` → expanded sidenav shows the new monochrome treatment; New chat reads as the main CTA, New project as a secondary fill, both clearly part of the same system as the chat input below.
+- Collapsed-mode New chat is still a 32×32 icon-only square with the new fill.
+- Focus ring on both buttons still visible (primary-color outline).
+- Dark theme + light theme both look right (both fills resolve via CSS variables).
+
+## References
+
+- Sub-project A: `docs/superpowers/specs/2026-05-17-sidenav-polish-design.md`
+- Sub-project B: `docs/superpowers/specs/2026-05-17-chat-surface-polish-design.md`
+- Anchor button styles: `libs/chat/src/lib/styles/chat-input.styles.ts` (`.chat-input__send`)
+- Visual mockup: `.superpowers/brainstorm/57568-1779038013/content/buttons.html`

--- a/libs/a2ui/package.json
+++ b/libs/a2ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/a2ui",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/ag-ui/package.json
+++ b/libs/ag-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/ag-ui",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "peerDependencies": {
     "@ngaf/chat": "*",
     "@ngaf/licensing": "*",

--- a/libs/chat/package.json
+++ b/libs/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/chat",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "exports": {
     ".": {
       "types": "./index.d.ts",

--- a/libs/chat/src/lib/compositions/chat-sidenav/chat-sidenav.component.spec.ts
+++ b/libs/chat/src/lib/compositions/chat-sidenav/chat-sidenav.component.spec.ts
@@ -329,11 +329,11 @@ describe('ChatSidenavComponent — footer slots', () => {
 });
 
 describe('ChatSidenavComponent — New chat primary CTA', () => {
-  it('renders the new-chat button with a primary-pill styling token', () => {
+  it('renders the new-chat button with a monochrome text-color CTA token', () => {
     // Styles array is the second member of @Component decorator metadata.
     const styles = (ChatSidenavComponent as unknown as { ɵcmp: { styles: string[] } }).ɵcmp.styles.join('\n');
-    // Primary pill family: matches chat-input send button.
-    expect(styles).toMatch(/\.chat-sidenav__action--new[^{]*\{[^}]*background:\s*var\(--ngaf-chat-primary/);
+    // Monochrome CTA: late-cascade block uses text/bg for contrast.
+    expect(styles).toMatch(/\.chat-sidenav__action\.chat-sidenav__action--new[^{]*\{[^}]*background:\s*var\(--ngaf-chat-text/);
     expect(styles).toMatch(/\.chat-sidenav__action--new[^{]*\{[^}]*border-radius:\s*9999px/);
   });
 });

--- a/libs/chat/src/lib/primitives/chat-project-list/chat-project-list.component.spec.ts
+++ b/libs/chat/src/lib/primitives/chat-project-list/chat-project-list.component.spec.ts
@@ -153,10 +153,10 @@ describe('ChatProjectListComponent', () => {
 });
 
 describe('ChatProjectListComponent — New project secondary pill', () => {
-  it('renders the new-project button with secondary-pill styling', () => {
+  it('renders the new-project button with borderless surface-alt pill styling', () => {
     const styles = (ChatProjectListComponent as unknown as { ɵcmp: { styles: string[] } }).ɵcmp.styles.join('\n');
-    expect(styles).toMatch(/\.chat-project-list__new[^{]*\{[^}]*background:\s*var\(--ngaf-chat-surface/);
+    expect(styles).toMatch(/\.chat-project-list__new[^{]*\{[^}]*background:\s*var\(--ngaf-chat-surface-alt/);
     expect(styles).toMatch(/\.chat-project-list__new[^{]*\{[^}]*border-radius:\s*9999px/);
-    expect(styles).toMatch(/\.chat-project-list__new[^{]*\{[^}]*border:\s*1px solid var\(--ngaf-chat-separator/);
+    expect(styles).toMatch(/\.chat-project-list__new[^{]*\{[^}]*border:\s*0/);
   });
 });

--- a/libs/chat/src/lib/styles/chat-project-list.styles.spec.ts
+++ b/libs/chat/src/lib/styles/chat-project-list.styles.spec.ts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+import { describe, it, expect } from 'vitest';
+import { CHAT_PROJECT_LIST_STYLES } from './chat-project-list.styles';
+
+describe('CHAT_PROJECT_LIST_STYLES — New project button', () => {
+  const normalized = CHAT_PROJECT_LIST_STYLES.replace(/\s+/g, ' ');
+
+  it('uses --ngaf-chat-surface-alt fill (solid secondary, not outlined)', () => {
+    expect(normalized).toMatch(
+      /\.chat-project-list__new\s*\{[^}]*background:\s*var\(--ngaf-chat-surface-alt\)\s*;/,
+    );
+  });
+
+  it('uses --ngaf-chat-text color (full strength, not muted)', () => {
+    expect(normalized).toMatch(
+      /\.chat-project-list__new\s*\{[^}]*color:\s*var\(--ngaf-chat-text\)\s*;/,
+    );
+  });
+
+  it('removes the separator border', () => {
+    expect(normalized).toMatch(
+      /\.chat-project-list__new\s*\{[^}]*border:\s*0\s*;/,
+    );
+  });
+
+  it('uses 10px / 16px padding for more presence', () => {
+    expect(normalized).toMatch(
+      /\.chat-project-list__new\s*\{[^}]*padding:\s*10px\s+16px\s*;/,
+    );
+  });
+
+  it('lifts hover via color-mix on top of surface-alt', () => {
+    expect(normalized).toMatch(
+      /\.chat-project-list__new:hover\s*\{[^}]*background:\s*color-mix\(in srgb,\s*var\(--ngaf-chat-text\)\s*8%,\s*var\(--ngaf-chat-surface-alt\)\)\s*;/,
+    );
+  });
+});

--- a/libs/chat/src/lib/styles/chat-project-list.styles.ts
+++ b/libs/chat/src/lib/styles/chat-project-list.styles.ts
@@ -75,10 +75,10 @@ export const CHAT_PROJECT_LIST_STYLES = `
     box-sizing: border-box;
   }
   .chat-project-list__new {
-    background: var(--ngaf-chat-surface);
-    color: var(--ngaf-chat-text-muted);
-    border: 1px solid var(--ngaf-chat-separator);
-    padding: 8px 14px;
+    background: var(--ngaf-chat-surface-alt);
+    color: var(--ngaf-chat-text);
+    border: 0;
+    padding: 10px 16px;
     border-radius: 9999px;
     font-size: 12px;
     display: flex;
@@ -88,7 +88,7 @@ export const CHAT_PROJECT_LIST_STYLES = `
     width: 100%;
   }
   .chat-project-list__new:hover {
-    background: var(--ngaf-chat-surface-alt);
+    background: color-mix(in srgb, var(--ngaf-chat-text) 8%, var(--ngaf-chat-surface-alt));
     color: var(--ngaf-chat-text);
   }
 `;

--- a/libs/chat/src/lib/styles/chat-sidenav.styles.spec.ts
+++ b/libs/chat/src/lib/styles/chat-sidenav.styles.spec.ts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+import { describe, it, expect } from 'vitest';
+import { CHAT_SIDENAV_STYLES } from './chat-sidenav.styles';
+
+describe('CHAT_SIDENAV_STYLES — New chat button', () => {
+  const normalized = CHAT_SIDENAV_STYLES.replace(/\s+/g, ' ');
+
+  it('uses --ngaf-chat-text as the late-cascade fill (monochrome CTA, not brand-primary)', () => {
+    expect(normalized).toMatch(
+      /\.chat-sidenav__action\.chat-sidenav__action--new\s*\{[^}]*background:\s*var\(--ngaf-chat-text\)\s*;/,
+    );
+  });
+
+  it('uses --ngaf-chat-bg as the late-cascade text color (inverse for contrast)', () => {
+    expect(normalized).toMatch(
+      /\.chat-sidenav__action\.chat-sidenav__action--new\s*\{[^}]*color:\s*var\(--ngaf-chat-bg\)\s*;/,
+    );
+  });
+
+  it('uses 12px / 18px padding for a slightly larger CTA presence', () => {
+    expect(normalized).toMatch(
+      /\.chat-sidenav__action\.chat-sidenav__action--new\s*\{[^}]*padding:\s*12px\s+18px\s*;/,
+    );
+  });
+
+  it('uses brightness(0.92) on hover (subtle darken on the light fill)', () => {
+    expect(normalized).toMatch(
+      /\.chat-sidenav__action\.chat-sidenav__action--new:hover\s*\{[^}]*filter:\s*brightness\(0\.92\)\s*;/,
+    );
+  });
+
+  it('keeps the primary-color focus ring (a11y affordance, not chrome)', () => {
+    expect(normalized).toMatch(
+      /\.chat-sidenav__action--new:focus-visible\s*\{[^}]*outline:\s*2px\s+solid\s+var\(--ngaf-chat-primary\)\s*;/,
+    );
+  });
+});

--- a/libs/chat/src/lib/styles/chat-sidenav.styles.ts
+++ b/libs/chat/src/lib/styles/chat-sidenav.styles.ts
@@ -100,10 +100,10 @@ export const CHAT_SIDENAV_STYLES = `
     display: none;
   }
   .chat-sidenav__action--new {
-    background: var(--ngaf-chat-primary);
-    color: var(--ngaf-chat-on-primary);
+    /* Geometry only — fill/color set by the late-cascade
+       .chat-sidenav__action.chat-sidenav__action--new block. */
     border: 0;
-    padding: 10px 16px;
+    padding: 12px 18px;
     border-radius: 9999px;
     font-size: 13px;
     font-weight: 600;
@@ -112,9 +112,6 @@ export const CHAT_SIDENAV_STYLES = `
     gap: 8px;
     cursor: pointer;
     width: 100%;
-  }
-  .chat-sidenav__action--new:hover {
-    filter: brightness(1.1);
   }
   .chat-sidenav__action--new:focus-visible {
     outline: 2px solid var(--ngaf-chat-primary);
@@ -176,16 +173,16 @@ export const CHAT_SIDENAV_STYLES = `
      collapsed-mode overrides (which are :host-prefixed, higher
      specificity, so they still apply). */
   .chat-sidenav__action.chat-sidenav__action--new {
-    background: var(--ngaf-chat-primary);
-    color: var(--ngaf-chat-on-primary);
+    background: var(--ngaf-chat-text);
+    color: var(--ngaf-chat-bg);
     border-radius: 9999px;
-    padding: 10px 16px;
+    padding: 12px 18px;
     font-weight: 600;
     font-size: 13px;
   }
   .chat-sidenav__action.chat-sidenav__action--new:hover {
-    background: var(--ngaf-chat-primary);
-    filter: brightness(1.1);
+    background: var(--ngaf-chat-text);
+    filter: brightness(0.92);
   }
   .chat-sidenav__action-icon {
     width: 16px;

--- a/libs/langgraph/package.json
+++ b/libs/langgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/langgraph",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "peerDependencies": {
     "@ngaf/chat": "*",
     "@ngaf/licensing": "*",

--- a/libs/licensing/package.json
+++ b/libs/licensing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/licensing",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/render/package.json
+++ b/libs/render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/render",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "peerDependencies": {
     "@angular/core": "^20.0.0 || ^21.0.0",
     "@angular/common": "^20.0.0 || ^21.0.0",

--- a/libs/telemetry/package.json
+++ b/libs/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/telemetry",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "license": "MIT",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
- New chat becomes a text-color pill (\`--ngaf-chat-text\` fill, \`--ngaf-chat-bg\` text, 12/18 padding) — mirrors the chat-input send button.
- New project becomes a borderless surface-alt pill (\`--ngaf-chat-surface-alt\` fill, full-strength text, 10/16 padding).
- Focus rings stay primary-color for a11y.
- @ngaf/* 0.0.37 (uniform publishable release group).

## Test plan
- [x] \`pnpm nx test chat\` — 765 tests pass (includes 2 new style specs + 2 component-spec updates)
- [x] Local chrome-mcp verification: both buttons match spec values on \`localhost:4200\` (collapsed + expanded modes)
- [ ] Canonical demo redeploys; both buttons appear in the new monochrome treatment on demo.cacheplane.ai

Spec: \`docs/superpowers/specs/2026-05-17-sidenav-button-treatment-design.md\`
Plan: \`docs/superpowers/plans/2026-05-17-sidenav-button-treatment.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)