### PR TITLE
Polish pass 3: drop left-accent bar, restyle Archived as nav item

### DIFF
--- a/libs/a2ui/package.json
+++ b/libs/a2ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/a2ui",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/ag-ui/package.json
+++ b/libs/ag-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/ag-ui",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "peerDependencies": {
     "@ngaf/chat": "*",
     "@ngaf/licensing": "*",

--- a/libs/chat/package.json
+++ b/libs/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/chat",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "exports": {
     ".": {
       "types": "./index.d.ts",

--- a/libs/chat/src/lib/styles/chat-project-list.styles.spec.ts
+++ b/libs/chat/src/lib/styles/chat-project-list.styles.spec.ts
@@ -41,3 +41,12 @@ describe('CHAT_PROJECT_LIST_STYLES — New project button', () => {
     );
   });
 });
+
+describe('CHAT_PROJECT_LIST_STYLES — active item', () => {
+  const normalized = CHAT_PROJECT_LIST_STYLES.replace(/\s+/g, ' ');
+  it('does NOT use a left-accent box-shadow for the active item (symmetric bg-only indication)', () => {
+    expect(normalized).not.toMatch(
+      /\.chat-project-list__item\[data-active="true"\]\s*\{[^}]*box-shadow:\s*inset\s+2px\s+0\s+0/,
+    );
+  });
+});

--- a/libs/chat/src/lib/styles/chat-project-list.styles.ts
+++ b/libs/chat/src/lib/styles/chat-project-list.styles.ts
@@ -31,7 +31,6 @@ export const CHAT_PROJECT_LIST_STYLES = `
   .chat-project-list__item[data-active="true"] {
     background: var(--ngaf-chat-surface-alt);
     font-weight: 500;
-    box-shadow: inset 2px 0 0 var(--a2ui-primary, var(--ngaf-chat-primary));
   }
   .chat-project-list__kebab {
     flex-shrink: 0;

--- a/libs/chat/src/lib/styles/chat-sidenav.styles.spec.ts
+++ b/libs/chat/src/lib/styles/chat-sidenav.styles.spec.ts
@@ -41,3 +41,43 @@ describe('CHAT_SIDENAV_STYLES — New chat button', () => {
     );
   });
 });
+
+describe('CHAT_SIDENAV_STYLES — Archived disclosure', () => {
+  const normalized = CHAT_SIDENAV_STYLES.replace(/\s+/g, ' ');
+
+  it('uses sidenav-nav-item padding (8px 12px) — not the small 8px 12px 4px label padding', () => {
+    expect(normalized).toMatch(
+      /\.chat-sidenav__archived-heading\s*\{[^}]*padding:\s*8px\s+12px\s*;/,
+    );
+  });
+
+  it('uses 8px border-radius so it reads as a clickable nav item', () => {
+    expect(normalized).toMatch(
+      /\.chat-sidenav__archived-heading\s*\{[^}]*border-radius:\s*8px\s*;/,
+    );
+  });
+
+  it('uses --ngaf-chat-text color (full strength, not muted)', () => {
+    expect(normalized).toMatch(
+      /\.chat-sidenav__archived-heading\s*\{[^}]*color:\s*var\(--ngaf-chat-text\)\s*;/,
+    );
+  });
+
+  it('uses sm font-size — not the 11px label size', () => {
+    expect(normalized).toMatch(
+      /\.chat-sidenav__archived-heading\s*\{[^}]*font-size:\s*var\(--ngaf-chat-font-size-sm\)\s*;/,
+    );
+  });
+
+  it('no longer uppercases the label', () => {
+    expect(normalized).not.toMatch(
+      /\.chat-sidenav__archived-heading\s*\{[^}]*text-transform:\s*uppercase/,
+    );
+  });
+
+  it('hovers to surface-alt (matching .chat-sidenav__action)', () => {
+    expect(normalized).toMatch(
+      /\.chat-sidenav__archived-heading:hover\s*\{[^}]*background:\s*var\(--ngaf-chat-surface-alt\)/,
+    );
+  });
+});

--- a/libs/chat/src/lib/styles/chat-sidenav.styles.ts
+++ b/libs/chat/src/lib/styles/chat-sidenav.styles.ts
@@ -273,20 +273,22 @@ export const CHAT_SIDENAV_STYLES = `
   .chat-sidenav__archived-heading {
     display: flex;
     align-items: center;
-    gap: 6px;
+    gap: 8px;
     width: 100%;
-    padding: 8px 12px 4px;
+    padding: 8px 12px;
     border: 0;
+    border-radius: 8px;
     background: transparent;
-    color: var(--ngaf-chat-text-muted);
+    color: var(--ngaf-chat-text);
     font: inherit;
-    font-size: 11px;
-    text-transform: uppercase;
-    letter-spacing: 0.4px;
+    font-size: var(--ngaf-chat-font-size-sm);
     text-align: left;
     cursor: pointer;
   }
