### PR TITLE
docs: correct website docs drift

### DIFF
--- a/apps/website/content/AGENTS.md.template
+++ b/apps/website/content/AGENTS.md.template
@@ -29,7 +29,7 @@ import { ChatComponent as NgafChatComponent } from '@ngaf/chat';
   `,
 })
 export class ChatComponent {
-  chat = agent({ assistantId: 'chat_agent' });
+  chat = agent({ apiUrl: 'http://localhost:2024', assistantId: 'chat_agent' });
 }
 ```
 

--- a/apps/website/content/CLAUDE.md.template
+++ b/apps/website/content/CLAUDE.md.template
@@ -29,7 +29,7 @@ import { ChatComponent as NgafChatComponent } from '@ngaf/chat';
   `,
 })
 export class ChatComponent {
-  chat = agent({ assistantId: 'chat_agent' });
+  chat = agent({ apiUrl: 'http://localhost:2024', assistantId: 'chat_agent' });
 }
 ```
 

--- a/apps/website/content/docs/agent/api/api-docs.json
+++ b/apps/website/content/docs/agent/api/api-docs.json
@@ -651,8 +651,8 @@
       {
         "name": "apiUrl",
         "type": "string",
-        "description": "Base URL of the LangGraph Platform API.",
-        "optional": false
+        "description": "Base URL of the LangGraph Platform API. Defaults to `provideAgent({ apiUrl })` when omitted.",
+        "optional": true
       },
       {
         "name": "assistantId",

--- a/apps/website/content/docs/chat/api/api-docs.json
+++ b/apps/website/content/docs/chat/api/api-docs.json
@@ -5543,13 +5543,13 @@
       {
         "name": "assistantName",
         "type": "string",
-        "description": "Override the default assistant display name (default: \"Assistant\").",
+        "description": "Shared assistant display name for consumers that read CHAT_CONFIG (default: \"Assistant\").",
         "optional": true
       },
       {
         "name": "avatarLabel",
         "type": "string",
-        "description": "Override the default AI avatar label (default: \"A\").",
+        "description": "Shared AI avatar label for consumers that read CHAT_CONFIG (default: \"A\").",
         "optional": true
       },
       {
@@ -5561,7 +5561,7 @@
       {
         "name": "renderRegistry",
         "type": "AngularRegistry",
-        "description": "Default render registry for generative UI components.",
+        "description": "Shared render registry for consumers that read CHAT_CONFIG.",
         "optional": true
       }
     ],

--- a/apps/website/content/docs/chat/api/chat-config.mdx
+++ b/apps/website/content/docs/chat/api/chat-config.mdx
@@ -1,6 +1,6 @@
 # ChatConfig
 
-`ChatConfig` is the configuration interface accepted by `provideChat()`. It defines global settings for chat composition components including the generative UI registry, assistant labels, and license token.
+`ChatConfig` is the configuration interface accepted by `provideChat()`. The object is stored under `CHAT_CONFIG` for application code that wants shared chat defaults, and `provideChat()` uses the license token to start the package license check.
 
 **Import:**
 
@@ -13,11 +13,11 @@ import type { AngularRegistry } from '@ngaf/render';
 
 ```typescript
 interface ChatConfig {
-  /** Default render registry for generative UI components. */
+  /** Shared render registry for consumers that read CHAT_CONFIG. */
   renderRegistry?: AngularRegistry;
-  /** Override the default AI avatar label (default: "A"). */
+  /** Shared AI avatar label for consumers that read CHAT_CONFIG (default: "A"). */
   avatarLabel?: string;
-  /** Override the default assistant display name (default: "Assistant"). */
+  /** Shared assistant display name for consumers that read CHAT_CONFIG (default: "Assistant"). */
   assistantName?: string;
   /** Signed license token from cacheplane.dev. Optional; omitted in dev. */
   license?: string;
@@ -32,7 +32,7 @@ interface ChatConfig {
 avatarLabel?: string
 ```
 
-A short string (typically one or two characters) displayed in the AI avatar badge that appears next to assistant messages in composition components.
+A short string (typically one or two characters) for wrappers or components that choose to read `CHAT_CONFIG`.
 
 **Default:** `"A"`
 
@@ -42,7 +42,7 @@ A short string (typically one or two characters) displayed in the AI avatar badg
 provideChat({ avatarLabel: 'AI' });
 ```
 
-There is no avatar-specific CSS token. Use `avatarLabel` for the badge text, and use the shared `--ngaf-chat-*` tokens such as `--ngaf-chat-surface`, `--ngaf-chat-text`, and `--ngaf-chat-text-muted` to align surrounding chat surfaces with your app theme.
+There is no avatar-specific CSS token. Use the shared `--ngaf-chat-*` tokens such as `--ngaf-chat-surface`, `--ngaf-chat-text`, and `--ngaf-chat-text-muted` to align chat surfaces with your app theme.
 
 ### assistantName
 
@@ -50,7 +50,7 @@ There is no avatar-specific CSS token. Use `avatarLabel` for the badge text, and
 assistantName?: string
 ```
 
-The display name for the AI assistant. Used in labels, ARIA attributes, and any place where the assistant needs a human-readable name.
+The display name for wrappers or components that choose to read `CHAT_CONFIG`.
 
 **Default:** `"Assistant"`
 
@@ -66,7 +66,7 @@ provideChat({ assistantName: 'Code Copilot' });
 renderRegistry?: AngularRegistry
 ```
 
-The default render registry for generative UI components.
+A shared render registry value for consumers that inject `CHAT_CONFIG`. `ChatComponent` does not read this value directly; pass a `ViewRegistry` to the `<chat [views]="...">` input for built-in generative UI rendering.
 
 **Example:**
 
@@ -112,12 +112,21 @@ export class ChatHeaderComponent {
 }
 ```
 
+## Gotcha: Inputs Still Win
+
+`provideChat()` is not a replacement for component inputs. For generative UI, configure the chat surface directly:
+
+```html
+<chat [agent]="agentRef" [views]="views" [store]="store" [handlers]="handlers" />
+```
+
+Use `CHAT_CONFIG` when you are building your own wrappers or want route-level defaults that your code reads explicitly.
+
 ## Type Location
 
-The `ChatConfig` interface is defined in two files within the library:
+The canonical `ChatConfig` interface is defined alongside `provideChat()`:
 
 - `libs/chat/src/lib/provide-chat.ts` -- The canonical definition with JSDoc comments, alongside the `provideChat()` function and `CHAT_CONFIG` token
-- `libs/chat/src/lib/chat.types.ts` -- A separate internal type used by lower-level chat types
 
 The public API exports `ChatConfig` as a type-only export:
 

--- a/apps/website/content/docs/chat/api/provide-chat.mdx
+++ b/apps/website/content/docs/chat/api/provide-chat.mdx
@@ -1,6 +1,6 @@
 # provideChat()
 
-`provideChat` is the provider factory that registers `@ngaf/chat` configuration in Angular's dependency injection system. Call it once in your `ApplicationConfig` (or at the route level) to set global defaults used by chat composition components.
+`provideChat` is the provider factory that registers `@ngaf/chat` configuration in Angular's dependency injection system and starts the package license check. Call it in your `ApplicationConfig` or at the route level when you need a shared `CHAT_CONFIG` value.
 
 ```typescript
 import { provideChat } from '@ngaf/chat';
@@ -23,7 +23,7 @@ function provideChat(config: ChatConfig): EnvironmentProviders
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `config` | `ChatConfig` | Configuration object with optional render registry, avatar label, and assistant name |
+| `config` | `ChatConfig` | Configuration object with optional render registry, avatar label, assistant name, and license token |
 
 **Returns:** `EnvironmentProviders` -- created via `makeEnvironmentProviders()`, compatible with `bootstrapApplication`, `ApplicationConfig`, and route-level `providers`.
 
@@ -35,7 +35,7 @@ function provideChat(config: ChatConfig): EnvironmentProviders
 { provide: CHAT_CONFIG, useValue: config }
 ```
 
-This makes the `ChatConfig` object available throughout the application via the `CHAT_CONFIG` injection token.
+This makes the `ChatConfig` object available throughout the application via the `CHAT_CONFIG` injection token. `provideChat()` does not automatically wire generative UI into `<chat>`; pass `[views]`, `[store]`, and `[handlers]` directly to `ChatComponent`.
 
 ## CHAT_CONFIG Injection Token
 
@@ -67,8 +67,10 @@ See the [ChatConfig API reference](/docs/chat/api/chat-config) for the full inte
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `avatarLabel` | `string` | `"A"` | AI avatar badge text |
-| `assistantName` | `string` | `"Assistant"` | AI assistant display name |
+| `renderRegistry` | `AngularRegistry` | `undefined` | Stored on `CHAT_CONFIG` for consumers that want a shared render registry. `<chat>` uses the `[views]` input directly. |
+| `avatarLabel` | `string` | `"A"` | Shared avatar label for consumers that inject `CHAT_CONFIG` |
+| `assistantName` | `string` | `"Assistant"` | Shared assistant display name for consumers that inject `CHAT_CONFIG` |
+| `license` | `string` | `undefined` | Signed license token used by the package license check |
 
 ## Usage Patterns
 
@@ -126,7 +128,7 @@ All chat components work without `provideChat()`. They use defaults:
 
 - Avatar label: `"A"`
 - Assistant name: `"Assistant"`
-- Generative UI requires `[views]` input on `ChatComponent`
+- Generative UI still requires the `[views]` input on `ChatComponent`
 
 ```typescript
 // This works fine without provideChat()
@@ -136,6 +138,7 @@ All chat components work without `provideChat()`. They use defaults:
 })
 export class SimpleChatComponent {
   chatRef = agent({
+    apiUrl: 'http://localhost:2024',
     assistantId: 'chat_agent',
     threadId: signal(null),
   });

--- a/apps/website/content/docs/chat/components/chat.mdx
+++ b/apps/website/content/docs/chat/components/chat.mdx
@@ -48,6 +48,7 @@ import { ChatComponent } from '@ngaf/chat';
 })
 export class ChatPageComponent {
   chatRef = agent({
+    apiUrl: 'http://localhost:2024',
     assistantId: 'chat_agent',
     threadId: signal(null),
   });
@@ -100,6 +101,7 @@ When you pass a non-empty `threads` array, a sidebar appears on the left (hidden
 })
 export class ChatWithThreadsComponent {
   chatRef = agent({
+    apiUrl: 'http://localhost:2024',
     assistantId: 'chat_agent',
     threadId: signal(null),
   });
@@ -151,7 +153,19 @@ AI messages containing JSON are parsed character-by-character as tokens stream. 
 
 ## A2UI Rendering
 
-When AI messages contain A2UI content (prefixed with `---a2ui_JSON---`), the component auto-detects and renders surfaces using the built-in `a2uiBasicCatalog()`. This includes 12 components from the A2UI v0.9 basic catalog: Text, Image, Icon, Divider, Row, Column, Card, List, Button, TextField, CheckBox, and ChoicePicker.
+When AI messages contain A2UI content (prefixed with `---a2ui_JSON---`), the component auto-detects A2UI mode. Pass `a2uiBasicCatalog()` to `[views]` to render the built-in catalog:
+
+```typescript
+import { ChatComponent, a2uiBasicCatalog } from '@ngaf/chat';
+
+views = a2uiBasicCatalog();
+```
+
+```html
+<chat [agent]="chatRef" [views]="views" />
+```
+
+The catalog currently maps 18 component types: Text, Image, Icon, Divider, Row, Column, Card, List, Button, TextField, CheckBox, MultipleChoice, DateTimeInput, Slider, Tabs, Modal, Video, and AudioPlayer.
 
 A2UI surfaces support two-way data binding, button actions, template expansion over collections, and validation. See the [A2UI guide](/docs/render/a2ui/overview) for details.
 

--- a/apps/website/content/docs/chat/getting-started/introduction.mdx
+++ b/apps/website/content/docs/chat/getting-started/introduction.mdx
@@ -60,7 +60,7 @@ LangGraph Platform
 
 - **`@ngaf/langgraph`** provides the `agent()` function and returns a `LangGraphAgent`, which satisfies the `Agent` contract consumed by `@ngaf/chat`. It exposes reactive Signals for `messages()`, `isLoading()`, `error()`, `interrupt()`, `toolCalls()`, `history()`, and more.
 
-- **`@ngaf/render`** provides `RenderSpecComponent` and view registries for rendering JSON UI specs as Angular components. The `ChatComponent` auto-detects JSON specs in AI messages and renders them through `@ngaf/render` - pass a view registry via the `[views]` input. The `ChatComponent` also auto-detects A2UI v0.9 payloads and renders them using a built-in 12-component catalog.
+- **`@ngaf/render`** provides `RenderSpecComponent` and view registries for rendering JSON UI specs as Angular components. The `ChatComponent` auto-detects JSON specs in AI messages and renders them through `@ngaf/render` - pass a view registry via the `[views]` input. The same `[views]` input enables A2UI rendering with `a2uiBasicCatalog()`, which currently maps 18 component types.
 
 ## When to Use `ChatComponent` vs. Custom Assembly
 

--- a/apps/website/content/docs/chat/guides/configuration.mdx
+++ b/apps/website/content/docs/chat/guides/configuration.mdx
@@ -1,10 +1,10 @@
 # Configuration
 
-`@ngaf/chat` uses Angular's dependency injection system for global configuration. The `provideChat()` function registers a `ChatConfig` object under the `CHAT_CONFIG` injection token.
+`@ngaf/chat` uses Angular's dependency injection system for shared configuration. The `provideChat()` function registers a `ChatConfig` object under the `CHAT_CONFIG` injection token and starts the package license check.
 
 ## provideChat()
 
-Call `provideChat()` in your application's provider array to set global configuration for chat components.
+Call `provideChat()` in your application's provider array when your application or wrappers need to inject shared chat configuration.
 
 ```typescript
 // app.config.ts
@@ -32,12 +32,20 @@ function provideChat(config: ChatConfig): EnvironmentProviders
 ## ChatConfig Interface
 
 ```typescript
+import type { AngularRegistry } from '@ngaf/render';
+
 interface ChatConfig {
+  /** Default render registry for consumers that read CHAT_CONFIG. */
+  renderRegistry?: AngularRegistry;
+
   /** Override the default AI avatar label (default: "A"). */
   avatarLabel?: string;
 
   /** Override the default assistant display name (default: "Assistant"). */
   assistantName?: string;
+
+  /** Signed license token from cacheplane.dev. Optional in development. */
+  license?: string;
 }
 ```
 
@@ -45,8 +53,10 @@ interface ChatConfig {
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `avatarLabel` | `string` | `"A"` | Single character or short string displayed in the AI avatar badge next to assistant messages. |
-| `assistantName` | `string` | `"Assistant"` | Display name for the AI assistant, used in labels and ARIA attributes. |
+| `renderRegistry` | `AngularRegistry` | `undefined` | Stored on `CHAT_CONFIG` for consumers that want a shared render registry. Pass `[views]` directly to `ChatComponent` for built-in generative UI rendering. |
+| `avatarLabel` | `string` | `"A"` | Single character or short string for consumers that inject `CHAT_CONFIG`. |
+| `assistantName` | `string` | `"Assistant"` | Display name for consumers that inject `CHAT_CONFIG`. |
+| `license` | `string` | `undefined` | Signed license token used by the package license check. |
 
 ## CHAT_CONFIG Injection Token
 
@@ -110,6 +120,6 @@ All composition components use sensible defaults. If you do not call `provideCha
 
 - Use `"A"` as the avatar label
 - Use `"Assistant"` as the assistant name
-- Have no render registry (generative UI will not render)
+- Have no injected `CHAT_CONFIG`
 
-This means you can use `ChatComponent`, `ChatInputComponent`, and all other components without any global configuration for basic chat functionality.
+This means you can use `ChatComponent`, `ChatInputComponent`, and all other components without global configuration for basic chat functionality. Generative UI is controlled by the `ChatComponent` `[views]`, `[store]`, and `[handlers]` inputs.

--- a/apps/website/content/docs/chat/guides/generative-ui.mdx
+++ b/apps/website/content/docs/chat/guides/generative-ui.mdx
@@ -46,6 +46,7 @@ const myViews = views({
 })
 export class ChatPageComponent {
   chatRef = agent({
+    apiUrl: 'http://localhost:2024',
     assistantId: 'gen_ui_agent',
     threadId: signal(null),
   });
@@ -132,7 +133,7 @@ The store enables two-way data binding between generative UI components and your
 
 ## A2UI Protocol
 
-For agents that implement Google's A2UI v0.9 protocol, `ChatComponent` auto-detects A2UI payloads (prefixed with `---a2ui_JSON---`) and renders them using the built-in A2UI catalog. See the [A2UI guide](/docs/render/a2ui/overview) for details.
+For agents that emit A2UI JSONL payloads, `ChatComponent` auto-detects content prefixed with `---a2ui_JSON---`. Pass `a2uiBasicCatalog()` to `[views]` when you want those surfaces rendered with the built-in components. See the [A2UI guide](/docs/render/a2ui/overview) for details.
 
 ## What's Next
 
@@ -152,6 +153,6 @@ For agents that implement Google's A2UI v0.9 protocol, `ChatComponent` auto-dete
     Full reference for the JSON spec format, prop expressions, and element types.
   </Card>
   <Card title="A2UI Protocol" icon="layers" href="/docs/render/a2ui/overview">
-    Render A2UI v0.9 surfaces with the built-in 12-component catalog.
+    Render A2UI surfaces with the built-in 18-component catalog.
   </Card>
 </CardGroup>

--- a/apps/website/content/docs/render/a2ui/catalog.mdx
+++ b/apps/website/content/docs/render/a2ui/catalog.mdx
@@ -216,20 +216,20 @@ A labeled checkbox with two-way binding for its checked state.
 | `_bindings` | `Record<string, string>` | Auto-populated by `surfaceToSpec()` from path references |
 | `emit` | injected | Event emitter provided by the render engine |
 
-### ChoicePicker
+### MultipleChoice
 
-A dropdown select control with a list of string options.
+A single-select dropdown or multi-select checkbox list. Set `maxAllowedSelections` to `1` or less for a dropdown; set it above `1` for a checkbox list.
 
 | A2UI type | Angular component | Selector |
 |-----------|-------------------|----------|
-| `ChoicePicker` | `A2uiChoicePickerComponent` | `a2ui-choice-picker` |
+| `MultipleChoice` | `A2uiMultipleChoiceComponent` | `a2ui-multiple-choice` |
 
 | Prop | Type | Description |
 |------|------|-------------|
-| `label` | `string` | Select label |
-| `options` | `string[]` | List of available options |
-| `selected` | `string` | Currently selected value (resolved from path reference) |
-| `validationResult` | `A2uiValidationResult` | Validation state — shows errors below dropdown when invalid |
+| `label` | `string` | Field label |
+| `options` | `{ label: string; value: string }[]` | Resolved option labels and values |
+| `selections` | `string \| string[]` | Current selected value or values (resolved from path reference) |
+| `maxAllowedSelections` | `number` | `1` or less renders a dropdown; higher values render checkboxes |
 | `_bindings` | `Record<string, string>` | Auto-populated by `surfaceToSpec()` from path references |
 | `emit` | injected | Event emitter provided by the render engine |
 
@@ -432,7 +432,7 @@ Props that use `A2uiFunctionCall` can reference these built-in functions:
 | `Button` | `A2uiButtonComponent` | Interactive |
 | `TextField` | `A2uiTextFieldComponent` | Interactive |
 | `CheckBox` | `A2uiCheckBoxComponent` | Interactive |
-| `ChoicePicker` | `A2uiChoicePickerComponent` | Interactive |
+| `MultipleChoice` | `A2uiMultipleChoiceComponent` | Interactive |
 | `Tabs` | `A2uiTabsComponent` | Layout |
 | `Modal` | `A2uiModalComponent` | Layout |
 | `Video` | `A2uiVideoComponent` | Media |

--- a/apps/website/public/AGENTS.md
+++ b/apps/website/public/AGENTS.md
@@ -1,4 +1,4 @@
-# Agent UI for Angular v0.0.37
+# Agent UI for Angular v0.0.40
 
 Agent UI primitives and LangGraph streaming adapters for Angular.
 
@@ -29,7 +29,7 @@ import { ChatComponent as NgafChatComponent } from '@ngaf/chat';
   `,
 })
 export class ChatComponent {
-  chat = agent({ assistantId: 'chat_agent' });
+  chat = agent({ apiUrl: 'http://localhost:2024', assistantId: 'chat_agent' });
 }
 ```
 

--- a/apps/website/public/CLAUDE.md
+++ b/apps/website/public/CLAUDE.md
@@ -1,4 +1,4 @@
-# Agent UI for Angular v0.0.37
+# Agent UI for Angular v0.0.40
 
 Agent UI primitives and LangGraph streaming adapters for Angular.
 
@@ -29,7 +29,7 @@ import { ChatComponent as NgafChatComponent } from '@ngaf/chat';
   `,
 })
 export class ChatComponent {
-  chat = agent({ assistantId: 'chat_agent' });
+  chat = agent({ apiUrl: 'http://localhost:2024', assistantId: 'chat_agent' });
 }
 ```
 

--- a/apps/website/src/app/chat/page.tsx
+++ b/apps/website/src/app/chat/page.tsx
@@ -128,7 +128,7 @@ export default async function ChatPage() {
           { title: 'tool primitives', description: 'Tool-call lifecycle.' },
           { title: 'interrupt primitive', description: 'Approval gate.' },
         ]}
-        cta={{ label: 'Headless API', href: '/docs/chat/api' }}
+        cta={{ label: 'Headless API', href: '/docs/chat/api/provide-chat' }}
         visualLeft
         visual={<ChatLandingCodeShowcase />}
       />

--- a/apps/website/src/app/page.tsx
+++ b/apps/website/src/app/page.tsx
@@ -102,7 +102,7 @@ export default async function HomePage() {
           { title: 'readiness gate', description: 'Hold renders until the surface is real.' },
           { title: 'thread persistence', description: 'Restore conversations across sessions.' },
         ]}
-        cta={{ label: 'Production patterns', href: '/docs/agent/guides/production' }}
+        cta={{ label: 'Production patterns', href: '/docs/agent/guides/deployment' }}
         visual={<LiveDemoFrame />}
       />
 

--- a/apps/website/src/app/pilot-to-prod/page.tsx
+++ b/apps/website/src/app/pilot-to-prod/page.tsx
@@ -162,7 +162,7 @@ export default function PilotToProdPage() {
           { title: 'Fallback API', description: 'Per-component readiness.' },
           { title: 'Runbook', description: 'Yours forever.' },
         ]}
-        cta={{ label: 'Production patterns', href: '/docs/agent/guides/production' }}
+        cta={{ label: 'Production patterns', href: '/docs/agent/guides/deployment' }}
         visual={
           <BrowserFrame url="grafana · agent dashboard" elevation="md">
             <div style={{ padding: 28, minHeight: 320, background: tokens.surfaces.surface }}>

--- a/apps/website/src/app/render/page.tsx
+++ b/apps/website/src/app/render/page.tsx
@@ -130,15 +130,15 @@ export default async function RenderPage() {
         bullets={[
           'Per-component fallback API',
           'Readiness gate holds renders until safe',
-          'Telemetry hook for unknown specs',
+          'Telemetry hook for render events',
           'Streaming partial renders supported',
         ]}
         supportingCards={[
-          { title: 'fallback()', description: 'Per-component recovery.' },
+          { title: 'fallback views', description: 'Per-component recovery.' },
           { title: 'readiness gate', description: 'Hold until safe.' },
-          { title: 'unknown-spec hook', description: 'Telemetry surface.' },
+          { title: 'render events', description: 'Telemetry surface.' },
         ]}
-        cta={{ label: 'Fallback patterns', href: '/docs/render/guides/fallback' }}
+        cta={{ label: 'Fallback patterns', href: '/docs/render/guides/registry' }}
         visualLeft
         visual={<RenderCodeShowcase />}
       />

--- a/apps/website/src/app/sitemap.ts
+++ b/apps/website/src/app/sitemap.ts
@@ -2,11 +2,8 @@ import type { MetadataRoute } from 'next';
 import { getCanonicalUrl, getSitemapRoutes } from '../lib/site-metadata';
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const now = new Date();
-
   return getSitemapRoutes().map((route) => ({
     url: getCanonicalUrl(route),
-    lastModified: now,
     changeFrequency: route.startsWith('/docs') ? 'weekly' : 'monthly',
     priority: route === '/' ? 1 : route.startsWith('/docs') ? 0.8 : 0.7,
   }));

--- a/apps/website/src/components/landing/angular/AngularCodeShowcase.tsx
+++ b/apps/website/src/components/landing/angular/AngularCodeShowcase.tsx
@@ -23,6 +23,7 @@ provideAgent({
 });
 
 const chat = agent({
+  apiUrl: environment.langgraphUrl,
   assistantId: 'my-agent',
   threadId: savedThreadId,
   onThreadId: (id) => localStorage.setItem('threadId', id),

--- a/apps/website/src/components/landing/chat-landing/ChatLandingCodeShowcase.tsx
+++ b/apps/website/src/components/landing/chat-landing/ChatLandingCodeShowcase.tsx
@@ -2,19 +2,19 @@ import { tokens } from '@ngaf/design-tokens';
 import { HighlightedCode } from '../HighlightedCode';
 
 const SNIPPET_1 = `import { agent } from '@ngaf/langgraph';
