### PR TITLE
Fix website lint on main

### DIFF
--- a/apps/website/src/components/blog/AuthorByline.tsx
+++ b/apps/website/src/components/blog/AuthorByline.tsx
@@ -12,7 +12,6 @@ export function AuthorByline({ author }: { author: Author }) {
       }}
     >
       {author.avatar ? (
-        // eslint-disable-next-line @next/next/no-img-element
         <img
           src={author.avatar}
           alt={`${author.name} avatar`}
@@ -23,7 +22,9 @@ export function AuthorByline({ author }: { author: Author }) {
       ) : null}
       <div>
         <span style={{ fontWeight: 600 }}>{author.name}</span>
-        {author.role ? <span style={{ opacity: 0.7 }}> · {author.role}</span> : null}
+        {author.role ? (
+          <span style={{ opacity: 0.7 }}> · {author.role}</span>
+        ) : null}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- remove a stale `@next/next/no-img-element` eslint-disable comment from the blog author byline
- keep the component behavior unchanged; the repo does not configure that Next ESLint rule, so the disable comment itself broke lint

## Verification
- `PATH=/tmp/codex-node-v24/bin:$PATH npx nx lint website`
- `PATH=/tmp/codex-node-v24/bin:$PATH npx nx build website`
- `PATH=/tmp/codex-node-v24/bin:$PATH npx prettier --check apps/website/src/components/blog/AuthorByline.tsx && git diff --check`
