### PR TITLE
feat(cockpit-registry): migrate c-generative-ui to per-cap backend

### DIFF
--- a/apps/cockpit/scripts/capability-registry.ts
+++ b/apps/cockpit/scripts/capability-registry.ts
@@ -43,7 +43,7 @@ export const capabilities: readonly Capability[] = [
   { id: 'c-subagents', product: 'chat', topic: 'subagents', angularProject: 'cockpit-chat-subagents-angular', port: 4505, pythonPort: 5505, pythonDir: 'cockpit/chat/subagents/python', graphName: 'c-subagents' },
   { id: 'c-threads', product: 'chat', topic: 'threads', angularProject: 'cockpit-chat-threads-angular', port: 4506, pythonPort: 5506, pythonDir: 'cockpit/chat/threads/python', graphName: 'c-threads' },
   { id: 'c-timeline', product: 'chat', topic: 'timeline', angularProject: 'cockpit-chat-timeline-angular', port: 4507, pythonPort: 5507, pythonDir: 'cockpit/chat/timeline/python', graphName: 'c-timeline' },
-  { id: 'c-generative-ui', product: 'chat', topic: 'generative-ui', angularProject: 'cockpit-chat-generative-ui-angular', port: 4508, pythonPort: 5508, pythonDir: 'cockpit/langgraph/streaming/python', graphName: 'c-generative-ui' },
+  { id: 'c-generative-ui', product: 'chat', topic: 'generative-ui', angularProject: 'cockpit-chat-generative-ui-angular', port: 4508, pythonPort: 5508, pythonDir: 'cockpit/chat/generative-ui/python', graphName: 'c-generative-ui' },
   { id: 'c-debug', product: 'chat', topic: 'debug', angularProject: 'cockpit-chat-debug-angular', port: 4509, pythonPort: 5509, pythonDir: 'cockpit/chat/debug/python', graphName: 'c-debug' },
   { id: 'c-theming', product: 'chat', topic: 'theming', angularProject: 'cockpit-chat-theming-angular', port: 4510, pythonPort: 5510, pythonDir: 'cockpit/chat/theming/python', graphName: 'c-theming' },
   { id: 'c-a2ui', product: 'chat', topic: 'a2ui', angularProject: 'cockpit-chat-a2ui-angular', port: 4511, pythonPort: 5511, pythonDir: 'cockpit/langgraph/streaming/python', graphName: 'c-a2ui' },

--- a/docs/superpowers/plans/2026-05-18-c-generative-ui-migration.md
+++ b/docs/superpowers/plans/2026-05-18-c-generative-ui-migration.md
@@ -1,0 +1,538 @@
+# c-generative-ui per-cap migration — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Switch `c-generative-ui` from consuming the umbrella `cockpit/langgraph/streaming/python/` to its already-built per-cap standalone backend at `cockpit/chat/generative-ui/python/`, by editing one `pythonDir` value in `apps/cockpit/scripts/capability-registry.ts`.
+
+**Architecture:** Identical to Tier A migration (PR #413): one-line registry edit + heavier verification because the graph is multi-node (router → generate_shell / plan_tools → call_tools → emit_state → respond) and dispatches custom events via `get_stream_writer`. Local-dev-only — production deploy stays on umbrella until the deploy-script extension PR lands.
+
+**Tech Stack:** TypeScript (registry), Python 3.12 + uv (per-cap backend), LangGraph 1.x (`get_stream_writer`, `ToolNode`, `Command`), `langgraph_sdk` HTTP API.
+
+---
+
+## Pre-flight notes (READ FIRST)
+
+**Spec branch:** `claude/c-generative-ui-migration-spec` (commit `75b2fd36`, off origin/main).
+
+**Working tree.** Create the implementation branch off the spec branch:
+
+```bash
+git fetch origin
+git checkout -b claude/c-generative-ui-migration claude/c-generative-ui-migration-spec
+git rebase origin/main
+```
+
+**Pre-flight verified during plan-write (2026-05-18):**
+- `cockpit/chat/generative-ui/python/src/graph.py` uses `get_stream_writer` (lines 107, 136).
+- Fixture constants (`KPI_SNAPSHOT`, `ON_TIME_TREND`, `FLIGHTS_BY_AIRLINE`, `RECENT_DISRUPTIONS`) are byte-identical between per-cap `dashboard_tools.py` and umbrella `aviation_data.py`.
+- Per-cap `langgraph.json` registers exactly `c-generative-ui`.
+- Per-cap `proxy.conf.json` targets `localhost:5508` (matches registry `pythonPort`).
+
+**Hard rules.**
+- One commit per code-modifying task (Task 1 only). All verification tasks (0, 2–7) are no-commit.
+- Never `git add -A` or `git add .` — stage specific paths only.
+- Never push, open PR, or `--amend` (Task 8 = orchestrator).
+- Never skip hooks.
+- STOP and report if ANY verification step fails first-run.
+
+**Shared-checkout chaos.** Parallel agents switch branches on this checkout. After any long-running step, confirm `git branch --show-current` = `claude/c-generative-ui-migration` before continuing.
+
+**Heavy steps.** Task 4 hits real OpenAI for two turns (~30–90s; uses gpt-5 + gpt-5-mini). Task 6 runs 3 existing cockpit e2e suites (~5 min).
+
+---
+
+## File Structure
+
+**Modified:** `apps/cockpit/scripts/capability-registry.ts` — 1 line changed.
+
+**Untouched** (all already correct):
+- `cockpit/chat/generative-ui/python/src/graph.py` (176 lines, multi-node)
+- `cockpit/chat/generative-ui/python/src/dashboard_tools.py` (117 lines, 4 `@tool` functions, inlined fixtures)
+- `cockpit/chat/generative-ui/python/langgraph.json`
+- `cockpit/chat/generative-ui/python/prompts/dashboard.md`
+- `cockpit/chat/generative-ui/angular/proxy.conf.json` (targets 5508)
+- `cockpit/chat/generative-ui/angular/src/environments/environment.development.ts`
+- `cockpit/langgraph/streaming/python/...` (umbrella stays put)
+
+---
+
+## Task 0: Pre-flight verify (no commit)
+
+Confirm the spec's pre-flight audits are still true on the branch.
+
+- [ ] **Step 1: Confirm per-cap dir has expected files**
+
+```bash
+for f in src/graph.py src/dashboard_tools.py langgraph.json prompts/dashboard.md; do
+  p="cockpit/chat/generative-ui/python/$f"
+  [ -f "$p" ] && echo "  ✓ $f" || echo "  ✗ MISSING $f"
+done
+```
+
+Expected: 4 ✓ marks.
+
+- [ ] **Step 2: Confirm per-cap graph uses `get_stream_writer`**
+
+```bash
+grep -n 'get_stream_writer' cockpit/chat/generative-ui/python/src/graph.py
+```
+
+Expected: at least two matches (import + call site).
+
+- [ ] **Step 3: Confirm fixture values match umbrella's `aviation_data.py`**
+
+```bash
+python3 -c "
+import re
+um = open('cockpit/langgraph/streaming/python/src/aviation_data.py').read()
+pc = open('cockpit/chat/generative-ui/python/src/dashboard_tools.py').read()
+ok = True
+for sym in ['KPI_SNAPSHOT', 'ON_TIME_TREND', 'FLIGHTS_BY_AIRLINE', 'RECENT_DISRUPTIONS']:
+    um_block = re.search(rf'{sym}\s*=\s*([\[\{{].*?[\]\}}])\s*(?:\n\n|\Z)', um, re.S)
+    pc_block = re.search(rf'{sym}\s*=\s*([\[\{{].*?[\]\}}])\s*(?:\n\n|\Z)', pc, re.S)
+    if not um_block or not pc_block:
+        print(f'{sym}: missing in one side'); ok = False; continue
+    same = um_block.group(1).strip() == pc_block.group(1).strip()
+    print(f'{sym}: {\"identical\" if same else \"DIFFERS\"}'); ok = ok and same
+import sys; sys.exit(0 if ok else 1)
+"
+```
+
+Expected: 4 lines each `identical`, exit 0. If anything differs, STOP — the spec assumes byte-identical values.
+
+- [ ] **Step 4: Confirm registry currently points c-generative-ui at the umbrella**
+
+```bash
+grep "id: 'c-generative-ui'" apps/cockpit/scripts/capability-registry.ts
+```
+
+Expected: one line containing `pythonDir: 'cockpit/langgraph/streaming/python'`.
+
+---
+
+## Task 1: Flip the `pythonDir` in the registry
+
+**Files:**
+- Modify: `apps/cockpit/scripts/capability-registry.ts`
+
+- [ ] **Step 1: Apply the edit**
+
+```bash
+sed -i '' "s|id: 'c-generative-ui', product: 'chat', topic: 'generative-ui', angularProject: 'cockpit-chat-generative-ui-angular', port: 4508, pythonPort: 5508, pythonDir: 'cockpit/langgraph/streaming/python'|id: 'c-generative-ui', product: 'chat', topic: 'generative-ui', angularProject: 'cockpit-chat-generative-ui-angular', port: 4508, pythonPort: 5508, pythonDir: 'cockpit/chat/generative-ui/python'|" apps/cockpit/scripts/capability-registry.ts
+```
+
+- [ ] **Step 2: Verify the file still parses + shows expected diff**
+
+```bash
+npx tsc --noEmit apps/cockpit/scripts/capability-registry.ts 2>&1 | tail -5
+```
+
+Expected: no errors. If tsc complains, sed missed — revert with `git checkout HEAD -- apps/cockpit/scripts/capability-registry.ts` and STOP.
+
+```bash
+git diff apps/cockpit/scripts/capability-registry.ts
+```
+
+Expected: exactly one line changed, replacing `cockpit/langgraph/streaming/python` with `cockpit/chat/generative-ui/python` on the `c-generative-ui` row. No other changes.
+
+- [ ] **Step 3: Verify the cap now points at the per-cap dir**
+
+```bash
+grep "id: 'c-generative-ui'" apps/cockpit/scripts/capability-registry.ts | grep -c 'cockpit/chat/generative-ui/python'
+```
+
+Expected: `1`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/cockpit/scripts/capability-registry.ts
+git commit -m "$(cat <<'EOF'
+feat(cockpit-registry): migrate c-generative-ui to per-cap backend
+
+Flip pythonDir from cockpit/langgraph/streaming/python (the umbrella)
+to cockpit/chat/generative-ui/python. Per-cap backend was scaffolded
+by PR #396 with the full multi-node graph (router → plan_tools →
+call_tools → emit_state → respond), 4 KPI tools with inlined fixtures
+(byte-identical to umbrella's aviation_data.py), and get_stream_writer
+state emission (LangGraph 1.x).
+
+Sub-project 3 of the per-cap migration chain (Tier A batch was #413,
+c-interrupts in flight via #382). After this, 9 of 11 c-* caps are
+on per-cap backends. Remaining: c-interrupts, c-a2ui.
+
+Local-dev-only — production deploy continues to serve from the
+umbrella's dashboard_graph.py until the deploy-script extension PR.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Verify shared-deployment manifest is byte-identical (no commit)
+
+The deploy script skips chat caps; the manifest must not change.
+
+- [ ] **Step 1: Snapshot AFTER (current branch)**
+
+```bash
+npx tsx scripts/generate-shared-deployment-config.ts 2>&1 | tail -2
+python3 -c "import json; d=json.load(open('deployments/shared-dev/langgraph.json')); print('count=',len(d['graphs'])); print(sorted(d['graphs']))" > /tmp/cgenui-after.txt
+cat /tmp/cgenui-after.txt
+```
+
+Expected: `count= 26` with the same graph list as PR #413's post-merge state.
+
+- [ ] **Step 2: Snapshot BEFORE (revert the registry edit, regenerate, compare)**
+
+```bash
+git stash push -m "cgenui-rebase-temp" -- apps/cockpit/scripts/capability-registry.ts 2>&1 | tail -3
+# After stash, working tree has Task 1's commit reverted to working-dir state
+# Actually stash doesn't revert commits; we need to checkout from prior commit
+git checkout HEAD~1 -- apps/cockpit/scripts/capability-registry.ts
+npx tsx scripts/generate-shared-deployment-config.ts 2>&1 | tail -2
+python3 -c "import json; d=json.load(open('deployments/shared-dev/langgraph.json')); print('count=',len(d['graphs'])); print(sorted(d['graphs']))" > /tmp/cgenui-before.txt
+# Restore the post-Task-1 file
+git checkout HEAD -- apps/cockpit/scripts/capability-registry.ts
+git stash drop 2>/dev/null || true
+```
+
+- [ ] **Step 3: Confirm graph names + count IDENTICAL**
+
+```bash
+diff /tmp/cgenui-before.txt /tmp/cgenui-after.txt && echo "IDENTICAL"
+```
+
+Expected: `IDENTICAL`. If non-empty diff, STOP and investigate.
+
+- [ ] **Step 4: Confirm c-generative-ui's deploy entrypoint still points at umbrella**
+
+```bash
+python3 -c "
+import json
+d = json.load(open('deployments/shared-dev/langgraph.json'))
+p = d['graphs'].get('c-generative-ui', '<missing>')
+print(f'c-generative-ui: {p}')
+print(f'  {\"OK (still umbrella — local-dev-only migration)\" if p.startswith(\"./deps/streaming/\") else \"UNEXPECTED\"}')
+"
+```
+
+Expected: path starts with `./deps/streaming/src/dashboard_graph.py:graph`, marked `OK`. This proves the migration is local-dev-only, matching the spec's intent.
+
+- [ ] **Step 5: Cleanup**
+
+```bash
+rm -f /tmp/cgenui-before.txt /tmp/cgenui-after.txt
+git checkout HEAD -- deployments/shared-dev/langgraph.json
+git status --short
+```
+
+Expected: clean working tree (no staged or modified files).
+
+---
+
+## Task 3: Verify per-cap backend imports + boots (no commit)
+
+- [ ] **Step 1: uv sync + import smoke**
+
+```bash
+(cd cockpit/chat/generative-ui/python && uv sync 2>&1 | tail -2)
+```
+
+Expected: `Resolved … packages`, no errors.
+
+```bash
+set -a; source examples/chat/python/.env 2>/dev/null || source cockpit/langgraph/streaming/python/.env 2>/dev/null; set +a
+test -n "$OPENAI_API_KEY" && echo "key OK" || (echo "MISSING OPENAI_API_KEY — STOP"; exit 1)
+(cd cockpit/chat/generative-ui/python && uv run python -c "from src.graph import graph; print(type(graph).__name__)" 2>&1 | tail -2)
+```
+
+Expected: `key OK`, then `CompiledStateGraph`. Any traceback STOPs.
+
+- [ ] **Step 2: Boot `langgraph dev` and confirm one graph**
+
+Free the port:
+
+```bash
+lsof -t -i :5508 2>/dev/null | xargs kill -9 2>/dev/null
+```
+
+Boot:
+
+```bash
+cd cockpit/chat/generative-ui/python && nohup uv run langgraph dev --no-browser --host 127.0.0.1 --port 5508 > /tmp/cgenui-lg.log 2>&1 &
+echo "PID=$!"
+cd -
+```
+
+Wait for ready:
+
+```bash
+until grep -qE "Application started up" /tmp/cgenui-lg.log 2>/dev/null; do sleep 1; done
+echo READY
+```
+
+Inspect:
+
+```bash
+grep -E "graph_id|Importing graph" /tmp/cgenui-lg.log | head -5
+```
+
+Expected: exactly one `graph_id=c-generative-ui`, no traceback.
+
+Keep this langgraph dev RUNNING for Task 4 (don't kill yet).
+
+---
+
+## Task 4: Two-turn SDK exchange (no commit)
+
+Exercises the multi-node pathway end-to-end against real OpenAI.
+
+- [ ] **Step 1: Write a verification script**
+
+Save as `/tmp/cgenui-turn-test.py`:
+
+```python
+"""Two-turn SDK exchange against the per-cap c-generative-ui backend."""
+import asyncio, sys
+from langgraph_sdk import get_client
+
+
+async def get_last_ai_and_tools(state):
+    msgs = state.get("values", {}).get("messages", [])
+    last_ai = None
+    tool_names = []
+    for m in msgs:
+        if m.get("type") == "ai" and m.get("content"):
+            last_ai = m["content"]
+        if m.get("type") == "tool":
+            # ToolMessage doesn't always include the tool name; pull from the
+            # preceding ai message's tool_calls if needed
+            pass
+        if m.get("type") == "ai":
+            for tc in (m.get("tool_calls") or []):
+                tool_names.append(tc.get("name"))
+    return last_ai, tool_names
+
+
+async def main():
+    client = get_client(url="http://127.0.0.1:5508")
+    thread = await client.threads.create()
+    tid = thread["thread_id"]
+
+    print("=== Turn 1: dashboard request ===")
+    async for _ in client.runs.stream(
+        thread_id=tid,
+        assistant_id="c-generative-ui",
+        input={"messages": [{"role": "user", "content": "Show me the airline operations dashboard."}]},
+        stream_mode=["values"],
+    ):
+        pass
+    state = await client.threads.get_state(tid)
+    text1, tools1 = await get_last_ai_and_tools(state)
+    print(f"  tools called: {tools1}")
+    print(f"  final ai text: {(text1 or '')[:120]!r}")
+    if not tools1:
+        print("  FAIL: no tool calls in turn 1")
+        sys.exit(1)
+    if not text1:
+        print("  FAIL: no final assistant text in turn 1")
+        sys.exit(1)
+    print("  PASS")
+
+    print("=== Turn 2: on-time trend follow-up ===")
+    async for _ in client.runs.stream(
+        thread_id=tid,
+        assistant_id="c-generative-ui",
+        input={"messages": [{"role": "user", "content": "What's the on-time trend?"}]},
+        stream_mode=["values"],
+    ):
+        pass
+    state = await client.threads.get_state(tid)
+    text2, tools2 = await get_last_ai_and_tools(state)
+    print(f"  tools called (cumulative): {tools2}")
+    print(f"  final ai text: {(text2 or '')[:120]!r}")
+    has_trend_call = any('on_time_trend' in (t or '') for t in tools2)
+    if not has_trend_call:
+        print(f"  FAIL: expected a query_on_time_trend tool call somewhere, got: {tools2}")
+        sys.exit(1)
+    if not text2:
+        print("  FAIL: no final assistant text in turn 2")
+        sys.exit(1)
+    print("  PASS")
+
+asyncio.run(main())
+```
+
+- [ ] **Step 2: Run it**
+
+```bash
+uv run --python 3.12 --with langgraph-sdk --with typing_extensions python /tmp/cgenui-turn-test.py
+```
+
+Expected: two `PASS` blocks. If gpt-5 has transient issues, the first run may fail with an OpenAI error — re-run once before reporting a true migration issue.
+
+- [ ] **Step 3: Kill langgraph dev + cleanup**
+
+```bash
+lsof -t -i :5508 2>/dev/null | xargs kill -9 2>/dev/null
+rm -f /tmp/cgenui-lg.log /tmp/cgenui-turn-test.py
+```
+
+---
+
+## Task 5: Reverse audit (no commit)
+
+- [ ] **Step 1: Confirm c-interrupts + c-a2ui are still on the umbrella**
+
+```bash
+grep -E "id: 'c-(interrupts|a2ui)'" apps/cockpit/scripts/capability-registry.ts | grep -c 'cockpit/langgraph/streaming/python'
+```
+
+Expected: `2`. (If less, some other cap got migrated by accident — STOP.)
+
+- [ ] **Step 2: Confirm umbrella's dashboard_graph.py + dashboard_tools.py are untouched**
+
+```bash
+git diff origin/main -- cockpit/langgraph/streaming/python/src/dashboard_graph.py cockpit/langgraph/streaming/python/src/dashboard_tools.py
+```
+
+Expected: empty. The umbrella's dashboard code is untouched in this PR.
+
+- [ ] **Step 3: Confirm the 9 chat caps on per-cap dirs (Tier A + tool-calls + subagents + this PR)**
+
+```bash
+grep -E "id: 'c-" apps/cockpit/scripts/capability-registry.ts | grep -c 'cockpit/chat/'
+```
+
+Expected: `9`. (Tier A 6 + tool-calls + subagents + c-generative-ui.)
+
+---
+
+## Task 6: Regression — existing cockpit e2es still pass (no commit)
+
+- [ ] **Step 1: Run sequentially**
+
+```bash
+npx nx e2e cockpit-langgraph-streaming-angular --skip-nx-cache \
+  && npx nx e2e cockpit-chat-tool-calls-angular --skip-nx-cache \
+  && npx nx e2e cockpit-chat-subagents-angular --skip-nx-cache
+```
+
+Expected: all three pass. Combined runtime ~5 minutes.
+
+If any fails, STOP. None of these touch generative-ui's backend; a failure would indicate something unexpected (e.g., shared lib regression from a parallel agent's commit on main).
+
+---
+
+## Task 7: Final reference grep (no commit)
+
+- [ ] **Step 1: Visual confirmation of end state**
+
+```bash
+echo "=== caps on per-cap dirs ==="
+grep -E "id: 'c-" apps/cockpit/scripts/capability-registry.ts | grep 'cockpit/chat/' | awk -F"'" '{print "  " $2}'
+echo
+echo "=== caps still on umbrella ==="
+grep -E "id: 'c-" apps/cockpit/scripts/capability-registry.ts | grep 'cockpit/langgraph/streaming/python' | awk -F"'" '{print "  " $2}'
+```
+
+Expected:
+```
+=== caps on per-cap dirs ===
+  c-messages
+  c-input
+  c-tool-calls
+  c-subagents
+  c-threads
+  c-timeline
+  c-generative-ui
+  c-debug
+  c-theming
+
+=== caps still on umbrella ===
+  c-interrupts
+  c-a2ui
+```
+
+(Order may vary — visually verify the two groups are correct: 9 + 2 = 11 total.)
+
+---
+
+## Task 8: Push, open PR, watch CI, merge
+
+Orchestrator task. Implementer STOPS after Task 7.
+
+- [ ] **Step 1: Push branch**
+
+```bash
+git push -u origin claude/c-generative-ui-migration
+```
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create --title "feat(cockpit-registry): migrate c-generative-ui to per-cap backend" --body "$(cat <<'EOF'
+## Summary
+- Flip \`pythonDir\` for \`c-generative-ui\` in \`apps/cockpit/scripts/capability-registry.ts\` from \`cockpit/langgraph/streaming/python\` (the umbrella) to \`cockpit/chat/generative-ui/python\` (per-cap standalone backend).
+- Per-cap dir built by PR #396 with full multi-node graph (router → plan_tools → call_tools → emit_state → respond), 4 KPI tools with inlined fixtures (byte-identical to umbrella's aviation_data.py), and \`get_stream_writer\` state emission (LangGraph 1.x).
+- Sub-project 3 of 5 in the per-cap migration chain. After this lands, 9 of 11 c-* caps are on per-cap backends. Remaining: c-interrupts (in flight via PR #382), c-a2ui.
+
+## Scope
+**Local-dev-only.** \`scripts/generate-shared-deployment-config.ts\` line 54 skips chat capabilities; production deploy continues to serve c-generative-ui from the umbrella's \`dashboard_graph.py\`. End state: two byte-identical copies of the graph until the deploy-script extension PR (last in the chain).
+
+## Test plan
+- [x] Per-cap import smoke: \`from src.graph import graph\` returns \`CompiledStateGraph\`
+- [x] Per-cap graph uses \`get_stream_writer\` (LangGraph 1.x API)
+- [x] Fixture constants byte-identical between per-cap \`dashboard_tools.py\` and umbrella \`aviation_data.py\`
+- [x] \`langgraph dev\` boots with exactly \`c-generative-ui\`, no traceback
+- [x] Turn 1 (\"Show me the airline operations dashboard.\"): tool call(s) present + non-empty assistant text
+- [x] Turn 2 (\"What's the on-time trend?\"): \`query_on_time_trend\` tool call + non-empty assistant text
+- [x] Shared-deployment manifest byte-identical before/after (deploy unchanged)
+- [x] c-interrupts + c-a2ui still on umbrella
+- [x] Umbrella's \`dashboard_graph.py\` + \`dashboard_tools.py\` untouched
+- [x] \`nx e2e cockpit-langgraph-streaming-angular\`, \`cockpit-chat-tool-calls-angular\`, \`cockpit-chat-subagents-angular\` pass
+- [ ] CI \`Cockpit — e2e\` + \`Cockpit — build all examples\` green
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Watch CI**
+
+```bash
+gh pr checks <PR#>
+```
+
+- [ ] **Step 4: Merge on green**
+
+```bash
+gh pr merge <PR#> --squash --delete-branch
+```
+
+---
+
+## Self-review notes
+
+**Spec coverage:**
+- "Single code edit" → Task 1.
+- Pre-flight drift audits → Task 0.
+- "Production deploy is byte-identical" → Task 2.
+- "Multi-node graph end-to-end via SDK" (two-turn exchange) → Task 4.
+- "Regression" → Task 6.
+- "Reverse audit" → Task 5.
+- "Per-cap graph uses `get_stream_writer`" → Task 0 Step 2.
+- Acceptance: registry shows c-generative-ui on per-cap → Task 1 Step 3, Task 7.
+- Acceptance: shared-deploy unchanged → Task 2.
+- Acceptance: tool calls + assistant text per turn → Task 4.
+- Acceptance: existing cockpit e2es pass → Task 6.
+- Acceptance: umbrella untouched → Task 5 Step 2.
+
+**Placeholder scan:** none. Every step has either exact code or a complete command with expected output.
+
+**Type consistency:** cap id `c-generative-ui` consistent across all tasks. Port `5508` consistent in Task 2/3/4. Path `cockpit/chat/generative-ui/python` consistent throughout.
+
+**Concurrency note:** pre-flight warning + Task 0 + clean-tree check at Task 2 Step 5 cover the parallel-agent risk.

--- a/docs/superpowers/specs/2026-05-18-c-generative-ui-migration-design.md
+++ b/docs/superpowers/specs/2026-05-18-c-generative-ui-migration-design.md
@@ -1,0 +1,96 @@
+# c-generative-ui per-cap migration — design
+
+> **Place in the larger plan.** Sub-project 3 of the per-cap migration chain (Tier A batch was sub-project 1, c-interrupts via PR #382 is sub-project 2). Flips `c-generative-ui`'s `pythonDir` in the capability registry to its per-cap standalone backend. Local-dev-only migration — production continues to deploy from the umbrella's `dashboard_graph.py` until the deploy-script extension PR lands (last in the chain).
+>
+> **Side-note follow-up:** the cockpit chat demos' suggested-prompt chips (the welcome-state starter chips from PR #383) should align with the prompts our aimock e2e specs exercise. Audited in a separate spawned task; not in scope here. This PR's test prompts are chosen so future chip alignment is easy.
+
+## Goal
+
+Switch `c-generative-ui` from consuming the umbrella's `dashboard_graph.py` + `dashboard_tools.py` to its already-built per-cap standalone backend at `cockpit/chat/generative-ui/python/`. Heavier verification than Tier A because the graph is multi-node (router → generate_shell / plan_tools → call_tools → emit_state → respond) and dispatches custom events for progressive structured state.
+
+## Non-goals
+
+- Reconciling the inlined-vs-imported fixture difference between per-cap `dashboard_tools.py` (inlines `KPI_SNAPSHOT` etc.) and umbrella `dashboard_tools.py` (imports from `src.aviation_data`). Per-cap chose inlining intentionally (no `aviation_data.py` exists in the per-cap dir). Data values are byte-identical; that's enough.
+- Modifying the per-cap graph or tools logic. They were already built by PR #396 (and refined by PRs #360, #363, #371, #372). This PR just connects them.
+- Modifying the umbrella's `dashboard_graph.py` or `dashboard_tools.py`. Those keep serving production until the deploy-script extension.
+- Suggested-prompt chip alignment. Tracked in a separate spawned task.
+
+## Architecture (post per-cap)
+
+The c-generative-ui demo runs as a self-contained pair:
+- **Backend:** `cockpit/chat/generative-ui/python/` — multi-node LangGraph with router/plan_tools/call_tools/emit_state/respond nodes, ToolNode wrapping 4 KPI query tools, `get_stream_writer`-based state emission. Default dev port: 5508.
+- **Frontend:** `cockpit/chat/generative-ui/angular/` — Angular app proxying `/api` → backend. Default dev port: 4508.
+
+Production continues to deploy `c-generative-ui` from the umbrella's `dashboard_graph.py` (registered in `cockpit/langgraph/streaming/python/langgraph.json`).
+
+## What changes
+
+### Single code edit
+
+`apps/cockpit/scripts/capability-registry.ts` — change `pythonDir` on one row:
+
+| Cap id | Before | After |
+|---|---|---|
+| `c-generative-ui` | `cockpit/langgraph/streaming/python` | `cockpit/chat/generative-ui/python` |
+
+No other rows touched. `pythonPort: 5508` stays — already aligned with the per-cap `proxy.conf.json` target.
+
+### No other files changed
+
+- `cockpit/chat/generative-ui/python/src/graph.py` — exists, 176 lines, multi-node ToolNode+emit_state pattern.
+- `cockpit/chat/generative-ui/python/src/dashboard_tools.py` — exists, 117 lines, four `@tool` functions (`query_airline_kpis`, `query_on_time_trend`, `query_flights_by_airline`, `query_recent_disruptions`) with inlined fixtures.
+- `cockpit/chat/generative-ui/python/prompts/dashboard.md` — exists.
+- `cockpit/chat/generative-ui/python/langgraph.json` — registers exactly `c-generative-ui`.
+- `cockpit/chat/generative-ui/angular/proxy.conf.json` — already targets `localhost:5508`.
+- `cockpit/chat/generative-ui/angular/src/environments/environment.development.ts` — `/api` + `streamingAssistantId: 'c-generative-ui'`.
+
+## Verification
+
+### Pre-flight drift audits
+
+1. **Per-cap graph.py vs umbrella dashboard_graph.py:** diff. Expect only comment/import minor differences (already observed during brainstorm).
+2. **Per-cap dashboard_tools.py vs umbrella dashboard_tools.py:** diff. Expect the inlined-fixtures vs imported-from-aviation_data difference. Confirm the numerical fixture values are identical (manually compare the inlined `KPI_SNAPSHOT`, `ON_TIME_TREND`, `FLIGHTS_BY_AIRLINE`, `RECENT_DISRUPTIONS` in per-cap vs the values in `cockpit/langgraph/streaming/python/src/aviation_data.py`).
+3. **Per-cap graph uses `get_stream_writer`:** grep the per-cap `graph.py` for `get_stream_writer`. Required because the chat-generative-ui UI consumes the emitted state. If missing, the migration would produce a working agent that doesn't render structured state. (PR #360 added this fix — the per-cap version must have inherited it.)
+
+### Production deploy is byte-identical
+
+Same as Tier A. `scripts/generate-shared-deployment-config.ts` skips chat caps; c-generative-ui reaches production via the umbrella's manifest. Manifest must be byte-identical before/after.
+
+### Multi-node graph end-to-end via SDK
+
+Single-turn "Hello" doesn't exercise the dashboard pathway. Use two representative prompts in sequence on the same thread:
+
+1. **Turn 1 (shell generation):** `"Show me the airline operations dashboard."` → expect at least one tool call (`query_airline_kpis` typically first) + final assistant text.
+2. **Turn 2 (follow-up):** `"What's the on-time trend?"` → expect `query_on_time_trend` tool call + final assistant text.
+
+Both turns must complete `status=success`. Both turns' final assistant text should be non-empty. The tool-call presence proves the planner → ToolNode flow works; the emit_state events are inferred (verified at UI layer in a future e2e, out of scope here).
+
+### Regression
+
+- `nx e2e cockpit-langgraph-streaming-angular` passes (the umbrella's streaming graph is independent of the dashboard cleanup).
+- `nx e2e cockpit-chat-tool-calls-angular`, `nx e2e cockpit-chat-subagents-angular` pass (per-cap demos unaffected).
+- If a `cockpit-chat-generative-ui-angular` aimock e2e suite exists, run it. (Spot-checked during brainstorm: no `e2e/` dir scaffolded yet for this cap — bonus item if it appears.)
+
+### Reverse audit
+
+- Registry still has `c-interrupts` and `c-a2ui` on `cockpit/langgraph/streaming/python` (the remaining unmigrated caps).
+- Umbrella's `dashboard_graph.py` + `dashboard_tools.py` untouched.
+
+## Risk surface
+
+- **Per-cap graph never battle-tested locally.** The scaffolded `graph.py` and `dashboard_tools.py` import clean (verified at brainstorm time) but haven't run an end-to-end turn against a real LLM in the migrated state. Verification via SDK turn exchange catches any wiring bug per-cap.
+- **gpt-5 planner availability.** The graph uses `ChatOpenAI(model='gpt-5', reasoning_effort='minimal')` for the planner (per PR #372). If gpt-5 has transient availability issues during verification, both turn-exchange tests could fail spuriously — distinguish from migration issues by re-running.
+- **`get_stream_writer` API.** Per-cap graph must use the LangGraph 1.x API (`get_stream_writer`) rather than the deprecated `emit_state`/`dispatch_custom_event` pattern. Verified at pre-flight audit step.
+- **Fixture-data drift.** If a future PR updates `cockpit/langgraph/streaming/python/src/aviation_data.py` constants, the per-cap inlined copies won't pick that up automatically. Accepted as part of the "two copies" tech debt until the deploy-script extension makes per-cap the single source of truth.
+- **Shared-checkout chaos.** Same as prior PRs in this chain — parallel agents have caused branch drift. Implementer must `git fetch origin && git rebase origin/main` before final push.
+
+## Acceptance criteria
+
+- `apps/cockpit/scripts/capability-registry.ts` shows `c-generative-ui` → `cockpit/chat/generative-ui/python`. No other rows changed.
+- Pre-flight diffs: graph.py minor comment/import drift only; dashboard_tools.py fixture values numerically identical (inlined vs imported); per-cap graph uses `get_stream_writer`.
+- Per-cap `langgraph dev` boots with exactly 1 graph (`c-generative-ui`), no traceback.
+- SDK turn 1 (`"Show me the airline operations dashboard."`): `status=success`, tool-call(s) present, non-empty assistant text.
+- SDK turn 2 (`"What's the on-time trend?"`): `status=success`, `query_on_time_trend` tool call present, non-empty assistant text.
+- `npx tsx scripts/generate-shared-deployment-config.ts` output: shared-deploy manifest byte-identical before/after.
+- Existing cockpit aimock e2es (streaming, tool-calls, subagents) still pass.
+- Umbrella's `dashboard_graph.py` + `dashboard_tools.py` untouched (`git diff origin/main -- cockpit/langgraph/streaming/python/` empty for those files).


### PR DESCRIPTION
## Summary
- Flip \`pythonDir\` for \`c-generative-ui\` in \`apps/cockpit/scripts/capability-registry.ts\` from \`cockpit/langgraph/streaming/python\` (the umbrella) to \`cockpit/chat/generative-ui/python\` (per-cap standalone backend).
- Per-cap dir built by PR #396 with full multi-node graph (router → plan_tools → call_tools → emit_state → respond), 4 KPI tools with inlined fixtures (byte-identical to umbrella's \`aviation_data.py\`), and \`get_stream_writer\` state emission (LangGraph 1.x).
- Sub-project 3 of 5 in the per-cap migration chain. After this lands, 9 of 11 c-* caps are on per-cap backends. Remaining: c-interrupts (in flight via PR #382), c-a2ui.

## Scope
**Local-dev-only.** \`scripts/generate-shared-deployment-config.ts\` line 54 skips chat capabilities; production deploy continues to serve c-generative-ui from the umbrella's \`chat_graphs.py\` (which transitively imports the dashboard graph). End state: two byte-identical copies of the graph until the deploy-script extension PR (last in the chain).

## Test plan
- [x] Per-cap import smoke: \`from src.graph import graph\` returns \`CompiledStateGraph\`
- [x] Per-cap graph uses \`get_stream_writer\` (LangGraph 1.x API, lines 107 + 136)
- [x] Fixture constants byte-identical between per-cap \`dashboard_tools.py\` and umbrella \`aviation_data.py\`
- [x] \`langgraph dev\` boots with exactly \`c-generative-ui\`, no traceback
- [x] Turn 1 (\"Show me the airline operations dashboard.\"): 4 tool calls + non-empty assistant text
- [x] Turn 2 (\"What's the on-time trend?\"): \`query_on_time_trend\` present + non-empty assistant text
- [x] Shared-deployment manifest byte-identical before/after (deploy unchanged)
- [x] c-interrupts + c-a2ui still on umbrella
- [x] Umbrella's \`dashboard_graph.py\` + \`dashboard_tools.py\` untouched
- [x] \`nx e2e cockpit-langgraph-streaming-angular\`, \`cockpit-chat-tool-calls-angular\`, \`cockpit-chat-subagents-angular\` pass
- [ ] CI \`Cockpit — e2e\` + \`Cockpit — build all examples\` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)