### PR TITLE
[codex] Align chat smoke checklist with root env

### DIFF
--- a/examples/chat/smoke/CHECKLIST.md
+++ b/examples/chat/smoke/CHECKLIST.md
@@ -6,7 +6,7 @@ changes land in libs/chat, libs/langgraph, libs/render, libs/ag-ui.
 
 ## Pre-flight
 
-- [ ] `OPENAI_API_KEY` present in `examples/chat/python/.env`
+- [ ] `OPENAI_API_KEY` present in the repository root `.env`
 - [ ] `nx run examples-chat-python:serve` running on :2024 — `curl localhost:2024/ok` returns `{"ok":true}`
 - [ ] Smoke consumer started — page loads at :4200
 - [ ] No console errors on initial load (license warning OK, telemetry DNS failure OK)


### PR DESCRIPTION
## Summary
- Update the canonical chat smoke checklist pre-flight to point at the repository root `.env` for `OPENAI_API_KEY`.

## Validation
- `git diff --check`
- Live protocol verification was run from PR #419 work: started `examples/chat/python` LangGraph dev server with `/Users/blove/repos/angular-agent-framework/.env` loaded, confirmed `/ok`, then ran `LANGGRAPH_URL=http://127.0.0.1:61234 npx nx e2e examples-chat-protocol-e2e --skip-nx-cache`.