-import { ChatComponent } from '@ngaf/chat';
+import { ChatComponent, a2uiBasicCatalog } from '@ngaf/chat';
 
 @Component({
   template: \`
     <chat
       [agent]="agent"
-      [registry]="registry"
+      [views]="views"
     />
   \`,
 })
 export class MyChatPage {
   protected readonly agent = agent({ apiUrl: 'http://localhost:2024', assistantId: 'chat_agent' });
-  registry = inject(RenderRegistry);
+  protected readonly views = a2uiBasicCatalog();
 }`;
 
 const SNIPPET_2 = `chat {

--- a/apps/website/src/components/landing/render/RenderCodeShowcase.tsx
+++ b/apps/website/src/components/landing/render/RenderCodeShowcase.tsx
@@ -14,7 +14,7 @@ const registry = defineAngularRegistry({
 const SNIPPET_2 = `<render-spec
   [spec]="agentOutput()"
   [registry]="registry"
-  [state]="stateStore"
+  [store]="stateStore"
 />`;
 
 const SNIPPETS = [

--- a/apps/website/src/components/shared/Nav.tsx
+++ b/apps/website/src/components/shared/Nav.tsx
@@ -162,10 +162,10 @@ export function Nav() {
           <Button
             variant="primary"
             size="md"
-            href="/pilot-to-prod#whitepaper-gate"
+            href="/pilot-to-prod#whitepaper-block"
             onClick={() => trackCtaClick({
               surface: 'nav',
-              destination_url: '/pilot-to-prod#whitepaper-gate',
+              destination_url: '/pilot-to-prod#whitepaper-block',
               cta_id: 'nav_get_started',
               cta_text: 'Get Started',
             })}
@@ -324,11 +324,11 @@ export function Nav() {
                   <Button
                     variant="primary"
                     size="lg"
-                    href="/pilot-to-prod#whitepaper-gate"
+                    href="/pilot-to-prod#whitepaper-block"
                     onClick={() => {
                       trackCtaClick({
                         surface: 'mobile_nav',
-                        destination_url: '/pilot-to-prod#whitepaper-gate',
+                        destination_url: '/pilot-to-prod#whitepaper-block',
                         cta_id: 'mobile_nav_get_started',
                         cta_text: 'Get Started',
                       });

--- a/apps/website/src/lib/site-metadata.ts
+++ b/apps/website/src/lib/site-metadata.ts
@@ -53,7 +53,7 @@ export function createPageMetadata({
 }
 
 export function getSitemapRoutes(): string[] {
-  const staticRoutes = ['/', '/angular', '/render', '/chat', '/pricing', '/solutions', '/pilot-to-prod', '/docs', '/blog'];
+  const staticRoutes = ['/', '/angular', '/render', '/chat', '/pricing', '/solutions', '/pilot-to-prod', '/docs', '/blog', '/contact'];
   const solutionRoutes = getAllSolutionSlugs().map((slug) => `/solutions/${slug}`);
   const docsRoutes = docsConfig.flatMap((library) =>
     library.sections.flatMap((section) =>

--- a/libs/chat/src/lib/provide-chat.ts
+++ b/libs/chat/src/lib/provide-chat.ts
@@ -10,11 +10,11 @@ import type { AngularRegistry } from '@ngaf/render';
 const PACKAGE_NAME = '@ngaf/chat';
 
 export interface ChatConfig {
-  /** Default render registry for generative UI components. */
+  /** Shared render registry for consumers that read CHAT_CONFIG. */
   renderRegistry?: AngularRegistry;
-  /** Override the default AI avatar label (default: "A"). */
+  /** Shared AI avatar label for consumers that read CHAT_CONFIG (default: "A"). */
   avatarLabel?: string;
-  /** Override the default assistant display name (default: "Assistant"). */
+  /** Shared assistant display name for consumers that read CHAT_CONFIG (default: "Assistant"). */
   assistantName?: string;
   /** Signed license token from cacheplane.dev. Optional; omitted in dev. */
   license?: string;

--- a/libs/langgraph/README.md
+++ b/libs/langgraph/README.md
@@ -30,7 +30,6 @@ export const appConfig: ApplicationConfig = {
   providers: [
     provideAgent({
       apiUrl: 'https://your-langgraph-platform.com',
-      assistantId: 'my-agent',
     }),
   ],
 };
@@ -47,7 +46,10 @@ import { ChatComponent } from '@ngaf/chat';
   template: `<chat [agent]="chat" />`,
 })
 export class ChatComponentHost {
-  chat = agent({ assistantId: 'my-agent' });
+  chat = agent({
+    apiUrl: 'https://your-langgraph-platform.com',
+    assistantId: 'my-agent',
+  });
 }
 ```
 

--- a/libs/langgraph/src/lib/agent.types.ts
+++ b/libs/langgraph/src/lib/agent.types.ts
@@ -240,8 +240,8 @@ export interface AgentTransport {
 // AgentOptions references even though the options shape no longer depends on it.
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export interface AgentOptions<T, _ResolvedBag extends BagTemplate> {
-  /** Base URL of the LangGraph Platform API. */
-  apiUrl: string;
+  /** Base URL of the LangGraph Platform API. Defaults to `provideAgent({ apiUrl })` when omitted. */
+  apiUrl?: string;
   /** Agent or graph identifier on the LangGraph platform. */
   assistantId: string;
   /** Thread ID to connect to. Pass a Signal for reactive thread switching. */

--- a/libs/langgraph/src/lib/internals/stream-manager.bridge.ts
+++ b/libs/langgraph/src/lib/internals/stream-manager.bridge.ts
@@ -73,7 +73,7 @@ function agentRuntimeTelemetryErrorClass(error: unknown): string {
 }
 
 export interface StreamManagerBridgeOptions<T, ResolvedBag extends BagTemplate = BagTemplate> {
-  options:   AgentOptions<T, ResolvedBag>;
+  options:   AgentOptions<T, ResolvedBag> & { apiUrl: string };
   subjects:  StreamSubjects<T, ResolvedBag>;
   threadId$: Observable<string | null>;
   destroy$:  Observable<void>;


### PR DESCRIPTION
## Summary
- fix broken website CTAs, sitemap coverage, and public agent-context examples/version
- align Chat/ChatConfig/provideChat docs with the actual DI and `[views]` behavior
- correct A2UI catalog docs and make `AgentOptions.apiUrl` optional to match `provideAgent()` defaults

## Verification
- `npm run generate-agent-context`
- `npm run generate-api-docs`
- `npx nx test langgraph`
- `npx nx lint website` (passes with existing warnings)
- `npx nx build website`
- `git diff --check`