-  .chat-sidenav__archived-heading:hover { color: var(--ngaf-chat-text); }
+  .chat-sidenav__archived-heading:hover {
+    background: var(--ngaf-chat-surface-alt);
+    color: var(--ngaf-chat-text);
+  }
   .chat-sidenav__archived-heading:focus-visible {
     outline: 2px solid var(--ngaf-chat-primary);
     outline-offset: 2px;

--- a/libs/chat/src/lib/styles/chat-thread-list.styles.spec.ts
+++ b/libs/chat/src/lib/styles/chat-thread-list.styles.spec.ts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+import { describe, it, expect } from 'vitest';
+import { CHAT_THREAD_LIST_STYLES } from './chat-thread-list.styles';
+
+describe('CHAT_THREAD_LIST_STYLES — active item', () => {
+  const normalized = CHAT_THREAD_LIST_STYLES.replace(/\s+/g, ' ');
+  it('does NOT use a left-accent box-shadow for the active item (symmetric bg-only indication)', () => {
+    expect(normalized).not.toMatch(
+      /\.chat-thread-list__item\[data-active="true"\]\s*\{[^}]*box-shadow:\s*inset\s+2px\s+0\s+0/,
+    );
+  });
+});

--- a/libs/chat/src/lib/styles/chat-thread-list.styles.ts
+++ b/libs/chat/src/lib/styles/chat-thread-list.styles.ts
@@ -23,7 +23,6 @@ export const CHAT_THREAD_LIST_STYLES = `
   .chat-thread-list__item[data-active="true"] {
     background: var(--ngaf-chat-surface-alt);
     font-weight: 500;
-    box-shadow: inset 2px 0 0 var(--a2ui-primary, var(--ngaf-chat-primary));
   }
   .chat-thread-list__item-title {
     overflow: hidden;

--- a/libs/langgraph/package.json
+++ b/libs/langgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/langgraph",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "peerDependencies": {
     "@ngaf/chat": "*",
     "@ngaf/licensing": "*",

--- a/libs/licensing/package.json
+++ b/libs/licensing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/licensing",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/render/package.json
+++ b/libs/render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/render",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "peerDependencies": {
     "@angular/core": "^20.0.0 || ^21.0.0",
     "@angular/common": "^20.0.0 || ^21.0.0",

--- a/libs/telemetry/package.json
+++ b/libs/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngaf/telemetry",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "license": "MIT",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
- Active thread + project list items no longer show the asymmetric left-side accent bar (\`box-shadow: inset 2px 0 0 ...\`). Active state is now indicated only by \`surface-alt\` background + \`font-weight: 500\` — symmetric, calmer.
- "Archived" disclosure restyled from a faded 11px uppercase label to a proper sidenav nav item: \`padding: 8px 12px\`, \`border-radius: 8px\`, \`font-size: 14px\`, full text color, hover lifts to \`surface-alt\` — visually consistent with the Search action.
- Archived thread list uses the same \`<chat-thread-list>\` primitive as Recent so item rendering is pixel-identical.
- @ngaf/* 0.0.39.

## Test plan
- [x] \`pnpm nx test chat\` — 775 tests pass
- [x] \`pnpm nx test examples-chat-angular\` — 17 tests pass
- [x] Local chrome-mcp verify: archived a thread → archived list item computed styles match recent list item exactly (\`match: true\`); active item box-shadow gone; Archived header matches Search nav-item geometry
- [ ] Canonical demo redeploys; both fixes live on demo.cacheplane.ai

🤖 Generated with [Claude Code](https://claude.com/claude-code)