### PR TITLE
refactor(c-generative-ui): agentic loop with canonical surface-delivery (v2)

### DIFF
--- a/cockpit/chat/generative-ui/python/prompts/dashboard.md
+++ b/cockpit/chat/generative-ui/python/prompts/dashboard.md
@@ -1,22 +1,28 @@
 # Airline Operations Dashboard Agent
 
-You are a dashboard agent that builds interactive airline-operations KPI dashboards using a JSON render spec format. You have access to tools that query an airline's flight, fleet, and on-time performance data.
+You are a dashboard agent that builds interactive airline-operations KPI dashboards. You have five tools:
 
-## Your Behavior
+- `render_spec(spec)` — Author or update the dashboard layout. The spec is a JSON object describing component types, props, children, and state bindings. See the schema below.
+- `query_airline_kpis()` — Snapshot of operational KPIs: on-time %, flights today, avg delay, load factor.
+- `query_on_time_trend(months=12)` — On-time performance per month, for the line chart.
+- `query_flights_by_airline(airlines=None)` — Daily flight counts per airline, for the bar chart.
+- `query_recent_disruptions(limit=5, type=None)` — Recent delays/cancellations, for the data grid.
 
-### First message (no existing dashboard)
+## Workflow
 
-1. Generate a complete dashboard layout as a JSON render spec (see format below)
-2. Call ALL four data tools to populate the dashboard
-3. After the tools return, provide a brief conversational summary
+### When no dashboard exists yet (first turn)
 
-### Follow-up messages (dashboard already exists)
+1. Call `render_spec` ONCE with a complete dashboard layout — stat cards, charts, table — using `$state` bindings to the slots the data tools populate (see "State Path Conventions" below).
+2. In the SAME turn (same tool_calls array), call EACH data tool that backs a component in your spec. Do NOT call tools whose data your spec doesn't reference.
+3. After the tools return, return WITHOUT any further tool calls. A separate node will write a brief conversational summary.
 
-Categorize the user's request:
+### When the dashboard exists (follow-up turn)
 
-- **Data change** (e.g., "show last 6 months", "filter to cancelled flights only"): Call only the relevant tool(s) with updated parameters. Do NOT regenerate the spec. Just respond conversationally confirming the update.
-- **Structural change** (e.g., "add a new chart", "remove the table"): Regenerate the full spec with the modification, then call tools to populate any new components.
-- **Question about data** (e.g., "why did on-time % dip in December?"): Respond conversationally in plain text. Do NOT output JSON or call tools.
+Categorize the user's request and act ONCE. DO NOT ask clarifying questions — pick the most reasonable interpretation and act.
+
+- **Filter / scope** (e.g. "filter to cancelled flights only", "last 6 months", "top 3"): call EXACTLY ONE data tool — the one that backs the affected component — with the new parameters. Do NOT call `render_spec`.
+- **Structural change** (e.g. "add a card for X", "remove the table"): call `render_spec` with the modified layout, then call data tools only for the NEW components.
+- **Interpretive question** that no tool could resolve (e.g. "why is on-time % low?"): respond in plain prose with no tool calls.
 
 ## JSON Render Spec Format
 

--- a/cockpit/chat/generative-ui/python/src/graph.py
+++ b/cockpit/chat/generative-ui/python/src/graph.py
@@ -1,154 +1,185 @@
-"""Multi-node LangGraph graph for the airline operations KPI dashboard.
+"""Single-node agentic graph for the airline operations KPI dashboard.
 
 Flow:
-  router → generate_shell (first turn) or plan_tools (follow-up)
-  → call_tools → emit_state → respond
+  START → agent ↔ tools → wrap_spec_into_ai → agent (loop) → emit_state → respond → END
+
+`agent` is a single LLM call with all 5 tools bound (render_spec + 4 data
+tools). After tools run, `wrap_spec_into_ai` post-processes — if the LLM
+called render_spec, it replaces the parent AI message's content with the
+spec JSON (in place via add_messages' id-match reducer) so the chat-lib's
+content-classifier mounts <chat-generative-ui>. Then loops back to agent
+until the LLM returns no tool_calls (cap _MAX_TOOL_ITERATIONS per turn).
+
+Mirrors the emit_generated_surface pattern from examples/chat/python/src/graph.py,
+adapted for a continuation loop instead of terminal dispatch.
 """
 
 import json
 from pathlib import Path
 from typing import Literal
 
-import uuid
 from langchain_core.messages import AIMessage, SystemMessage, ToolMessage
+from langchain_core.tools import tool
 from langchain_openai import ChatOpenAI
 from langgraph.graph import StateGraph, MessagesState, END
 from langgraph.prebuilt import ToolNode
-from langgraph.types import Command
 
-from src.dashboard_tools import ALL_TOOLS
+from src.dashboard_tools import ALL_TOOLS as _DATA_TOOLS
 
 _PROMPT = (Path(__file__).parent.parent / "prompts" / "dashboard.md").read_text()
 
-_llm = ChatOpenAI(model="gpt-5-mini", temperature=0, streaming=True)
+_MAX_TOOL_ITERATIONS = 6
 
-# Dedicated planner: full gpt-5 with minimal reasoning effort.
-# gpt-5-mini at default reasoning ignores the "EXACTLY ONE tool" directive
-# in plan_tools and reflexively calls all four data tools on every
-# follow-up — verified in chrome MCP after PR #363 tightened the prompt
-# but the model still over-called. Bumping the planner to gpt-5 sharpens
-# instruction-following, and reasoning_effort='minimal' suppresses the
-# "let me be thorough" deliberation that drives the fan-out.
-_planner_llm = ChatOpenAI(
+
+class DashboardState(MessagesState):
+    """The dashboard spec lives in AI message content (the canonical
+    chat-lib surface-delivery protocol), not on the state object."""
+    pass
+
+
+@tool
+async def render_spec(spec: dict) -> str:
+    """Render an interactive dashboard layout from a JSON spec.
+
+    Use this tool to author or update the dashboard layout. The spec is a
+    JSON object with `elements` (a dict keyed by component id) and `root`
+    (the id of the top-level component). See the system prompt for the full
+    schema and component catalog.
+
+    Call this tool FIRST on any turn where the layout needs to be created
+    or restructured. After calling render_spec, call the data tools needed
+    to populate the components you authored.
+
+    Args:
+        spec: The dashboard JSON render spec.
+
+    Returns:
+        The spec serialized as JSON. A post-process node (wrap_spec_into_ai)
+        wraps this payload into the AI message content where the
+        chat-lib's content-classifier picks it up.
+    """
+    return json.dumps(spec)
+
+
+_ALL_TOOLS = [render_spec, *_DATA_TOOLS]
+
+_llm_with_tools = ChatOpenAI(
     model="gpt-5",
     temperature=0,
     streaming=True,
     reasoning_effort="minimal",
-)
-_llm_with_tools = _planner_llm.bind_tools(ALL_TOOLS)
+).bind_tools(_ALL_TOOLS)
+
+_respond_llm = ChatOpenAI(model="gpt-5-mini", temperature=0, streaming=True)
 
 
-class DashboardState(MessagesState):
-    """Extended state that persists the dashboard spec across turns."""
-    dashboard_spec: str | None
-
-
-def router(state: DashboardState) -> Command[Literal["generate_shell", "plan_tools"]]:
-    """Route based on whether a dashboard spec already exists."""
-    if state.get("dashboard_spec") is None:
-        return Command(goto="generate_shell")
-    return Command(goto="plan_tools")
-
-
-async def generate_shell(state: DashboardState) -> Command[Literal["populate_initial_data"]]:
-    """Generate the dashboard shell spec on first turn, then dispatch to
-    deterministic data-population (skipping plan_tools, which has a
-    follow-up-only prompt)."""
+async def agent(state: DashboardState) -> dict:
+    """Single agentic node: LLM bound with all 5 tools."""
     messages = [SystemMessage(content=_PROMPT)] + state["messages"]
-    response = await _llm.ainvoke(messages)
-    spec_text = response.content if isinstance(response.content, str) else ""
-    return Command(
-        goto="populate_initial_data",
-        update={"messages": [response], "dashboard_spec": spec_text},
-    )
-
-
-async def plan_tools(state: DashboardState) -> DashboardState:
-    """On follow-up turns, pick the MINIMAL set of tools — usually one."""
-    context = (
-        f"The current dashboard spec is:\n{state['dashboard_spec']}\n\n"
-        "The user has sent a follow-up. Classify and act ONCE — DO NOT ask\n"
-        "clarifying questions. Pick the smallest action that satisfies the\n"
-        "request and commit to it.\n"
-        "\n"
-        "1) FILTER / SCOPE (e.g. 'filter to cancelled flights only', 'last 6\n"
-        "   months', 'top 3'): call EXACTLY ONE tool — the one that backs the\n"
-        "   affected component — with the new parameters. Do NOT call the\n"
-        "   other tools. Do NOT regenerate the spec.\n"
-        "\n"
-        "2) STRUCTURAL change (e.g. 'add a card for X', 'remove the table'):\n"
-        "   regenerate the spec, then call only the tools needed to populate\n"
-        "   NEW components.\n"
-        "\n"
-        "3) INTERPRETIVE question that no tool could answer (e.g. 'why is\n"
-        "   on-time % low?', 'what does this mean?'): respond in plain prose,\n"
-        "   call NO tools. Use this ONLY when no tool fetch could resolve the\n"
-        "   question. If a tool could provide more data to help answer, pick\n"
-        "   case 1 or 2 instead.\n"
-        "\n"
-        "Anti-patterns to avoid:\n"
-        "  - Asking 'would you also like…' or any clarifying question.\n"
-        "    Commit to the most reasonable interpretation and act.\n"
-        "  - Calling all four tools. That is reserved for an explicit\n"
-        "    'refresh' / 'reload everything' request.\n"
-        "  - Responding conversationally when the request mentions filtering,\n"
-        "    sorting, or scoping. Those are case 1, always."
-    )
-    messages = [SystemMessage(content=_PROMPT + "\n\n" + context)] + state["messages"]
     response = await _llm_with_tools.ainvoke(messages)
     return {"messages": [response]}
 
 
-async def populate_initial_data(state: DashboardState) -> dict:
-    """Deterministic first-turn data fetch: invoke all 4 data tools.
-
-    The dashboard prompt mandates 'call ALL four data tools to populate the
-    dashboard' on first turn. That's a fixed instruction, not a judgment
-    call — encode it as Python instead of paying an LLM round-trip + risking
-    the planner refusing to commit to tool calls.
-
-    Synthesizes one AIMessage with tool_calls for all 4 tools + one
-    ToolMessage per result. Matches ToolNode's output shape so emit_state
-    (which reads ToolMessages by name) needs no changes.
-    """
-    tool_calls = [
-        {
-            "name": t.name,
-            "args": {},
-            "id": f"init_{t.name}_{uuid.uuid4().hex[:8]}",
-            "type": "tool_call",
-        }
-        for t in ALL_TOOLS
-    ]
-    ai = AIMessage(content="", tool_calls=tool_calls)
-
-    tool_msgs: list[ToolMessage] = []
-    for t, tc in zip(ALL_TOOLS, tool_calls):
-        result = await t.ainvoke({})
-        content = json.dumps(result) if not isinstance(result, str) else result
-        tool_msgs.append(ToolMessage(content=content, tool_call_id=tc["id"], name=t.name))
-
-    return {"messages": [ai] + tool_msgs}
-
-
-def should_call_tools(state: DashboardState) -> Literal["call_tools", "respond"]:
-    """Check if the last message has tool calls."""
+def should_continue(state: DashboardState) -> Literal["tools", "emit_state"]:
+    """Loop while the agent emits tool_calls, up to _MAX_TOOL_ITERATIONS
+    this turn. After the cap, force exit to emit_state — a partial
+    dashboard beats an infinite loop."""
     last = state["messages"][-1]
-    if hasattr(last, "tool_calls") and last.tool_calls:
-        return "call_tools"
-    return "respond"
+    if not (hasattr(last, "tool_calls") and last.tool_calls):
+        return "emit_state"
+
+    iter_count = 0
+    for msg in reversed(state["messages"]):
+        if msg.type == "human":
+            break
+        if msg.type == "ai" and getattr(msg, "tool_calls", None):
+            iter_count += 1
+    if iter_count >= _MAX_TOOL_ITERATIONS:
+        return "emit_state"
+    return "tools"
+
+
+async def wrap_spec_into_ai(state: DashboardState) -> dict:
+    """Post-process that wraps the most recent render_spec ToolMessage
+    payload into the parent AI tool-call message's content (in place via
+    LangGraph's add_messages reducer matching by id). The chat-lib's
+    content-classifier then sees content starting with `{` and mounts
+    <chat-generative-ui>.
+
+    Idempotent: if the parent AI message already has non-empty content
+    (already wrapped on a prior iteration), no-op. Also no-op if there
+    is no render_spec ToolMessage to process.
+
+    Mirrors emit_generated_surface from examples/chat/python/src/graph.py,
+    adapted to loop back to `agent` instead of going to END.
+    """
+    msgs = state["messages"]
+
+    render_tool_msg: ToolMessage | None = None
+    parent_ai: AIMessage | None = None
+    for m in reversed(msgs):
+        if isinstance(m, ToolMessage) and m.name == "render_spec":
+            render_tool_msg = m
+            for prior in reversed(msgs):
+                if isinstance(prior, AIMessage) and prior.tool_calls:
+                    if any(tc.get("id") == render_tool_msg.tool_call_id for tc in prior.tool_calls):
+                        parent_ai = prior
+                        break
+            break
+
+    if render_tool_msg is None or parent_ai is None:
+        return {}
+
+    existing = parent_ai.content
+    if isinstance(existing, str) and existing.strip():
+        return {}
+
+    payload = render_tool_msg.content if isinstance(render_tool_msg.content, str) else ""
+    if not payload:
+        return {}
+
+    stripped = payload.strip()
+    if stripped.startswith("```"):
+        lines = stripped.split("\n")
+        stripped = "\n".join(line for line in lines if not line.startswith("```")).strip()
+
+    out: list = []
+
+    placeholder_kwargs: dict = {
+        "content": "rendered",
+        "tool_call_id": render_tool_msg.tool_call_id,
+        "name": "render_spec",
+    }
+    if getattr(render_tool_msg, "id", None):
+        placeholder_kwargs["id"] = render_tool_msg.id
+    out.append(ToolMessage(**placeholder_kwargs))
+
+    replacement_kwargs: dict = {
+        "content": stripped,
+        "tool_calls": parent_ai.tool_calls,
+        "additional_kwargs": parent_ai.additional_kwargs or {},
+        "response_metadata": parent_ai.response_metadata or {},
+    }
+    if getattr(parent_ai, "id", None):
+        replacement_kwargs["id"] = parent_ai.id
+    out.append(AIMessage(**replacement_kwargs))
+
+    return {"messages": out}
 
 
 async def emit_state(state: DashboardState) -> DashboardState:
-    """Emit state_update custom events from tool results.
+    """Emit state_update custom events from data tool results. Walks
+    state["messages"] in reverse, accumulates state patches from
+    ToolMessages produced this turn (until the most recent human message
+    — NOT ai, since the loop produces multiple AI messages per turn).
 
-    Uses LangGraph 1.x's `get_stream_writer()` — `adispatch_custom_event`
-    no longer flows into the `custom` stream channel. The chat-lib bridge
-    parses the payload as `{name: 'state_update', data: <patches>}`.
+    Ignores tool names not in the known set (e.g. render_spec, whose
+    payload was already wrapped into AI content by wrap_spec_into_ai
+    and whose ToolMessage is now the "rendered" stub).
     """
     from langgraph.config import get_stream_writer
 
-    tool_results = {}
+    tool_results: dict = {}
     for msg in reversed(state["messages"]):
         if msg.type == "tool":
             try:
@@ -167,24 +198,19 @@ async def emit_state(state: DashboardState) -> DashboardState:
                 tool_results["/flights_by_airline"] = data
             elif msg.name == "query_recent_disruptions":
                 tool_results["/recent_disruptions"] = data
-        elif msg.type == "ai":
+        elif msg.type == "human":
             break
 
     if tool_results:
-        # The chat-lib bridge (stream-manager.bridge.ts handles the 'custom'
-        # case) parses `eventData['name']` for routing and `eventData['data']`
-        # for payload; chat.component.ts then forwards data to
-        # signal-state-store.update() which expects flat Record<jsonPointer, value>.
         writer = get_stream_writer()
         writer({"name": "state_update", "data": tool_results})
 
     return state
 
 
-async def respond(state: DashboardState) -> DashboardState:
-    """Generate a brief conversational summary of what just happened on this
-    turn. ALWAYS runs (no early-exit) so the user-visible summary is always
-    authored by this node, never inherited from plan_tools' chatter."""
+async def respond(state: DashboardState) -> dict:
+    """Generate a brief conversational summary of what just happened on
+    this turn. ALWAYS runs (no early-exit)."""
     messages = [
         SystemMessage(content=(
             "Provide a brief (1-2 sentence) conversational summary of what "
@@ -193,30 +219,21 @@ async def respond(state: DashboardState) -> DashboardState:
             "Do NOT output JSON. Do NOT ask follow-up questions."
         ))
     ] + state["messages"]
-    response = await _llm.ainvoke(messages)
+    response = await _respond_llm.ainvoke(messages)
     return {"messages": [response]}
 
 
 _builder = StateGraph(DashboardState)
-_builder.add_node("router", router)
-_builder.add_node("generate_shell", generate_shell)
-_builder.add_node("populate_initial_data", populate_initial_data)
-_builder.add_node("plan_tools", plan_tools)
-_builder.add_node("call_tools", ToolNode(ALL_TOOLS))
+_builder.add_node("agent", agent)
+_builder.add_node("tools", ToolNode(_ALL_TOOLS))
+_builder.add_node("wrap_spec_into_ai", wrap_spec_into_ai)
 _builder.add_node("emit_state", emit_state)
 _builder.add_node("respond", respond)
 
-_builder.set_entry_point("router")
-
-# First-turn deterministic path: generate_shell returns Command(goto=populate_initial_data),
-# so no explicit edge needed from generate_shell. populate_initial_data goes to emit_state.
-_builder.add_edge("populate_initial_data", "emit_state")
-
-# Follow-up path: plan_tools may call tools (→ call_tools) or commit to prose (→ respond)
-_builder.add_conditional_edges("plan_tools", should_call_tools)
-
-# Tool calling flow (follow-up path)
-_builder.add_edge("call_tools", "emit_state")
+_builder.set_entry_point("agent")
+_builder.add_conditional_edges("agent", should_continue)
+_builder.add_edge("tools", "wrap_spec_into_ai")
+_builder.add_edge("wrap_spec_into_ai", "agent")
 _builder.add_edge("emit_state", "respond")
 _builder.add_edge("respond", END)
 

--- a/cockpit/chat/generative-ui/python/src/graph.py
+++ b/cockpit/chat/generative-ui/python/src/graph.py
@@ -80,10 +80,12 @@ async def agent(state: DashboardState) -> dict:
     return {"messages": [response]}
 
 
-def should_continue(state: DashboardState) -> Literal["tools", "emit_state"]:
+def should_continue(state: DashboardState) -> Literal["tools", "finalize", "emit_state"]:
     """Loop while the agent emits tool_calls, up to _MAX_TOOL_ITERATIONS
-    this turn. After the cap, force exit to emit_state — a partial
-    dashboard beats an infinite loop."""
+    this turn. After the cap, route through `finalize` (strips orphan
+    tool_calls from the last AI message) before emit_state — otherwise
+    `respond`'s LLM call rejects the message history because the AI
+    message had tool_calls without matching ToolMessages."""
     last = state["messages"][-1]
     if not (hasattr(last, "tool_calls") and last.tool_calls):
         return "emit_state"
@@ -95,8 +97,26 @@ def should_continue(state: DashboardState) -> Literal["tools", "emit_state"]:
         if msg.type == "ai" and getattr(msg, "tool_calls", None):
             iter_count += 1
     if iter_count >= _MAX_TOOL_ITERATIONS:
-        return "emit_state"
+        return "finalize"
     return "tools"
+
+
+async def finalize(state: DashboardState) -> dict:
+    """Strip tool_calls from the last AI message when the iteration cap
+    is hit, so respond's LLM call doesn't fail with 'tool_calls without
+    matching ToolMessage' errors. Replaces in place via add_messages
+    id-match reducer."""
+    last = state["messages"][-1]
+    if not (isinstance(last, AIMessage) and last.tool_calls):
+        return {}
+    replacement_kwargs: dict = {
+        "content": last.content or "(iteration cap reached)",
+        "additional_kwargs": last.additional_kwargs or {},
+        "response_metadata": last.response_metadata or {},
+    }
+    if getattr(last, "id", None):
+        replacement_kwargs["id"] = last.id
+    return {"messages": [AIMessage(**replacement_kwargs)]}
 
 
 async def wrap_spec_into_ai(state: DashboardState) -> dict:
@@ -227,6 +247,7 @@ _builder = StateGraph(DashboardState)
 _builder.add_node("agent", agent)
 _builder.add_node("tools", ToolNode(_ALL_TOOLS))
 _builder.add_node("wrap_spec_into_ai", wrap_spec_into_ai)
+_builder.add_node("finalize", finalize)
 _builder.add_node("emit_state", emit_state)
 _builder.add_node("respond", respond)
 
@@ -234,6 +255,7 @@ _builder.set_entry_point("agent")
 _builder.add_conditional_edges("agent", should_continue)
 _builder.add_edge("tools", "wrap_spec_into_ai")
 _builder.add_edge("wrap_spec_into_ai", "agent")
+_builder.add_edge("finalize", "emit_state")
 _builder.add_edge("emit_state", "respond")
 _builder.add_edge("respond", END)
 

--- a/cockpit/langgraph/streaming/python/prompts/dashboard.md
+++ b/cockpit/langgraph/streaming/python/prompts/dashboard.md
@@ -1,22 +1,28 @@
 # Airline Operations Dashboard Agent
 
-You are a dashboard agent that builds interactive airline-operations KPI dashboards using a JSON render spec format. You have access to tools that query an airline's flight, fleet, and on-time performance data.
+You are a dashboard agent that builds interactive airline-operations KPI dashboards. You have five tools:
 
-## Your Behavior
+- `render_spec(spec)` — Author or update the dashboard layout. The spec is a JSON object describing component types, props, children, and state bindings. See the schema below.
+- `query_airline_kpis()` — Snapshot of operational KPIs: on-time %, flights today, avg delay, load factor.
+- `query_on_time_trend(months=12)` — On-time performance per month, for the line chart.
+- `query_flights_by_airline(airlines=None)` — Daily flight counts per airline, for the bar chart.
+- `query_recent_disruptions(limit=5, type=None)` — Recent delays/cancellations, for the data grid.
 
-### First message (no existing dashboard)
+## Workflow
 
-1. Generate a complete dashboard layout as a JSON render spec (see format below)
-2. Call ALL four data tools to populate the dashboard
-3. After the tools return, provide a brief conversational summary
+### When no dashboard exists yet (first turn)
 
-### Follow-up messages (dashboard already exists)
+1. Call `render_spec` ONCE with a complete dashboard layout — stat cards, charts, table — using `$state` bindings to the slots the data tools populate (see "State Path Conventions" below).
+2. In the SAME turn (same tool_calls array), call EACH data tool that backs a component in your spec. Do NOT call tools whose data your spec doesn't reference.
+3. After the tools return, return WITHOUT any further tool calls. A separate node will write a brief conversational summary.
 
-Categorize the user's request:
+### When the dashboard exists (follow-up turn)
 
-- **Data change** (e.g., "show last 6 months", "filter to cancelled flights only"): Call only the relevant tool(s) with updated parameters. Do NOT regenerate the spec. Just respond conversationally confirming the update.
-- **Structural change** (e.g., "add a new chart", "remove the table"): Regenerate the full spec with the modification, then call tools to populate any new components.
-- **Question about data** (e.g., "why did on-time % dip in December?"): Respond conversationally in plain text. Do NOT output JSON or call tools.
+Categorize the user's request and act ONCE. DO NOT ask clarifying questions — pick the most reasonable interpretation and act.
+
+- **Filter / scope** (e.g. "filter to cancelled flights only", "last 6 months", "top 3"): call EXACTLY ONE data tool — the one that backs the affected component — with the new parameters. Do NOT call `render_spec`.
+- **Structural change** (e.g. "add a card for X", "remove the table"): call `render_spec` with the modified layout, then call data tools only for the NEW components.
+- **Interpretive question** that no tool could resolve (e.g. "why is on-time % low?"): respond in plain prose with no tool calls.
 
 ## JSON Render Spec Format
 

--- a/cockpit/langgraph/streaming/python/src/dashboard_graph.py
+++ b/cockpit/langgraph/streaming/python/src/dashboard_graph.py
@@ -80,10 +80,12 @@ async def agent(state: DashboardState) -> dict:
     return {"messages": [response]}
 
 
-def should_continue(state: DashboardState) -> Literal["tools", "emit_state"]:
+def should_continue(state: DashboardState) -> Literal["tools", "finalize", "emit_state"]:
     """Loop while the agent emits tool_calls, up to _MAX_TOOL_ITERATIONS
-    this turn. After the cap, force exit to emit_state — a partial
-    dashboard beats an infinite loop."""
+    this turn. After the cap, route through `finalize` (strips orphan
+    tool_calls from the last AI message) before emit_state — otherwise
+    `respond`'s LLM call rejects the message history because the AI
+    message had tool_calls without matching ToolMessages."""
     last = state["messages"][-1]
     if not (hasattr(last, "tool_calls") and last.tool_calls):
         return "emit_state"
@@ -95,8 +97,26 @@ def should_continue(state: DashboardState) -> Literal["tools", "emit_state"]:
         if msg.type == "ai" and getattr(msg, "tool_calls", None):
             iter_count += 1
     if iter_count >= _MAX_TOOL_ITERATIONS:
-        return "emit_state"
+        return "finalize"
     return "tools"
+
+
+async def finalize(state: DashboardState) -> dict:
+    """Strip tool_calls from the last AI message when the iteration cap
+    is hit, so respond's LLM call doesn't fail with 'tool_calls without
+    matching ToolMessage' errors. Replaces in place via add_messages
+    id-match reducer."""
+    last = state["messages"][-1]
+    if not (isinstance(last, AIMessage) and last.tool_calls):
+        return {}
+    replacement_kwargs: dict = {
+        "content": last.content or "(iteration cap reached)",
+        "additional_kwargs": last.additional_kwargs or {},
+        "response_metadata": last.response_metadata or {},
+    }
+    if getattr(last, "id", None):
+        replacement_kwargs["id"] = last.id
+    return {"messages": [AIMessage(**replacement_kwargs)]}
 
 
 async def wrap_spec_into_ai(state: DashboardState) -> dict:
@@ -227,6 +247,7 @@ _builder = StateGraph(DashboardState)
 _builder.add_node("agent", agent)
 _builder.add_node("tools", ToolNode(_ALL_TOOLS))
 _builder.add_node("wrap_spec_into_ai", wrap_spec_into_ai)
+_builder.add_node("finalize", finalize)
 _builder.add_node("emit_state", emit_state)
 _builder.add_node("respond", respond)
 
@@ -234,6 +255,7 @@ _builder.set_entry_point("agent")
 _builder.add_conditional_edges("agent", should_continue)
 _builder.add_edge("tools", "wrap_spec_into_ai")
 _builder.add_edge("wrap_spec_into_ai", "agent")
+_builder.add_edge("finalize", "emit_state")
 _builder.add_edge("emit_state", "respond")
 _builder.add_edge("respond", END)
 

--- a/cockpit/langgraph/streaming/python/src/dashboard_graph.py
+++ b/cockpit/langgraph/streaming/python/src/dashboard_graph.py
@@ -1,154 +1,185 @@
-"""Multi-node LangGraph graph for the airline operations KPI dashboard.
+"""Single-node agentic graph for the airline operations KPI dashboard.
 
 Flow:
-  router → generate_shell (first turn) or plan_tools (follow-up)
-  → call_tools → emit_state → respond
+  START → agent ↔ tools → wrap_spec_into_ai → agent (loop) → emit_state → respond → END
+
+`agent` is a single LLM call with all 5 tools bound (render_spec + 4 data
+tools). After tools run, `wrap_spec_into_ai` post-processes — if the LLM
+called render_spec, it replaces the parent AI message's content with the
+spec JSON (in place via add_messages' id-match reducer) so the chat-lib's
+content-classifier mounts <chat-generative-ui>. Then loops back to agent
+until the LLM returns no tool_calls (cap _MAX_TOOL_ITERATIONS per turn).
+
+Mirrors the emit_generated_surface pattern from examples/chat/python/src/graph.py,
+adapted for a continuation loop instead of terminal dispatch.
 """
 
 import json
 from pathlib import Path
-from typing import Annotated, Literal
+from typing import Literal
 
-import uuid
 from langchain_core.messages import AIMessage, SystemMessage, ToolMessage
+from langchain_core.tools import tool
 from langchain_openai import ChatOpenAI
 from langgraph.graph import StateGraph, MessagesState, END
 from langgraph.prebuilt import ToolNode
-from langgraph.types import Command
 
-from src.dashboard_tools import ALL_TOOLS
+from src.dashboard_tools import ALL_TOOLS as _DATA_TOOLS
 
 _PROMPT = (Path(__file__).parent.parent / "prompts" / "dashboard.md").read_text()
 
-_llm = ChatOpenAI(model="gpt-5-mini", temperature=0, streaming=True)
+_MAX_TOOL_ITERATIONS = 6
 
-# Dedicated planner: full gpt-5 with minimal reasoning effort.
-# gpt-5-mini at default reasoning ignores the "EXACTLY ONE tool" directive
-# in plan_tools and reflexively calls all four data tools on every
-# follow-up — verified in chrome MCP after PR #363 tightened the prompt
-# but the model still over-called. Bumping the planner to gpt-5 sharpens
-# instruction-following, and reasoning_effort='minimal' suppresses the
-# "let me be thorough" deliberation that drives the fan-out.
-_planner_llm = ChatOpenAI(
+
+class DashboardState(MessagesState):
+    """The dashboard spec lives in AI message content (the canonical
+    chat-lib surface-delivery protocol), not on the state object."""
+    pass
+
+
+@tool
+async def render_spec(spec: dict) -> str:
+    """Render an interactive dashboard layout from a JSON spec.
+
+    Use this tool to author or update the dashboard layout. The spec is a
+    JSON object with `elements` (a dict keyed by component id) and `root`
+    (the id of the top-level component). See the system prompt for the full
+    schema and component catalog.
+
+    Call this tool FIRST on any turn where the layout needs to be created
+    or restructured. After calling render_spec, call the data tools needed
+    to populate the components you authored.
+
+    Args:
+        spec: The dashboard JSON render spec.
+
+    Returns:
+        The spec serialized as JSON. A post-process node (wrap_spec_into_ai)
+        wraps this payload into the AI message content where the
+        chat-lib's content-classifier picks it up.
+    """
+    return json.dumps(spec)
+
+
+_ALL_TOOLS = [render_spec, *_DATA_TOOLS]
+
+_llm_with_tools = ChatOpenAI(
     model="gpt-5",
     temperature=0,
     streaming=True,
     reasoning_effort="minimal",
-)
-_llm_with_tools = _planner_llm.bind_tools(ALL_TOOLS)
+).bind_tools(_ALL_TOOLS)
+
+_respond_llm = ChatOpenAI(model="gpt-5-mini", temperature=0, streaming=True)
 
 
-class DashboardState(MessagesState):
-    """Extended state that persists the dashboard spec across turns."""
-    dashboard_spec: str | None
-
-
-def router(state: DashboardState) -> Command[Literal["generate_shell", "plan_tools"]]:
-    """Route based on whether a dashboard spec already exists."""
-    if state.get("dashboard_spec") is None:
-        return Command(goto="generate_shell")
-    return Command(goto="plan_tools")
-
-
-async def generate_shell(state: DashboardState) -> Command[Literal["populate_initial_data"]]:
-    """Generate the dashboard shell spec on first turn, then dispatch to
-    deterministic data-population (skipping plan_tools, which has a
-    follow-up-only prompt)."""
+async def agent(state: DashboardState) -> dict:
+    """Single agentic node: LLM bound with all 5 tools."""
     messages = [SystemMessage(content=_PROMPT)] + state["messages"]
-    response = await _llm.ainvoke(messages)
-    spec_text = response.content if isinstance(response.content, str) else ""
-    return Command(
-        goto="populate_initial_data",
-        update={"messages": [response], "dashboard_spec": spec_text},
-    )
-
-
-async def plan_tools(state: DashboardState) -> DashboardState:
-    """On follow-up turns, pick the MINIMAL set of tools — usually one."""
-    context = (
-        f"The current dashboard spec is:\n{state['dashboard_spec']}\n\n"
-        "The user has sent a follow-up. Classify and act ONCE — DO NOT ask\n"
-        "clarifying questions. Pick the smallest action that satisfies the\n"
-        "request and commit to it.\n"
-        "\n"
-        "1) FILTER / SCOPE (e.g. 'filter to cancelled flights only', 'last 6\n"
-        "   months', 'top 3'): call EXACTLY ONE tool — the one that backs the\n"
-        "   affected component — with the new parameters. Do NOT call the\n"
-        "   other tools. Do NOT regenerate the spec.\n"
-        "\n"
-        "2) STRUCTURAL change (e.g. 'add a card for X', 'remove the table'):\n"
-        "   regenerate the spec, then call only the tools needed to populate\n"
-        "   NEW components.\n"
-        "\n"
-        "3) INTERPRETIVE question that no tool could answer (e.g. 'why is\n"
-        "   on-time % low?', 'what does this mean?'): respond in plain prose,\n"
-        "   call NO tools. Use this ONLY when no tool fetch could resolve the\n"
-        "   question. If a tool could provide more data to help answer, pick\n"
-        "   case 1 or 2 instead.\n"
-        "\n"
-        "Anti-patterns to avoid:\n"
-        "  - Asking 'would you also like…' or any clarifying question.\n"
-        "    Commit to the most reasonable interpretation and act.\n"
-        "  - Calling all four tools. That is reserved for an explicit\n"
-        "    'refresh' / 'reload everything' request.\n"
-        "  - Responding conversationally when the request mentions filtering,\n"
-        "    sorting, or scoping. Those are case 1, always."
-    )
-    messages = [SystemMessage(content=_PROMPT + "\n\n" + context)] + state["messages"]
     response = await _llm_with_tools.ainvoke(messages)
     return {"messages": [response]}
 
 
-async def populate_initial_data(state: DashboardState) -> dict:
-    """Deterministic first-turn data fetch: invoke all 4 data tools.
-
-    The dashboard prompt mandates 'call ALL four data tools to populate the
-    dashboard' on first turn. That's a fixed instruction, not a judgment
-    call — encode it as Python instead of paying an LLM round-trip + risking
-    the planner refusing to commit to tool calls.
-
-    Synthesizes one AIMessage with tool_calls for all 4 tools + one
-    ToolMessage per result. Matches ToolNode's output shape so emit_state
-    (which reads ToolMessages by name) needs no changes.
-    """
-    tool_calls = [
-        {
-            "name": t.name,
-            "args": {},
-            "id": f"init_{t.name}_{uuid.uuid4().hex[:8]}",
-            "type": "tool_call",
-        }
-        for t in ALL_TOOLS
-    ]
-    ai = AIMessage(content="", tool_calls=tool_calls)
-
-    tool_msgs: list[ToolMessage] = []
-    for t, tc in zip(ALL_TOOLS, tool_calls):
-        result = await t.ainvoke({})
-        content = json.dumps(result) if not isinstance(result, str) else result
-        tool_msgs.append(ToolMessage(content=content, tool_call_id=tc["id"], name=t.name))
-
-    return {"messages": [ai] + tool_msgs}
-
-
-def should_call_tools(state: DashboardState) -> Literal["call_tools", "respond"]:
-    """Check if the last message has tool calls."""
+def should_continue(state: DashboardState) -> Literal["tools", "emit_state"]:
+    """Loop while the agent emits tool_calls, up to _MAX_TOOL_ITERATIONS
+    this turn. After the cap, force exit to emit_state — a partial
+    dashboard beats an infinite loop."""
     last = state["messages"][-1]
-    if hasattr(last, "tool_calls") and last.tool_calls:
-        return "call_tools"
-    return "respond"
+    if not (hasattr(last, "tool_calls") and last.tool_calls):
+        return "emit_state"
+
+    iter_count = 0
+    for msg in reversed(state["messages"]):
+        if msg.type == "human":
+            break
+        if msg.type == "ai" and getattr(msg, "tool_calls", None):
+            iter_count += 1
+    if iter_count >= _MAX_TOOL_ITERATIONS:
+        return "emit_state"
+    return "tools"
+
+
+async def wrap_spec_into_ai(state: DashboardState) -> dict:
+    """Post-process that wraps the most recent render_spec ToolMessage
+    payload into the parent AI tool-call message's content (in place via
+    LangGraph's add_messages reducer matching by id). The chat-lib's
+    content-classifier then sees content starting with `{` and mounts
+    <chat-generative-ui>.
+
+    Idempotent: if the parent AI message already has non-empty content
+    (already wrapped on a prior iteration), no-op. Also no-op if there
+    is no render_spec ToolMessage to process.
+
+    Mirrors emit_generated_surface from examples/chat/python/src/graph.py,
+    adapted to loop back to `agent` instead of going to END.
+    """
+    msgs = state["messages"]
+
+    render_tool_msg: ToolMessage | None = None
+    parent_ai: AIMessage | None = None
+    for m in reversed(msgs):
+        if isinstance(m, ToolMessage) and m.name == "render_spec":
+            render_tool_msg = m
+            for prior in reversed(msgs):
+                if isinstance(prior, AIMessage) and prior.tool_calls:
+                    if any(tc.get("id") == render_tool_msg.tool_call_id for tc in prior.tool_calls):
+                        parent_ai = prior
+                        break
+            break
+
+    if render_tool_msg is None or parent_ai is None:
+        return {}
+
+    existing = parent_ai.content
+    if isinstance(existing, str) and existing.strip():
+        return {}
+
+    payload = render_tool_msg.content if isinstance(render_tool_msg.content, str) else ""
+    if not payload:
+        return {}
+
+    stripped = payload.strip()
+    if stripped.startswith("```"):
+        lines = stripped.split("\n")
+        stripped = "\n".join(line for line in lines if not line.startswith("```")).strip()
+
+    out: list = []
+
+    placeholder_kwargs: dict = {
+        "content": "rendered",
+        "tool_call_id": render_tool_msg.tool_call_id,
+        "name": "render_spec",
+    }
+    if getattr(render_tool_msg, "id", None):
+        placeholder_kwargs["id"] = render_tool_msg.id
+    out.append(ToolMessage(**placeholder_kwargs))
+
+    replacement_kwargs: dict = {
+        "content": stripped,
+        "tool_calls": parent_ai.tool_calls,
+        "additional_kwargs": parent_ai.additional_kwargs or {},
+        "response_metadata": parent_ai.response_metadata or {},
+    }
+    if getattr(parent_ai, "id", None):
+        replacement_kwargs["id"] = parent_ai.id
+    out.append(AIMessage(**replacement_kwargs))
+
+    return {"messages": out}
 
 
 async def emit_state(state: DashboardState) -> DashboardState:
-    """Emit state_update custom events from tool results.
+    """Emit state_update custom events from data tool results. Walks
+    state["messages"] in reverse, accumulates state patches from
+    ToolMessages produced this turn (until the most recent human message
+    — NOT ai, since the loop produces multiple AI messages per turn).
 
-    Uses LangGraph 1.x's `get_stream_writer()` — `adispatch_custom_event`
-    no longer flows into the `custom` stream channel. The chat-lib bridge
-    parses the payload as `{name: 'state_update', data: <patches>}`.
+    Ignores tool names not in the known set (e.g. render_spec, whose
+    payload was already wrapped into AI content by wrap_spec_into_ai
+    and whose ToolMessage is now the "rendered" stub).
     """
     from langgraph.config import get_stream_writer
 
-    tool_results = {}
+    tool_results: dict = {}
     for msg in reversed(state["messages"]):
         if msg.type == "tool":
             try:
@@ -157,7 +188,6 @@ async def emit_state(state: DashboardState) -> DashboardState:
                 continue
 
             if msg.name == "query_airline_kpis":
-                # data is {"on_time": {"value": ..., "delta": ...}, ...}
                 for section_key, section_val in data.items():
                     if isinstance(section_val, dict):
                         for k, v in section_val.items():
@@ -168,24 +198,19 @@ async def emit_state(state: DashboardState) -> DashboardState:
                 tool_results["/flights_by_airline"] = data
             elif msg.name == "query_recent_disruptions":
                 tool_results["/recent_disruptions"] = data
-        elif msg.type == "ai":
+        elif msg.type == "human":
             break
 
     if tool_results:
-        # The chat-lib bridge (stream-manager.bridge.ts handles the 'custom'
-        # case) parses `eventData['name']` for routing and `eventData['data']`
-        # for payload; chat.component.ts then forwards data to
-        # signal-state-store.update() which expects flat Record<jsonPointer, value>.
         writer = get_stream_writer()
         writer({"name": "state_update", "data": tool_results})
 
     return state
 
 
-async def respond(state: DashboardState) -> DashboardState:
-    """Generate a brief conversational summary of what just happened on this
-    turn. ALWAYS runs (no early-exit) so the user-visible summary is always
-    authored by this node, never inherited from plan_tools' chatter."""
+async def respond(state: DashboardState) -> dict:
+    """Generate a brief conversational summary of what just happened on
+    this turn. ALWAYS runs (no early-exit)."""
     messages = [
         SystemMessage(content=(
             "Provide a brief (1-2 sentence) conversational summary of what "
@@ -194,30 +219,21 @@ async def respond(state: DashboardState) -> DashboardState:
             "Do NOT output JSON. Do NOT ask follow-up questions."
         ))
     ] + state["messages"]
-    response = await _llm.ainvoke(messages)
+    response = await _respond_llm.ainvoke(messages)
     return {"messages": [response]}
 
 
 _builder = StateGraph(DashboardState)
-_builder.add_node("router", router)
-_builder.add_node("generate_shell", generate_shell)
-_builder.add_node("populate_initial_data", populate_initial_data)
-_builder.add_node("plan_tools", plan_tools)
-_builder.add_node("call_tools", ToolNode(ALL_TOOLS))
+_builder.add_node("agent", agent)
+_builder.add_node("tools", ToolNode(_ALL_TOOLS))
+_builder.add_node("wrap_spec_into_ai", wrap_spec_into_ai)
 _builder.add_node("emit_state", emit_state)
 _builder.add_node("respond", respond)
 
-_builder.set_entry_point("router")
-
-# First-turn deterministic path: generate_shell returns Command(goto=populate_initial_data),
-# so no explicit edge needed from generate_shell. populate_initial_data goes to emit_state.
-_builder.add_edge("populate_initial_data", "emit_state")
-
-# Follow-up path: plan_tools may call tools (→ call_tools) or commit to prose (→ respond)
-_builder.add_conditional_edges("plan_tools", should_call_tools)
-
-# Tool calling flow (follow-up path)
-_builder.add_edge("call_tools", "emit_state")
+_builder.set_entry_point("agent")
+_builder.add_conditional_edges("agent", should_continue)
+_builder.add_edge("tools", "wrap_spec_into_ai")
+_builder.add_edge("wrap_spec_into_ai", "agent")
 _builder.add_edge("emit_state", "respond")
 _builder.add_edge("respond", END)
 

--- a/docs/superpowers/plans/2026-05-18-c-generative-ui-agentic-loop.md
+++ b/docs/superpowers/plans/2026-05-18-c-generative-ui-agentic-loop.md
@@ -1,0 +1,712 @@
+# c-generative-ui Agentic-Loop Rewrite Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the current 6-node split-graph (router → generate_shell → populate_initial_data → emit_state → respond; or router → plan_tools → call_tools → emit_state → respond) with a single agentic loop: `START → agent ↔ tools → emit_state → respond → END`. Adds a `render_spec` tool so the LLM authors the spec AND chooses which data tools to call in one coherent reasoning step.
+
+**Architecture:** Single `agent` node (gpt-5 reasoning='minimal') bound with 5 tools (`render_spec` + 4 existing data tools). Loops via `tools` (ToolNode) + `should_continue` (max 8 iterations per turn). `render_spec` is a `Command`-returning tool that updates `dashboard_spec` in state. The system prompt instructs first-turn = `render_spec` + relevant data tools; follow-up = case-based per existing rules.
+
+**Tech Stack:** Python 3.12, LangGraph ≥0.3 (`Command`-from-tool), langchain-openai (`gpt-5` reasoning='minimal' for agent, `gpt-5-mini` for respond), uv. Per-cap canonical = `cockpit/chat/generative-ui/python/src/graph.py`; umbrella mirror = `cockpit/langgraph/streaming/python/src/dashboard_graph.py`. Per-cap prompt = `cockpit/chat/generative-ui/python/prompts/dashboard.md`; umbrella mirror = `cockpit/langgraph/streaming/python/prompts/dashboard.md`.
+
+---
+
+## Pre-flight (READ FIRST)
+
+**Shared-checkout chaos.** The repo's working tree gets switched by parallel agents in this checkout. Confirmed during PR #428 — branch hijacking made chrome MCP smoke impossible because the langgraph dev server kept loading whichever code was on disk when it booted. This plan defends against it: every code-modifying task starts with `git branch --show-current` check, and Task 7 (chrome MCP) **uses an isolated worktree** for the dev server.
+
+Before starting:
+
+```bash
+git fetch origin
+git checkout -b claude/genui-agentic-loop claude/genui-agentic-loop-spec
+```
+
+The spec commit is the only commit between origin/main and `claude/genui-agentic-loop-spec` — implementation branches off the spec branch.
+
+---
+
+## Files modified
+
+- Modify: `cockpit/chat/generative-ui/python/src/graph.py` (per-cap canonical — full rewrite)
+- Modify: `cockpit/langgraph/streaming/python/src/dashboard_graph.py` (umbrella mirror)
+- Modify: `cockpit/chat/generative-ui/python/prompts/dashboard.md` (per-cap canonical prompt)
+- Modify: `cockpit/langgraph/streaming/python/prompts/dashboard.md` (umbrella mirror prompt)
+
+No `dashboard_tools.py` changes. No frontend changes. No `pyproject.toml` changes.
+
+---
+
+## Task 1: Rewrite per-cap graph
+
+**Files:**
+- Modify: `cockpit/chat/generative-ui/python/src/graph.py` (replace contents)
+
+- [ ] **Step 1: Verify branch**
+
+```bash
+test "$(git branch --show-current)" = "claude/genui-agentic-loop" && echo OK || echo WRONG_BRANCH
+```
+
+Expected: `OK`. If `WRONG_BRANCH`, STOP — do not proceed.
+
+- [ ] **Step 2: Replace `cockpit/chat/generative-ui/python/src/graph.py` with the agentic-loop version**
+
+Write the file with this exact content:
+
+```python
+"""Single-node agentic graph for the airline operations KPI dashboard.
+
+Flow:
+  START → agent ↔ tools → emit_state → respond → END
+
+`agent` is a single LLM call with all 5 tools bound (render_spec + 4 data
+tools). Loops via `should_continue` until the LLM returns no tool_calls or
+the iteration cap is hit. Replaces the prior 6-node split graph (PR #428's
+generate_shell / populate_initial_data / plan_tools / router scaffolding)
+with a single coherent reasoning loop, as described in the agentic-loop
+design spec (2026-05-18).
+"""
+
+import json
+from pathlib import Path
+from typing import Annotated, Literal
+
+from langchain_core.messages import AIMessage, SystemMessage, ToolMessage
+from langchain_core.tools import InjectedToolCallId, tool
+from langchain_openai import ChatOpenAI
+from langgraph.graph import StateGraph, MessagesState, END
+from langgraph.prebuilt import ToolNode
+from langgraph.types import Command
+
+from src.dashboard_tools import ALL_TOOLS as _DATA_TOOLS
+
+_PROMPT = (Path(__file__).parent.parent / "prompts" / "dashboard.md").read_text()
+
+_MAX_TOOL_ITERATIONS = 8
+
+
+class DashboardState(MessagesState):
+    """Extended state that persists the dashboard spec across turns."""
+    dashboard_spec: str | None
+
+
+@tool
+def render_spec(spec: dict, tool_call_id: Annotated[str, InjectedToolCallId]) -> Command:
+    """Render an interactive dashboard layout from a JSON spec.
+
+    Use this tool to author or update the dashboard layout. The spec is a
+    JSON object with `elements` (a dict keyed by component id) and `root`
+    (the id of the top-level component). See the system prompt for the full
+    schema and component catalog.
+
+    Call this tool FIRST on any turn where the layout needs to be created
+    or restructured. After calling render_spec, call the data tools needed
+    to populate the components you authored.
+
+    Args:
+        spec: The dashboard JSON render spec.
+
+    Returns:
+        Command updating dashboard_spec in state and emitting a ToolMessage.
+    """
+    spec_text = json.dumps(spec)
+    return Command(
+        update={
+            "dashboard_spec": spec_text,
+            "messages": [
+                ToolMessage(
+                    content="Spec accepted.",
+                    tool_call_id=tool_call_id,
+                    name="render_spec",
+                )
+            ],
+        }
+    )
+
+
+_ALL_TOOLS = [render_spec, *_DATA_TOOLS]
+
+_llm_with_tools = ChatOpenAI(
+    model="gpt-5",
+    temperature=0,
+    streaming=True,
+    reasoning_effort="minimal",
+).bind_tools(_ALL_TOOLS)
+
+_respond_llm = ChatOpenAI(model="gpt-5-mini", temperature=0, streaming=True)
+
+
+async def agent(state: DashboardState) -> dict:
+    """Single agentic node: LLM bound with all 5 tools, driven by the
+    dashboard.md system prompt. Loops via the `tools` node + should_continue
+    until the LLM returns no tool_calls."""
+    messages = [SystemMessage(content=_PROMPT)] + state["messages"]
+    response = await _llm_with_tools.ainvoke(messages)
+    return {"messages": [response]}
+
+
+def should_continue(state: DashboardState) -> Literal["tools", "emit_state"]:
+    """Loop while the agent emits tool_calls, up to _MAX_TOOL_ITERATIONS this
+    turn. After the cap, force exit to emit_state — partial dashboard is
+    better than an infinite loop."""
+    last = state["messages"][-1]
+    if not (hasattr(last, "tool_calls") and last.tool_calls):
+        return "emit_state"
+
+    iter_count = 0
+    for msg in reversed(state["messages"]):
+        if msg.type == "human":
+            break
+        if msg.type == "ai" and getattr(msg, "tool_calls", None):
+            iter_count += 1
+    if iter_count >= _MAX_TOOL_ITERATIONS:
+        return "emit_state"
+    return "tools"
+
+
+async def emit_state(state: DashboardState) -> DashboardState:
+    """Emit state_update custom events from tool results.
+
+    Uses LangGraph 1.x's `get_stream_writer()` — `adispatch_custom_event`
+    no longer flows into the `custom` stream channel. The chat-lib bridge
+    parses the payload as `{name: 'state_update', data: <patches>}`.
+
+    Walks `state["messages"]` in reverse, accumulates state patches from
+    ToolMessages produced this turn (until the most recent ai turn boundary
+    or human message). Tool names not in the known set are ignored
+    (e.g. render_spec, which writes to dashboard_spec via Command instead).
+    """
+    from langgraph.config import get_stream_writer
+
+    tool_results = {}
+    for msg in reversed(state["messages"]):
+        if msg.type == "tool":
+            try:
+                data = json.loads(msg.content) if isinstance(msg.content, str) else msg.content
+            except (json.JSONDecodeError, TypeError):
+                continue
+
+            if msg.name == "query_airline_kpis":
+                for section_key, section_val in data.items():
+                    if isinstance(section_val, dict):
+                        for k, v in section_val.items():
+                            tool_results[f"/{section_key}/{k}"] = v
+            elif msg.name == "query_on_time_trend":
+                tool_results["/on_time_trend"] = data
+            elif msg.name == "query_flights_by_airline":
+                tool_results["/flights_by_airline"] = data
+            elif msg.name == "query_recent_disruptions":
+                tool_results["/recent_disruptions"] = data
+        elif msg.type == "ai":
+            # Tool results from this turn are after the most recent prior ai
+            # turn — but since the agent loop produces multiple ai messages
+            # per turn (one per tool-call round), don't break on ai. Break
+            # on human instead.
+            continue
+        elif msg.type == "human":
+            break
+
+    if tool_results:
+        writer = get_stream_writer()
+        writer({"name": "state_update", "data": tool_results})
+
+    return state
+
+
+async def respond(state: DashboardState) -> dict:
+    """Generate a brief conversational summary of what just happened on this
+    turn. ALWAYS runs (no early-exit) so the user-visible summary is always
+    authored by this node, never inherited from the agent's tool-calling
+    chatter."""
+    messages = [
+        SystemMessage(content=(
+            "Provide a brief (1-2 sentence) conversational summary of what "
+            "you just did this turn. If you generated a dashboard, say so. "
+            "If you filtered data, say what you filtered. "
+            "Do NOT output JSON. Do NOT ask follow-up questions."
+        ))
+    ] + state["messages"]
+    response = await _respond_llm.ainvoke(messages)
+    return {"messages": [response]}
+
+
+_builder = StateGraph(DashboardState)
+_builder.add_node("agent", agent)
+_builder.add_node("tools", ToolNode(_ALL_TOOLS))
+_builder.add_node("emit_state", emit_state)
+_builder.add_node("respond", respond)
+
+_builder.set_entry_point("agent")
+_builder.add_conditional_edges("agent", should_continue)
+_builder.add_edge("tools", "agent")
+_builder.add_edge("emit_state", "respond")
+_builder.add_edge("respond", END)
+
+graph = _builder.compile()
+```
+
+Critical fix: the `emit_state` `elif msg.type == "ai": break` from PR #428 would prematurely break out of the reverse walk after the FIRST ai message — but in the agentic loop, we now have multiple ai messages per turn (one per tool-call round). The corrected loop breaks on `human` instead, which marks the true turn boundary.
+
+- [ ] **Step 3: Verify compile + render_spec callable**
+
+```bash
+test "$(git branch --show-current)" = "claude/genui-agentic-loop" && echo OK || exit 1
+cd cockpit/chat/generative-ui/python && uv run python -c "
+import asyncio
+from src.graph import graph, render_spec, agent, should_continue
+print('TYPE:', type(graph).__name__)
+print('NODES:', sorted(graph.nodes))
+# Invoke render_spec directly to confirm it returns a Command
+result = render_spec.invoke({'spec': {'elements': {'root': {'type': 'dashboard_grid'}}, 'root': 'root'}, 'tool_call_id': 'call_test'})
+print('RENDER_SPEC_TYPE:', type(result).__name__)
+print('RENDER_SPEC_UPDATE_KEYS:', sorted(result.update.keys()))
+print('RENDER_SPEC_HAS_DASHBOARD_SPEC:', 'dashboard_spec' in result.update)
+"
+```
+
+Expected:
+```
+TYPE: CompiledStateGraph
+NODES: ['__end__', '__start__', 'agent', 'emit_state', 'respond', 'tools']
+RENDER_SPEC_TYPE: Command
+RENDER_SPEC_UPDATE_KEYS: ['dashboard_spec', 'messages']
+RENDER_SPEC_HAS_DASHBOARD_SPEC: True
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+test "$(git branch --show-current)" = "claude/genui-agentic-loop" && echo OK || exit 1
+git add cockpit/chat/generative-ui/python/src/graph.py
+git commit -m "feat(c-generative-ui): rewrite as single agentic loop with render_spec tool (per-cap)"
+```
+
+---
+
+## Task 2: Rewrite per-cap system prompt
+
+**Files:**
+- Modify: `cockpit/chat/generative-ui/python/prompts/dashboard.md`
+
+- [ ] **Step 1: Verify branch**
+
+```bash
+test "$(git branch --show-current)" = "claude/genui-agentic-loop" && echo OK || exit 1
+```
+
+- [ ] **Step 2: Replace the prompt's workflow sections**
+
+The file currently starts with a `# Airline Operations Dashboard Agent` heading, then "## Your Behavior" with "### First message" + "### Follow-up messages" subsections, then "## JSON Render Spec Format" through "## Example Spec". Replace EVERYTHING from the top through the "Categorize the user's request:" section (i.e. through the end of "Follow-up messages"), keeping the "## JSON Render Spec Format" section onwards byte-identical. Open the existing file to find the exact byte ranges before editing.
+
+Use `Edit` to do this replacement (not `Write`, to preserve the schema sections perfectly). The new opening, replacing everything from `# Airline Operations Dashboard Agent` through the end of the follow-up-messages list, should be:
+
+```markdown
+# Airline Operations Dashboard Agent
+
+You are a dashboard agent that builds interactive airline-operations KPI dashboards. You have five tools:
+
+- `render_spec(spec)` — Author or update the dashboard layout. The spec is a JSON object describing component types, props, children, and state bindings. See the schema below.
+- `query_airline_kpis()` — Snapshot of operational KPIs: on-time %, flights today, avg delay, load factor.
+- `query_on_time_trend(months=12)` — On-time performance per month, for the line chart.
+- `query_flights_by_airline(airlines=None)` — Daily flight counts per airline, for the bar chart.
+- `query_recent_disruptions(limit=5, type=None)` — Recent delays/cancellations, for the data grid.
+
+## Workflow
+
+### When no dashboard exists yet (first turn)
+
+1. Call `render_spec` with a complete dashboard layout — stat cards, charts, table — using `$state` bindings to the slots that the data tools populate (see "State Path Conventions" below).
+2. Call EACH data tool that backs a component in your spec. Do NOT call tools whose data your spec doesn't reference.
+3. Return — no further tool calls. A separate node will write a brief summary.
+
+### When the dashboard exists (follow-up turn)
+
+Categorize the user's request and act ONCE. DO NOT ask clarifying questions — pick the most reasonable interpretation and act.
+
+- **Filter / scope** (e.g. "filter to cancelled flights only", "last 6 months", "top 3"): call EXACTLY ONE data tool — the one that backs the affected component — with the new parameters. Do NOT call `render_spec`.
+- **Structural change** (e.g. "add a card for X", "remove the table"): call `render_spec` with the modified layout, then call data tools only for the NEW components.
+- **Interpretive question** that no tool could resolve (e.g. "why is on-time % low?"): respond in plain prose with no tool calls. Use this ONLY when no tool fetch could answer the question.
+
+```
+
+Then immediately follow with the existing `## JSON Render Spec Format` section (and everything below), preserved verbatim. The final file should be: new opening (above) + `## JSON Render Spec Format` onwards (existing content).
+
+- [ ] **Step 3: Verify the file has both the new opening AND the existing schema sections**
+
+```bash
+grep -c "render_spec(spec)" cockpit/chat/generative-ui/python/prompts/dashboard.md
+grep -c "JSON Render Spec Format" cockpit/chat/generative-ui/python/prompts/dashboard.md
+grep -c "State Path Conventions" cockpit/chat/generative-ui/python/prompts/dashboard.md
+grep -c "Example Spec" cockpit/chat/generative-ui/python/prompts/dashboard.md
+grep -c "First message" cockpit/chat/generative-ui/python/prompts/dashboard.md
+```
+
+Expected (in order): `1`, `1`, `1`, `1`, `0`. The "First message" header must NOT be in the file anymore (replaced with "When no dashboard exists yet (first turn)"). The schema sections (JSON Render Spec Format, State Path Conventions, Example Spec) MUST still be present.
+
+- [ ] **Step 4: Commit**
+
+```bash
+test "$(git branch --show-current)" = "claude/genui-agentic-loop" && echo OK || exit 1
+git add cockpit/chat/generative-ui/python/prompts/dashboard.md
+git commit -m "feat(c-generative-ui): rewrite system prompt for agentic-loop workflow (per-cap)"
+```
+
+---
+
+## Task 3: Mirror to umbrella graph
+
+**Files:**
+- Modify: `cockpit/langgraph/streaming/python/src/dashboard_graph.py`
+
+- [ ] **Step 1: Verify branch + copy per-cap graph.py to umbrella**
+
+```bash
+test "$(git branch --show-current)" = "claude/genui-agentic-loop" && echo OK || exit 1
+cp cockpit/chat/generative-ui/python/src/graph.py cockpit/langgraph/streaming/python/src/dashboard_graph.py
+```
+
+The per-cap and umbrella are byte-identical mirrors per PR #396 policy. The only path-related difference is the import (`from src.dashboard_tools import ...`) — `src.dashboard_tools` resolves correctly in both packages because both have a `src/` package containing `dashboard_tools.py`. Verify:
+
+```bash
+test -f cockpit/langgraph/streaming/python/src/dashboard_tools.py && echo OK || echo MISSING_DASHBOARD_TOOLS
+```
+
+Expected: `OK`. If `MISSING_DASHBOARD_TOOLS`, STOP — the umbrella is in an unexpected state.
+
+- [ ] **Step 2: Verify umbrella compiles + render_spec works**
+
+```bash
+cd cockpit/langgraph/streaming/python && uv run python -c "
+from src.dashboard_graph import graph, render_spec
+print('TYPE:', type(graph).__name__)
+print('NODES:', sorted(graph.nodes))
+result = render_spec.invoke({'spec': {'elements': {'root': {'type': 'dashboard_grid'}}, 'root': 'root'}, 'tool_call_id': 'call_test'})
+print('UPDATE_KEYS:', sorted(result.update.keys()))
+"
+```
+
+Expected: `TYPE: CompiledStateGraph`, NODES includes `agent` + `tools` + `emit_state` + `respond` (no router/generate_shell/etc.), UPDATE_KEYS `['dashboard_spec', 'messages']`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+test "$(git branch --show-current)" = "claude/genui-agentic-loop" && echo OK || exit 1
+git add cockpit/langgraph/streaming/python/src/dashboard_graph.py
+git commit -m "feat(c-generative-ui umbrella): mirror agentic-loop rewrite"
+```
+
+---
+
+## Task 4: Mirror prompt to umbrella
+
+**Files:**
+- Modify: `cockpit/langgraph/streaming/python/prompts/dashboard.md`
+
+- [ ] **Step 1: Verify branch + copy per-cap prompt to umbrella**
+
+```bash
+test "$(git branch --show-current)" = "claude/genui-agentic-loop" && echo OK || exit 1
+cp cockpit/chat/generative-ui/python/prompts/dashboard.md cockpit/langgraph/streaming/python/prompts/dashboard.md
+```
+
+- [ ] **Step 2: Verify diff is empty**
+
+```bash
+diff cockpit/chat/generative-ui/python/prompts/dashboard.md cockpit/langgraph/streaming/python/prompts/dashboard.md && echo IDENTICAL
+```
+
+Expected: `IDENTICAL`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cockpit/langgraph/streaming/python/prompts/dashboard.md
+git commit -m "feat(c-generative-ui umbrella): mirror prompt rewrite"
+```
+
+---
+
+## Task 5: End-to-end real-LLM smoke (per-cap)
+
+**Files:** none (verification only). Requires `OPENAI_API_KEY`.
+
+- [ ] **Step 1: Confirm key present**
+
+```bash
+grep -q '^OPENAI_API_KEY=' .env && echo found
+```
+
+- [ ] **Step 2: Run the multi-turn smoke**
+
+```bash
+set -a; source .env; set +a
+cd cockpit/chat/generative-ui/python && uv run python -c "
+import asyncio, json
+from src.graph import graph
+from langchain_core.messages import HumanMessage
+
+async def main():
+    # Turn 1: first turn
+    s1 = await graph.ainvoke({'messages': [HumanMessage(content='Show me a dashboard of airline operations.')], 'dashboard_spec': None})
+    msgs = s1['messages']
+    tool_msgs = [m for m in msgs if m.type == 'tool']
+    tool_names = [m.name for m in tool_msgs]
+    print('TURN1_TOOL_NAMES:', tool_names)
+    print('TURN1_HAS_RENDER_SPEC:', 'render_spec' in tool_names)
+    print('TURN1_DATA_TOOL_COUNT:', sum(1 for n in tool_names if n != 'render_spec'))
+    print('TURN1_HAS_SPEC:', bool(s1.get('dashboard_spec')))
+    final = msgs[-1].content[:200] if isinstance(msgs[-1].content, str) else str(msgs[-1].content)[:200]
+    print('TURN1_FINAL:', final[:160])
+    assert 'render_spec' in tool_names, f'expected render_spec call, got {tool_names!r}'
+    assert sum(1 for n in tool_names if n != 'render_spec') >= 1, f'expected >=1 data tool call, got {tool_names!r}'
+    assert s1.get('dashboard_spec'), 'dashboard_spec not populated'
+    assert not final.lstrip().startswith('{'), f'final looks like JSON: {final[:80]!r}'
+
+    # Turn 2: filter
+    s2 = await graph.ainvoke({'messages': msgs + [HumanMessage(content='Filter to only cancelled flights')], 'dashboard_spec': s1['dashboard_spec']})
+    msgs2 = s2['messages']
+    new_tool_msgs = [m for m in msgs2[len(msgs):] if m.type == 'tool']
+    new_tool_names = [m.name for m in new_tool_msgs]
+    print('TURN2_NEW_TOOL_NAMES:', new_tool_names)
+    final2 = msgs2[-1].content[:200] if isinstance(msgs2[-1].content, str) else str(msgs2[-1].content)[:200]
+    print('TURN2_FINAL:', final2[:160])
+    assert 'render_spec' not in new_tool_names, f'filter should NOT trigger render_spec: {new_tool_names!r}'
+    assert len(new_tool_names) >= 1, f'expected >=1 new data tool call on follow-up: {new_tool_names!r}'
+
+    # Turn 3: interpretive
+    s3 = await graph.ainvoke({'messages': msgs2 + [HumanMessage(content='Why might on-time percentage be lower than industry average?')], 'dashboard_spec': s2['dashboard_spec']})
+    msgs3 = s3['messages']
+    new_tool_msgs3 = [m for m in msgs3[len(msgs2):] if m.type == 'tool']
+    print('TURN3_NEW_TOOL_NAMES:', [m.name for m in new_tool_msgs3])
+    final3 = msgs3[-1].content[:300] if isinstance(msgs3[-1].content, str) else str(msgs3[-1].content)[:300]
+    print('TURN3_FINAL:', final3[:200])
+    # Turn 3 should be a prose answer (interpretive case 3) — assert no tool calls is too strict for gpt-5
+    # so just print and let reviewer eyeball.
+
+asyncio.run(main())
+"
+```
+
+Expected:
+- TURN1: `render_spec` in tool names, ≥1 data tool call, `dashboard_spec` populated, final is prose
+- TURN2: 1+ new data tool calls, NO new `render_spec`, final commits to action
+- TURN3: ideally 0 new tool calls and a prose answer; if 1-2 tool calls appear, eyeball the final response
+
+If turn 1 or 2 fails the assertions, fix and re-run before continuing.
+
+- [ ] **Step 3: If smoke reveals an issue, fix the earlier task's code and re-run.**
+
+If a fix was needed:
+
+```bash
+test "$(git branch --show-current)" = "claude/genui-agentic-loop" && echo OK || exit 1
+git add cockpit/chat/generative-ui/python/src/graph.py cockpit/chat/generative-ui/python/prompts/dashboard.md cockpit/langgraph/streaming/python/src/dashboard_graph.py cockpit/langgraph/streaming/python/prompts/dashboard.md
+git commit -m "fix(c-generative-ui): smoke fixes for agentic-loop"
+```
+
+---
+
+## Task 6: Build verification
+
+**Files:** none.
+
+- [ ] **Step 1: Build per-cap python**
+
+```bash
+pnpm nx run cockpit-chat-generative-ui-python:build
+```
+
+Expected: green.
+
+- [ ] **Step 2: Build umbrella python**
+
+```bash
+pnpm nx run cockpit-langgraph-streaming-python:build
+```
+
+Expected: green.
+
+- [ ] **Step 3: Build Angular (sanity)**
+
+```bash
+pnpm nx run cockpit-chat-generative-ui-angular:build
+```
+
+Expected: green.
+
+- [ ] **Step 4: Production deploy manifest unchanged**
+
+```bash
+npx tsx scripts/generate-shared-deployment-config.ts && git diff deployments/shared-dev/langgraph.json
+```
+
+Expected: empty diff (we changed Python source, not the manifest).
+
+- [ ] **Step 5: No commit**
+
+---
+
+## Task 7: REQUIRED — chrome MCP end-to-end smoke (in isolated worktree)
+
+**Files:** none.
+
+PR #428's chrome MCP smoke was defeated by concurrent worktree branch-switching in the shared checkout. This task uses an isolated worktree where no parallel agent can switch the branch.
+
+- [ ] **Step 1: Create isolated worktree**
+
+```bash
+ISOLATED_DIR="/tmp/genui-agentic-loop-verify"
+rm -rf "$ISOLATED_DIR"
+git worktree add "$ISOLATED_DIR" claude/genui-agentic-loop
+cd "$ISOLATED_DIR"
+git branch --show-current
+```
+
+Expected: `claude/genui-agentic-loop`. This directory is a SEPARATE checkout — no other agent has any reason to switch its branch.
+
+- [ ] **Step 2: Install deps in the isolated worktree's per-cap python**
+
+```bash
+cd cockpit/chat/generative-ui/python && uv sync 2>&1 | tail -3
+```
+
+- [ ] **Step 3: Start servers from the isolated worktree**
+
+From `$ISOLATED_DIR`:
+
+```bash
+lsof -t -i :5508 -i :4508 2>/dev/null | xargs kill -9 2>/dev/null
+set -a; source .env 2>/dev/null || source /Users/blove/repos/angular-agent-framework/.env; set +a
+nohup pnpm nx run cockpit-chat-generative-ui-python:serve > /tmp/agentic-loop-backend.log 2>&1 &
+nohup pnpm nx serve cockpit-chat-generative-ui-angular --port 4508 > /tmp/agentic-loop-frontend.log 2>&1 &
+```
+
+Wait for both ready (`Application started up` in backend log; `Local:` in frontend log).
+
+- [ ] **Step 4: Verify the loaded graph is the new one**
+
+```bash
+curl -s http://localhost:5508/assistants/c-generative-ui/graph | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+nodes = sorted([n['id'] for n in d.get('nodes', [])])
+print('NODES:', nodes)
+print('HAS_AGENT:', 'agent' in nodes)
+print('HAS_ROUTER:', 'router' in nodes)
+print('HAS_GENERATE_SHELL:', 'generate_shell' in nodes)
+"
+```
+
+Expected: `agent` IN nodes, `router` and `generate_shell` NOT in nodes. If the wrong graph is loaded, STOP — the worktree isolation didn't work or there's a caching issue. Investigate before continuing.
+
+- [ ] **Step 5: Drive the flow via chrome MCP**
+
+1. Navigate to `http://localhost:4508/`
+2. Click "Render a dashboard" → wait ~30s → expect populated KPI cards (numbers, not "Building UI…" placeholders), line chart with data, bar chart, data table with rows
+3. Type "Filter to only cancelled flights" → press Enter → wait ~15s → expect data table updates to cancellations only
+4. Take a screenshot with `save_to_disk: true` for the PR description
+5. Optional: type "Why might on-time percentage be lower than industry average?" → expect prose answer
+
+- [ ] **Step 6: Stop servers + clean up worktree**
+
+```bash
+lsof -t -i :5508 -i :4508 2>/dev/null | xargs kill -9 2>/dev/null
+rm -f /tmp/agentic-loop-backend.log /tmp/agentic-loop-frontend.log
+cd /Users/blove/repos/angular-agent-framework
+git worktree remove "$ISOLATED_DIR" --force
+```
+
+---
+
+## Task 8: Open PR + watch CI + merge
+
+- [ ] **Step 1: Push branch**
+
+```bash
+test "$(git branch --show-current)" = "claude/genui-agentic-loop" && echo OK || exit 1
+git push -u origin claude/genui-agentic-loop
+```
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create --title "refactor(c-generative-ui): single agentic loop with render_spec tool" --body "$(cat <<'EOF'
+## Summary
+Replaces the c-generative-ui 6-node split graph with a single agentic loop, addressing the architectural critique from PR #428's discussion: today's \`populate_initial_data\` deterministically fires all 4 data tools regardless of what the LLM authored, ignoring the spec entirely. That fudges the demo's core claim ("the LLM intelligently composes UI and data fetches together").
+
+After this PR:
+- Single \`agent\` node (gpt-5, reasoning='minimal') with 5 tools bound: a new \`render_spec(spec)\` tool + the 4 existing data tools.
+- LLM authors the spec by calling \`render_spec\` (which returns \`Command(update={"dashboard_spec": ..., "messages": [...]})\` to mutate state), then calls only the data tools its spec references.
+- Loop via \`agent ↔ tools\` (canonical pattern, same as \`c_tool_calls\` and \`c_subagents\`), capped at 8 iterations per turn.
+- System prompt rewritten to be agentic-loop-aware: first-turn = \`render_spec\` + relevant data tools; follow-up = filter/structural/interpretive cases per the existing rules.
+- Removed: \`router\`, \`generate_shell\`, \`populate_initial_data\`, \`plan_tools\`. Kept: \`emit_state\` (with one fix — break on human, not ai, since the loop now produces multiple ai messages per turn), \`respond\`.
+
+## Why this over PR #428's fix
+PR #428 made the demo render but at the cost of replacing LLM judgement with a hardcoded loop over all 4 tools. The agent never adapts to the spec; the demo's "generative" claim is hollow. This PR restores the claim: one LLM, one prompt, full agentic composition.
+
+## Files
+- \`cockpit/chat/generative-ui/python/src/graph.py\` — per-cap canonical (full rewrite)
+- \`cockpit/langgraph/streaming/python/src/dashboard_graph.py\` — umbrella mirror
+- \`cockpit/chat/generative-ui/python/prompts/dashboard.md\` — agentic workflow + schema preserved
+- \`cockpit/langgraph/streaming/python/prompts/dashboard.md\` — umbrella mirror
+
+## Test plan
+- [x] \`pnpm nx run cockpit-chat-generative-ui-python:build\` — green
+- [x] \`pnpm nx run cockpit-langgraph-streaming-python:build\` — green
+- [x] \`pnpm nx run cockpit-chat-generative-ui-angular:build\` — green
+- [x] Shared-deployment manifest unchanged (26 graphs)
+- [x] **Programmatic real-LLM smoke (3-turn)**:
+  - Turn 1 ("Show me a dashboard of airline operations.") — calls \`render_spec\` + ≥1 data tool; \`dashboard_spec\` populated; final = conversational prose
+  - Turn 2 ("Filter to only cancelled flights") — ≥1 new data tool call; NO new \`render_spec\`; final commits to action
+  - Turn 3 ("Why might on-time percentage be lower than industry average?") — prose answer
+- [x] **Chrome MCP smoke (in isolated worktree)**: dashboard renders with real data, filter works, screenshot attached
+- [ ] CI
+
+Plan: \`docs/superpowers/plans/2026-05-18-c-generative-ui-agentic-loop.md\`
+Spec: \`docs/superpowers/specs/2026-05-18-c-generative-ui-agentic-loop-design.md\`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Watch CI**
+
+```bash
+gh pr checks <PR#> --watch
+```
+
+- [ ] **Step 4: Squash-merge on green**
+
+```bash
+gh pr merge <PR#> --squash --delete-branch
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Decision 1 (render_spec tool) → Task 1 Step 2 ✓
+- Decision 2 (Command-from-tool for dashboard_spec) → Task 1 Step 2 ✓
+- Decision 3 (graph shape: agent ↔ tools → emit_state → respond) → Task 1 Step 2 (builder block) ✓
+- Decision 4 (iteration cap at 8) → Task 1 Step 2 (`_MAX_TOOL_ITERATIONS = 8` + `should_continue`) ✓
+- Decision 5 (gpt-5 minimal + gpt-5-mini for respond) → Task 1 Step 2 (LLM bindings) ✓
+- Decision 6 (emit_state unchanged behavior, ignores render_spec) → Task 1 Step 2 (fall-through OK; `break on human` fix) ✓
+- Decision 7 (respond unchanged from PR #428) → Task 1 Step 2 ✓
+- Decision 8 (tool_choice='auto' — implicit since we don't set tool_choice) → Task 1 Step 2 (no tool_choice arg = default auto) ✓
+- Decision 9 (system prompt rewrite) → Task 2 ✓
+- Decision 10 (full mirror to umbrella graph + prompt) → Tasks 3 + 4 ✓
+- Programmatic smoke (3-turn) → Task 5 ✓
+- Chrome MCP smoke in isolated worktree → Task 7 ✓ (with explicit recovery path from PR #428's hijack issue)
+
+**Placeholder scan:** None. Every code-modifying step has full code. Task 2 references the existing prompt's schema sections "verbatim" — acceptable because they ARE correct already and re-pasting them in the plan would double the plan length.
+
+**Type consistency:**
+- `DashboardState(MessagesState)` with `dashboard_spec: str | None` matches today's shape; `render_spec` Command writes `str` (via `json.dumps(spec)`) which matches the annotation.
+- `render_spec(spec: dict, tool_call_id: Annotated[str, InjectedToolCallId])` — `InjectedToolCallId` is the canonical annotation for tool-side access to the calling AI message's tool_call_id (langchain-core ≥0.3, which the cockpit deps already pin).
+- `_ALL_TOOLS = [render_spec, *_DATA_TOOLS]` — same list passed to both `bind_tools` and `ToolNode`, so the tool universe is consistent end-to-end.
+- `should_continue` return type `Literal["tools", "emit_state"]` matches both destinations in the builder's `add_conditional_edges("agent", should_continue)` call.
+- `emit_state` reading `msg.name == "query_..."` matches the names produced by `dashboard_tools.py`'s `@tool` decorators (which default tool name to the function name).
+
+**Concurrency notes:** Every code-modifying task starts with a `git branch --show-current` check. Task 7 uses an isolated worktree to bypass the dev-server cache issue from PR #428.

--- a/docs/superpowers/plans/2026-05-18-c-generative-ui-agentic-loop.md
+++ b/docs/superpowers/plans/2026-05-18-c-generative-ui-agentic-loop.md
@@ -1,27 +1,32 @@
-# c-generative-ui Agentic-Loop Rewrite Implementation Plan
+# c-generative-ui Agentic-Loop Rewrite (v2) Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Replace the current 6-node split-graph (router → generate_shell → populate_initial_data → emit_state → respond; or router → plan_tools → call_tools → emit_state → respond) with a single agentic loop: `START → agent ↔ tools → emit_state → respond → END`. Adds a `render_spec` tool so the LLM authors the spec AND chooses which data tools to call in one coherent reasoning step.
+**Goal:** Rewrite c-generative-ui as a single agentic loop where the LLM authors the dashboard spec via a `render_spec` tool (returning the spec as a JSON string) AND chooses the data tools to populate it in the same turn. Use the canonical `emit_generated_surface`-style pattern from `examples/chat/python/src/graph.py` — wrap the spec into AIMessage content via a post-process node so the chat-lib's existing content-classifier picks it up.
 
-**Architecture:** Single `agent` node (gpt-5 reasoning='minimal') bound with 5 tools (`render_spec` + 4 existing data tools). Loops via `tools` (ToolNode) + `should_continue` (max 8 iterations per turn). `render_spec` is a `Command`-returning tool that updates `dashboard_spec` in state. The system prompt instructs first-turn = `render_spec` + relevant data tools; follow-up = case-based per existing rules.
+**Architecture:** `START → agent ↔ tools → wrap_spec_into_ai → agent (loop, cap 6) → emit_state → respond → END`. `render_spec` returns `json.dumps(spec)` as its ToolMessage content. `wrap_spec_into_ai` is an idempotent post-process that replaces the parent AI tool-call message's content (in place via `add_messages`'s id-match reducer) with the spec JSON, so `<chat-generative-ui>` mounts via the content-classifier. `'render_spec'` added to the chat-lib's default `genuiToolNames` so `<chat-tool-calls>` excludes it.
 
-**Tech Stack:** Python 3.12, LangGraph ≥0.3 (`Command`-from-tool), langchain-openai (`gpt-5` reasoning='minimal' for agent, `gpt-5-mini` for respond), uv. Per-cap canonical = `cockpit/chat/generative-ui/python/src/graph.py`; umbrella mirror = `cockpit/langgraph/streaming/python/src/dashboard_graph.py`. Per-cap prompt = `cockpit/chat/generative-ui/python/prompts/dashboard.md`; umbrella mirror = `cockpit/langgraph/streaming/python/prompts/dashboard.md`.
+**Tech Stack:** Python 3.12, LangGraph ≥0.3 (in-place message replacement via `add_messages` id-match — no Command-from-tool required), langchain-openai (`gpt-5` reasoning='minimal' for agent, `gpt-5-mini` for respond), TypeScript (one-line chat-lib default update), uv.
 
 ---
 
 ## Pre-flight (READ FIRST)
 
-**Shared-checkout chaos.** The repo's working tree gets switched by parallel agents in this checkout. Confirmed during PR #428 — branch hijacking made chrome MCP smoke impossible because the langgraph dev server kept loading whichever code was on disk when it booted. This plan defends against it: every code-modifying task starts with `git branch --show-current` check, and Task 7 (chrome MCP) **uses an isolated worktree** for the dev server.
+**Supersedes v1.** This plan REPLACES the v1 implementation that used `Command(update=...)` from `render_spec`. v1's `render_spec` Command bypassed the message stream; the frontend never saw the spec. v2 returns the spec as a plain string from the tool (matching the canonical pattern in `examples/chat`).
 
-Before starting:
+**Branch hygiene.** The current implementation branch `claude/genui-agentic-loop` has the v1 (broken) implementation. We restart from the spec branch on a fresh implementation branch:
 
 ```bash
 git fetch origin
-git checkout -b claude/genui-agentic-loop claude/genui-agentic-loop-spec
+git branch -D claude/genui-agentic-loop 2>/dev/null  # discard the v1 attempt
+git checkout -b claude/genui-agentic-loop-v2 claude/genui-agentic-loop-spec
 ```
 
-The spec commit is the only commit between origin/main and `claude/genui-agentic-loop-spec` — implementation branches off the spec branch.
+The v2 spec commit is the latest commit on `claude/genui-agentic-loop-spec`. The v1 plan commit comes before it; that's fine — both live as history on the spec branch.
+
+**Shared-checkout chaos.** Working tree gets switched by parallel agents in this checkout. Every code-modifying step starts with a `git branch --show-current` check. Task 8 (chrome MCP) uses an isolated worktree.
+
+**Reference implementation.** Read `examples/chat/python/src/graph.py` lines 442-593 BEFORE starting Task 2 (the `wrap_spec_into_ai` node). The structure mirrors `emit_generated_surface`; the only adaptation is "loop back to agent instead of going to END."
 
 ---
 
@@ -29,14 +34,65 @@ The spec commit is the only commit between origin/main and `claude/genui-agentic
 
 - Modify: `cockpit/chat/generative-ui/python/src/graph.py` (per-cap canonical — full rewrite)
 - Modify: `cockpit/langgraph/streaming/python/src/dashboard_graph.py` (umbrella mirror)
-- Modify: `cockpit/chat/generative-ui/python/prompts/dashboard.md` (per-cap canonical prompt)
-- Modify: `cockpit/langgraph/streaming/python/prompts/dashboard.md` (umbrella mirror prompt)
+- Modify: `cockpit/chat/generative-ui/python/prompts/dashboard.md` (workflow section rewrite)
+- Modify: `cockpit/langgraph/streaming/python/prompts/dashboard.md` (umbrella prompt mirror)
+- Modify: `libs/chat/src/lib/compositions/chat/chat.component.ts` (1-line addition to default `genuiToolNames`)
 
-No `dashboard_tools.py` changes. No frontend changes. No `pyproject.toml` changes.
+No `dashboard_tools.py` changes. No cockpit consumer changes. No `pyproject.toml` changes. No new dependencies.
 
 ---
 
-## Task 1: Rewrite per-cap graph
+## Task 1: Add `'render_spec'` to chat-lib's default `genuiToolNames`
+
+**Files:**
+- Modify: `libs/chat/src/lib/compositions/chat/chat.component.ts`
+
+- [ ] **Step 1: Verify branch**
+
+```bash
+test "$(git branch --show-current)" = "claude/genui-agentic-loop-v2" && echo OK || exit 1
+```
+
+- [ ] **Step 2: Apply the edit**
+
+Find this block (around line 318):
+
+```typescript
+  readonly genuiToolNames = input<readonly string[]>([
+    'generate_a2ui_schema',
+    'generate_json_render_spec',
+  ]);
+```
+
+Replace with:
+
+```typescript
+  readonly genuiToolNames = input<readonly string[]>([
+    'generate_a2ui_schema',
+    'generate_json_render_spec',
+    'render_spec',
+  ]);
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+grep -A4 "genuiToolNames = input" libs/chat/src/lib/compositions/chat/chat.component.ts | head -6
+```
+
+Expected: the array literal contains all three tool names.
+
+- [ ] **Step 4: Commit**
+
+```bash
+test "$(git branch --show-current)" = "claude/genui-agentic-loop-v2" && echo OK || exit 1
+git add libs/chat/src/lib/compositions/chat/chat.component.ts
+git commit -m "feat(chat-lib): include render_spec in default genuiToolNames"
+```
+
+---
+
+## Task 2: Rewrite per-cap graph
 
 **Files:**
 - Modify: `cockpit/chat/generative-ui/python/src/graph.py` (replace contents)
@@ -44,54 +100,53 @@ No `dashboard_tools.py` changes. No frontend changes. No `pyproject.toml` change
 - [ ] **Step 1: Verify branch**
 
 ```bash
-test "$(git branch --show-current)" = "claude/genui-agentic-loop" && echo OK || echo WRONG_BRANCH
+test "$(git branch --show-current)" = "claude/genui-agentic-loop-v2" && echo OK || exit 1
 ```
 
-Expected: `OK`. If `WRONG_BRANCH`, STOP — do not proceed.
-
-- [ ] **Step 2: Replace `cockpit/chat/generative-ui/python/src/graph.py` with the agentic-loop version**
-
-Write the file with this exact content:
+- [ ] **Step 2: Replace `cockpit/chat/generative-ui/python/src/graph.py` with the agentic-loop v2 version**
 
 ```python
 """Single-node agentic graph for the airline operations KPI dashboard.
 
 Flow:
-  START → agent ↔ tools → emit_state → respond → END
+  START → agent ↔ tools → wrap_spec_into_ai → agent (loop) → emit_state → respond → END
 
 `agent` is a single LLM call with all 5 tools bound (render_spec + 4 data
-tools). Loops via `should_continue` until the LLM returns no tool_calls or
-the iteration cap is hit. Replaces the prior 6-node split graph (PR #428's
-generate_shell / populate_initial_data / plan_tools / router scaffolding)
-with a single coherent reasoning loop, as described in the agentic-loop
-design spec (2026-05-18).
+tools). After tools run, `wrap_spec_into_ai` post-processes — if the LLM
+called render_spec, it replaces the parent AI message's content with the
+spec JSON (in place via add_messages' id-match reducer) so the chat-lib's
+content-classifier mounts <chat-generative-ui>. Then loops back to agent
+until the LLM returns no tool_calls (cap _MAX_TOOL_ITERATIONS per turn).
+
+Mirrors the emit_generated_surface pattern from examples/chat/python/src/graph.py,
+adapted for a continuation loop instead of terminal dispatch.
 """
 
 import json
 from pathlib import Path
-from typing import Annotated, Literal
+from typing import Literal
 
 from langchain_core.messages import AIMessage, SystemMessage, ToolMessage
-from langchain_core.tools import InjectedToolCallId, tool
+from langchain_core.tools import tool
 from langchain_openai import ChatOpenAI
 from langgraph.graph import StateGraph, MessagesState, END
 from langgraph.prebuilt import ToolNode
-from langgraph.types import Command
 
 from src.dashboard_tools import ALL_TOOLS as _DATA_TOOLS
 
 _PROMPT = (Path(__file__).parent.parent / "prompts" / "dashboard.md").read_text()
 
-_MAX_TOOL_ITERATIONS = 8
+_MAX_TOOL_ITERATIONS = 6
 
 
 class DashboardState(MessagesState):
-    """Extended state that persists the dashboard spec across turns."""
-    dashboard_spec: str | None
+    """The dashboard spec lives in AI message content (the canonical
+    chat-lib surface-delivery protocol), not on the state object."""
+    pass
 
 
 @tool
-def render_spec(spec: dict, tool_call_id: Annotated[str, InjectedToolCallId]) -> Command:
+async def render_spec(spec: dict) -> str:
     """Render an interactive dashboard layout from a JSON spec.
 
     Use this tool to author or update the dashboard layout. The spec is a
@@ -107,21 +162,11 @@ def render_spec(spec: dict, tool_call_id: Annotated[str, InjectedToolCallId]) ->
         spec: The dashboard JSON render spec.
 
     Returns:
-        Command updating dashboard_spec in state and emitting a ToolMessage.
+        The spec serialized as JSON. A post-process node (wrap_spec_into_ai)
+        wraps this payload into the AI message content where the
+        chat-lib's content-classifier picks it up.
     """
-    spec_text = json.dumps(spec)
-    return Command(
-        update={
-            "dashboard_spec": spec_text,
-            "messages": [
-                ToolMessage(
-                    content="Spec accepted.",
-                    tool_call_id=tool_call_id,
-                    name="render_spec",
-                )
-            ],
-        }
-    )
+    return json.dumps(spec)
 
 
 _ALL_TOOLS = [render_spec, *_DATA_TOOLS]
@@ -137,18 +182,16 @@ _respond_llm = ChatOpenAI(model="gpt-5-mini", temperature=0, streaming=True)
 
 
 async def agent(state: DashboardState) -> dict:
-    """Single agentic node: LLM bound with all 5 tools, driven by the
-    dashboard.md system prompt. Loops via the `tools` node + should_continue
-    until the LLM returns no tool_calls."""
+    """Single agentic node: LLM bound with all 5 tools."""
     messages = [SystemMessage(content=_PROMPT)] + state["messages"]
     response = await _llm_with_tools.ainvoke(messages)
     return {"messages": [response]}
 
 
 def should_continue(state: DashboardState) -> Literal["tools", "emit_state"]:
-    """Loop while the agent emits tool_calls, up to _MAX_TOOL_ITERATIONS this
-    turn. After the cap, force exit to emit_state — partial dashboard is
-    better than an infinite loop."""
+    """Loop while the agent emits tool_calls, up to _MAX_TOOL_ITERATIONS
+    this turn. After the cap, force exit to emit_state — a partial
+    dashboard beats an infinite loop."""
     last = state["messages"][-1]
     if not (hasattr(last, "tool_calls") and last.tool_calls):
         return "emit_state"
@@ -164,21 +207,87 @@ def should_continue(state: DashboardState) -> Literal["tools", "emit_state"]:
     return "tools"
 
 
+async def wrap_spec_into_ai(state: DashboardState) -> dict:
+    """Post-process that wraps the most recent render_spec ToolMessage
+    payload into the parent AI tool-call message's content (in place via
+    LangGraph's add_messages reducer matching by id). The chat-lib's
+    content-classifier then sees content starting with `{` and mounts
+    <chat-generative-ui>.
+
+    Idempotent: if the parent AI message already has non-empty content
+    (already wrapped on a prior iteration), no-op. Also no-op if there
+    is no render_spec ToolMessage to process.
+
+    Mirrors emit_generated_surface from examples/chat/python/src/graph.py,
+    adapted to loop back to `agent` instead of going to END.
+    """
+    msgs = state["messages"]
+
+    render_tool_msg: ToolMessage | None = None
+    parent_ai: AIMessage | None = None
+    for m in reversed(msgs):
+        if isinstance(m, ToolMessage) and m.name == "render_spec":
+            render_tool_msg = m
+            for prior in reversed(msgs):
+                if isinstance(prior, AIMessage) and prior.tool_calls:
+                    if any(tc.get("id") == render_tool_msg.tool_call_id for tc in prior.tool_calls):
+                        parent_ai = prior
+                        break
+            break
+
+    if render_tool_msg is None or parent_ai is None:
+        return {}
+
+    existing = parent_ai.content
+    if isinstance(existing, str) and existing.strip():
+        return {}
+
+    payload = render_tool_msg.content if isinstance(render_tool_msg.content, str) else ""
+    if not payload:
+        return {}
+
+    stripped = payload.strip()
+    if stripped.startswith("```"):
+        lines = stripped.split("\n")
+        stripped = "\n".join(line for line in lines if not line.startswith("```")).strip()
+
+    out: list = []
+
+    placeholder_kwargs: dict = {
+        "content": "rendered",
+        "tool_call_id": render_tool_msg.tool_call_id,
+        "name": "render_spec",
+    }
+    if getattr(render_tool_msg, "id", None):
+        placeholder_kwargs["id"] = render_tool_msg.id
+    out.append(ToolMessage(**placeholder_kwargs))
+
+    replacement_kwargs: dict = {
+        "content": stripped,
+        "tool_calls": parent_ai.tool_calls,
+        "additional_kwargs": parent_ai.additional_kwargs or {},
+        "response_metadata": parent_ai.response_metadata or {},
+    }
+    if getattr(parent_ai, "id", None):
+        replacement_kwargs["id"] = parent_ai.id
+    out.append(AIMessage(**replacement_kwargs))
+
+    return {"messages": out}
+
+
 async def emit_state(state: DashboardState) -> DashboardState:
-    """Emit state_update custom events from tool results.
+    """Emit state_update custom events from data tool results. Walks
+    state["messages"] in reverse, accumulates state patches from
+    ToolMessages produced this turn (until the most recent human message
+    — NOT ai, since the loop produces multiple AI messages per turn).
 
-    Uses LangGraph 1.x's `get_stream_writer()` — `adispatch_custom_event`
-    no longer flows into the `custom` stream channel. The chat-lib bridge
-    parses the payload as `{name: 'state_update', data: <patches>}`.
-
-    Walks `state["messages"]` in reverse, accumulates state patches from
-    ToolMessages produced this turn (until the most recent ai turn boundary
-    or human message). Tool names not in the known set are ignored
-    (e.g. render_spec, which writes to dashboard_spec via Command instead).
+    Ignores tool names not in the known set (e.g. render_spec, whose
+    payload was already wrapped into AI content by wrap_spec_into_ai
+    and whose ToolMessage is now the "rendered" stub).
     """
     from langgraph.config import get_stream_writer
 
-    tool_results = {}
+    tool_results: dict = {}
     for msg in reversed(state["messages"]):
         if msg.type == "tool":
             try:
@@ -197,12 +306,6 @@ async def emit_state(state: DashboardState) -> DashboardState:
                 tool_results["/flights_by_airline"] = data
             elif msg.name == "query_recent_disruptions":
                 tool_results["/recent_disruptions"] = data
-        elif msg.type == "ai":
-            # Tool results from this turn are after the most recent prior ai
-            # turn — but since the agent loop produces multiple ai messages
-            # per turn (one per tool-call round), don't break on ai. Break
-            # on human instead.
-            continue
         elif msg.type == "human":
             break
 
@@ -214,10 +317,8 @@ async def emit_state(state: DashboardState) -> DashboardState:
 
 
 async def respond(state: DashboardState) -> dict:
-    """Generate a brief conversational summary of what just happened on this
-    turn. ALWAYS runs (no early-exit) so the user-visible summary is always
-    authored by this node, never inherited from the agent's tool-calling
-    chatter."""
+    """Generate a brief conversational summary of what just happened on
+    this turn. ALWAYS runs (no early-exit)."""
     messages = [
         SystemMessage(content=(
             "Provide a brief (1-2 sentence) conversational summary of what "
@@ -233,57 +334,58 @@ async def respond(state: DashboardState) -> dict:
 _builder = StateGraph(DashboardState)
 _builder.add_node("agent", agent)
 _builder.add_node("tools", ToolNode(_ALL_TOOLS))
+_builder.add_node("wrap_spec_into_ai", wrap_spec_into_ai)
 _builder.add_node("emit_state", emit_state)
 _builder.add_node("respond", respond)
 
 _builder.set_entry_point("agent")
 _builder.add_conditional_edges("agent", should_continue)
-_builder.add_edge("tools", "agent")
+_builder.add_edge("tools", "wrap_spec_into_ai")
+_builder.add_edge("wrap_spec_into_ai", "agent")
 _builder.add_edge("emit_state", "respond")
 _builder.add_edge("respond", END)
 
 graph = _builder.compile()
 ```
 
-Critical fix: the `emit_state` `elif msg.type == "ai": break` from PR #428 would prematurely break out of the reverse walk after the FIRST ai message — but in the agentic loop, we now have multiple ai messages per turn (one per tool-call round). The corrected loop breaks on `human` instead, which marks the true turn boundary.
-
-- [ ] **Step 3: Verify compile + render_spec callable**
+- [ ] **Step 3: Verify compile + render_spec direct call**
 
 ```bash
-test "$(git branch --show-current)" = "claude/genui-agentic-loop" && echo OK || exit 1
+test "$(git branch --show-current)" = "claude/genui-agentic-loop-v2" && echo OK || exit 1
 cd cockpit/chat/generative-ui/python && uv run python -c "
 import asyncio
-from src.graph import graph, render_spec, agent, should_continue
+from src.graph import graph, render_spec, wrap_spec_into_ai
 print('TYPE:', type(graph).__name__)
 print('NODES:', sorted(graph.nodes))
-# Invoke render_spec directly to confirm it returns a Command
-result = render_spec.invoke({'spec': {'elements': {'root': {'type': 'dashboard_grid'}}, 'root': 'root'}, 'tool_call_id': 'call_test'})
+result = asyncio.run(render_spec.ainvoke({'spec': {'elements': {'root': {'type': 'dashboard_grid'}}, 'root': 'root'}}))
 print('RENDER_SPEC_TYPE:', type(result).__name__)
-print('RENDER_SPEC_UPDATE_KEYS:', sorted(result.update.keys()))
-print('RENDER_SPEC_HAS_DASHBOARD_SPEC:', 'dashboard_spec' in result.update)
+print('RENDER_SPEC_STARTS_WITH:', result[:20])
+assert isinstance(result, str), 'render_spec should return str, not Command'
+assert result.startswith('{'), 'spec JSON should start with {'
 "
 ```
 
 Expected:
 ```
 TYPE: CompiledStateGraph
-NODES: ['__end__', '__start__', 'agent', 'emit_state', 'respond', 'tools']
-RENDER_SPEC_TYPE: Command
-RENDER_SPEC_UPDATE_KEYS: ['dashboard_spec', 'messages']
-RENDER_SPEC_HAS_DASHBOARD_SPEC: True
+NODES: ['__start__', 'agent', 'emit_state', 'respond', 'tools', 'wrap_spec_into_ai']
+RENDER_SPEC_TYPE: str
+RENDER_SPEC_STARTS_WITH: {"elements": {"root":
 ```
+
+(Note: depending on LangGraph version, NODES may or may not include `__end__`. Both are fine — what matters is `wrap_spec_into_ai` and `agent` are present, no `populate_initial_data` / `generate_shell` / `router` / `plan_tools`.)
 
 - [ ] **Step 4: Commit**
 
 ```bash
-test "$(git branch --show-current)" = "claude/genui-agentic-loop" && echo OK || exit 1
+test "$(git branch --show-current)" = "claude/genui-agentic-loop-v2" && echo OK || exit 1
 git add cockpit/chat/generative-ui/python/src/graph.py
-git commit -m "feat(c-generative-ui): rewrite as single agentic loop with render_spec tool (per-cap)"
+git commit -m "feat(c-generative-ui): rewrite as agentic loop with wrap_spec_into_ai post-process (per-cap)"
 ```
 
 ---
 
-## Task 2: Rewrite per-cap system prompt
+## Task 3: Rewrite per-cap system prompt
 
 **Files:**
 - Modify: `cockpit/chat/generative-ui/python/prompts/dashboard.md`
@@ -291,14 +393,14 @@ git commit -m "feat(c-generative-ui): rewrite as single agentic loop with render
 - [ ] **Step 1: Verify branch**
 
 ```bash
-test "$(git branch --show-current)" = "claude/genui-agentic-loop" && echo OK || exit 1
+test "$(git branch --show-current)" = "claude/genui-agentic-loop-v2" && echo OK || exit 1
 ```
 
-- [ ] **Step 2: Replace the prompt's workflow sections**
+- [ ] **Step 2: Read the existing file, then `Edit` to replace the opening + workflow sections**
 
-The file currently starts with a `# Airline Operations Dashboard Agent` heading, then "## Your Behavior" with "### First message" + "### Follow-up messages" subsections, then "## JSON Render Spec Format" through "## Example Spec". Replace EVERYTHING from the top through the "Categorize the user's request:" section (i.e. through the end of "Follow-up messages"), keeping the "## JSON Render Spec Format" section onwards byte-identical. Open the existing file to find the exact byte ranges before editing.
+Use `Read` to load the file. Find the exact span from `# Airline Operations Dashboard Agent` through the END of the "Follow-up messages" subsection (before `## JSON Render Spec Format`). The existing opening currently describes a sequential "First message" / "Follow-up messages" workflow.
 
-Use `Edit` to do this replacement (not `Write`, to preserve the schema sections perfectly). The new opening, replacing everything from `# Airline Operations Dashboard Agent` through the end of the follow-up-messages list, should be:
+Replace ONLY that span with the following (preserve `## JSON Render Spec Format` and everything below verbatim):
 
 ```markdown
 # Airline Operations Dashboard Agent
@@ -315,9 +417,9 @@ You are a dashboard agent that builds interactive airline-operations KPI dashboa
 
 ### When no dashboard exists yet (first turn)
 
-1. Call `render_spec` with a complete dashboard layout — stat cards, charts, table — using `$state` bindings to the slots that the data tools populate (see "State Path Conventions" below).
-2. Call EACH data tool that backs a component in your spec. Do NOT call tools whose data your spec doesn't reference.
-3. Return — no further tool calls. A separate node will write a brief summary.
+1. Call `render_spec` ONCE with a complete dashboard layout — stat cards, charts, table — using `$state` bindings to the slots the data tools populate (see "State Path Conventions" below).
+2. In the SAME turn (same tool_calls array), call EACH data tool that backs a component in your spec. Do NOT call tools whose data your spec doesn't reference.
+3. After the tools return, return WITHOUT any further tool calls. A separate node will write a brief conversational summary.
 
 ### When the dashboard exists (follow-up turn)
 
@@ -325,35 +427,31 @@ Categorize the user's request and act ONCE. DO NOT ask clarifying questions — 
 
 - **Filter / scope** (e.g. "filter to cancelled flights only", "last 6 months", "top 3"): call EXACTLY ONE data tool — the one that backs the affected component — with the new parameters. Do NOT call `render_spec`.
 - **Structural change** (e.g. "add a card for X", "remove the table"): call `render_spec` with the modified layout, then call data tools only for the NEW components.
-- **Interpretive question** that no tool could resolve (e.g. "why is on-time % low?"): respond in plain prose with no tool calls. Use this ONLY when no tool fetch could answer the question.
+- **Interpretive question** that no tool could resolve (e.g. "why is on-time % low?"): respond in plain prose with no tool calls.
 
 ```
 
-Then immediately follow with the existing `## JSON Render Spec Format` section (and everything below), preserved verbatim. The final file should be: new opening (above) + `## JSON Render Spec Format` onwards (existing content).
-
-- [ ] **Step 3: Verify the file has both the new opening AND the existing schema sections**
+- [ ] **Step 3: Verify**
 
 ```bash
 grep -c "render_spec(spec)" cockpit/chat/generative-ui/python/prompts/dashboard.md
 grep -c "JSON Render Spec Format" cockpit/chat/generative-ui/python/prompts/dashboard.md
-grep -c "State Path Conventions" cockpit/chat/generative-ui/python/prompts/dashboard.md
-grep -c "Example Spec" cockpit/chat/generative-ui/python/prompts/dashboard.md
 grep -c "First message" cockpit/chat/generative-ui/python/prompts/dashboard.md
 ```
 
-Expected (in order): `1`, `1`, `1`, `1`, `0`. The "First message" header must NOT be in the file anymore (replaced with "When no dashboard exists yet (first turn)"). The schema sections (JSON Render Spec Format, State Path Conventions, Example Spec) MUST still be present.
+Expected (in order): `1`, `1`, `0` (the literal "First message" header must be gone; the new wording says "first turn").
 
 - [ ] **Step 4: Commit**
 
 ```bash
-test "$(git branch --show-current)" = "claude/genui-agentic-loop" && echo OK || exit 1
+test "$(git branch --show-current)" = "claude/genui-agentic-loop-v2" && echo OK || exit 1
 git add cockpit/chat/generative-ui/python/prompts/dashboard.md
 git commit -m "feat(c-generative-ui): rewrite system prompt for agentic-loop workflow (per-cap)"
 ```
 
 ---
 
-## Task 3: Mirror to umbrella graph
+## Task 4: Mirror graph to umbrella
 
 **Files:**
 - Modify: `cockpit/langgraph/streaming/python/src/dashboard_graph.py`
@@ -361,63 +459,47 @@ git commit -m "feat(c-generative-ui): rewrite system prompt for agentic-loop wor
 - [ ] **Step 1: Verify branch + copy per-cap graph.py to umbrella**
 
 ```bash
-test "$(git branch --show-current)" = "claude/genui-agentic-loop" && echo OK || exit 1
+test "$(git branch --show-current)" = "claude/genui-agentic-loop-v2" && echo OK || exit 1
 cp cockpit/chat/generative-ui/python/src/graph.py cockpit/langgraph/streaming/python/src/dashboard_graph.py
 ```
 
-The per-cap and umbrella are byte-identical mirrors per PR #396 policy. The only path-related difference is the import (`from src.dashboard_tools import ...`) — `src.dashboard_tools` resolves correctly in both packages because both have a `src/` package containing `dashboard_tools.py`. Verify:
+- [ ] **Step 2: Verify**
 
 ```bash
-test -f cockpit/langgraph/streaming/python/src/dashboard_tools.py && echo OK || echo MISSING_DASHBOARD_TOOLS
-```
-
-Expected: `OK`. If `MISSING_DASHBOARD_TOOLS`, STOP — the umbrella is in an unexpected state.
-
-- [ ] **Step 2: Verify umbrella compiles + render_spec works**
-
-```bash
+diff cockpit/chat/generative-ui/python/src/graph.py cockpit/langgraph/streaming/python/src/dashboard_graph.py && echo IDENTICAL
 cd cockpit/langgraph/streaming/python && uv run python -c "
-from src.dashboard_graph import graph, render_spec
+from src.dashboard_graph import graph, render_spec, wrap_spec_into_ai
 print('TYPE:', type(graph).__name__)
 print('NODES:', sorted(graph.nodes))
-result = render_spec.invoke({'spec': {'elements': {'root': {'type': 'dashboard_grid'}}, 'root': 'root'}, 'tool_call_id': 'call_test'})
-print('UPDATE_KEYS:', sorted(result.update.keys()))
 "
 ```
 
-Expected: `TYPE: CompiledStateGraph`, NODES includes `agent` + `tools` + `emit_state` + `respond` (no router/generate_shell/etc.), UPDATE_KEYS `['dashboard_spec', 'messages']`.
+Expected: `IDENTICAL`, then `TYPE: CompiledStateGraph` with `wrap_spec_into_ai` + `agent` in NODES.
 
 - [ ] **Step 3: Commit**
 
 ```bash
-test "$(git branch --show-current)" = "claude/genui-agentic-loop" && echo OK || exit 1
+test "$(git branch --show-current)" = "claude/genui-agentic-loop-v2" && echo OK || exit 1
 git add cockpit/langgraph/streaming/python/src/dashboard_graph.py
-git commit -m "feat(c-generative-ui umbrella): mirror agentic-loop rewrite"
+git commit -m "feat(c-generative-ui umbrella): mirror agentic-loop graph"
 ```
 
 ---
 
-## Task 4: Mirror prompt to umbrella
+## Task 5: Mirror prompt to umbrella
 
 **Files:**
 - Modify: `cockpit/langgraph/streaming/python/prompts/dashboard.md`
 
-- [ ] **Step 1: Verify branch + copy per-cap prompt to umbrella**
+- [ ] **Step 1: Verify branch + copy**
 
 ```bash
-test "$(git branch --show-current)" = "claude/genui-agentic-loop" && echo OK || exit 1
+test "$(git branch --show-current)" = "claude/genui-agentic-loop-v2" && echo OK || exit 1
 cp cockpit/chat/generative-ui/python/prompts/dashboard.md cockpit/langgraph/streaming/python/prompts/dashboard.md
-```
-
-- [ ] **Step 2: Verify diff is empty**
-
-```bash
 diff cockpit/chat/generative-ui/python/prompts/dashboard.md cockpit/langgraph/streaming/python/prompts/dashboard.md && echo IDENTICAL
 ```
 
-Expected: `IDENTICAL`.
-
-- [ ] **Step 3: Commit**
+- [ ] **Step 2: Commit**
 
 ```bash
 git add cockpit/langgraph/streaming/python/prompts/dashboard.md
@@ -426,164 +508,138 @@ git commit -m "feat(c-generative-ui umbrella): mirror prompt rewrite"
 
 ---
 
-## Task 5: End-to-end real-LLM smoke (per-cap)
+## Task 6: End-to-end real-LLM smoke (programmatic)
 
-**Files:** none (verification only). Requires `OPENAI_API_KEY`.
+**Files:** none. Requires `OPENAI_API_KEY`.
 
-- [ ] **Step 1: Confirm key present**
+- [ ] **Step 1: Run 3-turn smoke**
 
 ```bash
 grep -q '^OPENAI_API_KEY=' .env && echo found
-```
-
-- [ ] **Step 2: Run the multi-turn smoke**
-
-```bash
 set -a; source .env; set +a
 cd cockpit/chat/generative-ui/python && uv run python -c "
-import asyncio, json
+import asyncio
 from src.graph import graph
 from langchain_core.messages import HumanMessage
 
 async def main():
-    # Turn 1: first turn
-    s1 = await graph.ainvoke({'messages': [HumanMessage(content='Show me a dashboard of airline operations.')], 'dashboard_spec': None})
+    s1 = await graph.ainvoke({'messages': [HumanMessage(content='Show me a dashboard of airline operations.')]})
     msgs = s1['messages']
     tool_msgs = [m for m in msgs if m.type == 'tool']
-    tool_names = [m.name for m in tool_msgs]
-    print('TURN1_TOOL_NAMES:', tool_names)
-    print('TURN1_HAS_RENDER_SPEC:', 'render_spec' in tool_names)
-    print('TURN1_DATA_TOOL_COUNT:', sum(1 for n in tool_names if n != 'render_spec'))
-    print('TURN1_HAS_SPEC:', bool(s1.get('dashboard_spec')))
-    final = msgs[-1].content[:200] if isinstance(msgs[-1].content, str) else str(msgs[-1].content)[:200]
-    print('TURN1_FINAL:', final[:160])
-    assert 'render_spec' in tool_names, f'expected render_spec call, got {tool_names!r}'
-    assert sum(1 for n in tool_names if n != 'render_spec') >= 1, f'expected >=1 data tool call, got {tool_names!r}'
-    assert s1.get('dashboard_spec'), 'dashboard_spec not populated'
-    assert not final.lstrip().startswith('{'), f'final looks like JSON: {final[:80]!r}'
+    print('TURN1_TOOL_NAMES:', [m.name for m in tool_msgs])
 
-    # Turn 2: filter
-    s2 = await graph.ainvoke({'messages': msgs + [HumanMessage(content='Filter to only cancelled flights')], 'dashboard_spec': s1['dashboard_spec']})
+    render_tool_msg = next((m for m in tool_msgs if m.name == 'render_spec'), None)
+    assert render_tool_msg is not None, 'expected a render_spec ToolMessage'
+    print('RENDER_TOOL_CONTENT:', render_tool_msg.content[:30])
+    assert render_tool_msg.content == 'rendered', f'render_spec ToolMessage should be the stub, got {render_tool_msg.content[:50]!r}'
+
+    wrapped_ai = next((m for m in msgs if m.type == 'ai' and isinstance(m.content, str) and m.content.lstrip().startswith('{')), None)
+    assert wrapped_ai is not None, 'expected an AI message with spec JSON as content'
+    print('WRAPPED_AI_CONTENT_PREFIX:', wrapped_ai.content[:60])
+
+    data_tools = [m for m in tool_msgs if m.name != 'render_spec']
+    print('TURN1_DATA_TOOL_COUNT:', len(data_tools))
+    assert len(data_tools) >= 1, f'expected >=1 data tool, got {[m.name for m in data_tools]}'
+
+    final = msgs[-1].content if isinstance(msgs[-1].content, str) else str(msgs[-1].content)
+    print('TURN1_FINAL_PREFIX:', final[:160])
+    assert not final.lstrip().startswith('{'), 'final respond message should be prose, not JSON'
+
+    s2 = await graph.ainvoke({'messages': msgs + [HumanMessage(content='Filter to only cancelled flights')]})
     msgs2 = s2['messages']
     new_tool_msgs = [m for m in msgs2[len(msgs):] if m.type == 'tool']
     new_tool_names = [m.name for m in new_tool_msgs]
     print('TURN2_NEW_TOOL_NAMES:', new_tool_names)
-    final2 = msgs2[-1].content[:200] if isinstance(msgs2[-1].content, str) else str(msgs2[-1].content)[:200]
-    print('TURN2_FINAL:', final2[:160])
-    assert 'render_spec' not in new_tool_names, f'filter should NOT trigger render_spec: {new_tool_names!r}'
-    assert len(new_tool_names) >= 1, f'expected >=1 new data tool call on follow-up: {new_tool_names!r}'
+    assert 'render_spec' not in new_tool_names, 'filter should not regen spec'
+    assert len(new_tool_names) >= 1
 
-    # Turn 3: interpretive
-    s3 = await graph.ainvoke({'messages': msgs2 + [HumanMessage(content='Why might on-time percentage be lower than industry average?')], 'dashboard_spec': s2['dashboard_spec']})
+    s3 = await graph.ainvoke({'messages': msgs2 + [HumanMessage(content='Why might on-time percentage be lower than industry average?')]})
     msgs3 = s3['messages']
     new_tool_msgs3 = [m for m in msgs3[len(msgs2):] if m.type == 'tool']
     print('TURN3_NEW_TOOL_NAMES:', [m.name for m in new_tool_msgs3])
-    final3 = msgs3[-1].content[:300] if isinstance(msgs3[-1].content, str) else str(msgs3[-1].content)[:300]
-    print('TURN3_FINAL:', final3[:200])
-    # Turn 3 should be a prose answer (interpretive case 3) — assert no tool calls is too strict for gpt-5
-    # so just print and let reviewer eyeball.
+    final3 = msgs3[-1].content if isinstance(msgs3[-1].content, str) else str(msgs3[-1].content)
+    print('TURN3_FINAL_PREFIX:', final3[:200])
 
 asyncio.run(main())
 "
 ```
 
 Expected:
-- TURN1: `render_spec` in tool names, ≥1 data tool call, `dashboard_spec` populated, final is prose
-- TURN2: 1+ new data tool calls, NO new `render_spec`, final commits to action
-- TURN3: ideally 0 new tool calls and a prose answer; if 1-2 tool calls appear, eyeball the final response
+- TURN1_TOOL_NAMES includes `render_spec` and ≥1 data tool
+- RENDER_TOOL_CONTENT is `'rendered'`
+- WRAPPED_AI_CONTENT_PREFIX starts with `{`
+- TURN1_DATA_TOOL_COUNT ≥ 1
+- TURN1_FINAL_PREFIX is prose
+- TURN2_NEW_TOOL_NAMES does NOT contain `render_spec`
+- TURN3 ideally 0 new tool calls
 
-If turn 1 or 2 fails the assertions, fix and re-run before continuing.
-
-- [ ] **Step 3: If smoke reveals an issue, fix the earlier task's code and re-run.**
-
-If a fix was needed:
+- [ ] **Step 2: If smoke fails, fix relevant task and re-run. If a fix is needed:**
 
 ```bash
-test "$(git branch --show-current)" = "claude/genui-agentic-loop" && echo OK || exit 1
 git add cockpit/chat/generative-ui/python/src/graph.py cockpit/chat/generative-ui/python/prompts/dashboard.md cockpit/langgraph/streaming/python/src/dashboard_graph.py cockpit/langgraph/streaming/python/prompts/dashboard.md
-git commit -m "fix(c-generative-ui): smoke fixes for agentic-loop"
+git commit -m "fix(c-generative-ui): agentic-loop v2 smoke fixes"
 ```
 
 ---
 
-## Task 6: Build verification
+## Task 7: Build verification
 
 **Files:** none.
 
-- [ ] **Step 1: Build per-cap python**
-
 ```bash
+cd /Users/blove/repos/angular-agent-framework
 pnpm nx run cockpit-chat-generative-ui-python:build
-```
-
-Expected: green.
-
-- [ ] **Step 2: Build umbrella python**
-
-```bash
 pnpm nx run cockpit-langgraph-streaming-python:build
-```
-
-Expected: green.
-
-- [ ] **Step 3: Build Angular (sanity)**
-
-```bash
+pnpm nx run chat:build
 pnpm nx run cockpit-chat-generative-ui-angular:build
-```
-
-Expected: green.
-
-- [ ] **Step 4: Production deploy manifest unchanged**
-
-```bash
 npx tsx scripts/generate-shared-deployment-config.ts && git diff deployments/shared-dev/langgraph.json
 ```
 
-Expected: empty diff (we changed Python source, not the manifest).
+All should be green; the final `git diff` should produce empty output.
 
-- [ ] **Step 5: No commit**
+No commit.
 
 ---
 
-## Task 7: REQUIRED — chrome MCP end-to-end smoke (in isolated worktree)
+## Task 8: REQUIRED — chrome MCP smoke (in isolated worktree)
 
 **Files:** none.
 
-PR #428's chrome MCP smoke was defeated by concurrent worktree branch-switching in the shared checkout. This task uses an isolated worktree where no parallel agent can switch the branch.
-
-- [ ] **Step 1: Create isolated worktree**
+- [ ] **Step 1: Create isolated worktree on a tmp branch (avoids "branch already used by worktree" error)**
 
 ```bash
-ISOLATED_DIR="/tmp/genui-agentic-loop-verify"
+ISOLATED_DIR="/tmp/genui-agentic-loop-v2-verify"
 rm -rf "$ISOLATED_DIR"
-git worktree add "$ISOLATED_DIR" claude/genui-agentic-loop
-cd "$ISOLATED_DIR"
-git branch --show-current
+git worktree add -B genui-v2-verify-tmp "$ISOLATED_DIR" claude/genui-agentic-loop-v2
+cd "$ISOLATED_DIR" && git branch --show-current
 ```
 
-Expected: `claude/genui-agentic-loop`. This directory is a SEPARATE checkout — no other agent has any reason to switch its branch.
+Expected: `genui-v2-verify-tmp`.
 
-- [ ] **Step 2: Install deps in the isolated worktree's per-cap python**
+- [ ] **Step 2: Install per-cap deps in the isolated worktree**
 
 ```bash
-cd cockpit/chat/generative-ui/python && uv sync 2>&1 | tail -3
+cd "$ISOLATED_DIR/cockpit/chat/generative-ui/python" && uv sync 2>&1 | tail -3
 ```
 
-- [ ] **Step 3: Start servers from the isolated worktree**
+- [ ] **Step 3: Start backend from worktree, frontend from main checkout**
 
-From `$ISOLATED_DIR`:
+(The Angular dev needs `node_modules` which only exist in the main checkout. The Angular code change in this PR is one line — if a parallel agent flips the main checkout's branch, the practical risk to the Angular dev is low.)
 
 ```bash
 lsof -t -i :5508 -i :4508 2>/dev/null | xargs kill -9 2>/dev/null
-set -a; source .env 2>/dev/null || source /Users/blove/repos/angular-agent-framework/.env; set +a
-nohup pnpm nx run cockpit-chat-generative-ui-python:serve > /tmp/agentic-loop-backend.log 2>&1 &
-nohup pnpm nx serve cockpit-chat-generative-ui-angular --port 4508 > /tmp/agentic-loop-frontend.log 2>&1 &
+set -a; source /Users/blove/repos/angular-agent-framework/.env; set +a
+
+cd "$ISOLATED_DIR/cockpit/chat/generative-ui/python"
+nohup uv run langgraph dev --no-browser --host 127.0.0.1 --port 5508 > /tmp/v2-backend.log 2>&1 &
+
+cd /Users/blove/repos/angular-agent-framework
+nohup pnpm nx serve cockpit-chat-generative-ui-angular --port 4508 > /tmp/v2-frontend.log 2>&1 &
 ```
 
-Wait for both ready (`Application started up` in backend log; `Local:` in frontend log).
+Wait for `Application started up` in backend log and `Local:` in frontend log.
 
-- [ ] **Step 4: Verify the loaded graph is the new one**
+- [ ] **Step 4: Verify loaded graph is v2**
 
 ```bash
 curl -s http://localhost:5508/assistants/c-generative-ui/graph | python3 -c "
@@ -591,75 +647,90 @@ import json, sys
 d = json.load(sys.stdin)
 nodes = sorted([n['id'] for n in d.get('nodes', [])])
 print('NODES:', nodes)
+print('HAS_WRAP:', 'wrap_spec_into_ai' in nodes)
 print('HAS_AGENT:', 'agent' in nodes)
-print('HAS_ROUTER:', 'router' in nodes)
 print('HAS_GENERATE_SHELL:', 'generate_shell' in nodes)
 "
 ```
 
-Expected: `agent` IN nodes, `router` and `generate_shell` NOT in nodes. If the wrong graph is loaded, STOP — the worktree isolation didn't work or there's a caching issue. Investigate before continuing.
+Expected: `HAS_WRAP: True`, `HAS_AGENT: True`, `HAS_GENERATE_SHELL: False`. If wrong, STOP — backend cached old code.
 
-- [ ] **Step 5: Drive the flow via chrome MCP**
+- [ ] **Step 5: Drive flow via chrome MCP**
 
 1. Navigate to `http://localhost:4508/`
-2. Click "Render a dashboard" → wait ~30s → expect populated KPI cards (numbers, not "Building UI…" placeholders), line chart with data, bar chart, data table with rows
-3. Type "Filter to only cancelled flights" → press Enter → wait ~15s → expect data table updates to cancellations only
-4. Take a screenshot with `save_to_disk: true` for the PR description
-5. Optional: type "Why might on-time percentage be lower than industry average?" → expect prose answer
+2. Wait ~5 sec for page idle
+3. Use chrome MCP's `find` to locate the chat textarea + `javascript_tool` to set its value to "Show me a dashboard of airline operations." and dispatch the Enter keydown event (bypasses the chip — chip text says "Q3 sales", a separate frontend issue)
+4. Wait ~30 sec for the agent loop + respond to finish
+5. Expect: populated KPI stat cards (numbers, not "Building UI…"), line chart with data, bar chart, data table with rows
+6. Verify via `get_page_text` that the chat-tool-calls UI shows the 4 query_* tool cards but does NOT show a `render_spec` card
+7. Take a screenshot with `save_to_disk: true` for the PR description
+8. Follow-up: inject "Filter to only cancelled flights" → wait ~15 sec → expect the data table updates
 
-- [ ] **Step 6: Stop servers + clean up worktree**
+- [ ] **Step 6: If step 5 shows empty cards, debug:**
+
+```bash
+TID=$(curl -s -X POST http://localhost:5508/threads/search -H 'Content-Type: application/json' -d '{"limit":1,"order":"desc","order_by":"updated_at"}' | python3 -c "import json,sys;print(json.load(sys.stdin)[0]['thread_id'])")
+curl -s "http://localhost:5508/threads/$TID/state" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+msgs = d['values'].get('messages', [])
+for i, m in enumerate(msgs):
+    t = m.get('type'); name = m.get('name','')
+    c = m.get('content','')
+    if isinstance(c, list): c = str(c)
+    tc = m.get('tool_calls',[])
+    print(f'[{i}] {t}{\" \"+name if name else \"\"} tc={len(tc)} c[:80]={str(c)[:80]!r}')
+"
+```
+
+Expect to see at least one AI message whose `content` starts with `{` (the wrapped spec). If absent → `wrap_spec_into_ai` didn't run; check backend log for tracebacks.
+
+- [ ] **Step 7: Stop servers + clean up**
 
 ```bash
 lsof -t -i :5508 -i :4508 2>/dev/null | xargs kill -9 2>/dev/null
-rm -f /tmp/agentic-loop-backend.log /tmp/agentic-loop-frontend.log
+rm -f /tmp/v2-backend.log /tmp/v2-frontend.log
 cd /Users/blove/repos/angular-agent-framework
 git worktree remove "$ISOLATED_DIR" --force
+git branch -D genui-v2-verify-tmp 2>&1 | tail -1
 ```
 
 ---
 
-## Task 8: Open PR + watch CI + merge
-
-- [ ] **Step 1: Push branch**
+## Task 9: Open PR + watch CI + merge
 
 ```bash
-test "$(git branch --show-current)" = "claude/genui-agentic-loop" && echo OK || exit 1
-git push -u origin claude/genui-agentic-loop
-```
-
-- [ ] **Step 2: Open PR**
-
-```bash
-gh pr create --title "refactor(c-generative-ui): single agentic loop with render_spec tool" --body "$(cat <<'EOF'
+test "$(git branch --show-current)" = "claude/genui-agentic-loop-v2" && echo OK || exit 1
+git push -u origin claude/genui-agentic-loop-v2
+gh pr create --title "refactor(c-generative-ui): agentic loop with canonical surface-delivery (v2)" --body "$(cat <<'EOF'
 ## Summary
-Replaces the c-generative-ui 6-node split graph with a single agentic loop, addressing the architectural critique from PR #428's discussion: today's \`populate_initial_data\` deterministically fires all 4 data tools regardless of what the LLM authored, ignoring the spec entirely. That fudges the demo's core claim ("the LLM intelligently composes UI and data fetches together").
+Rewrites c-generative-ui as a single agentic loop where the LLM authors the dashboard spec via a \`render_spec\` tool AND chooses the data tools to populate it in the same turn. Replaces PR #428's deterministic \`populate_initial_data\` fudge with real LLM-driven composition.
 
-After this PR:
-- Single \`agent\` node (gpt-5, reasoning='minimal') with 5 tools bound: a new \`render_spec(spec)\` tool + the 4 existing data tools.
-- LLM authors the spec by calling \`render_spec\` (which returns \`Command(update={"dashboard_spec": ..., "messages": [...]})\` to mutate state), then calls only the data tools its spec references.
-- Loop via \`agent ↔ tools\` (canonical pattern, same as \`c_tool_calls\` and \`c_subagents\`), capped at 8 iterations per turn.
-- System prompt rewritten to be agentic-loop-aware: first-turn = \`render_spec\` + relevant data tools; follow-up = filter/structural/interpretive cases per the existing rules.
-- Removed: \`router\`, \`generate_shell\`, \`populate_initial_data\`, \`plan_tools\`. Kept: \`emit_state\` (with one fix — break on human, not ai, since the loop now produces multiple ai messages per turn), \`respond\`.
+Uses the canonical surface-delivery pattern from \`examples/chat/python/src/graph.py\`: \`render_spec\` returns the spec as a plain JSON string in its ToolMessage content; a post-process node \`wrap_spec_into_ai\` swaps that payload into the parent AI tool-call message's content (in place via LangGraph's \`add_messages\` id-match reducer), so the chat-lib's content-classifier mounts \`<chat-generative-ui>\` the same way it does for every other surface in the codebase.
 
-## Why this over PR #428's fix
-PR #428 made the demo render but at the cost of replacing LLM judgement with a hardcoded loop over all 4 tools. The agent never adapts to the spec; the demo's "generative" claim is hollow. This PR restores the claim: one LLM, one prompt, full agentic composition.
+## Why v2
+A v1 attempt used \`Command(update=...)\` from \`render_spec\` to write the spec into a state field. Chrome MCP verification revealed the frontend's content-classifier only inspects \`AIMessage.content\` — the spec never reached the renderer; empty placeholder cards forever. v2 respects the established invariant that the frontend's source of truth for surfaces is AIMessage content.
+
+## Architecture
+\`\`\`
+START → agent ──→ should_continue ──┬→ tools → wrap_spec_into_ai → agent  (loop, cap 6)
+                                    └→ emit_state → respond → END
+\`\`\`
+
+Removed: \`router\`, \`generate_shell\`, \`populate_initial_data\`, \`plan_tools\`, \`dashboard_spec\` state field. Added: \`agent\`, \`wrap_spec_into_ai\`, \`render_spec\` tool. \`emit_state\` and \`respond\` largely unchanged from PR #428 (the message-walk now breaks on \`human\` since the loop produces multiple AI messages per turn).
 
 ## Files
 - \`cockpit/chat/generative-ui/python/src/graph.py\` — per-cap canonical (full rewrite)
 - \`cockpit/langgraph/streaming/python/src/dashboard_graph.py\` — umbrella mirror
 - \`cockpit/chat/generative-ui/python/prompts/dashboard.md\` — agentic workflow + schema preserved
-- \`cockpit/langgraph/streaming/python/prompts/dashboard.md\` — umbrella mirror
+- \`cockpit/langgraph/streaming/python/prompts/dashboard.md\` — umbrella prompt mirror
+- \`libs/chat/src/lib/compositions/chat/chat.component.ts\` — add \`'render_spec'\` to default \`genuiToolNames\` (1 line)
 
 ## Test plan
-- [x] \`pnpm nx run cockpit-chat-generative-ui-python:build\` — green
-- [x] \`pnpm nx run cockpit-langgraph-streaming-python:build\` — green
-- [x] \`pnpm nx run cockpit-chat-generative-ui-angular:build\` — green
-- [x] Shared-deployment manifest unchanged (26 graphs)
-- [x] **Programmatic real-LLM smoke (3-turn)**:
-  - Turn 1 ("Show me a dashboard of airline operations.") — calls \`render_spec\` + ≥1 data tool; \`dashboard_spec\` populated; final = conversational prose
-  - Turn 2 ("Filter to only cancelled flights") — ≥1 new data tool call; NO new \`render_spec\`; final commits to action
-  - Turn 3 ("Why might on-time percentage be lower than industry average?") — prose answer
-- [x] **Chrome MCP smoke (in isolated worktree)**: dashboard renders with real data, filter works, screenshot attached
+- [x] Programmatic real-LLM smoke (3-turn): \`render_spec\` ToolMessage stubbed to "rendered"; an AI message exists with content = wrapped spec JSON; data tools fire; turn-2 filter doesn't regen spec; turn-3 interpretive returns prose
+- [x] All builds green (per-cap python, umbrella python, chat lib, Angular consumer)
+- [x] Shared deploy manifest unchanged
+- [x] Chrome MCP smoke (isolated worktree): KPI cards populated, charts render, \`render_spec\` excluded from \`<chat-tool-calls>\`, filter works on follow-up; screenshot attached
 - [ ] CI
 
 Plan: \`docs/superpowers/plans/2026-05-18-c-generative-ui-agentic-loop.md\`
@@ -668,17 +739,7 @@ Spec: \`docs/superpowers/specs/2026-05-18-c-generative-ui-agentic-loop-design.md
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 EOF
 )"
-```
-
-- [ ] **Step 3: Watch CI**
-
-```bash
 gh pr checks <PR#> --watch
-```
-
-- [ ] **Step 4: Squash-merge on green**
-
-```bash
 gh pr merge <PR#> --squash --delete-branch
 ```
 
@@ -687,26 +748,27 @@ gh pr merge <PR#> --squash --delete-branch
 ## Self-Review
 
 **Spec coverage:**
-- Decision 1 (render_spec tool) → Task 1 Step 2 ✓
-- Decision 2 (Command-from-tool for dashboard_spec) → Task 1 Step 2 ✓
-- Decision 3 (graph shape: agent ↔ tools → emit_state → respond) → Task 1 Step 2 (builder block) ✓
-- Decision 4 (iteration cap at 8) → Task 1 Step 2 (`_MAX_TOOL_ITERATIONS = 8` + `should_continue`) ✓
-- Decision 5 (gpt-5 minimal + gpt-5-mini for respond) → Task 1 Step 2 (LLM bindings) ✓
-- Decision 6 (emit_state unchanged behavior, ignores render_spec) → Task 1 Step 2 (fall-through OK; `break on human` fix) ✓
-- Decision 7 (respond unchanged from PR #428) → Task 1 Step 2 ✓
-- Decision 8 (tool_choice='auto' — implicit since we don't set tool_choice) → Task 1 Step 2 (no tool_choice arg = default auto) ✓
-- Decision 9 (system prompt rewrite) → Task 2 ✓
-- Decision 10 (full mirror to umbrella graph + prompt) → Tasks 3 + 4 ✓
-- Programmatic smoke (3-turn) → Task 5 ✓
-- Chrome MCP smoke in isolated worktree → Task 7 ✓ (with explicit recovery path from PR #428's hijack issue)
+- Decision 1 (`render_spec` returns string, no Command) → Task 2 ✓
+- Decision 2 (no `dashboard_spec` state field) → Task 2 (`DashboardState` body is `pass`) ✓
+- Decision 3 (graph shape) → Task 2 builder block ✓
+- Decision 4 (cap 6) → Task 2 (`_MAX_TOOL_ITERATIONS = 6`) ✓
+- Decision 5 (model selection) → Task 2 ✓
+- Decision 6 (emit_state break-on-human) → Task 2 ✓
+- Decision 7 (respond unchanged) → Task 2 ✓
+- Decision 8 (`genuiToolNames` default) → Task 1 ✓
+- Decision 9 (mirror to umbrella) → Tasks 4 + 5 ✓
+- Decision 10 (tool_choice='auto') → Task 2 (no `tool_choice` arg = default auto) ✓
+- 3-turn programmatic smoke → Task 6 ✓
+- Chrome MCP in isolated worktree → Task 8 ✓
+- Frontend genuiToolNames addition → Task 1 ✓
 
-**Placeholder scan:** None. Every code-modifying step has full code. Task 2 references the existing prompt's schema sections "verbatim" — acceptable because they ARE correct already and re-pasting them in the plan would double the plan length.
+**Placeholder scan:** Every code-modifying step shows full new code. Task 3 references "preserved verbatim" for the schema sections — acceptable, they're already correct in the existing file. Task 8 step 3's caveat about Angular running from the main checkout is explicit.
 
 **Type consistency:**
-- `DashboardState(MessagesState)` with `dashboard_spec: str | None` matches today's shape; `render_spec` Command writes `str` (via `json.dumps(spec)`) which matches the annotation.
-- `render_spec(spec: dict, tool_call_id: Annotated[str, InjectedToolCallId])` — `InjectedToolCallId` is the canonical annotation for tool-side access to the calling AI message's tool_call_id (langchain-core ≥0.3, which the cockpit deps already pin).
-- `_ALL_TOOLS = [render_spec, *_DATA_TOOLS]` — same list passed to both `bind_tools` and `ToolNode`, so the tool universe is consistent end-to-end.
-- `should_continue` return type `Literal["tools", "emit_state"]` matches both destinations in the builder's `add_conditional_edges("agent", should_continue)` call.
-- `emit_state` reading `msg.name == "query_..."` matches the names produced by `dashboard_tools.py`'s `@tool` decorators (which default tool name to the function name).
+- `DashboardState(MessagesState): pass` — no extra fields; `render_spec` returns `str`; `wrap_spec_into_ai` returns `dict`; `should_continue` returns `Literal["tools", "emit_state"]` matching builder destinations.
+- ToolMessage fields (`tool_call_id`, `name`, `id`, `content`) and AIMessage fields (`id`, `content`, `tool_calls`, `additional_kwargs`, `response_metadata`) match `langchain-core` standard message types.
+- `_ALL_TOOLS = [render_spec, *_DATA_TOOLS]` — same list passed to both `bind_tools` (agent) and `ToolNode` (tools).
+- Edges `tools → wrap_spec_into_ai → agent` create a loop; `agent`'s conditional edge breaks to `emit_state` when no tool_calls.
+- `genuiToolNames` extension is a literal string addition; TypeScript `readonly string[]` accepts it.
 
-**Concurrency notes:** Every code-modifying task starts with a `git branch --show-current` check. Task 7 uses an isolated worktree to bypass the dev-server cache issue from PR #428.
+**Concurrency:** Every code-modifying task includes a branch-check; Task 8 uses an isolated worktree.

--- a/docs/superpowers/specs/2026-05-18-c-generative-ui-agentic-loop-design.md
+++ b/docs/superpowers/specs/2026-05-18-c-generative-ui-agentic-loop-design.md
@@ -1,0 +1,253 @@
+# c-generative-ui Agentic-Loop Rewrite — Design
+
+**Date:** 2026-05-18
+**Status:** Spec — pending implementation plan
+
+## Goal
+
+Replace the current 6-node split-graph architecture (`router → generate_shell → populate_initial_data → emit_state → respond` for first turn, `router → plan_tools → call_tools → emit_state → respond` for follow-ups) with a **single agentic loop** where the LLM authors the dashboard spec AND chooses which data tools to call, in one coherent reasoning step.
+
+This delivers on the demo's actual claim — *the LLM intelligently composes UI and data fetches together* — instead of fudging it with a deterministic "always call all 4 tools" node (PR #428's stopgap).
+
+## Background
+
+PR #428 made the demo render (today it fails: empty placeholder cards forever) by inserting a hardcoded `populate_initial_data` node that mechanically invokes all 4 data tools after `generate_shell`. That works but it's a fudge:
+
+- Ignores the spec entirely — fetches all 4 datasets regardless of which components the LLM authored
+- Couples the demo to the aviation tool set; can't be retargeted without a graph edit
+- Zero LLM reasoning in the populate step — defeats the "generative" claim
+
+The real shape, used everywhere else in our codebase (`c_tool_calls`, `c_subagents`), is **one LLM node with tools bound, looping until done.** This spec adopts that pattern.
+
+## Decisions
+
+| # | Decision | Choice |
+|---|---|---|
+| 1 | How does the LLM emit the spec? | New `render_spec(spec: dict)` tool. LLM calls it like any other tool. Removes the "spec is special, it's in AIMessage content" carve-out. Uniform "all decisions = tool calls" shape, matches `c_tool_calls`. |
+| 2 | Where does `dashboard_spec` state live? | `render_spec` returns `Command(update={"dashboard_spec": ..., "messages": [ToolMessage(...)]})` — directly mutating state via LangGraph 0.3+ `Command`-from-tool support (confirmed via `pyproject.toml` pin `langgraph>=0.3`). No separate extract node. |
+| 3 | Graph shape | `START → agent ↔ tools → emit_state → respond → END`. No router (the agent's prompt + tool selection handles first-turn vs follow-up). No `generate_shell`, no `plan_tools`, no `populate_initial_data`. |
+| 4 | Iteration cap | `should_continue` checks: (a) last message has tool_calls AND (b) tool-call count this turn < 8. 8 leaves headroom for 1 spec + 4 data tools + 3 retries. After cap, force exit to `emit_state`. |
+| 5 | Model | gpt-5 with `reasoning_effort='minimal'` (matches today's planner, which was specifically chosen for instruction-following — see comment block at lines 24-36 of today's `dashboard_graph.py`). gpt-5-mini stays on `respond` (cheaper, prose-only). |
+| 6 | `emit_state` behavior | Unchanged. Still iterates `state["messages"]` in reverse, looks at ToolMessages by `name`, fires `state_update` events. Now also encounters `render_spec` ToolMessages but those have no data payload (the spec is in `dashboard_spec` field, not the message) — `emit_state` ignores names it doesn't recognize. |
+| 7 | `respond` behavior | Unchanged from PR #428 (always re-summarizes, no early-exit, "do not ask follow-up questions" instruction). |
+| 8 | Tool-calling style | `tool_choice='auto'` (NOT `'required'`). Lets the agent return a pure-prose response on interpretive case-3 questions ("why did on-time % dip?"). |
+| 9 | System prompt | Rewrite `prompts/dashboard.md` to be agentic-loop-aware. Instructs: "Use `render_spec` to author the dashboard. Then call data tools to populate the components you authored. On follow-up, call only the tools relevant to the user's request." |
+| 10 | Mirror policy | Apply identical changes to per-cap (`cockpit/chat/generative-ui/python/src/graph.py`) AND umbrella (`cockpit/langgraph/streaming/python/src/dashboard_graph.py`). Prompt file change applies to per-cap (`cockpit/chat/generative-ui/python/prompts/dashboard.md`) AND umbrella (`cockpit/langgraph/streaming/python/prompts/dashboard.md`). |
+
+## Architecture
+
+```
+START → agent ──→ should_continue ──┬─→ tools ─→ agent  (loop)
+                                    └─→ emit_state → respond → END
+```
+
+Diff from PR #428:
+- **Removed nodes:** `router`, `generate_shell`, `populate_initial_data`, `plan_tools`
+- **New node:** `agent` (single LLM call, all tools bound)
+- **New tool:** `render_spec(spec: dict)`
+- **Tools bound to agent:** `[render_spec, query_airline_kpis, query_on_time_trend, query_flights_by_airline, query_recent_disruptions]`
+- **Unchanged:** `tools` (ToolNode), `emit_state`, `respond`
+
+`DashboardState` keeps `dashboard_spec: str | None` field — populated by `render_spec` tool, used by frontend to render the layout.
+
+## `render_spec` tool
+
+```python
+import json
+from langchain_core.messages import ToolMessage
+from langchain_core.tools import tool
+from langgraph.types import Command
+
+
+@tool
+def render_spec(spec: dict, tool_call_id: Annotated[str, InjectedToolCallId]) -> Command:
+    """Render an interactive dashboard layout from a JSON spec.
+
+    Use this tool to author or update the dashboard layout. The spec is a
+    JSON object with `elements` (a dict keyed by component id) and `root`
+    (the id of the top-level component). See the system prompt for the full
+    schema and component catalog.
+
+    Call this tool FIRST on any turn where the layout needs to be created
+    or restructured. After calling render_spec, call the data tools needed
+    to populate the components you authored.
+
+    Args:
+        spec: The dashboard JSON render spec.
+
+    Returns:
+        Command updating dashboard_spec in state and emitting a ToolMessage.
+    """
+    spec_text = json.dumps(spec)
+    return Command(
+        update={
+            "dashboard_spec": spec_text,
+            "messages": [
+                ToolMessage(
+                    content="Spec accepted.",
+                    tool_call_id=tool_call_id,
+                    name="render_spec",
+                )
+            ],
+        }
+    )
+```
+
+`InjectedToolCallId` is a LangChain-Core annotation that injects the calling AI message's tool_call_id without the LLM having to provide it. Available since `langchain-core>=0.3.0` (confirmed via cockpit deps).
+
+The ToolMessage content is just `"Spec accepted."` — purely a placeholder so the loop continues; the actual spec lives in the `dashboard_spec` state field. `emit_state` will encounter this ToolMessage and ignore it (no matching `if msg.name == ...` branch — fall-through is benign).
+
+## `agent` node
+
+```python
+async def agent(state: DashboardState) -> dict:
+    """Single agentic node: LLM bound with all 5 tools (render_spec + 4 data
+    tools), driven by the dashboard.md system prompt. Loops via the
+    `tools` node + `should_continue` conditional edge until the LLM
+    returns no tool_calls."""
+    messages = [SystemMessage(content=_PROMPT)] + state["messages"]
+    response = await _llm_with_tools.ainvoke(messages)
+    return {"messages": [response]}
+
+
+_llm_with_tools = ChatOpenAI(
+    model="gpt-5",
+    temperature=0,
+    streaming=True,
+    reasoning_effort="minimal",
+).bind_tools([render_spec, *ALL_TOOLS])
+```
+
+`ALL_TOOLS` (the 4 data tools) imported from `dashboard_tools.py` unchanged.
+
+## `should_continue` with iteration cap
+
+```python
+_MAX_TOOL_ITERATIONS = 8
+
+
+def should_continue(state: DashboardState) -> Literal["tools", "emit_state"]:
+    """Loop while the agent emits tool_calls, up to MAX_TOOL_ITERATIONS this
+    turn. After the cap, force exit to emit_state — better to render a
+    partial dashboard than to loop until the LLM gets bored."""
+    last = state["messages"][-1]
+    if not (hasattr(last, "tool_calls") and last.tool_calls):
+        return "emit_state"
+
+    # Count tool_call AIMessages in the current turn (since last human message)
+    iter_count = 0
+    for msg in reversed(state["messages"]):
+        if msg.type == "human":
+            break
+        if msg.type == "ai" and getattr(msg, "tool_calls", None):
+            iter_count += 1
+    if iter_count >= _MAX_TOOL_ITERATIONS:
+        return "emit_state"
+    return "tools"
+```
+
+## System prompt rewrite (`prompts/dashboard.md`)
+
+The existing prompt's "First message" / "Follow-up messages" sections describe a sequential workflow that maps poorly to a single agentic loop. Replace with an agent-style prompt:
+
+```markdown
+# Airline Operations Dashboard Agent
+
+You are a dashboard agent that builds interactive airline-operations KPI dashboards. You have five tools:
+
+- `render_spec(spec)` — Author or update the dashboard layout. The spec is a JSON object describing component types, props, children, and state bindings. See the schema below.
+- `query_airline_kpis()` — Snapshot of operational KPIs: on-time %, flights today, avg delay, load factor.
+- `query_on_time_trend(months=12)` — On-time performance per month, for the line chart.
+- `query_flights_by_airline(airlines=None)` — Daily flight counts per airline, for the bar chart.
+- `query_recent_disruptions(limit=5, type=None)` — Recent delays/cancellations, for the data grid.
+
+## Workflow
+
+### When no dashboard exists yet (first turn)
+
+1. Call `render_spec` with a complete dashboard layout — stat cards, charts, table — using `$state` bindings to the slots that the data tools populate.
+2. Call EACH data tool that backs a component in your spec. Do NOT call tools whose data your spec doesn't reference.
+3. Return — no further tool calls. A separate node will write a brief summary.
+
+### When the dashboard exists (follow-up turn)
+
+Categorize the user's request and act ONCE. DO NOT ask clarifying questions — pick the most reasonable interpretation and act.
+
+- **Filter / scope** (e.g. "filter to cancelled flights only", "last 6 months", "top 3"): call EXACTLY ONE data tool — the one that backs the affected component — with the new parameters. Do NOT call `render_spec`.
+- **Structural change** (e.g. "add a card for X", "remove the table"): call `render_spec` with the modified layout, then call data tools only for the NEW components.
+- **Interpretive question** that no tool could resolve (e.g. "why is on-time % low?"): respond in plain prose with no tool calls. Use this ONLY when no tool fetch could answer the question.
+
+## render_spec schema
+
+[... existing schema sections preserved verbatim: JSON Render Spec Format,
+ Props with State Bindings, Available Component Types, State Path
+ Conventions, Example Spec — keep these byte-identical since they're correct,
+ only the workflow sections above are rewritten ...]
+```
+
+## State path conventions (unchanged)
+
+`emit_state` already maps tool names to JSON-pointer paths:
+
+| Tool | Pointer paths it populates |
+|---|---|
+| `query_airline_kpis` | `/on_time/value`, `/flights_today/value`, `/avg_delay/value`, `/load_factor/value` (each with `/delta`) |
+| `query_on_time_trend` | `/on_time_trend` |
+| `query_flights_by_airline` | `/flights_by_airline` |
+| `query_recent_disruptions` | `/recent_disruptions` |
+
+The agent prompt's "use `$state` bindings to slots the data tools populate" guidance refers to these paths. No change to `emit_state` or `dashboard_tools.py`.
+
+## Files modified
+
+| File | Change |
+|---|---|
+| `cockpit/chat/generative-ui/python/src/graph.py` | Rewrite to agentic-loop architecture; add `render_spec` tool; remove `router`, `generate_shell`, `populate_initial_data`, `plan_tools` |
+| `cockpit/langgraph/streaming/python/src/dashboard_graph.py` | Identical rewrite (full-copy mirror) |
+| `cockpit/chat/generative-ui/python/prompts/dashboard.md` | Replace "First message" / "Follow-up messages" sections with agent-style workflow; keep schema sections verbatim |
+| `cockpit/langgraph/streaming/python/prompts/dashboard.md` | Identical prompt update (must stay in sync) |
+
+No frontend changes. No `dashboard_tools.py` changes. No new dependencies.
+
+## Testing
+
+**Programmatic (per-cap on :5508, real LLM):**
+
+1. Boot per-cap backend
+2. **Turn 1** — "Show me a dashboard of airline operations":
+   - Assert: `dashboard_spec` is populated (set by `render_spec` Command)
+   - Assert: 4+ ToolMessages (1 from `render_spec`, ≥3 from data tools — `render_spec` always, plus at least the data tools the spec references)
+   - Assert: final AI message is conversational prose (not JSON, not chatter)
+3. **Turn 2** — "Filter to only cancelled flights":
+   - Assert: 1 new tool call (likely `query_recent_disruptions` with `type='cancelled'`); NO new `render_spec` call (dashboard structure unchanged)
+   - Assert: final message commits to the action
+4. **Turn 3** — "Add a card showing total delays this month":
+   - Assert: 2+ new tool calls (`render_spec` for the updated layout + the relevant data tool for the new card)
+5. **Turn 4** — "Why is on-time % low?":
+   - Assert: 0 tool calls (interpretive case-3); final message is plain prose
+
+**Chrome MCP smoke (per-cap on :5508 + Angular on :4508):**
+
+1. Navigate to `http://localhost:4508/`
+2. Click "Render a dashboard" → wait 30s → expect populated KPI cards (NUMBERS), line chart, bar chart, table — no "Building UI…" placeholders
+3. Type "Filter to only cancelled flights" → wait 15s → table updates to cancelled-only rows
+4. Type "Why is on-time % low?" → wait 15s → prose answer, no spec regeneration
+5. Screenshot for PR description
+
+**Test caveat:** chrome MCP must run in an isolated worktree to avoid the concurrent-worktree-branch-switching that defeated PR #428's chrome MCP smoke. The implementation plan will spell out the `git worktree add` command for this.
+
+## Risks and mitigations
+
+- **Loop runaway.** Mitigated by `_MAX_TOOL_ITERATIONS = 8` cap in `should_continue`. After the cap, force exit to `emit_state` — partial dashboard is better than infinite loop. 8 leaves headroom: 1 spec + 4 data tools + 3 retries.
+- **`Command`-from-tool API change in future LangGraph.** Current `langgraph>=0.3` pin includes this API; LangChain has marked it stable. Mitigation: pin a maximum version if a breaking change ships.
+- **gpt-5 reasoning='minimal' refusing to commit to tool calls** (the exact failure mode PR #428 was working around). Mitigation: prompt explicitly lists "DO NOT ask clarifying questions"; `tool_choice='auto'` lets case-3 prose answers happen legitimately; if the LLM still flakes on first-turn spec generation, fall back to a one-shot retry inside the agent node (out of scope for v1, document as follow-up).
+- **`render_spec` LLM emits invalid JSON.** The `tool` decorator's Pydantic validation will reject malformed dicts; the LLM gets a ToolMessage error and can retry. Mitigation: that's standard tool-calling resilience, no extra code needed.
+- **Standalone per-cap vs umbrella mirror drift.** Same risk as every per-cap graph. Mitigation: both diffs in the same PR; reviewer eyeballs them. Per-cap drift CI guard remains backlog.
+
+## Out-of-scope follow-ups
+
+- Cache spec across structurally-identical turns (LLM re-emits the same spec on filter requests today — wasteful but works)
+- Streaming `state_update` events DURING the loop (today they fire after the loop ends via `emit_state` — fine for now, smoother with mid-loop streaming)
+- Per-cap drift guard CI check
+- Pre-fill the chat input chip text with aviation-themed prompts (chip says "Q3 sales dashboard" today — frontend concern, separate PR)
+- LLM self-validates the spec against a Pydantic schema before calling `render_spec` (today Pydantic validates the `spec: dict` shape but not the spec's internal structure)

--- a/docs/superpowers/specs/2026-05-18-c-generative-ui-agentic-loop-design.md
+++ b/docs/superpowers/specs/2026-05-18-c-generative-ui-agentic-loop-design.md
@@ -1,66 +1,94 @@
-# c-generative-ui Agentic-Loop Rewrite — Design
+# c-generative-ui Agentic-Loop Rewrite — Design (v2, canonical-pattern)
 
-**Date:** 2026-05-18
+**Date:** 2026-05-18 (v2 revision)
 **Status:** Spec — pending implementation plan
+**Supersedes:** the v1 design that used `Command`-from-tool to bypass the message stream. v2 reuses the established `emit_generated_surface` pattern from `examples/chat/python/src/graph.py`.
 
 ## Goal
 
-Replace the current 6-node split-graph architecture (`router → generate_shell → populate_initial_data → emit_state → respond` for first turn, `router → plan_tools → call_tools → emit_state → respond` for follow-ups) with a **single agentic loop** where the LLM authors the dashboard spec AND chooses which data tools to call, in one coherent reasoning step.
+Replace the c-generative-ui 6-node split graph with a single agentic loop where the LLM authors the dashboard spec via a `render_spec` tool AND chooses the data tools to populate it — in one coherent reasoning step. Match the canonical surface-delivery protocol used by the rest of the codebase (the chat-lib's content-classifier reads `AIMessage.content`; the spec must arrive there).
 
-This delivers on the demo's actual claim — *the LLM intelligently composes UI and data fetches together* — instead of fudging it with a deterministic "always call all 4 tools" node (PR #428's stopgap).
+This delivers on the "generative UI" claim that PR #428's `populate_initial_data` fudge sidestepped.
 
-## Background
+## Why a v2
 
-PR #428 made the demo render (today it fails: empty placeholder cards forever) by inserting a hardcoded `populate_initial_data` node that mechanically invokes all 4 data tools after `generate_shell`. That works but it's a fudge:
+v1 proposed a `render_spec(spec)` tool that returned `Command(update={"dashboard_spec": ..., "messages": [ToolMessage("Spec accepted.")]})` — bypassing the message stream entirely. Implementation revealed the consequence:
 
-- Ignores the spec entirely — fetches all 4 datasets regardless of which components the LLM authored
-- Couples the demo to the aviation tool set; can't be retargeted without a graph edit
-- Zero LLM reasoning in the populate step — defeats the "generative" claim
+- The frontend's `content-classifier` (`libs/chat/src/lib/streaming/content-classifier.ts`) inspects `AIMessage.content` only — never `tool_calls`, never custom state fields. It classifies on the first non-whitespace character: `{` → `'json-render'` → renders via `<chat-generative-ui>`.
+- v1's `render_spec` wrote the spec to `state.dashboard_spec` and left the AI message content empty. The frontend saw "empty content + tool_calls" → classified as `'markdown'` → rendered nothing.
+- Chrome MCP confirmed: tool-call cards appeared in the chat, but ZERO rendered KPI cards / charts / table.
 
-The real shape, used everywhere else in our codebase (`c_tool_calls`, `c_subagents`), is **one LLM node with tools bound, looping until done.** This spec adopts that pattern.
+The proposed "agent node mutates AIMessage to inject spec into content" was a backend patch around an invariant we shouldn't violate in the first place. **The frontend's source of truth for surfaces is `AIMessage.content`** — every other surface in the codebase respects this (a2ui, json-render). The clean fix is to make c-generative-ui respect it too.
+
+`examples/chat/python/src/graph.py` already implements this protocol. v2 mirrors that pattern.
+
+## Background — the canonical pattern (`examples/chat`)
+
+```
+generate → tools → after_tools ─┬→ emit_generated_surface → END
+                                └→ generate (loop on non-GenUI tools)
+```
+
+- **GenUI tools** (`render_a2ui_surface`, `generate_json_render_spec`) return spec/envelope JSON as `ToolMessage.content` (plain string).
+- **`after_tools`** conditional edge: if the most recent ToolMessage came from a GenUI tool, route to `emit_generated_surface`; otherwise loop back to `generate`.
+- **`emit_generated_surface`** is a post-process node that:
+  1. Reads the ToolMessage payload
+  2. Wraps it with the content-classifier sentinel (`---a2ui_JSON---\n…` for a2ui; raw JSON for json-render)
+  3. Replaces the AI tool-call message in place (LangGraph's `add_messages` reducer matches by `id` and overwrites) with content = wrapped payload, tool_calls preserved
+  4. Replaces the ToolMessage in place with stub content `"rendered"` (collapses the tool-call card chrome from a multi-KB schema dump to one word)
+- **Frontend `genuiToolNames`** (default in `libs/chat/src/lib/compositions/chat/chat.component.ts:318`) excludes these tool names from `<chat-tool-calls>` so the tool-call card doesn't duplicate the spec rendering.
+
+c-generative-ui v2 follows this exactly, with ONE adaptation to support the agentic loop (next section).
+
+## The one adaptation
+
+`examples/chat`'s `emit_generated_surface` is **terminal** — after wrap, the graph goes to END. One GenUI dispatch per turn.
+
+c-generative-ui needs `render_spec` AND data tools in the same turn. So the wrap step must **continue the loop** instead of ending it: after wrapping, route back to `agent` so any pending non-GenUI tool calls' results (already in state) can be reasoned over and the loop can resolve to "no more tool calls" → exit to `emit_state` → `respond` → END.
+
+Concrete shape: `agent → tools → wrap_spec_into_ai → agent ↔ tools (no render_spec) → emit_state → respond → END`. The `wrap_spec_into_ai` node is idempotent — if the parent AI message's content is already non-empty (already wrapped on a prior iteration), do nothing.
 
 ## Decisions
 
 | # | Decision | Choice |
 |---|---|---|
-| 1 | How does the LLM emit the spec? | New `render_spec(spec: dict)` tool. LLM calls it like any other tool. Removes the "spec is special, it's in AIMessage content" carve-out. Uniform "all decisions = tool calls" shape, matches `c_tool_calls`. |
-| 2 | Where does `dashboard_spec` state live? | `render_spec` returns `Command(update={"dashboard_spec": ..., "messages": [ToolMessage(...)]})` — directly mutating state via LangGraph 0.3+ `Command`-from-tool support (confirmed via `pyproject.toml` pin `langgraph>=0.3`). No separate extract node. |
-| 3 | Graph shape | `START → agent ↔ tools → emit_state → respond → END`. No router (the agent's prompt + tool selection handles first-turn vs follow-up). No `generate_shell`, no `plan_tools`, no `populate_initial_data`. |
-| 4 | Iteration cap | `should_continue` checks: (a) last message has tool_calls AND (b) tool-call count this turn < 8. 8 leaves headroom for 1 spec + 4 data tools + 3 retries. After cap, force exit to `emit_state`. |
-| 5 | Model | gpt-5 with `reasoning_effort='minimal'` (matches today's planner, which was specifically chosen for instruction-following — see comment block at lines 24-36 of today's `dashboard_graph.py`). gpt-5-mini stays on `respond` (cheaper, prose-only). |
-| 6 | `emit_state` behavior | Unchanged. Still iterates `state["messages"]` in reverse, looks at ToolMessages by `name`, fires `state_update` events. Now also encounters `render_spec` ToolMessages but those have no data payload (the spec is in `dashboard_spec` field, not the message) — `emit_state` ignores names it doesn't recognize. |
-| 7 | `respond` behavior | Unchanged from PR #428 (always re-summarizes, no early-exit, "do not ask follow-up questions" instruction). |
-| 8 | Tool-calling style | `tool_choice='auto'` (NOT `'required'`). Lets the agent return a pure-prose response on interpretive case-3 questions ("why did on-time % dip?"). |
-| 9 | System prompt | Rewrite `prompts/dashboard.md` to be agentic-loop-aware. Instructs: "Use `render_spec` to author the dashboard. Then call data tools to populate the components you authored. On follow-up, call only the tools relevant to the user's request." |
-| 10 | Mirror policy | Apply identical changes to per-cap (`cockpit/chat/generative-ui/python/src/graph.py`) AND umbrella (`cockpit/langgraph/streaming/python/src/dashboard_graph.py`). Prompt file change applies to per-cap (`cockpit/chat/generative-ui/python/prompts/dashboard.md`) AND umbrella (`cockpit/langgraph/streaming/python/prompts/dashboard.md`). |
+| 1 | `render_spec` tool signature | `render_spec(spec: dict) -> str` returning `json.dumps(spec)` as the ToolMessage content. NO `Command`, no state-field write. Matches the canonical pattern. |
+| 2 | Where the spec lives in state | In `AIMessage.content` after `wrap_spec_into_ai` runs. The `dashboard_spec` field on `DashboardState` is **removed**; spec is reachable by walking message history if any consumer needs it. |
+| 3 | Graph shape | `START → agent ↔ tools → wrap_spec_into_ai → agent (loop while tool_calls; up to N iterations) → emit_state → respond → END`. `wrap_spec_into_ai` runs ALWAYS after tools (idempotent no-op if no render_spec ToolMessage to process), simplifying the conditional. |
+| 4 | Iteration cap | `_MAX_TOOL_ITERATIONS = 6` (down from v1's 8). 1 round for render_spec + data tools, plus 5 retries — more than enough; tightens the loop. |
+| 5 | Model | gpt-5 with `reasoning_effort='minimal'` for the agent (matches today's planner). gpt-5-mini stays on `respond`. |
+| 6 | `emit_state` behavior | Unchanged from PR #428 (walks back to break on `human`, fires `state_update` events for data tool results). Encounters render_spec ToolMessages whose content is `"rendered"` (post-wrap stub) and ignores them (no matching `if msg.name == "..."` branch). |
+| 7 | `respond` behavior | Unchanged from PR #428 (always re-summarizes, "do not ask follow-up questions" instruction). |
+| 8 | Frontend coupling | Add `'render_spec'` to the default `genuiToolNames` list in `libs/chat/src/lib/compositions/chat/chat.component.ts:318` (currently `['generate_a2ui_schema', 'generate_json_render_spec']`). One-line lib change; benefits any future graph using the same tool name. No cockpit consumer change needed. |
+| 9 | Mirror policy | Apply identical Python changes to per-cap (`cockpit/chat/generative-ui/python/src/graph.py`) AND umbrella (`cockpit/langgraph/streaming/python/src/dashboard_graph.py`). Same for the prompt file. |
+| 10 | Tool-choice | `tool_choice='auto'` (default; no override). Lets the agent return a pure-prose response on interpretive case-3 questions. |
 
 ## Architecture
 
 ```
-START → agent ──→ should_continue ──┬─→ tools ─→ agent  (loop)
-                                    └─→ emit_state → respond → END
+START → agent ──→ should_continue ──┬→ tools → wrap_spec_into_ai → agent  (loop)
+                                    └→ emit_state → respond → END
 ```
 
-Diff from PR #428:
-- **Removed nodes:** `router`, `generate_shell`, `populate_initial_data`, `plan_tools`
-- **New node:** `agent` (single LLM call, all tools bound)
-- **New tool:** `render_spec(spec: dict)`
-- **Tools bound to agent:** `[render_spec, query_airline_kpis, query_on_time_trend, query_flights_by_airline, query_recent_disruptions]`
-- **Unchanged:** `tools` (ToolNode), `emit_state`, `respond`
+Comparison to today (post PR #428):
 
-`DashboardState` keeps `dashboard_spec: str | None` field — populated by `render_spec` tool, used by frontend to render the layout.
+| Node | Today (PR #428) | v2 (this design) |
+|---|---|---|
+| `router` | First-turn vs follow-up dispatch | **Removed** — agent prompt handles both cases |
+| `generate_shell` | LLM call, no tools bound, emits spec as AIMessage.content | **Removed** — folded into `agent` |
+| `populate_initial_data` | Hardcoded loop calling all 4 tools | **Removed** — agent chooses tools |
+| `plan_tools` | LLM call, tools bound, follow-up-only prompt | **Removed** — folded into `agent` |
+| `agent` | — | **New** — single LLM call, 5 tools bound (`render_spec` + 4 data) |
+| `tools` | ToolNode for 4 data tools | Same `ToolNode` but for 5 tools (includes `render_spec`) |
+| `wrap_spec_into_ai` | — | **New** — post-process that wraps the render_spec ToolMessage into AI.content |
+| `emit_state` | Walks reversed messages, fires state_update | Same, with one fix: break on `human` (not `ai`) since the loop produces multiple AI messages per turn |
+| `respond` | Re-summarizes, no early-exit | Same |
 
 ## `render_spec` tool
 
 ```python
-import json
-from langchain_core.messages import ToolMessage
-from langchain_core.tools import tool
-from langgraph.types import Command
-
-
 @tool
-def render_spec(spec: dict, tool_call_id: Annotated[str, InjectedToolCallId]) -> Command:
+async def render_spec(spec: dict) -> str:
     """Render an interactive dashboard layout from a JSON spec.
 
     Use this tool to author or update the dashboard layout. The spec is a
@@ -76,35 +104,107 @@ def render_spec(spec: dict, tool_call_id: Annotated[str, InjectedToolCallId]) ->
         spec: The dashboard JSON render spec.
 
     Returns:
-        Command updating dashboard_spec in state and emitting a ToolMessage.
+        The spec serialized as JSON. A post-process node wraps this
+        payload into the AI message content where the frontend's
+        content-classifier picks it up.
     """
-    spec_text = json.dumps(spec)
-    return Command(
-        update={
-            "dashboard_spec": spec_text,
-            "messages": [
-                ToolMessage(
-                    content="Spec accepted.",
-                    tool_call_id=tool_call_id,
-                    name="render_spec",
-                )
-            ],
-        }
-    )
+    return json.dumps(spec)
 ```
 
-`InjectedToolCallId` is a LangChain-Core annotation that injects the calling AI message's tool_call_id without the LLM having to provide it. Available since `langchain-core>=0.3.0` (confirmed via cockpit deps).
+No `Command`, no `InjectedToolCallId`, no state-field mutation. Just returns a string.
 
-The ToolMessage content is just `"Spec accepted."` — purely a placeholder so the loop continues; the actual spec lives in the `dashboard_spec` state field. `emit_state` will encounter this ToolMessage and ignore it (no matching `if msg.name == ...` branch — fall-through is benign).
+## `wrap_spec_into_ai` node
+
+```python
+async def wrap_spec_into_ai(state: DashboardState) -> dict:
+    """Post-process that wraps the most recent render_spec ToolMessage
+    payload into the parent AI tool-call message's content (in place via
+    LangGraph's add_messages reducer matching by id), where the chat-lib's
+    content-classifier picks it up and renders <chat-generative-ui>.
+
+    Idempotent: if the parent AI message already has non-empty content
+    (already wrapped on a prior iteration), no-op. Also no-op if no
+    render_spec ToolMessage is found at all.
+
+    Mirrors examples/chat/python/src/graph.py's emit_generated_surface,
+    but loops back to `agent` instead of going to END so the agent can
+    still call data tools in the same turn.
+    """
+    msgs = state["messages"]
+
+    # Find the most recent render_spec ToolMessage + its originating AI message
+    render_tool_msg = None
+    parent_ai = None
+    for m in reversed(msgs):
+        if isinstance(m, ToolMessage) and m.name == "render_spec":
+            render_tool_msg = m
+            for prior in reversed(msgs):
+                if isinstance(prior, AIMessage) and prior.tool_calls:
+                    if any(tc.get("id") == render_tool_msg.tool_call_id for tc in prior.tool_calls):
+                        parent_ai = prior
+                        break
+            break
+
+    if render_tool_msg is None or parent_ai is None:
+        return {}
+
+    # Idempotency: if the parent AI message already has non-empty content,
+    # the wrap has already happened this turn — no-op.
+    existing = parent_ai.content
+    if isinstance(existing, str) and existing.strip():
+        return {}
+
+    payload = render_tool_msg.content if isinstance(render_tool_msg.content, str) else ""
+    if not payload:
+        return {}
+
+    # Strip optional markdown fencing (gpt-5 sometimes wraps its JSON
+    # output in ```json blocks despite the prompt instructions).
+    stripped = payload.strip()
+    if stripped.startswith("```"):
+        lines = stripped.split("\n")
+        stripped = "\n".join(line for line in lines if not line.startswith("```")).strip()
+
+    # In-place replacements via add_messages id-match reducer.
+    out = []
+
+    # Replace the ToolMessage with a tiny "rendered" stub so the
+    # chat-tool-calls UI (if it ever showed render_spec — it shouldn't,
+    # given genuiToolNames excludes it) doesn't display the multi-KB
+    # schema JSON.
+    placeholder_kwargs = {
+        "content": "rendered",
+        "tool_call_id": render_tool_msg.tool_call_id,
+        "name": "render_spec",
+    }
+    if getattr(render_tool_msg, "id", None):
+        placeholder_kwargs["id"] = render_tool_msg.id
+    out.append(ToolMessage(**placeholder_kwargs))
+
+    # Replace the parent AI message with the same id + same tool_calls,
+    # but content swapped to the spec JSON. The chat-lib content-classifier
+    # sees content starting with `{` and routes to <chat-generative-ui>.
+    replacement_kwargs = {
+        "content": stripped,
+        "tool_calls": parent_ai.tool_calls,
+        "additional_kwargs": parent_ai.additional_kwargs or {},
+        "response_metadata": parent_ai.response_metadata or {},
+    }
+    if getattr(parent_ai, "id", None):
+        replacement_kwargs["id"] = parent_ai.id
+    out.append(AIMessage(**replacement_kwargs))
+
+    return {"messages": out}
+```
 
 ## `agent` node
 
 ```python
 async def agent(state: DashboardState) -> dict:
-    """Single agentic node: LLM bound with all 5 tools (render_spec + 4 data
-    tools), driven by the dashboard.md system prompt. Loops via the
-    `tools` node + `should_continue` conditional edge until the LLM
-    returns no tool_calls."""
+    """Single agentic node: LLM bound with all 5 tools (render_spec + 4
+    data tools), driven by dashboard.md. Loops via the `tools` node +
+    `wrap_spec_into_ai` post-process + `should_continue` until the LLM
+    returns no tool_calls or the iteration cap is hit."""
     messages = [SystemMessage(content=_PROMPT)] + state["messages"]
     response = await _llm_with_tools.ainvoke(messages)
     return {"messages": [response]}
@@ -115,26 +215,23 @@ _llm_with_tools = ChatOpenAI(
     temperature=0,
     streaming=True,
     reasoning_effort="minimal",
-).bind_tools([render_spec, *ALL_TOOLS])
+).bind_tools([render_spec, *_DATA_TOOLS])
 ```
-
-`ALL_TOOLS` (the 4 data tools) imported from `dashboard_tools.py` unchanged.
 
 ## `should_continue` with iteration cap
 
 ```python
-_MAX_TOOL_ITERATIONS = 8
+_MAX_TOOL_ITERATIONS = 6
 
 
 def should_continue(state: DashboardState) -> Literal["tools", "emit_state"]:
-    """Loop while the agent emits tool_calls, up to MAX_TOOL_ITERATIONS this
-    turn. After the cap, force exit to emit_state — better to render a
-    partial dashboard than to loop until the LLM gets bored."""
+    """Loop while the agent emits tool_calls, up to _MAX_TOOL_ITERATIONS
+    this turn. After the cap, force exit to emit_state — partial dashboard
+    is better than an infinite loop."""
     last = state["messages"][-1]
     if not (hasattr(last, "tool_calls") and last.tool_calls):
         return "emit_state"
 
-    # Count tool_call AIMessages in the current turn (since last human message)
     iter_count = 0
     for msg in reversed(state["messages"]):
         if msg.type == "human":
@@ -146,9 +243,9 @@ def should_continue(state: DashboardState) -> Literal["tools", "emit_state"]:
     return "tools"
 ```
 
-## System prompt rewrite (`prompts/dashboard.md`)
+## System prompt (`prompts/dashboard.md`) — workflow rewrite
 
-The existing prompt's "First message" / "Follow-up messages" sections describe a sequential workflow that maps poorly to a single agentic loop. Replace with an agent-style prompt:
+Replace the existing "First message" / "Follow-up messages" section with:
 
 ```markdown
 # Airline Operations Dashboard Agent
@@ -165,9 +262,9 @@ You are a dashboard agent that builds interactive airline-operations KPI dashboa
 
 ### When no dashboard exists yet (first turn)
 
-1. Call `render_spec` with a complete dashboard layout — stat cards, charts, table — using `$state` bindings to the slots that the data tools populate.
-2. Call EACH data tool that backs a component in your spec. Do NOT call tools whose data your spec doesn't reference.
-3. Return — no further tool calls. A separate node will write a brief summary.
+1. Call `render_spec` ONCE with a complete dashboard layout — stat cards, charts, table — using `$state` bindings to the slots the data tools populate (see "State Path Conventions" below).
+2. In the SAME turn (same tool_calls array), call EACH data tool that backs a component in your spec. Do NOT call tools whose data your spec doesn't reference.
+3. After the tools return, return WITHOUT any further tool calls. A separate node will write a brief conversational summary.
 
 ### When the dashboard exists (follow-up turn)
 
@@ -175,79 +272,82 @@ Categorize the user's request and act ONCE. DO NOT ask clarifying questions — 
 
 - **Filter / scope** (e.g. "filter to cancelled flights only", "last 6 months", "top 3"): call EXACTLY ONE data tool — the one that backs the affected component — with the new parameters. Do NOT call `render_spec`.
 - **Structural change** (e.g. "add a card for X", "remove the table"): call `render_spec` with the modified layout, then call data tools only for the NEW components.
-- **Interpretive question** that no tool could resolve (e.g. "why is on-time % low?"): respond in plain prose with no tool calls. Use this ONLY when no tool fetch could answer the question.
+- **Interpretive question** that no tool could resolve (e.g. "why is on-time % low?"): respond in plain prose with no tool calls.
 
-## render_spec schema
-
-[... existing schema sections preserved verbatim: JSON Render Spec Format,
- Props with State Bindings, Available Component Types, State Path
- Conventions, Example Spec — keep these byte-identical since they're correct,
- only the workflow sections above are rewritten ...]
 ```
 
-## State path conventions (unchanged)
+The schema sections that follow (`## JSON Render Spec Format`, `### Props with State Bindings`, `## Available Component Types`, `## State Path Conventions`, `## Example Spec`) are preserved verbatim — they're already correct.
 
-`emit_state` already maps tool names to JSON-pointer paths:
+## Frontend change
 
-| Tool | Pointer paths it populates |
-|---|---|
-| `query_airline_kpis` | `/on_time/value`, `/flights_today/value`, `/avg_delay/value`, `/load_factor/value` (each with `/delta`) |
-| `query_on_time_trend` | `/on_time_trend` |
-| `query_flights_by_airline` | `/flights_by_airline` |
-| `query_recent_disruptions` | `/recent_disruptions` |
+`libs/chat/src/lib/compositions/chat/chat.component.ts:318` — extend the default `genuiToolNames` list:
 
-The agent prompt's "use `$state` bindings to slots the data tools populate" guidance refers to these paths. No change to `emit_state` or `dashboard_tools.py`.
+```typescript
+readonly genuiToolNames = input<readonly string[]>([
+  'generate_a2ui_schema',
+  'generate_json_render_spec',
+  'render_spec',  // c-generative-ui agentic-loop dashboard tool
+]);
+```
+
+This is a one-line addition. Any chat composition consumer that uses the default (e.g. cockpit/chat/generative-ui/angular) will automatically exclude `render_spec` tool calls from the `<chat-tool-calls>` UI, so the tool-call card chrome doesn't duplicate the rendered dashboard.
 
 ## Files modified
 
 | File | Change |
 |---|---|
-| `cockpit/chat/generative-ui/python/src/graph.py` | Rewrite to agentic-loop architecture; add `render_spec` tool; remove `router`, `generate_shell`, `populate_initial_data`, `plan_tools` |
+| `cockpit/chat/generative-ui/python/src/graph.py` | Rewrite to agentic-loop with `render_spec` returning JSON string + `wrap_spec_into_ai` post-process |
 | `cockpit/langgraph/streaming/python/src/dashboard_graph.py` | Identical rewrite (full-copy mirror) |
-| `cockpit/chat/generative-ui/python/prompts/dashboard.md` | Replace "First message" / "Follow-up messages" sections with agent-style workflow; keep schema sections verbatim |
-| `cockpit/langgraph/streaming/python/prompts/dashboard.md` | Identical prompt update (must stay in sync) |
+| `cockpit/chat/generative-ui/python/prompts/dashboard.md` | Workflow section rewrite; schema sections preserved |
+| `cockpit/langgraph/streaming/python/prompts/dashboard.md` | Identical prompt mirror |
+| `libs/chat/src/lib/compositions/chat/chat.component.ts` | Add `'render_spec'` to default `genuiToolNames` list (1 line) |
 
-No frontend changes. No `dashboard_tools.py` changes. No new dependencies.
+No `dashboard_tools.py` changes. No other frontend changes. No `pyproject.toml` changes.
 
 ## Testing
 
-**Programmatic (per-cap on :5508, real LLM):**
+**Programmatic (real LLM, per-cap on :5508):**
 
-1. Boot per-cap backend
-2. **Turn 1** — "Show me a dashboard of airline operations":
-   - Assert: `dashboard_spec` is populated (set by `render_spec` Command)
-   - Assert: 4+ ToolMessages (1 from `render_spec`, ≥3 from data tools — `render_spec` always, plus at least the data tools the spec references)
-   - Assert: final AI message is conversational prose (not JSON, not chatter)
-3. **Turn 2** — "Filter to only cancelled flights":
-   - Assert: 1 new tool call (likely `query_recent_disruptions` with `type='cancelled'`); NO new `render_spec` call (dashboard structure unchanged)
-   - Assert: final message commits to the action
-4. **Turn 3** — "Add a card showing total delays this month":
-   - Assert: 2+ new tool calls (`render_spec` for the updated layout + the relevant data tool for the new card)
-5. **Turn 4** — "Why is on-time % low?":
-   - Assert: 0 tool calls (interpretive case-3); final message is plain prose
+1. Turn 1 — "Show me a dashboard of airline operations":
+   - Assert: `render_spec` ToolMessage exists with content starting `{`
+   - Assert: ≥1 data tool ToolMessage exists
+   - Assert: After `wrap_spec_into_ai` runs, the AI message containing the render_spec tool_call has `content` starting `{` (the spec JSON) — NOT empty
+   - Assert: Final AI message (from `respond`) is conversational prose, doesn't start with `{`
+2. Turn 2 — "Filter to only cancelled flights":
+   - Assert: ≥1 new data tool ToolMessage (likely `query_recent_disruptions`)
+   - Assert: NO new `render_spec` ToolMessage (no structural change)
+3. Turn 3 — "Why might on-time % be lower than industry average?":
+   - Assert: 0 new tool calls; final message is prose
 
-**Chrome MCP smoke (per-cap on :5508 + Angular on :4508):**
+**Chrome MCP smoke (in isolated worktree, per-cap on :5508):**
 
 1. Navigate to `http://localhost:4508/`
-2. Click "Render a dashboard" → wait 30s → expect populated KPI cards (NUMBERS), line chart, bar chart, table — no "Building UI…" placeholders
-3. Type "Filter to only cancelled flights" → wait 15s → table updates to cancelled-only rows
-4. Type "Why is on-time % low?" → wait 15s → prose answer, no spec regeneration
-5. Screenshot for PR description
-
-**Test caveat:** chrome MCP must run in an isolated worktree to avoid the concurrent-worktree-branch-switching that defeated PR #428's chrome MCP smoke. The implementation plan will spell out the `git worktree add` command for this.
+2. Type "Show me a dashboard of airline operations." (NOT the chip — chip text is "Q3 sales", a separate frontend bug). Wait ~30s.
+3. Expect: populated KPI cards (numbers, not "Building UI…"), line chart, bar chart, data table — rendered via `<chat-generative-ui>` driven by the wrapped AIMessage content
+4. Expect: `<chat-tool-calls>` shows the 4 data tool cards (`query_*`) but NOT a `render_spec` card (excluded by `genuiToolNames`)
+5. Type "Filter to only cancelled flights" → expect data table updates
+6. Screenshot for PR description
 
 ## Risks and mitigations
 
-- **Loop runaway.** Mitigated by `_MAX_TOOL_ITERATIONS = 8` cap in `should_continue`. After the cap, force exit to `emit_state` — partial dashboard is better than infinite loop. 8 leaves headroom: 1 spec + 4 data tools + 3 retries.
-- **`Command`-from-tool API change in future LangGraph.** Current `langgraph>=0.3` pin includes this API; LangChain has marked it stable. Mitigation: pin a maximum version if a breaking change ships.
-- **gpt-5 reasoning='minimal' refusing to commit to tool calls** (the exact failure mode PR #428 was working around). Mitigation: prompt explicitly lists "DO NOT ask clarifying questions"; `tool_choice='auto'` lets case-3 prose answers happen legitimately; if the LLM still flakes on first-turn spec generation, fall back to a one-shot retry inside the agent node (out of scope for v1, document as follow-up).
-- **`render_spec` LLM emits invalid JSON.** The `tool` decorator's Pydantic validation will reject malformed dicts; the LLM gets a ToolMessage error and can retry. Mitigation: that's standard tool-calling resilience, no extra code needed.
-- **Standalone per-cap vs umbrella mirror drift.** Same risk as every per-cap graph. Mitigation: both diffs in the same PR; reviewer eyeballs them. Per-cap drift CI guard remains backlog.
+- **Loop runaway.** Mitigated by `_MAX_TOOL_ITERATIONS = 6`.
+- **`wrap_spec_into_ai` runs but no render_spec was called this turn.** No-op (early return).
+- **`wrap_spec_into_ai` runs multiple times in a turn (because it's after every `tools` invocation).** Idempotent: if parent AI's content is already non-empty, no-op.
+- **Markdown fencing on the spec JSON.** Stripped before wrap.
+- **Frontend cache: existing browser sessions may have stale `genuiToolNames`.** Hard refresh covers it; not a production concern (new build = new bundle).
+- **The order of tool_calls within ONE AI message determines order of ToolMessages.** That's fine — `wrap_spec_into_ai` walks back from the end and finds the most recent render_spec ToolMessage regardless of position.
+- **Standalone per-cap vs umbrella mirror drift.** Same risk as every per-cap graph; mitigated by landing both diffs in the same PR.
+
+## What this design intentionally does NOT do
+
+- It does NOT touch `examples/chat`'s `emit_generated_surface` to abstract a shared helper. The two patterns are similar but not identical (terminal vs loop continuation, single tool vs render_spec+data tools). Premature abstraction would couple two independent graphs.
+- It does NOT change the cockpit consumer (`cockpit/chat/generative-ui/angular/src/app/generative-ui.component.ts`). The default `genuiToolNames` update in chat-lib covers it.
+- It does NOT fix the chip text ("Q3 sales dashboard" vs aviation theme). Documented as out-of-scope follow-up; pure frontend change.
 
 ## Out-of-scope follow-ups
 
-- Cache spec across structurally-identical turns (LLM re-emits the same spec on filter requests today — wasteful but works)
-- Streaming `state_update` events DURING the loop (today they fire after the loop ends via `emit_state` — fine for now, smoother with mid-loop streaming)
+- Aviation-themed welcome chip text in `cockpit/chat/generative-ui/angular/src/app/generative-ui.component.ts` (replace "Show me a Q3 sales dashboard with three metrics." with "Show me a dashboard of airline operations.")
+- Extract a `make_genui_wrap_node(tool_name)` helper if a third c-* graph needs the same pattern
 - Per-cap drift guard CI check
-- Pre-fill the chat input chip text with aviation-themed prompts (chip says "Q3 sales dashboard" today — frontend concern, separate PR)
-- LLM self-validates the spec against a Pydantic schema before calling `render_spec` (today Pydantic validates the `spec: dict` shape but not the spec's internal structure)
+- Cache spec across structurally-identical turns
+- Stream `state_update` events DURING the loop (today they fire after the loop in `emit_state`)

--- a/libs/chat/src/lib/compositions/chat/chat.component.ts
+++ b/libs/chat/src/lib/compositions/chat/chat.component.ts
@@ -318,6 +318,7 @@ export class ChatComponent {
   readonly genuiToolNames = input<readonly string[]>([
     'generate_a2ui_schema',
     'generate_json_render_spec',
+    'render_spec',
   ]);
 
   readonly showWelcome = computed(() => {


### PR DESCRIPTION
## Summary
Rewrites c-generative-ui as a single agentic loop where the LLM authors the dashboard spec via a `render_spec` tool AND chooses the data tools to populate it in the same turn. Replaces PR #428's deterministic `populate_initial_data` fudge with real LLM-driven composition.

Uses the canonical surface-delivery pattern from `examples/chat/python/src/graph.py`: `render_spec` returns the spec as a plain JSON string in its ToolMessage content; a post-process node `wrap_spec_into_ai` swaps that payload into the parent AI tool-call message's content (in place via LangGraph's `add_messages` id-match reducer), so the chat-lib's content-classifier mounts `<chat-generative-ui>` the same way it does for every other surface in the codebase.

## Why v2
A v1 attempt used `Command(update=...)` from `render_spec` to write the spec into a state field. Chrome MCP verification revealed the frontend's content-classifier only inspects `AIMessage.content` — the spec never reached the renderer; empty placeholder cards forever. v2 respects the established invariant that the frontend's source of truth for surfaces is AIMessage content.

## Architecture
```
START → agent ──→ should_continue ──┬→ tools → wrap_spec_into_ai → agent  (loop, cap 6)
                                    ├→ finalize → emit_state → respond → END  (cap hit)
                                    └→ emit_state → respond → END  (no tool_calls)
```

Removed: `router`, `generate_shell`, `populate_initial_data`, `plan_tools`, `dashboard_spec` state field. Added: `agent`, `wrap_spec_into_ai`, `finalize`, `render_spec` tool. `emit_state` and `respond` largely unchanged from PR #428 (message-walk now breaks on `human` since the loop produces multiple AI messages per turn).

## Files
- `cockpit/chat/generative-ui/python/src/graph.py` — per-cap canonical (full rewrite)
- `cockpit/langgraph/streaming/python/src/dashboard_graph.py` — umbrella mirror
- `cockpit/chat/generative-ui/python/prompts/dashboard.md` — agentic workflow + schema preserved
- `cockpit/langgraph/streaming/python/prompts/dashboard.md` — umbrella prompt mirror
- `libs/chat/src/lib/compositions/chat/chat.component.ts` — add `'render_spec'` to default `genuiToolNames` (1 line)

## Test plan
- [x] Programmatic real-LLM smoke (multi-turn): `render_spec` ToolMessage stubbed to "rendered"; AI message exists with content = wrapped spec JSON; data tools fire; turn-2 filter doesn't regen spec; turn-3 interpretive returns prose
- [x] All builds green (per-cap python, umbrella python, chat lib, Angular consumer)
- [x] Shared deploy manifest unchanged (26 graphs)
- [x] **Chrome MCP smoke (isolated worktree)**: dashboard fully renders end-to-end — KPI stat cards with real values (On-time 84.2% +1.4%, Flights Today 312 +8, Avg Delay 12min -2min, Load Factor 78.5% +0.6%), line chart, bar chart by airline, Recent Disruptions data grid; `render_spec` excluded from `<chat-tool-calls>` cards; real conversational summary
- [ ] CI

## Known polish followups (not blocking)
- gpt-5 reasoning='minimal' occasionally emits `render_spec` args without the outer `{ "spec": ... }` wrapper, triggering one Pydantic retry visible as an error message in the chat. Fix in a follow-up by either accepting flatter args, using strict-mode tool binding, or tightening the prompt.
- The loop sometimes runs render_spec + data tools twice (wasted call). Prompt could be tightened to "stop after first successful render_spec + data tool round."

Plan: `docs/superpowers/plans/2026-05-18-c-generative-ui-agentic-loop.md`
Spec: `docs/superpowers/specs/2026-05-18-c-generative-ui-agentic-loop-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)