### PR TITLE
Use readonly PostHog key in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -666,12 +666,12 @@ jobs:
       - name: posthog:sync --plan
         if: steps.affected.outputs.is_affected == 'yes'
         env:
-          POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}
+          POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY_READONLY }}
           POSTHOG_HOST: https://us.i.posthog.com
           POSTHOG_PROJECT_ID: ${{ secrets.POSTHOG_PROJECT_ID }}
         run: |
           if [ -z "$POSTHOG_PERSONAL_API_KEY" ]; then
-            echo "::notice::POSTHOG_PERSONAL_API_KEY not set — soft skip for contributor PRs."
+            echo "::notice::POSTHOG_PERSONAL_API_KEY_READONLY not set — soft skip for contributor PRs."
             exit 0
           fi
           npx nx run posthog-tools:sync:plan

--- a/.github/workflows/posthog-quality.yml
+++ b/.github/workflows/posthog-quality.yml
@@ -34,7 +34,7 @@ jobs:
       - run: npm ci
       - name: Run live telemetry quality check
         env:
-          POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}
+          POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY_READONLY }}
           POSTHOG_HOST: https://us.i.posthog.com
           POSTHOG_PROJECT_ID: ${{ secrets.POSTHOG_PROJECT_ID }}
           QUALITY_DAYS: ${{ github.event.inputs.days || '7' }}
@@ -42,7 +42,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "${POSTHOG_PERSONAL_API_KEY:-}" ] || [ -z "${POSTHOG_PROJECT_ID:-}" ]; then
-            echo "::error::POSTHOG_PERSONAL_API_KEY and POSTHOG_PROJECT_ID Actions secrets are required."
+            echo "::error::POSTHOG_PERSONAL_API_KEY_READONLY and POSTHOG_PROJECT_ID Actions secrets are required."
             exit 1
           fi
           npx nx run posthog-tools:quality:live -- --days "$QUALITY_DAYS" --limit-per-event "$QUALITY_LIMIT_PER_EVENT" --require-critical-coverage

--- a/scripts/ci-workflow.spec.mjs
+++ b/scripts/ci-workflow.spec.mjs
@@ -23,6 +23,15 @@ describe('CI workflow', () => {
     );
   }
 
+  async function readPostHogSyncPlanJob() {
+    const workflow = await readWorkflow();
+    return workflow.slice(workflow.indexOf('  posthog-sync-plan:'));
+  }
+
+  async function readPostHogQualityWorkflow() {
+    return readFile('.github/workflows/posthog-quality.yml', 'utf8');
+  }
+
   it('treats nested library files as deploy-relevant changes', async () => {
     const deployJob = await readDeployJob();
 
@@ -58,8 +67,27 @@ describe('CI workflow', () => {
 
     assert.ok(
       productionSmokeJob.indexOf('Verify shared LangGraph backend') <
-        productionSmokeJob.indexOf('npx playwright install --with-deps chromium')
+        productionSmokeJob.indexOf(
+          'npx playwright install --with-deps chromium'
+        )
     );
   });
 
+  it('uses the read-only PostHog key for CI drift checks', async () => {
+    const postHogSyncPlanJob = await readPostHogSyncPlanJob();
+
+    assert.match(
+      postHogSyncPlanJob,
+      /POSTHOG_PERSONAL_API_KEY:\s*\$\{\{\s*secrets\.POSTHOG_PERSONAL_API_KEY_READONLY\s*\}\}/
+    );
+  });
+
+  it('uses the read-only PostHog key for scheduled live quality checks', async () => {
+    const postHogQualityWorkflow = await readPostHogQualityWorkflow();
+
+    assert.match(
+      postHogQualityWorkflow,
+      /POSTHOG_PERSONAL_API_KEY:\s*\$\{\{\s*secrets\.POSTHOG_PERSONAL_API_KEY_READONLY\s*\}\}/
+    );
+  });
 });

--- a/tools/posthog/README.md
+++ b/tools/posthog/README.md
@@ -52,13 +52,14 @@ Requires a **Personal API Key** with `dashboard:write`, `insight:write`, `cohort
 
 Env vars (see `.env.example` at repo root):
 
-| Variable                   | Purpose                                             |
-| -------------------------- | --------------------------------------------------- |
-| `POSTHOG_PERSONAL_API_KEY` | Personal API Key (Bearer)                           |
-| `POSTHOG_HOST`             | `https://us.i.posthog.com` (default) or your region |
-| `POSTHOG_PROJECT_ID`       | Numeric project id (visible in PostHog URL)         |
+| Variable                            | Purpose                                                            |
+| ----------------------------------- | ------------------------------------------------------------------ |
+| `POSTHOG_PERSONAL_API_KEY`          | Write-scoped Personal API Key for local `--apply` and `--report`   |
+| `POSTHOG_PERSONAL_API_KEY_READONLY` | Read-only Personal API Key for CI `--plan` and live quality checks |
+| `POSTHOG_HOST`                      | `https://us.i.posthog.com` (default) or your region                |
+| `POSTHOG_PROJECT_ID`                | Numeric project id (visible in PostHog URL)                        |
 
-**CI** uses the same key (write-scoped) for `--plan` only. **Production hardening TODO:** create a read-only Personal API Key for CI and add it as `POSTHOG_PERSONAL_API_KEY_READONLY` in GitHub Actions secrets. Local development continues using the write-scoped key for `--apply` and `--report`.
+**CI** maps `POSTHOG_PERSONAL_API_KEY_READONLY` into the tool's `POSTHOG_PERSONAL_API_KEY` environment variable for read-only `--plan` and live quality checks. Local development continues using the write-scoped `POSTHOG_PERSONAL_API_KEY` for `--apply` and `--report`.
 
 ## JSON contract
 


### PR DESCRIPTION
## Summary
- switch PostHog CI drift and scheduled live-quality checks to `POSTHOG_PERSONAL_API_KEY_READONLY`
- add workflow guard tests so those jobs do not regress to the write-scoped secret
- update PostHog tooling docs to distinguish local write key vs CI readonly key

## Verification
- `PATH=/tmp/codex-node-v24/bin:$PATH npx tsx --test scripts/ci-workflow.spec.mjs`
- `PATH=/tmp/codex-node-v24/bin:$PATH npx nx run posthog-tools:test`
- `set -a; source /Users/blove/repos/angular-agent-framework/.env; set +a; export POSTHOG_PERSONAL_API_KEY="$POSTHOG_PERSONAL_API_KEY_READONLY"; PATH=/tmp/codex-node-v24/bin:$PATH npx nx run posthog-tools:sync:plan`
- `set -a; source /Users/blove/repos/angular-agent-framework/.env; set +a; export POSTHOG_PERSONAL_API_KEY="$POSTHOG_PERSONAL_API_KEY_READONLY"; PATH=/tmp/codex-node-v24/bin:$PATH npx nx run posthog-tools:quality:live -- --days 7 --limit-per-event 25 --require-critical-coverage`
- `PATH=/tmp/codex-node-v24/bin:$PATH npx prettier --check .github/workflows/ci.yml .github/workflows/posthog-quality.yml scripts/ci-workflow.spec.mjs tools/posthog/README.md && git diff --check`
