### PR TITLE
fix(c-generative-ui): three polish followups (flat args, loop cap, chip text)

### DIFF
--- a/cockpit/chat/generative-ui/angular/src/app/generative-ui.component.ts
+++ b/cockpit/chat/generative-ui/angular/src/app/generative-ui.component.ts
@@ -22,8 +22,8 @@ const dashboardViews = views({
 });
 
 const WELCOME_SUGGESTIONS = [
-  { label: 'Render a dashboard', value: 'Show me a Q3 sales dashboard with three metrics.' },
-  { label: 'Render a form',      value: 'Create a contact form with name, email, and message.' },
+  { label: 'Airline operations dashboard', value: 'Show me a dashboard of airline operations.' },
+  { label: 'Filter to cancelled flights',  value: 'Filter to only the cancelled flights.' },
 ] as const;
 
 @Component({

--- a/cockpit/chat/generative-ui/python/prompts/dashboard.md
+++ b/cockpit/chat/generative-ui/python/prompts/dashboard.md
@@ -2,7 +2,7 @@
 
 You are a dashboard agent that builds interactive airline-operations KPI dashboards. You have five tools:
 
-- `render_spec(spec)` — Author or update the dashboard layout. The spec is a JSON object describing component types, props, children, and state bindings. See the schema below.
+- `render_spec(elements, root)` — Author or update the dashboard layout. `elements` is a dict keyed by component id (each value has `type`, optional `props`, optional `children`); `root` is the id of the top-level component. See the schema below.
 - `query_airline_kpis()` — Snapshot of operational KPIs: on-time %, flights today, avg delay, load factor.
 - `query_on_time_trend(months=12)` — On-time performance per month, for the line chart.
 - `query_flights_by_airline(airlines=None)` — Daily flight counts per airline, for the bar chart.
@@ -14,7 +14,7 @@ You are a dashboard agent that builds interactive airline-operations KPI dashboa
 
 1. Call `render_spec` ONCE with a complete dashboard layout — stat cards, charts, table — using `$state` bindings to the slots the data tools populate (see "State Path Conventions" below).
 2. In the SAME turn (same tool_calls array), call EACH data tool that backs a component in your spec. Do NOT call tools whose data your spec doesn't reference.
-3. After the tools return, return WITHOUT any further tool calls. A separate node will write a brief conversational summary.
+3. After the tools return, return WITHOUT any further tool calls. A separate node will write a brief conversational summary. **Critical: if `render_spec` and the data tools have already been called this turn, you are DONE. Return with no tool_calls. Do NOT call `render_spec` again. Do NOT re-call the data tools.**
 
 ### When the dashboard exists (follow-up turn)
 

--- a/cockpit/chat/generative-ui/python/src/graph.py
+++ b/cockpit/chat/generative-ui/python/src/graph.py
@@ -38,27 +38,27 @@ class DashboardState(MessagesState):
 
 
 @tool
-async def render_spec(spec: dict) -> str:
-    """Render an interactive dashboard layout from a JSON spec.
+async def render_spec(elements: dict, root: str) -> str:
+    """Render an interactive dashboard layout.
 
-    Use this tool to author or update the dashboard layout. The spec is a
-    JSON object with `elements` (a dict keyed by component id) and `root`
-    (the id of the top-level component). See the system prompt for the full
-    schema and component catalog.
+    Use this tool to author or update the dashboard layout. See the system
+    prompt for the full component catalog and state binding conventions.
 
-    Call this tool FIRST on any turn where the layout needs to be created
-    or restructured. After calling render_spec, call the data tools needed
-    to populate the components you authored.
+    Call this tool AT MOST ONCE per turn — only when the layout needs to
+    be created (first turn) or restructured (follow-up structural change).
+    Do NOT call it again to refresh data; the data tools handle that.
 
     Args:
-        spec: The dashboard JSON render spec.
+        elements: Dict keyed by component id. Each value has `type`, optional
+            `props`, and optional `children` (list of component ids).
+        root: The id of the top-level component (must be a key in `elements`).
 
     Returns:
         The spec serialized as JSON. A post-process node (wrap_spec_into_ai)
         wraps this payload into the AI message content where the
         chat-lib's content-classifier picks it up.
     """
-    return json.dumps(spec)
+    return json.dumps({"elements": elements, "root": root})
 
 
 _ALL_TOOLS = [render_spec, *_DATA_TOOLS]

--- a/cockpit/langgraph/streaming/python/prompts/dashboard.md
+++ b/cockpit/langgraph/streaming/python/prompts/dashboard.md
@@ -2,7 +2,7 @@
 
 You are a dashboard agent that builds interactive airline-operations KPI dashboards. You have five tools:
 
-- `render_spec(spec)` — Author or update the dashboard layout. The spec is a JSON object describing component types, props, children, and state bindings. See the schema below.
+- `render_spec(elements, root)` — Author or update the dashboard layout. `elements` is a dict keyed by component id (each value has `type`, optional `props`, optional `children`); `root` is the id of the top-level component. See the schema below.
 - `query_airline_kpis()` — Snapshot of operational KPIs: on-time %, flights today, avg delay, load factor.
 - `query_on_time_trend(months=12)` — On-time performance per month, for the line chart.
 - `query_flights_by_airline(airlines=None)` — Daily flight counts per airline, for the bar chart.
@@ -14,7 +14,7 @@ You are a dashboard agent that builds interactive airline-operations KPI dashboa
 
 1. Call `render_spec` ONCE with a complete dashboard layout — stat cards, charts, table — using `$state` bindings to the slots the data tools populate (see "State Path Conventions" below).
 2. In the SAME turn (same tool_calls array), call EACH data tool that backs a component in your spec. Do NOT call tools whose data your spec doesn't reference.
-3. After the tools return, return WITHOUT any further tool calls. A separate node will write a brief conversational summary.
+3. After the tools return, return WITHOUT any further tool calls. A separate node will write a brief conversational summary. **Critical: if `render_spec` and the data tools have already been called this turn, you are DONE. Return with no tool_calls. Do NOT call `render_spec` again. Do NOT re-call the data tools.**
 
 ### When the dashboard exists (follow-up turn)
 


### PR DESCRIPTION
## Summary
Three small followups to PR #436 that polish the c-generative-ui demo.

### 1. `render_spec` flat args
gpt-5 reasoning='minimal' frequently emits `render_spec` args as `{"elements": ..., "root": ...}` instead of the wrapped `{"spec": {"elements": ..., "root": ...}}` the tool signature required. Pydantic rejected the first call; the LLM retried successfully; but the user saw an ugly `Error invoking tool 'render_spec' with kwargs ... spec: Field required` block in the chat.

Fix: flatten the tool signature to `render_spec(elements: dict, root: str)`. Matches the spec's actual schema and matches what the LLM naturally emits. Tool body just wraps them back into `{"elements": elements, "root": root}` before serializing. Zero retries observed in the smoke run.

### 2. Loop-termination prompt tightening
The agent loop was running render_spec + the 4 data tools TWICE per first turn — wasted LLM calls. Existing prompt said "return without further tool calls" but gpt-5 ignored it.

Fix: add explicit "**Critical: if render_spec and the data tools have already been called this turn, you are DONE. Return with no tool_calls. Do NOT call render_spec again. Do NOT re-call the data tools.**" Smoke now shows exactly 1 render_spec + 4 data tools per first turn.

### 3. Welcome chip text aligned with aviation theme
Chip said "Show me a Q3 sales dashboard with three metrics" but the backend is aviation-themed. When the user clicked the chip, the LLM saw "Q3 sales" + an aviation tool catalog, got confused, and wrote a fictional sales dashboard description in prose instead of calling tools.

Fix: chip values now match the backend — "Show me a dashboard of airline operations." and "Filter to only the cancelled flights." (Replaces the broken second chip "Create a contact form" which was never relevant to this demo.)

## Files
- `cockpit/chat/generative-ui/python/src/graph.py` — flatten render_spec signature
- `cockpit/langgraph/streaming/python/src/dashboard_graph.py` — umbrella mirror
- `cockpit/chat/generative-ui/python/prompts/dashboard.md` — tighten loop instructions + update tool signature reference
- `cockpit/langgraph/streaming/python/prompts/dashboard.md` — umbrella mirror
- `cockpit/chat/generative-ui/angular/src/app/generative-ui.component.ts` — chip text

## Test plan
- [x] Real-LLM smoke against per-cap (3-turn): 1 render_spec call, 4 data tools, 0 Pydantic errors, clean conversational summary
- [x] `pnpm nx run cockpit-chat-generative-ui-python:build` — green
- [x] `pnpm nx run cockpit-langgraph-streaming-python:build` — green
- [x] `pnpm nx run cockpit-chat-generative-ui-angular:build` — green
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)