### PR TITLE
Explicitly opt CI installs out of telemetry

### DIFF
--- a/.github/workflows/aimock-drift.yml
+++ b/.github/workflows/aimock-drift.yml
@@ -15,6 +15,9 @@ permissions:
   contents: read
   issues: write
 
+env:
+  DO_NOT_TRACK: '1'
+
 jobs:
   drift:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  DO_NOT_TRACK: '1'
+
 jobs:
   ci-scope:
     name: CI scope

--- a/.github/workflows/deploy-langgraph.yml
+++ b/.github/workflows/deploy-langgraph.yml
@@ -24,6 +24,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  DO_NOT_TRACK: '1'
+
 jobs:
   deploy:
     name: Deploy shared cockpit-dev to LangGraph Cloud

--- a/.github/workflows/posthog-quality.yml
+++ b/.github/workflows/posthog-quality.yml
@@ -21,6 +21,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  DO_NOT_TRACK: '1'
+
 jobs:
   live-quality:
     name: Live telemetry contract and coverage

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
+env:
+  DO_NOT_TRACK: '1'
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/scripts/ci-workflow.spec.mjs
+++ b/scripts/ci-workflow.spec.mjs
@@ -1,4 +1,4 @@
-import { readFile } from 'node:fs/promises';
+import { readdir, readFile } from 'node:fs/promises';
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
@@ -30,6 +30,18 @@ describe('CI workflow', () => {
 
   async function readPostHogQualityWorkflow() {
     return readFile('.github/workflows/posthog-quality.yml', 'utf8');
+  }
+
+  async function readWorkflowFiles() {
+    const names = await readdir('.github/workflows');
+    return Promise.all(
+      names
+        .filter((name) => name.endsWith('.yml'))
+        .map(async (name) => ({
+          name,
+          text: await readFile(`.github/workflows/${name}`, 'utf8'),
+        }))
+    );
   }
 
   it('treats nested library files as deploy-relevant changes', async () => {
@@ -89,5 +101,21 @@ describe('CI workflow', () => {
       postHogQualityWorkflow,
       /POSTHOG_PERSONAL_API_KEY:\s*\$\{\{\s*secrets\.POSTHOG_PERSONAL_API_KEY_READONLY\s*\}\}/
     );
+  });
+
+  it('explicitly disables install telemetry in workflows that install npm dependencies', async () => {
+    const workflowsWithNpmInstall = (await readWorkflowFiles()).filter(
+      ({ text }) => /\brun:\s*npm (?:ci|install)\b/.test(text)
+    );
+
+    assert.notEqual(workflowsWithNpmInstall.length, 0);
+
+    for (const { name, text } of workflowsWithNpmInstall) {
+      assert.match(
+        text,
+        /\nenv:\n(?:  [A-Z0-9_]+: .+\n)*  DO_NOT_TRACK: ['"]1['"]/,
+        `${name} should set top-level DO_NOT_TRACK=1`
+      );
+    }
   });
 });


### PR DESCRIPTION
## Summary
- set top-level `DO_NOT_TRACK=1` in first-party workflows that run npm dependency installs
- add a CI workflow guard so future npm-install workflows keep the explicit install telemetry opt-out

## Verification
- `PATH=/tmp/codex-node-v24/bin:$PATH npx tsx --test scripts/ci-workflow.spec.mjs`
- `PATH=/tmp/codex-node-v24/bin:$PATH npx prettier --check .github/workflows/aimock-drift.yml .github/workflows/ci.yml .github/workflows/deploy-langgraph.yml .github/workflows/posthog-quality.yml .github/workflows/publish.yml scripts/ci-workflow.spec.mjs && git diff --check`
