### PR TITLE
[codex] Migrate deployment domain to ThreadPlane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,7 +206,7 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
-      - run: npx tsx apps/cockpit/scripts/deploy-smoke.ts --url https://cockpit.cacheplane.ai --dry-run
+      - run: npx tsx apps/cockpit/scripts/deploy-smoke.ts --url https://cockpit.threadplane.ai --dry-run
 
   examples-chat-smoke:
     name: examples/chat — python smoke
@@ -456,7 +456,7 @@ jobs:
         run: |
           mkdir -p .vercel
           cat > .vercel/project.json <<EOF
-          {"projectId":"${{ secrets.VERCEL_WEBSITE_PROJECT_ID }}","orgId":"${{ secrets.VERCEL_ORG_ID }}","projectName":"angular"}
+          {"projectId":"${{ secrets.VERCEL_WEBSITE_PROJECT_ID }}","orgId":"${{ secrets.VERCEL_ORG_ID }}","projectName":"threadplane"}
           EOF
           npx vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
           rm -rf .vercel/output
@@ -471,13 +471,13 @@ jobs:
         if: steps.affected.outputs.website == 'true'
         run: npx nx e2e website --skip-nx-cache
         env:
-          BASE_URL: https://cacheplane.ai
+          BASE_URL: https://threadplane.ai
       - name: Prepare cockpit Vercel project
         if: steps.affected.outputs.cockpit == 'true'
         run: |
           mkdir -p .vercel
           cat > .vercel/project.json <<EOF
-          {"projectId":"${{ secrets.VERCEL_COCKPIT_PROJECT_ID }}","orgId":"${{ secrets.VERCEL_ORG_ID }}","projectName":"cockpit"}
+          {"projectId":"${{ secrets.VERCEL_COCKPIT_PROJECT_ID }}","orgId":"${{ secrets.VERCEL_ORG_ID }}","projectName":"threadplane-cockpit"}
           EOF
           npx vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
           rm -rf .vercel/output
@@ -491,7 +491,7 @@ jobs:
       - name: Verify deployed cockpit
         if: steps.affected.outputs.cockpit == 'true'
         run: |
-          npx tsx apps/cockpit/scripts/deploy-smoke.ts --url https://cockpit.cacheplane.ai --retries 20 --retry-delay-ms 5000
+          npx tsx apps/cockpit/scripts/deploy-smoke.ts --url https://cockpit.threadplane.ai --retries 20 --retry-delay-ms 5000
 
       - name: Build and assemble Angular examples
         if: steps.examples_changed.outputs.changed == 'true'
@@ -502,7 +502,7 @@ jobs:
         run: |
           mkdir -p .vercel
           cat > .vercel/project.json <<EOF
-          {"projectId":"${{ secrets.VERCEL_EXAMPLES_PROJECT_ID }}","orgId":"${{ secrets.VERCEL_ORG_ID }}","projectName":"cockpit-examples"}
+          {"projectId":"${{ secrets.VERCEL_EXAMPLES_PROJECT_ID }}","orgId":"${{ secrets.VERCEL_ORG_ID }}","projectName":"threadplane-examples"}
           EOF
           npx vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
           npx vercel deploy --prebuilt --prod --yes --token=${{ secrets.VERCEL_TOKEN }}
@@ -536,13 +536,13 @@ jobs:
         run: |
           mkdir -p .vercel
           cat > .vercel/project.json <<EOF
-          {"projectId":"${{ secrets.VERCEL_DEMO_PROJECT_ID }}","orgId":"${{ secrets.VERCEL_ORG_ID }}","projectName":"demo"}
+          {"projectId":"${{ secrets.VERCEL_DEMO_PROJECT_ID }}","orgId":"${{ secrets.VERCEL_ORG_ID }}","projectName":"threadplane-demo"}
           EOF
           npx vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
           npx vercel deploy --prebuilt --prod --yes --token=${{ secrets.VERCEL_TOKEN }}
       - name: Verify canonical demo build stamp
         env:
-          DEMO_URL: https://demo.cacheplane.ai
+          DEMO_URL: https://demo.threadplane.ai
           EXPECTED_SHA: ${{ github.sha }}
         run: |
           node <<'NODE'
@@ -603,9 +603,9 @@ jobs:
       - name: Run production smoke tests
         run: npx playwright test apps/cockpit/e2e/production-smoke.spec.ts --reporter=list
         env:
-          BASE_URL: https://cockpit.cacheplane.ai
-          EXAMPLES_URL: https://examples.cacheplane.ai
-          DEMO_URL: https://demo.cacheplane.ai
+          BASE_URL: https://cockpit.threadplane.ai
+          EXAMPLES_URL: https://examples.threadplane.ai
+          DEMO_URL: https://demo.threadplane.ai
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
   posthog-sync-plan:

--- a/COMMERCIAL.md
+++ b/COMMERCIAL.md
@@ -4,9 +4,9 @@ The libraries in this repository (`@ngaf/langgraph`, `@ngaf/chat`, and all relat
 
 ## Minting Service
 
-The cacheplane minting service (`apps/minting-service/`) is a proprietary internal service and is not covered by the MIT License. See `apps/minting-service/LICENSE` for its terms.
+The ThreadPlane minting service (`apps/minting-service/`) is a proprietary internal service and is not covered by the MIT License. See `apps/minting-service/LICENSE` for its terms.
 
 ## Questions
 
-- Website: https://cacheplane.ai
+- Website: https://threadplane.ai
 - Email: hello@cacheplane.ai

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <img
-    src="https://cacheplane.ai/assets/hero.svg"
+    src="https://threadplane.ai/assets/hero.svg"
     alt="Agent UI for Angular — agent UI primitives for Angular"
     width="100%"
   />
@@ -108,7 +108,7 @@ That's it. `chat.messages()` and `chat.status()` are Angular Signals. Bind them 
 
 <p align="center">
   <img
-    src="https://cacheplane.ai/assets/arch-diagram.svg"
+    src="https://threadplane.ai/assets/arch-diagram.svg"
     alt="Agent UI for Angular architecture: Angular Component → agent() → StreamManager Bridge → LangGraph Platform, with signals returned reactively"
     width="100%"
   />
@@ -120,11 +120,11 @@ That's it. `chat.messages()` and `chat.status()` are Angular Signals. Bind them 
 
 ## Documentation
 
-- [Agent Quickstart](https://cacheplane.ai/docs/agent/getting-started/quickstart)
-- [agent() API](https://cacheplane.ai/docs/agent/api/agent)
-- [Chat Introduction](https://cacheplane.ai/docs/chat/getting-started/introduction)
-- [Human-in-the-Loop / Interrupts](https://cacheplane.ai/docs/agent/guides/interrupts)
-- [Subgraph and Subagent Streaming](https://cacheplane.ai/docs/agent/guides/subgraphs)
+- [Agent Quickstart](https://threadplane.ai/docs/agent/getting-started/quickstart)
+- [agent() API](https://threadplane.ai/docs/agent/api/agent)
+- [Chat Introduction](https://threadplane.ai/docs/chat/getting-started/introduction)
+- [Human-in-the-Loop / Interrupts](https://threadplane.ai/docs/agent/guides/interrupts)
+- [Subgraph and Subagent Streaming](https://threadplane.ai/docs/agent/guides/subgraphs)
 
 ---
 

--- a/apps/cockpit/e2e/production-smoke.spec.ts
+++ b/apps/cockpit/e2e/production-smoke.spec.ts
@@ -5,20 +5,20 @@ import { expect, test } from '@playwright/test';
  * example apps are reachable after production deploy.
  *
  * Requires:
- *   BASE_URL - e.g. https://cockpit.cacheplane.ai
- *   EXAMPLES_URL - e.g. https://examples.cacheplane.ai
+ *   BASE_URL - e.g. https://cockpit.threadplane.ai
+ *   EXAMPLES_URL - e.g. https://examples.threadplane.ai
  *   OPENAI_API_KEY - optional; enables the single live-provider canary
  *
  * Run:
- *   BASE_URL=https://cockpit.cacheplane.ai \
- *   EXAMPLES_URL=https://examples.cacheplane.ai \
+ *   BASE_URL=https://cockpit.threadplane.ai \
+ *   EXAMPLES_URL=https://examples.threadplane.ai \
  *   npx playwright test apps/cockpit/e2e/production-smoke.spec.ts
  */
 
-const COCKPIT_URL = process.env['BASE_URL'] ?? 'https://cockpit.cacheplane.ai';
+const COCKPIT_URL = process.env['BASE_URL'] ?? 'https://cockpit.threadplane.ai';
 const EXAMPLES_URL =
-  process.env['EXAMPLES_URL'] ?? 'https://examples.cacheplane.ai';
-const DEMO_URL = process.env['DEMO_URL'] ?? 'https://demo.cacheplane.ai';
+  process.env['EXAMPLES_URL'] ?? 'https://examples.threadplane.ai';
+const DEMO_URL = process.env['DEMO_URL'] ?? 'https://demo.threadplane.ai';
 
 const CHAT_CAPABILITIES = [
   'langgraph/streaming',

--- a/apps/cockpit/scripts/deploy-smoke.spec.ts
+++ b/apps/cockpit/scripts/deploy-smoke.spec.ts
@@ -6,7 +6,7 @@ describe('deploy smoke helper', () => {
     expect(
       parseDeploySmokeArgs([
         '--url',
-        'https://cockpit.cacheplane.ai',
+        'https://cockpit.threadplane.ai',
         '--dry-run',
         '--retries',
         '5',
@@ -14,7 +14,7 @@ describe('deploy smoke helper', () => {
         '1000',
       ])
     ).toEqual({
-      url: 'https://cockpit.cacheplane.ai',
+      url: 'https://cockpit.threadplane.ai',
       expectedTitle: 'Cockpit',
       dryRun: true,
       retries: 5,
@@ -25,11 +25,11 @@ describe('deploy smoke helper', () => {
   it('formats dry-run output without performing a network request', async () => {
     await expect(
       runDeploySmoke({
-        url: 'https://cockpit.cacheplane.ai',
+        url: 'https://cockpit.threadplane.ai',
         expectedTitle: 'Cockpit',
         dryRun: true,
       })
-    ).resolves.toBe('dry-run:https://cockpit.cacheplane.ai:Cockpit');
+    ).resolves.toBe('dry-run:https://cockpit.threadplane.ai:Cockpit');
   });
 
   it('retries until the deployment responds with the expected title', async () => {
@@ -46,13 +46,13 @@ describe('deploy smoke helper', () => {
 
     await expect(
       runDeploySmoke({
-        url: 'https://cockpit.cacheplane.ai',
+        url: 'https://cockpit.threadplane.ai',
         retries: 1,
         retryDelayMs: 1,
         fetchImpl,
         sleep,
       })
-    ).resolves.toBe('pass:https://cockpit.cacheplane.ai:Cockpit');
+    ).resolves.toBe('pass:https://cockpit.threadplane.ai:Cockpit');
 
     expect(fetchImpl).toHaveBeenCalledTimes(2);
     expect(sleep).toHaveBeenCalledTimes(1);

--- a/apps/cockpit/src/app/opengraph-image.tsx
+++ b/apps/cockpit/src/app/opengraph-image.tsx
@@ -129,7 +129,7 @@ export default async function OpenGraphImage() {
             }}
           >
             <span style={{ fontSize: 26 }}>🛩️</span>
-            <span>cockpit.cacheplane.ai</span>
+            <span>cockpit.threadplane.ai</span>
           </div>
         </div>
       </div>

--- a/apps/cockpit/src/lib/content-bundle.spec.ts
+++ b/apps/cockpit/src/lib/content-bundle.spec.ts
@@ -28,10 +28,10 @@ describe('resolveRuntimeUrl', () => {
   });
 
   it('uses NEXT_PUBLIC_COCKPIT_RUNTIME_BASE_URL when set', () => {
-    vi.stubEnv('NEXT_PUBLIC_COCKPIT_RUNTIME_BASE_URL', 'https://examples.cacheplane.ai');
+    vi.stubEnv('NEXT_PUBLIC_COCKPIT_RUNTIME_BASE_URL', 'https://examples.threadplane.ai');
     expect(
       resolveRuntimeUrl({ runtimeUrl: 'langgraph/streaming', devPort: 4300 })
-    ).toBe('https://examples.cacheplane.ai/langgraph/streaming');
+    ).toBe('https://examples.threadplane.ai/langgraph/streaming');
   });
 
   it('falls back to localhost with devPort when no env var is set', () => {
@@ -49,7 +49,7 @@ describe('resolveRuntimeUrl', () => {
   });
 
   it('returns null when runtimeUrl is undefined even with env var set', () => {
-    vi.stubEnv('NEXT_PUBLIC_COCKPIT_RUNTIME_BASE_URL', 'https://examples.cacheplane.ai');
+    vi.stubEnv('NEXT_PUBLIC_COCKPIT_RUNTIME_BASE_URL', 'https://examples.threadplane.ai');
     expect(
       resolveRuntimeUrl({ runtimeUrl: undefined, devPort: undefined })
     ).toBeNull();

--- a/apps/cockpit/src/lib/content-bundle.ts
+++ b/apps/cockpit/src/lib/content-bundle.ts
@@ -46,7 +46,7 @@ export function resolveRuntimeUrl(options: {
   }
 
   const baseUrl = process.env['NEXT_PUBLIC_COCKPIT_RUNTIME_BASE_URL']
-    ?? 'https://examples.cacheplane.ai';
+    ?? 'https://examples.threadplane.ai';
 
   if (baseUrl && runtimeUrl) {
     return `${baseUrl}/${runtimeUrl}`;

--- a/apps/minting-service/LICENSE
+++ b/apps/minting-service/LICENSE
@@ -1,15 +1,15 @@
 Commercial License
 
-Copyright (c) 2026 Brian Love d/b/a cacheplane. All rights reserved.
+Copyright (c) 2026 Brian Love d/b/a ThreadPlane. All rights reserved.
 
 This Commercial License ("License") governs commercial use of the
-cacheplane minting service ("Software"), located in apps/minting-service/
+ThreadPlane minting service ("Software"), located in apps/minting-service/
 of the angular-agent-framework repository. This License applies solely to
 the minting service component and does not govern any other part of the
 repository, which is released separately under the MIT License.
 
 Use of the Software for commercial purposes requires a valid license
-purchased from cacheplane.
+purchased from ThreadPlane.
 
 --- LICENSE TIERS ---
 
@@ -34,7 +34,7 @@ purchased from cacheplane.
 
 --- TERMS ---
 
-Grant of License. Subject to payment of the applicable license fee, cacheplane
+Grant of License. Subject to payment of the applicable license fee, ThreadPlane
 grants you a non-exclusive, non-transferable, worldwide license to use,
 reproduce, and distribute the Software solely as integrated into your
 applications, in accordance with the scope of the purchased tier.
@@ -47,7 +47,7 @@ Restrictions. You may not:
 
 No Redistribution. You may not distribute the Software or make it available
 to third parties as a service, package, or SDK, whether modified or
-unmodified, without a separate written agreement with cacheplane.
+unmodified, without a separate written agreement with ThreadPlane.
 
 Warranty Disclaimer. THE SOFTWARE IS PROVIDED "AS IS" WITHOUT WARRANTY OF
 ANY KIND. CACHEPLANE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
@@ -66,5 +66,5 @@ Deschutes County, United States, without regard to conflict of law principles.
 --- PURCHASING ---
 
 To purchase a license or inquire about Enterprise terms:
-  Website: https://cacheplane.ai/pricing
+  Website: https://threadplane.ai/pricing
   Email:   hello@cacheplane.ai

--- a/apps/minting-service/README.md
+++ b/apps/minting-service/README.md
@@ -1,6 +1,6 @@
 # @cacheplane/minting-service
 
-License minting service for Cacheplane. Receives Stripe webhooks, signs
+License minting service for ThreadPlane. Receives Stripe webhooks, signs
 Ed25519 license tokens via `@cacheplane/licensing`, persists them to
 Postgres via `@cacheplane/db`, and emails them to customers via Resend.
 

--- a/apps/minting-service/src/lib/email.spec.ts
+++ b/apps/minting-service/src/lib/email.spec.ts
@@ -22,7 +22,7 @@ describe('renderLicenseEmail', () => {
       token: 't.s',
       expiresAt: new Date('2027-04-20T00:00:00Z'),
     });
-    expect(out.subject).toBe('Your Cacheplane license — developer-seat (3 seats)');
+    expect(out.subject).toBe('Your ThreadPlane license — developer-seat (3 seats)');
   });
 
   it('subject uses singular seat for seats === 1', () => {
@@ -32,7 +32,7 @@ describe('renderLicenseEmail', () => {
       token: 't.s',
       expiresAt: new Date('2027-04-20T00:00:00Z'),
     });
-    expect(out.subject).toBe('Your Cacheplane license — app-deployment (1 seat)');
+    expect(out.subject).toBe('Your ThreadPlane license — app-deployment (1 seat)');
   });
 
   it('includes ISO 8601 UTC expiry in text body', () => {

--- a/apps/minting-service/src/lib/email.ts
+++ b/apps/minting-service/src/lib/email.ts
@@ -20,10 +20,10 @@ export interface RenderedEmail {
  */
 export function renderLicenseEmail(vars: LicenseEmailVars): RenderedEmail {
   const seatWord = vars.seats === 1 ? 'seat' : 'seats';
-  const subject = `Your Cacheplane license — ${vars.tier} (${vars.seats} ${seatWord})`;
+  const subject = `Your ThreadPlane license — ${vars.tier} (${vars.seats} ${seatWord})`;
   const expiresIso = vars.expiresAt.toISOString();
 
-  const text = `Thanks for subscribing to Cacheplane.
+  const text = `Thanks for subscribing to ThreadPlane.
 
 Your license token is below. Set it as the CACHEPLANE_LICENSE
 environment variable in your application:
@@ -42,13 +42,13 @@ Installation:
 Or in a .env file:
   CACHEPLANE_LICENSE=<paste token above>
 
-Docs: https://cacheplane.dev/docs/licensing
+Docs: https://threadplane.ai/docs/licensing
 Questions: reply to this email.
 
--- The Cacheplane team
+-- The ThreadPlane team
 `;
 
-  const html = `<p>Thanks for subscribing to Cacheplane.</p>
+  const html = `<p>Thanks for subscribing to ThreadPlane.</p>
 <p>Your license token is below. Set it as the <code>CACHEPLANE_LICENSE</code> environment variable in your application:</p>
 <pre style="white-space:pre-wrap;word-break:break-all;font-family:monospace;font-size:12px;background:#f4f4f4;padding:12px;border-radius:4px">-----BEGIN CACHEPLANE LICENSE-----
 ${escapeHtml(vars.token)}
@@ -58,9 +58,9 @@ ${escapeHtml(vars.token)}
 <strong>Expires:</strong> ${escapeHtml(expiresIso)}</p>
 <p><strong>Installation:</strong></p>
 <pre style="font-family:monospace;font-size:12px;background:#f4f4f4;padding:12px;border-radius:4px">export CACHEPLANE_LICENSE="&lt;paste token above&gt;"</pre>
-<p>Docs: <a href="https://cacheplane.dev/docs/licensing">cacheplane.dev/docs/licensing</a><br>
+<p>Docs: <a href="https://threadplane.ai/docs/licensing">threadplane.ai/docs/licensing</a><br>
 Questions: reply to this email.</p>
-<p>-- The Cacheplane team</p>
+<p>-- The ThreadPlane team</p>
 `;
 
   return { subject, text, html };

--- a/apps/minting-service/src/lib/tier.ts
+++ b/apps/minting-service/src/lib/tier.ts
@@ -6,7 +6,7 @@ export type MintableTier = Extract<LicenseTier, 'developer-seat' | 'app-deployme
 const VALID_TIERS: readonly MintableTier[] = ['developer-seat', 'app-deployment'] as const;
 
 /**
- * Extract the Cacheplane tier from a Stripe price metadata bag.
+ * Extract the ThreadPlane tier from a Stripe price metadata bag.
  * Throws if the field is missing or holds an unknown value.
  */
 export function extractTier(metadata: Record<string, string> | null | undefined): MintableTier {

--- a/apps/website/content/AGENTS.md.template
+++ b/apps/website/content/AGENTS.md.template
@@ -40,4 +40,4 @@ export class ChatComponent {
 - Testing: use `MockAgentTransport` — never mock `agent()` itself
 
 ## Version check
-If this file is stale, fetch the latest: https://cacheplane.ai/llms-full.txt
+If this file is stale, fetch the latest: https://threadplane.ai/llms-full.txt

--- a/apps/website/content/CLAUDE.md.template
+++ b/apps/website/content/CLAUDE.md.template
@@ -40,4 +40,4 @@ export class ChatComponent {
 - Testing: use `MockAgentTransport` — never mock `agent()` itself
 
 ## Version check
-If this file is stale, fetch the latest: https://cacheplane.ai/llms-full.txt
+If this file is stale, fetch the latest: https://threadplane.ai/llms-full.txt

--- a/apps/website/content/docs/agent/api/api-docs.json
+++ b/apps/website/content/docs/agent/api/api-docs.json
@@ -575,7 +575,7 @@
       {
         "name": "license",
         "type": "string",
-        "description": "Signed license token from cacheplane.dev. Optional; omitted in dev.",
+        "description": "Signed license token from threadplane.ai. Optional; omitted in dev.",
         "optional": true
       },
       {

--- a/apps/website/content/docs/chat/api/api-docs.json
+++ b/apps/website/content/docs/chat/api/api-docs.json
@@ -3182,6 +3182,12 @@
         "optional": false
       },
       {
+        "name": "triggerLabel",
+        "type": "Signal<string>",
+        "description": "",
+        "optional": false
+      },
+      {
         "name": "value",
         "type": "ModelSignal<string>",
         "description": "",

--- a/apps/website/content/docs/chat/api/api-docs.json
+++ b/apps/website/content/docs/chat/api/api-docs.json
@@ -5555,7 +5555,7 @@
       {
         "name": "license",
         "type": "string",
-        "description": "Signed license token from cacheplane.dev. Optional; omitted in dev.",
+        "description": "Signed license token from threadplane.ai. Optional; omitted in dev.",
         "optional": true
       },
       {

--- a/apps/website/content/docs/chat/api/api-docs.json
+++ b/apps/website/content/docs/chat/api/api-docs.json
@@ -3182,12 +3182,6 @@
         "optional": false
       },
       {
-        "name": "triggerLabel",
-        "type": "Signal<string>",
-        "description": "",
-        "optional": false
-      },
-      {
         "name": "value",
         "type": "ModelSignal<string>",
         "description": "",

--- a/apps/website/content/docs/chat/api/chat-config.mdx
+++ b/apps/website/content/docs/chat/api/chat-config.mdx
@@ -19,7 +19,7 @@ interface ChatConfig {
   avatarLabel?: string;
   /** Shared assistant display name for consumers that read CHAT_CONFIG (default: "Assistant"). */
   assistantName?: string;
-  /** Signed license token from cacheplane.dev. Optional; omitted in dev. */
+  /** Signed license token from threadplane.ai. Optional; omitted in dev. */
   license?: string;
 }
 ```
@@ -80,7 +80,7 @@ provideChat({ renderRegistry });
 license?: string
 ```
 
-A signed license token from cacheplane.dev. It is optional in development and should be provided from your production configuration.
+A signed license token from threadplane.ai. It is optional in development and should be provided from your production configuration.
 
 **Example:**
 

--- a/apps/website/content/docs/chat/getting-started/introduction.mdx
+++ b/apps/website/content/docs/chat/getting-started/introduction.mdx
@@ -3,7 +3,7 @@
 `@ngaf/chat` is the Angular UI component library for building chat interfaces on top of a runtime-neutral `Agent` contract. It provides a complete set of composable, Signal-driven components that render messages, handle user input, display tool calls, manage interrupts, and support generative UI -- all styled with CSS custom properties and built for Angular 20+.
 
 <Callout type="info" title="What you'll learn">
-This guide explains the library's two-tier architecture, how it relates to the rest of the Cacheplane stack, and when to reach for the all-in-one composition versus assembling primitives yourself.
+This guide explains the library's two-tier architecture, how it relates to the rest of the ThreadPlane stack, and when to reach for the all-in-one composition versus assembling primitives yourself.
 </Callout>
 
 ## Two-Tier Architecture
@@ -42,7 +42,7 @@ Compositions are opinionated, styled components that combine primitives into rea
 
 ## How the Stack Fits Together
 
-`@ngaf/chat` sits between your application and two other Cacheplane libraries:
+`@ngaf/chat` sits between your application and two other ThreadPlane libraries:
 
 ```
 Your App

--- a/apps/website/content/docs/chat/guides/configuration.mdx
+++ b/apps/website/content/docs/chat/guides/configuration.mdx
@@ -44,7 +44,7 @@ interface ChatConfig {
   /** Override the default assistant display name (default: "Assistant"). */
   assistantName?: string;
 
-  /** Signed license token from cacheplane.dev. Optional in development. */
+  /** Signed license token from threadplane.ai. Optional in development. */
   license?: string;
 }
 ```

--- a/apps/website/content/docs/licensing/guides/setup.mdx
+++ b/apps/website/content/docs/licensing/guides/setup.mdx
@@ -48,7 +48,7 @@ It warns once per package and status for:
 - `expired`;
 - `tampered`.
 
-The warning prefix is `[cacheplane]`, and the package keeps running.
+The warning prefix is `[threadplane]`, and the package keeps running.
 
 You can inject a custom warning sink:
 

--- a/apps/website/content/docs/render/api/api-docs.json
+++ b/apps/website/content/docs/render/api/api-docs.json
@@ -266,7 +266,7 @@
       {
         "name": "license",
         "type": "string",
-        "description": "Signed license token from cacheplane.dev. Optional; omitted in dev.",
+        "description": "Signed license token from threadplane.ai. Optional; omitted in dev.",
         "optional": true
       },
       {

--- a/apps/website/content/docs/telemetry/guides/node.mdx
+++ b/apps/website/content/docs/telemetry/guides/node.mdx
@@ -65,7 +65,7 @@ await captureStreamErrored({
 `captureEvent()` sends to:
 
 ```text
-https://cacheplane.ai/api/ingest
+https://threadplane.ai/api/ingest
 ```
 
 unless `NGAF_TELEMETRY_INGEST_URL` is set.

--- a/apps/website/content/docs/telemetry/reference/events.mdx
+++ b/apps/website/content/docs/telemetry/reference/events.mdx
@@ -86,4 +86,4 @@ Node delivery sends:
 }
 ```
 
-The public ingest key is a routing identifier accepted by the Cacheplane ingest proxy. It is not a secret.
+The public ingest key is a routing identifier accepted by the ThreadPlane ingest proxy. It is not a secret.

--- a/apps/website/e2e/primitives.spec.ts
+++ b/apps/website/e2e/primitives.spec.ts
@@ -46,7 +46,7 @@ test.describe('UI primitives showcase', () => {
   test('renders BrowserFrame with URL pill', async ({ page }) => {
     const frame = page.locator('[data-ui="browser-frame"]');
     await expect(frame).toBeVisible();
-    await expect(frame).toContainText('cockpit.cacheplane.ai');
+    await expect(frame).toContainText('cockpit.threadplane.ai');
   });
 
   test('renders Section with tinted surface variant', async ({ page }) => {

--- a/apps/website/e2e/website.spec.ts
+++ b/apps/website/e2e/website.spec.ts
@@ -95,7 +95,7 @@ test('robots.txt allows crawling and points at the sitemap', async ({ request })
   const body = await response.text();
   expect(body).toContain('User-Agent: *');
   expect(body).toContain('Allow: /');
-  expect(body).toContain('Sitemap: https://cacheplane.ai/sitemap.xml');
+  expect(body).toContain('Sitemap: https://threadplane.ai/sitemap.xml');
 });
 
 test('sitemap.xml includes configured docs pages', async ({ request }) => {
@@ -103,9 +103,9 @@ test('sitemap.xml includes configured docs pages', async ({ request }) => {
   expect(response.ok()).toBe(true);
 
   const body = await response.text();
-  expect(body).toContain('https://cacheplane.ai/docs');
-  expect(body).toContain('https://cacheplane.ai/docs/agent/getting-started/introduction');
-  expect(body).toContain('https://cacheplane.ai/docs/render/a2ui/overview');
+  expect(body).toContain('https://threadplane.ai/docs');
+  expect(body).toContain('https://threadplane.ai/docs/agent/getting-started/introduction');
+  expect(body).toContain('https://threadplane.ai/docs/render/a2ui/overview');
 });
 
 test('docs pages render canonical and social metadata', async ({ page }) => {
@@ -113,7 +113,7 @@ test('docs pages render canonical and social metadata', async ({ page }) => {
 
   await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
     'href',
-    'https://cacheplane.ai/docs/agent/guides/streaming',
+    'https://threadplane.ai/docs/agent/guides/streaming',
   );
   await expect(page.locator('meta[property="og:title"]')).toHaveAttribute(
     'content',
@@ -121,7 +121,7 @@ test('docs pages render canonical and social metadata', async ({ page }) => {
   );
   await expect(page.locator('meta[property="og:url"]')).toHaveAttribute(
     'content',
-    'https://cacheplane.ai/docs/agent/guides/streaming',
+    'https://threadplane.ai/docs/agent/guides/streaming',
   );
   await expect(page.locator('meta[name="twitter:title"]')).toHaveAttribute(
     'content',

--- a/apps/website/emails/angular-download.ts
+++ b/apps/website/emails/angular-download.ts
@@ -1,6 +1,6 @@
 import { wrapEmail, esc } from './email-wrapper';
 
-const DOWNLOAD_URL = 'https://cacheplane.ai/whitepapers/angular.pdf';
+const DOWNLOAD_URL = 'https://threadplane.ai/whitepapers/angular.pdf';
 
 export function angularDownloadHtml(name?: string): string {
   return wrapEmail({

--- a/apps/website/emails/chat-download.ts
+++ b/apps/website/emails/chat-download.ts
@@ -1,6 +1,6 @@
 import { wrapEmail, esc } from './email-wrapper';
 
-const DOWNLOAD_URL = 'https://cacheplane.ai/whitepapers/chat.pdf';
+const DOWNLOAD_URL = 'https://threadplane.ai/whitepapers/chat.pdf';
 
 export function chatDownloadHtml(name?: string): string {
   return wrapEmail({

--- a/apps/website/emails/drip-angular-followup.ts
+++ b/apps/website/emails/drip-angular-followup.ts
@@ -9,7 +9,7 @@ export function dripAngularFollowupHtml(day: number): { subject: string; html: s
           <p style="font-size:11px;font-family:monospace;text-transform:uppercase;letter-spacing:0.08em;color:#004090;font-weight:700;margin:0 0 8px">Angular Guide Follow-up</p>
           <p style="font-size:20px;font-weight:700;color:#1a1a2e;margin:0 0 14px;line-height:1.3">Did you read Chapter 2 on the agent() API?</p>
           <p style="font-size:14px;color:#555770;line-height:1.7;margin:0 0 24px">Chapter 2 dives into the <strong>agent() API</strong> — the signal-native primitive that connects your Angular component directly to a LangGraph streaming run. It's the chapter most teams bookmark first when they see how little boilerplate is required.</p>
-          <a href="https://cacheplane.ai/docs" style="display:inline-block;background-color:#004090;color:#fff;padding:12px 28px;border-radius:8px;font-size:14px;font-weight:700;text-decoration:none">Read the Docs →</a>
+          <a href="https://threadplane.ai/docs" style="display:inline-block;background-color:#004090;color:#fff;padding:12px 28px;border-radius:8px;font-size:14px;font-weight:700;text-decoration:none">Read the Docs →</a>
         `,
         showUnsubscribe: true,
       }),
@@ -24,7 +24,7 @@ export function dripAngularFollowupHtml(day: number): { subject: string; html: s
           <p style="font-size:11px;font-family:monospace;text-transform:uppercase;letter-spacing:0.08em;color:#004090;font-weight:700;margin:0 0 8px">Comparison</p>
           <p style="font-size:20px;font-weight:700;color:#1a1a2e;margin:0 0 14px;line-height:1.3">LangGraph Angular SDK vs @ngaf/langgraph</p>
           <p style="font-size:14px;color:#555770;line-height:1.7;margin:0 0 24px">The LangGraph JS SDK gives you a streaming client. <strong>@ngaf/langgraph</strong> gives you signal-native state, thread persistence, interrupt flows, and a full test harness — all wired together and optimized for Angular's change detection model. See the full comparison on our product page.</p>
-          <a href="https://cacheplane.ai/angular" style="display:inline-block;background-color:#004090;color:#fff;padding:12px 28px;border-radius:8px;font-size:14px;font-weight:700;text-decoration:none">See the Comparison →</a>
+          <a href="https://threadplane.ai/angular" style="display:inline-block;background-color:#004090;color:#fff;padding:12px 28px;border-radius:8px;font-size:14px;font-weight:700;text-decoration:none">See the Comparison →</a>
         `,
         showUnsubscribe: true,
       }),
@@ -44,7 +44,7 @@ export function dripAngularFollowupHtml(day: number): { subject: string; html: s
             <p style="font-size:13px;color:#555770;margin:0 0 4px;line-height:1.6"><strong style="color:#004090">Month 1</strong> · First agent in staging</p>
             <p style="font-size:13px;color:#555770;margin:0;line-height:1.6"><strong style="color:#004090">Month 3</strong> · Production deployment</p>
           </div>
-          <a href="https://cacheplane.ai/pilot-to-prod" style="display:inline-block;background-color:#004090;color:#fff;padding:12px 28px;border-radius:8px;font-size:14px;font-weight:700;text-decoration:none">Learn About the Pilot →</a>
+          <a href="https://threadplane.ai/pilot-to-prod" style="display:inline-block;background-color:#004090;color:#fff;padding:12px 28px;border-radius:8px;font-size:14px;font-weight:700;text-decoration:none">Learn About the Pilot →</a>
         `,
         showUnsubscribe: true,
       }),

--- a/apps/website/emails/drip-chat-followup.ts
+++ b/apps/website/emails/drip-chat-followup.ts
@@ -9,7 +9,7 @@ export function dripChatFollowupHtml(day: number): { subject: string; html: stri
           <p style="font-size:11px;font-family:monospace;text-transform:uppercase;letter-spacing:0.08em;color:#5a00c8;font-weight:700;margin:0 0 8px">Chat Guide Follow-up</p>
           <p style="font-size:20px;font-weight:700;color:#1a1a2e;margin:0 0 14px;line-height:1.3">Did you read Chapter 2 on batteries-included components?</p>
           <p style="font-size:14px;color:#555770;line-height:1.7;margin:0 0 24px">Chapter 2 covers the <strong>batteries-included component library</strong> — message bubbles, streaming indicators, thread lists, and input controls that are pre-wired to LangGraph state. Drop them in and your chat UI works on day one.</p>
-          <a href="https://cacheplane.ai/docs" style="display:inline-block;background-color:#5a00c8;color:#fff;padding:12px 28px;border-radius:8px;font-size:14px;font-weight:700;text-decoration:none">Read the Docs →</a>
+          <a href="https://threadplane.ai/docs" style="display:inline-block;background-color:#5a00c8;color:#fff;padding:12px 28px;border-radius:8px;font-size:14px;font-weight:700;text-decoration:none">Read the Docs →</a>
         `,
         showUnsubscribe: true,
       }),
@@ -24,7 +24,7 @@ export function dripChatFollowupHtml(day: number): { subject: string; html: stri
           <p style="font-size:11px;font-family:monospace;text-transform:uppercase;letter-spacing:0.08em;color:#5a00c8;font-weight:700;margin:0 0 8px">The Sprint Tax</p>
           <p style="font-size:20px;font-weight:700;color:#1a1a2e;margin:0 0 14px;line-height:1.3">The sprint tax: why every team rebuilds chat from scratch</p>
           <p style="font-size:14px;color:#555770;line-height:1.7;margin:0 0 24px">Most teams spend 2–4 sprints building a chat UI before a single agent feature lands. Streaming state management, optimistic updates, thread history, error recovery — it's the same work every time. @ngaf/chat eliminates the sprint tax so your team ships features from day one.</p>
-          <a href="https://cacheplane.ai/chat" style="display:inline-block;background-color:#5a00c8;color:#fff;padding:12px 28px;border-radius:8px;font-size:14px;font-weight:700;text-decoration:none">See How It Works →</a>
+          <a href="https://threadplane.ai/chat" style="display:inline-block;background-color:#5a00c8;color:#fff;padding:12px 28px;border-radius:8px;font-size:14px;font-weight:700;text-decoration:none">See How It Works →</a>
         `,
         showUnsubscribe: true,
       }),
@@ -44,7 +44,7 @@ export function dripChatFollowupHtml(day: number): { subject: string; html: stri
             <p style="font-size:13px;color:#555770;margin:0 0 4px;line-height:1.6"><strong style="color:#5a00c8">Month 1</strong> · First agent in staging</p>
             <p style="font-size:13px;color:#555770;margin:0;line-height:1.6"><strong style="color:#5a00c8">Month 3</strong> · Production deployment</p>
           </div>
-          <a href="https://cacheplane.ai/pilot-to-prod" style="display:inline-block;background-color:#5a00c8;color:#fff;padding:12px 28px;border-radius:8px;font-size:14px;font-weight:700;text-decoration:none">Learn About the Pilot →</a>
+          <a href="https://threadplane.ai/pilot-to-prod" style="display:inline-block;background-color:#5a00c8;color:#fff;padding:12px 28px;border-radius:8px;font-size:14px;font-weight:700;text-decoration:none">Learn About the Pilot →</a>
         `,
         showUnsubscribe: true,
       }),

--- a/apps/website/emails/drip-render-followup.ts
+++ b/apps/website/emails/drip-render-followup.ts
@@ -9,7 +9,7 @@ export function dripRenderFollowupHtml(day: number): { subject: string; html: st
           <p style="font-size:11px;font-family:monospace;text-transform:uppercase;letter-spacing:0.08em;color:#1a7a40;font-weight:700;margin:0 0 8px">Render Guide Follow-up</p>
           <p style="font-size:20px;font-weight:700;color:#1a1a2e;margin:0 0 14px;line-height:1.3">Did you read Chapter 2 on declarative UI specs?</p>
           <p style="font-size:14px;color:#555770;line-height:1.7;margin:0 0 24px">Chapter 2 covers <strong>declarative UI specs</strong> — how agents emit structured JSON that maps directly to your component registry instead of generating raw HTML. It's the foundation that makes generative UI predictable and testable.</p>
-          <a href="https://cacheplane.ai/docs" style="display:inline-block;background-color:#1a7a40;color:#fff;padding:12px 28px;border-radius:8px;font-size:14px;font-weight:700;text-decoration:none">Read the Docs →</a>
+          <a href="https://threadplane.ai/docs" style="display:inline-block;background-color:#1a7a40;color:#fff;padding:12px 28px;border-radius:8px;font-size:14px;font-weight:700;text-decoration:none">Read the Docs →</a>
         `,
         showUnsubscribe: true,
       }),
@@ -24,7 +24,7 @@ export function dripRenderFollowupHtml(day: number): { subject: string; html: st
           <p style="font-size:11px;font-family:monospace;text-transform:uppercase;letter-spacing:0.08em;color:#1a7a40;font-weight:700;margin:0 0 8px">Architecture</p>
           <p style="font-size:20px;font-weight:700;color:#1a1a2e;margin:0 0 14px;line-height:1.3">Why tight coupling between agents and UI kills iteration speed</p>
           <p style="font-size:14px;color:#555770;line-height:1.7;margin:0 0 24px">When an agent generates UI directly — raw HTML, string templates, hardcoded component names — every model change breaks the frontend and every UI change breaks the prompt. Decoupling via a declarative spec layer means agents and UI teams can iterate independently. See how @ngaf/render makes this the default.</p>
-          <a href="https://cacheplane.ai/render" style="display:inline-block;background-color:#1a7a40;color:#fff;padding:12px 28px;border-radius:8px;font-size:14px;font-weight:700;text-decoration:none">See How It Works →</a>
+          <a href="https://threadplane.ai/render" style="display:inline-block;background-color:#1a7a40;color:#fff;padding:12px 28px;border-radius:8px;font-size:14px;font-weight:700;text-decoration:none">See How It Works →</a>
         `,
         showUnsubscribe: true,
       }),
@@ -44,7 +44,7 @@ export function dripRenderFollowupHtml(day: number): { subject: string; html: st
             <p style="font-size:13px;color:#555770;margin:0 0 4px;line-height:1.6"><strong style="color:#1a7a40">Month 1</strong> · First agent in staging</p>
             <p style="font-size:13px;color:#555770;margin:0;line-height:1.6"><strong style="color:#1a7a40">Month 3</strong> · Production deployment</p>
           </div>
-          <a href="https://cacheplane.ai/pilot-to-prod" style="display:inline-block;background-color:#1a7a40;color:#fff;padding:12px 28px;border-radius:8px;font-size:14px;font-weight:700;text-decoration:none">Learn About the Pilot →</a>
+          <a href="https://threadplane.ai/pilot-to-prod" style="display:inline-block;background-color:#1a7a40;color:#fff;padding:12px 28px;border-radius:8px;font-size:14px;font-weight:700;text-decoration:none">Learn About the Pilot →</a>
         `,
         showUnsubscribe: true,
       }),

--- a/apps/website/emails/drip-whitepaper-followup.ts
+++ b/apps/website/emails/drip-whitepaper-followup.ts
@@ -9,7 +9,7 @@ export function dripWhitepaperFollowupHtml(day: number): { subject: string; html
           <p style="font-size:11px;font-family:monospace;text-transform:uppercase;letter-spacing:0.08em;color:#004090;font-weight:700;margin:0 0 8px">Whitepaper Follow-up</p>
           <p style="font-size:20px;font-weight:700;color:#1a1a2e;margin:0 0 14px;line-height:1.3">Did you get a chance to read Chapter 3?</p>
           <p style="font-size:14px;color:#555770;line-height:1.7;margin:0 0 24px">Chapter 3 covers <strong>tool-call rendering</strong> — how to surface agent actions as real UI instead of raw JSON. It's the chapter most teams bookmark first.</p>
-          <a href="https://cacheplane.ai/whitepaper.pdf" style="display:inline-block;background-color:#004090;color:#fff;padding:12px 28px;border-radius:8px;font-size:14px;font-weight:700;text-decoration:none">Read the Guide →</a>
+          <a href="https://threadplane.ai/whitepaper.pdf" style="display:inline-block;background-color:#004090;color:#fff;padding:12px 28px;border-radius:8px;font-size:14px;font-weight:700;text-decoration:none">Read the Guide →</a>
         `,
         showUnsubscribe: true,
       }),
@@ -24,7 +24,7 @@ export function dripWhitepaperFollowupHtml(day: number): { subject: string; html
           <p style="font-size:11px;font-family:monospace;text-transform:uppercase;letter-spacing:0.08em;color:#004090;font-weight:700;margin:0 0 8px">Production Readiness</p>
           <p style="font-size:20px;font-weight:700;color:#1a1a2e;margin:0 0 14px;line-height:1.3">The gap between demo and production</p>
           <p style="font-size:14px;color:#555770;line-height:1.7;margin:0 0 24px">Half of GenAI projects die after proof of concept. The gap isn't the model — it's the frontend production path: streaming state, thread persistence, human approval flows, and deterministic testing.</p>
-          <a href="https://cacheplane.ai/docs" style="display:inline-block;background-color:#004090;color:#fff;padding:12px 28px;border-radius:8px;font-size:14px;font-weight:700;text-decoration:none">See How It Works →</a>
+          <a href="https://threadplane.ai/docs" style="display:inline-block;background-color:#004090;color:#fff;padding:12px 28px;border-radius:8px;font-size:14px;font-weight:700;text-decoration:none">See How It Works →</a>
         `,
         showUnsubscribe: true,
       }),
@@ -44,7 +44,7 @@ export function dripWhitepaperFollowupHtml(day: number): { subject: string; html
             <p style="font-size:13px;color:#555770;margin:0 0 4px;line-height:1.6"><strong style="color:#004090">Month 1</strong> · First agent in staging</p>
             <p style="font-size:13px;color:#555770;margin:0;line-height:1.6"><strong style="color:#004090">Month 3</strong> · Production deployment</p>
           </div>
-          <a href="https://cacheplane.ai/pilot-to-prod" style="display:inline-block;background-color:#004090;color:#fff;padding:12px 28px;border-radius:8px;font-size:14px;font-weight:700;text-decoration:none">Learn About the Pilot →</a>
+          <a href="https://threadplane.ai/pilot-to-prod" style="display:inline-block;background-color:#004090;color:#fff;padding:12px 28px;border-radius:8px;font-size:14px;font-weight:700;text-decoration:none">Learn About the Pilot →</a>
         `,
         showUnsubscribe: true,
       }),

--- a/apps/website/emails/email-wrapper.ts
+++ b/apps/website/emails/email-wrapper.ts
@@ -19,7 +19,7 @@ export function wrapEmail(opts: {
     ${opts.body}
     <div style="border-top:1px solid #e6e8ee;margin-top:28px;padding-top:16px">
       <p style="font-size:11px;color:#8b8fa3;line-height:1.5;margin:0">Agent UI for Angular — Signal-native streaming for LangGraph.</p>
-      ${opts.showUnsubscribe ? '<p style="font-size:10px;color:#8b8fa3;margin:6px 0 0"><a href="https://cacheplane.ai/api/unsubscribe?email=RECIPIENT" style="color:#8b8fa3;text-decoration:underline">Unsubscribe</a></p>' : ''}
+      ${opts.showUnsubscribe ? '<p style="font-size:10px;color:#8b8fa3;margin:6px 0 0"><a href="https://threadplane.ai/api/unsubscribe?email=RECIPIENT" style="color:#8b8fa3;text-decoration:underline">Unsubscribe</a></p>' : ''}
     </div>
   </div>
 </div>

--- a/apps/website/emails/newsletter-welcome.ts
+++ b/apps/website/emails/newsletter-welcome.ts
@@ -5,7 +5,7 @@ export function newsletterWelcomeHtml(): string {
     body: `
       <p style="font-size:20px;font-weight:700;color:#1a1a2e;margin:0 0 8px;line-height:1.3">Welcome to Agent UI for Angular updates</p>
       <p style="font-size:14px;color:#555770;line-height:1.7;margin:0 0 24px">You'll receive updates on new capabilities, production patterns, and Angular agent best practices. We keep it focused and infrequent — no spam.</p>
-      <a href="https://cacheplane.ai/docs" style="display:inline-block;background-color:#004090;color:#fff;padding:12px 28px;border-radius:8px;font-size:14px;font-weight:700;text-decoration:none">Explore the Docs</a>
+      <a href="https://threadplane.ai/docs" style="display:inline-block;background-color:#004090;color:#fff;padding:12px 28px;border-radius:8px;font-size:14px;font-weight:700;text-decoration:none">Explore the Docs</a>
     `,
   });
 }

--- a/apps/website/emails/render-download.ts
+++ b/apps/website/emails/render-download.ts
@@ -1,6 +1,6 @@
 import { wrapEmail, esc } from './email-wrapper';
 
-const DOWNLOAD_URL = 'https://cacheplane.ai/whitepapers/render.pdf';
+const DOWNLOAD_URL = 'https://threadplane.ai/whitepapers/render.pdf';
 
 export function renderDownloadHtml(name?: string): string {
   return wrapEmail({

--- a/apps/website/emails/whitepaper-download.ts
+++ b/apps/website/emails/whitepaper-download.ts
@@ -1,6 +1,6 @@
 import { wrapEmail, esc } from './email-wrapper';
 
-const DOWNLOAD_URL = 'https://cacheplane.ai/whitepaper.pdf';
+const DOWNLOAD_URL = 'https://threadplane.ai/whitepaper.pdf';
 
 export function whitepaperDownloadHtml(name?: string): string {
   return wrapEmail({

--- a/apps/website/lib/resend.ts
+++ b/apps/website/lib/resend.ts
@@ -11,8 +11,8 @@ function getResend(): Resend | null {
 }
 
 export const AUDIENCE_ID = process.env.RESEND_AUDIENCE_ID || '';
-export const FROM = process.env.RESEND_FROM || 'Agent UI for Angular <hello@cacheplane.io>';
-export const NOTIFY_TO = process.env.RESEND_NOTIFY_TO || 'hello@cacheplane.io';
+export const FROM = process.env.RESEND_FROM || 'Agent UI for Angular <hello@cacheplane.ai>';
+export const NOTIFY_TO = process.env.RESEND_NOTIFY_TO || 'hello@cacheplane.ai';
 
 /** Send an email via Resend. No-ops when API key is missing. */
 export async function sendEmail(opts: { from: string; to: string; subject: string; html: string; scheduledAt?: string }) {

--- a/apps/website/public/AGENTS.md
+++ b/apps/website/public/AGENTS.md
@@ -40,4 +40,4 @@ export class ChatComponent {
 - Testing: use `MockAgentTransport` — never mock `agent()` itself
 
 ## Version check
-If this file is stale, fetch the latest: https://cacheplane.ai/llms-full.txt
+If this file is stale, fetch the latest: https://threadplane.ai/llms-full.txt

--- a/apps/website/public/CLAUDE.md
+++ b/apps/website/public/CLAUDE.md
@@ -40,4 +40,4 @@ export class ChatComponent {
 - Testing: use `MockAgentTransport` — never mock `agent()` itself
 
 ## Version check
-If this file is stale, fetch the latest: https://cacheplane.ai/llms-full.txt
+If this file is stale, fetch the latest: https://threadplane.ai/llms-full.txt

--- a/apps/website/public/assets/hero.svg
+++ b/apps/website/public/assets/hero.svg
@@ -13,7 +13,7 @@
     font-weight="700"
     letter-spacing="-2"
     fill="#EEF1FF"
-  >cacheplane</text>
+  >threadplane</text>
 
   <!-- Tagline -->
   <text

--- a/apps/website/public/whitepaper-preview.html
+++ b/apps/website/public/whitepaper-preview.html
@@ -23,7 +23,7 @@
   <div style="font-family:monospace;font-size:11px;text-transform:uppercase;letter-spacing:0.12em;color:#004090;font-weight:700;margin-bottom:24px">@ngaf/langgraph · Production Readiness Guide</div>
   <h1 style="font-family:'EB Garamond',serif;font-size:52px;font-weight:800;line-height:1.1;color:#1a1a2e;margin-bottom:20px">From<br>Prototype<br>to<br>Production</h1>
   <p style="font-family:'EB Garamond',serif;font-style:italic;font-size:20px;color:#555770;margin-bottom:40px">The Angular Agent Readiness Guide</p>
-  <div style="font-size:13px;color:#8b8fa3;font-family:monospace">cacheplane.ai · 2026</div>
+  <div style="font-size:13px;color:#8b8fa3;font-family:monospace">threadplane.ai · 2026</div>
 </div>
 
 <!-- TOC -->

--- a/apps/website/public/whitepapers/angular-preview.html
+++ b/apps/website/public/whitepapers/angular-preview.html
@@ -23,7 +23,7 @@
   <div style="font-family:monospace;font-size:11px;text-transform:uppercase;letter-spacing:0.12em;color:#004090;font-weight:700;margin-bottom:24px">@ngaf/langgraph · Enterprise Guide</div>
   <h1 style="font-family:'EB Garamond',serif;font-size:52px;font-weight:800;line-height:1.1;color:#1a1a2e;margin-bottom:20px">The<br>Enterprise<br>Guide<br>to<br>Agent<br>Streaming<br>in<br>Angular</h1>
   <p style="font-family:'EB Garamond',serif;font-style:italic;font-size:20px;color:#555770;margin-bottom:40px">Ship LangGraph agents in Angular — without building the plumbing</p>
-  <div style="font-size:13px;color:#8b8fa3;font-family:monospace">cacheplane.ai · 2026</div>
+  <div style="font-size:13px;color:#8b8fa3;font-family:monospace">threadplane.ai · 2026</div>
 </div>
 
 <!-- TOC -->

--- a/apps/website/public/whitepapers/chat-preview.html
+++ b/apps/website/public/whitepapers/chat-preview.html
@@ -23,7 +23,7 @@
   <div style="font-family:monospace;font-size:11px;text-transform:uppercase;letter-spacing:0.12em;color:#004090;font-weight:700;margin-bottom:24px">@ngaf/chat · Enterprise Guide</div>
   <h1 style="font-family:'EB Garamond',serif;font-size:52px;font-weight:800;line-height:1.1;color:#1a1a2e;margin-bottom:20px">The<br>Enterprise<br>Guide<br>to<br>Agent<br>Chat<br>Interfaces<br>in<br>Angular</h1>
   <p style="font-family:'EB Garamond',serif;font-style:italic;font-size:20px;color:#555770;margin-bottom:40px">Production agent chat UI in days, not sprints</p>
-  <div style="font-size:13px;color:#8b8fa3;font-family:monospace">cacheplane.ai · 2026</div>
+  <div style="font-size:13px;color:#8b8fa3;font-family:monospace">threadplane.ai · 2026</div>
 </div>
 
 <!-- TOC -->

--- a/apps/website/public/whitepapers/render-preview.html
+++ b/apps/website/public/whitepapers/render-preview.html
@@ -23,7 +23,7 @@
   <div style="font-family:monospace;font-size:11px;text-transform:uppercase;letter-spacing:0.12em;color:#004090;font-weight:700;margin-bottom:24px">@ngaf/render · Enterprise Guide</div>
   <h1 style="font-family:'EB Garamond',serif;font-size:52px;font-weight:800;line-height:1.1;color:#1a1a2e;margin-bottom:20px">The<br>Enterprise<br>Guide<br>to<br>Generative<br>UI<br>in<br>Angular</h1>
   <p style="font-family:'EB Garamond',serif;font-style:italic;font-size:20px;color:#555770;margin-bottom:40px">Agents that render UI — without coupling to your frontend</p>
-  <div style="font-size:13px;color:#8b8fa3;font-family:monospace">cacheplane.ai · 2026</div>
+  <div style="font-size:13px;color:#8b8fa3;font-family:monospace">threadplane.ai · 2026</div>
 </div>
 
 <!-- TOC -->

--- a/apps/website/scripts/capture-screenshots.ts
+++ b/apps/website/scripts/capture-screenshots.ts
@@ -2,7 +2,7 @@
  * Capture product screenshots from the live cockpit demo
  * for use in the marketing site's BrowserFrame placeholders.
  *
- * Captures cockpit.cacheplane.ai in each of its 4 modes (Run, Code,
+ * Captures cockpit.threadplane.ai in each of its 4 modes (Run, Code,
  * Docs, API) at 2× DPR, then crops the cockpit content well, optimizes
  * to WebP, and writes to apps/website/public/screenshots/.
  *
@@ -10,7 +10,7 @@
  *   pnpm tsx apps/website/scripts/capture-screenshots.ts
  *
  * Optional flags:
- *   --url <url>    Override the cockpit URL (default cockpit.cacheplane.ai)
+ *   --url <url>    Override the cockpit URL (default cockpit.threadplane.ai)
  *   --keep-png     Keep the intermediate PNG files (for debugging)
  *
  * The script is idempotent — it overwrites existing files in
@@ -25,7 +25,7 @@ import { dirname, join } from 'node:path';
 import { existsSync } from 'node:fs';
 
 const DEFAULT_COCKPIT_URL =
-  'https://cockpit.cacheplane.ai/langgraph/core-capabilities/streaming/overview/python';
+  'https://cockpit.threadplane.ai/langgraph/core-capabilities/streaming/overview/python';
 
 interface CaptureTarget {
   /** Output filename (without extension). */

--- a/apps/website/scripts/generate-whitepaper.ts
+++ b/apps/website/scripts/generate-whitepaper.ts
@@ -11,7 +11,7 @@ if (!process.env['ANTHROPIC_API_KEY'] && loadEnvFile && fs.existsSync('.env')) {
 const client = new Anthropic();
 const MODEL = process.env['ANTHROPIC_MODEL'] ?? 'claude-opus-4-5';
 
-const CURRENT_API_CONTEXT = `You are writing public technical whitepapers for Cacheplane Agent UI for Angular.
+const CURRENT_API_CONTEXT = `You are writing public technical whitepapers for ThreadPlane Agent UI for Angular.
 
 Use only the current API surface:
 - Package names are @ngaf/langgraph, @ngaf/render, @ngaf/chat, and @ngaf/ag-ui.
@@ -601,7 +601,7 @@ function buildHTML(
   <div style="font-family:monospace;font-size:11px;text-transform:uppercase;letter-spacing:0.12em;color:#004090;font-weight:700;margin-bottom:24px">${config.eyebrow}</div>
   <h1 style="font-family:'EB Garamond',serif;font-size:52px;font-weight:800;line-height:1.1;color:#1a1a2e;margin-bottom:20px">${config.title.replace(/ /g, '<br>')}</h1>
   <p style="font-family:'EB Garamond',serif;font-style:italic;font-size:20px;color:#555770;margin-bottom:40px">${config.subtitle}</p>
-  <div style="font-size:13px;color:#8b8fa3;font-family:monospace">cacheplane.ai · ${new Date().getFullYear()}</div>
+  <div style="font-size:13px;color:#8b8fa3;font-family:monospace">threadplane.ai · ${new Date().getFullYear()}</div>
 </div>
 
 <!-- TOC -->
@@ -681,7 +681,7 @@ async function generateWhitepaper(config: WhitepaperConfig): Promise<void> {
 
 // ── Main ─────────────────────────────────────────────────────────────────
 async function main() {
-  console.log('Cacheplane White Paper Generator\n');
+  console.log('ThreadPlane White Paper Generator\n');
   console.log(`Model: ${MODEL}`);
 
   const paperArg = process.argv.find(a => a.startsWith('--paper='))?.split('=')[1]

--- a/apps/website/src/app/api/email-preview/route.ts
+++ b/apps/website/src/app/api/email-preview/route.ts
@@ -20,7 +20,7 @@ const TEMPLATES: Record<string, () => { subject: string; html: string }> = {
     html: newsletterWelcomeHtml(),
   }),
   'lead-notification': () => ({
-    subject: 'New lead: Brian at Cacheplane',
+    subject: 'New lead: Brian at ThreadPlane',
     html: leadNotificationHtml({
       name: 'Sample Lead',
       email: 'demo@example.com',

--- a/apps/website/src/app/api/ingest/route.spec.ts
+++ b/apps/website/src/app/api/ingest/route.spec.ts
@@ -20,7 +20,7 @@ describe('/api/ingest', () => {
 
   it('accepts neutral browser telemetry payloads without requiring the public ingest key', async () => {
     shutdown.mockResolvedValue(undefined);
-    const response = await POST(new Request('https://cacheplane.ai/api/ingest', {
+    const response = await POST(new Request('https://threadplane.ai/api/ingest', {
       method: 'POST',
       body: JSON.stringify({
         event: 'ngaf:browser_chat_init',

--- a/apps/website/src/app/blog/[slug]/opengraph-image.tsx
+++ b/apps/website/src/app/blog/[slug]/opengraph-image.tsx
@@ -3,7 +3,7 @@ import { getPostBySlug } from '../../../lib/blog';
 import { getAuthor } from '../../../lib/blog-authors';
 
 export const runtime = 'nodejs';
-export const alt = 'Cacheplane blog post';
+export const alt = 'ThreadPlane blog post';
 export const size = { width: 1200, height: 630 };
 export const contentType = 'image/png';
 
@@ -61,7 +61,7 @@ export default async function og({ params }: Params) {
             fontSize: 64,
           }}
         >
-          Cacheplane
+          ThreadPlane
         </div>
       ),
       size,
@@ -103,7 +103,7 @@ export default async function og({ params }: Params) {
             opacity: 0.6,
           }}
         >
-          Cacheplane Blog
+          ThreadPlane Blog
         </div>
         <div
           style={{

--- a/apps/website/src/app/blog/[slug]/page.tsx
+++ b/apps/website/src/app/blog/[slug]/page.tsx
@@ -18,10 +18,10 @@ export async function generateMetadata({ params }: Params): Promise<Metadata> {
   const { slug } = await params;
   const post = getPostBySlug(slug);
   if (!post || post.frontmatter.draft) {
-    return { title: 'Post not found — Cacheplane' };
+    return { title: 'Post not found — ThreadPlane' };
   }
   return createPageMetadata({
-    title: `${post.frontmatter.title} — Cacheplane`,
+    title: `${post.frontmatter.title} — ThreadPlane`,
     description: post.frontmatter.description,
     pathname: `/blog/${post.slug}`,
     type: 'article',

--- a/apps/website/src/app/blog/page.tsx
+++ b/apps/website/src/app/blog/page.tsx
@@ -5,7 +5,7 @@ import { PostCard } from '../../components/blog/PostCard';
 import { TagChips } from '../../components/blog/TagChips';
 
 export const metadata = createPageMetadata({
-  title: 'Blog — Cacheplane',
+  title: 'Blog — ThreadPlane',
   description:
     'Long-form writing on agent UI for Angular: streaming, generative UI, threads, interrupts, production patterns.',
   pathname: '/blog',
@@ -39,7 +39,7 @@ export default function BlogIndexPage() {
           marginBottom: 12,
         }}
       >
-        Notes from Cacheplane
+        Notes from ThreadPlane
       </h1>
       <p style={{ fontSize: 18, opacity: 0.8, marginBottom: 32, maxWidth: '60ch' }}>
         Writing on agent UI for Angular — production patterns, design choices,

--- a/apps/website/src/app/blog/rss.xml/route.ts
+++ b/apps/website/src/app/blog/rss.xml/route.ts
@@ -31,7 +31,7 @@ export async function GET() {
   const xml = `<?xml version="1.0" encoding="UTF-8" ?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
-    <title>${escapeXml('Cacheplane Blog')}</title>
+    <title>${escapeXml('ThreadPlane Blog')}</title>
     <link>${SITE_ORIGIN}/blog</link>
     <atom:link href="${SITE_ORIGIN}/blog/rss.xml" rel="self" type="application/rss+xml" />
     <description>${escapeXml('Writing on agent UI for Angular.')}</description>

--- a/apps/website/src/app/chat/page.tsx
+++ b/apps/website/src/app/chat/page.tsx
@@ -52,7 +52,7 @@ export default async function ChatPage() {
             </p>
             <div style={{ display: 'flex', justifyContent: 'center', gap: 12, flexWrap: 'wrap', marginBottom: 20 }}>
               <Button variant="primary" size="lg" href="/docs/chat/getting-started/introduction">Get started</Button>
-              <Button variant="ghost" size="lg" href="https://cockpit.cacheplane.ai" target="_blank" rel="noopener noreferrer">
+              <Button variant="ghost" size="lg" href="https://cockpit.threadplane.ai" target="_blank" rel="noopener noreferrer">
                 See it live →
               </Button>
             </div>
@@ -83,7 +83,7 @@ export default async function ChatPage() {
         ]}
         cta={{ label: 'See @ngaf/chat docs', href: '/docs/chat/getting-started/introduction' }}
         visual={
-          <BrowserFrame url="cockpit.cacheplane.ai/chat-debug" elevation="md">
+          <BrowserFrame url="cockpit.threadplane.ai/chat-debug" elevation="md">
             <div style={{ padding: 24, minHeight: 320, background: 'linear-gradient(180deg, #fff, #f8fafc)' }}>
               <div style={{ display: 'flex', gap: 8, marginBottom: 16 }}>
                 <Pill variant="accent">streaming</Pill>

--- a/apps/website/src/app/contact/page.tsx
+++ b/apps/website/src/app/contact/page.tsx
@@ -11,11 +11,11 @@ import { SlaCard } from '../../components/contact/SlaCard';
 import { AltChannelRow } from '../../components/contact/AltChannelRow';
 
 export const metadata: Metadata = {
-  title: 'Talk to an engineer — Cacheplane',
+  title: 'Talk to an engineer — ThreadPlane',
   description:
     "Tell us what you're shipping. We'll reply within one business day — usually with code, not a calendar invite.",
   openGraph: {
-    title: 'Talk to an engineer — Cacheplane',
+    title: 'Talk to an engineer — ThreadPlane',
     description: "Tell us what you're shipping. We'll reply within one business day.",
     type: 'website',
   },

--- a/apps/website/src/app/dev/primitives/page.tsx
+++ b/apps/website/src/app/dev/primitives/page.tsx
@@ -89,7 +89,7 @@ export default function PrimitivesDevPage() {
 
           <h2 style={{ marginTop: 32 }}>BrowserFrame</h2>
           <div style={{ marginTop: 12, maxWidth: 600 }}>
-            <BrowserFrame url="cockpit.cacheplane.ai" elevation="md">
+            <BrowserFrame url="cockpit.threadplane.ai" elevation="md">
               <div
                 style={{
                   padding: 60,

--- a/apps/website/src/app/llms.txt/route.ts
+++ b/apps/website/src/app/llms.txt/route.ts
@@ -60,7 +60,7 @@ function buildLlmsTxt(): string {
     'MIT — free for any use, commercial or noncommercial.',
     '',
     '## Full reference',
-    'https://cacheplane.ai/llms-full.txt',
+    'https://threadplane.ai/llms-full.txt',
   ].join('\n');
 }
 

--- a/apps/website/src/app/opengraph-image.tsx
+++ b/apps/website/src/app/opengraph-image.tsx
@@ -157,7 +157,7 @@ export default async function OpenGraphImage() {
             }}
           >
             <span style={{ fontSize: 28 }}>🛩️</span>
-            <span>cacheplane.ai</span>
+            <span>threadplane.ai</span>
           </div>
         </div>
       </div>

--- a/apps/website/src/app/page.tsx
+++ b/apps/website/src/app/page.tsx
@@ -41,7 +41,7 @@ export default async function HomePage() {
         ]}
         cta={{ label: 'Read the streaming guide', href: '/docs/agent/api/agent' }}
         visual={
-          <BrowserFrame url="cockpit.cacheplane.ai/langgraph/streaming" elevation="md">
+          <BrowserFrame url="cockpit.threadplane.ai/langgraph/streaming" elevation="md">
             <img
               src="/screenshots/cockpit-docs.webp"
               alt="Cockpit reference app — Angular streaming guide with provideAgent setup"
@@ -73,7 +73,7 @@ export default async function HomePage() {
         cta={{ label: 'See @ngaf/render', href: '/render' }}
         visualLeft
         visual={
-          <BrowserFrame url="cockpit.cacheplane.ai/langgraph/api" elevation="md">
+          <BrowserFrame url="cockpit.threadplane.ai/langgraph/api" elevation="md">
             <img
               src="/screenshots/cockpit-api.webp"
               alt="Cockpit reference app — API reference rendered as structured cards"

--- a/apps/website/src/app/pilot-to-prod/page.tsx
+++ b/apps/website/src/app/pilot-to-prod/page.tsx
@@ -132,7 +132,7 @@ export default function PilotToProdPage() {
         cta={{ label: 'See @ngaf/chat', href: '/chat' }}
         visualLeft
         visual={
-          <BrowserFrame url="cockpit.cacheplane.ai" elevation="md">
+          <BrowserFrame url="cockpit.threadplane.ai" elevation="md">
             <img
               src="/screenshots/cockpit-run.webp"
               alt="Cockpit reference app — live chat surface ready to receive a message"

--- a/apps/website/src/components/contact/ContactForm.spec.tsx
+++ b/apps/website/src/components/contact/ContactForm.spec.tsx
@@ -34,7 +34,7 @@ beforeEach(() => {
   fetchMock.mockReset();
   vi.stubGlobal('fetch', fetchMock);
   Object.defineProperty(document, 'referrer', {
-    value: 'https://cacheplane.ai/pricing',
+    value: 'https://threadplane.ai/pricing',
     configurable: true,
   });
 });
@@ -55,7 +55,7 @@ describe('ContactForm', () => {
     expect(body.email).toBe('jane@acme.com');
     expect(body.source_page).toBe('home_hero');
     expect(body.track).toBe('enterprise');
-    expect(body.referrer_host).toBe('cacheplane.ai');
+    expect(body.referrer_host).toBe('threadplane.ai');
 
     expect(trackMock).toHaveBeenCalledWith(
       'marketing:lead_form_submit',

--- a/apps/website/src/components/landing/FinalCTA.tsx
+++ b/apps/website/src/components/landing/FinalCTA.tsx
@@ -8,7 +8,7 @@ interface FinalCTAProps {
   headline?: string;
   /** Sub-headline. Defaults to the homepage closer. */
   subtext?: string;
-  /** Primary CTA. Defaults to "Try the demo →" → demo.cacheplane.ai. */
+  /** Primary CTA. Defaults to "Try the demo →" → demo.threadplane.ai. */
   primary?: { label: string; href: string; external?: boolean };
   /** Optional secondary CTA. Defaults to "See each feature in action →" → cockpit. */
   secondary?: { label: string; href: string; external?: boolean } | null;
@@ -16,8 +16,8 @@ interface FinalCTAProps {
   caption?: string | null;
 }
 
-const DEFAULT_PRIMARY = { label: 'Try the demo →', href: 'https://demo.cacheplane.ai', external: true };
-const DEFAULT_SECONDARY = { label: 'See each feature in action →', href: 'https://cockpit.cacheplane.ai', external: true };
+const DEFAULT_PRIMARY = { label: 'Try the demo →', href: 'https://demo.threadplane.ai', external: true };
+const DEFAULT_SECONDARY = { label: 'See each feature in action →', href: 'https://cockpit.threadplane.ai', external: true };
 
 export function FinalCTA({
   headline = 'Stop stalling on agentic Angular.',

--- a/apps/website/src/components/landing/Hero.tsx
+++ b/apps/website/src/components/landing/Hero.tsx
@@ -137,14 +137,14 @@ export function Hero() {
                 maxWidth: '60ch',
               }}
             >
-              Not another backend agent runtime. Keep LangGraph, Genkit, Mastra, CrewAI, or your own service. Cacheplane solves the Angular UI layer.
+              Not another backend agent runtime. Keep LangGraph, Genkit, Mastra, CrewAI, or your own service. ThreadPlane solves the Angular UI layer.
             </p>
           </div>
 
           {/* Right column — layered collage (preserved verbatim from prior Hero.tsx) */}
           <div style={{ position: 'relative', minHeight: 420 }} aria-hidden="true">
             <BrowserFrame
-              url="demo.cacheplane.ai"
+              url="demo.threadplane.ai"
               rotate={-3}
               elevation="lg"
               style={{ position: 'absolute', top: 0, left: 0, width: '92%' }}

--- a/apps/website/src/components/landing/HomeFAQ.tsx
+++ b/apps/website/src/components/landing/HomeFAQ.tsx
@@ -27,7 +27,7 @@ const ITEMS: FAQItem[] = [
   },
   {
     q: 'Is this production-ready today?',
-    a: 'It runs the full stack in our reference deployment (cockpit.cacheplane.ai), and breaking changes are called out in release notes. We support Angular’s current and previous LTS versions.',
+    a: 'It runs the full stack in our reference deployment (cockpit.threadplane.ai), and breaking changes are called out in release notes. We support Angular’s current and previous LTS versions.',
   },
   {
     q: 'Where do I report issues?',

--- a/apps/website/src/components/landing/LiveDemoFrame.tsx
+++ b/apps/website/src/components/landing/LiveDemoFrame.tsx
@@ -28,10 +28,10 @@ export function LiveDemoFrame() {
 
   return (
     <div ref={ref}>
-      <BrowserFrame url="demo.cacheplane.ai" elevation="lg">
+      <BrowserFrame url="demo.threadplane.ai" elevation="lg">
         {shouldLoad ? (
           <iframe
-            src="https://demo.cacheplane.ai"
+            src="https://demo.threadplane.ai"
             title="Canonical demo — @ngaf/chat running against the shared LangGraph backend"
             loading="lazy"
             style={{

--- a/apps/website/src/components/shared/Footer.tsx
+++ b/apps/website/src/components/shared/Footer.tsx
@@ -175,8 +175,8 @@ export function Footer() {
               onMouseLeave={(e) => (e.currentTarget.style.color = tokens.colors.textSecondary)}>
               API Reference
             </Link>
-            <a href="https://demo.cacheplane.ai" className="transition-colors" style={{ color: tokens.colors.textSecondary }}
-              onClick={() => trackExternalLinkClick('https://demo.cacheplane.ai', {
+            <a href="https://demo.threadplane.ai" className="transition-colors" style={{ color: tokens.colors.textSecondary }}
+              onClick={() => trackExternalLinkClick('https://demo.threadplane.ai', {
                 surface: 'footer',
                 cta_id: 'footer_demo',
                 cta_text: 'Demo',
@@ -185,8 +185,8 @@ export function Footer() {
               onMouseLeave={(e) => (e.currentTarget.style.color = tokens.colors.textSecondary)}>
               Demo
             </a>
-            <a href="https://cockpit.cacheplane.ai" className="transition-colors" style={{ color: tokens.colors.textSecondary }}
-              onClick={() => trackExternalLinkClick('https://cockpit.cacheplane.ai', {
+            <a href="https://cockpit.threadplane.ai" className="transition-colors" style={{ color: tokens.colors.textSecondary }}
+              onClick={() => trackExternalLinkClick('https://cockpit.threadplane.ai', {
                 surface: 'footer',
                 cta_id: 'footer_examples',
                 cta_text: 'Examples',

--- a/apps/website/src/components/shared/Nav.tsx
+++ b/apps/website/src/components/shared/Nav.tsx
@@ -13,8 +13,8 @@ const links = [
   { label: 'Docs', href: '/docs', external: false },
   { label: 'Solutions', href: '/solutions', external: false },
   { label: 'API', href: '/docs/agent/api/agent', external: false },
-  { label: 'Demo', href: 'https://demo.cacheplane.ai', external: true },
-  { label: 'Examples', href: 'https://cockpit.cacheplane.ai', external: true },
+  { label: 'Demo', href: 'https://demo.threadplane.ai', external: true },
+  { label: 'Examples', href: 'https://cockpit.threadplane.ai', external: true },
   { label: 'Pricing', href: '/pricing', external: false },
   { label: 'Blog', href: '/blog', external: false },
 ];

--- a/apps/website/src/lib/blog-authors.ts
+++ b/apps/website/src/lib/blog-authors.ts
@@ -11,7 +11,7 @@ export interface Author {
 export const blogAuthors: Record<string, Author> = {
   brian: {
     name: 'Brian Love',
-    role: 'Founder, Cacheplane',
+    role: 'Founder, ThreadPlane',
     bio: 'Angular consultant and open-source maintainer. Building agent UI for Angular teams.',
     github: 'blove',
   },

--- a/apps/website/src/lib/docs.spec.ts
+++ b/apps/website/src/lib/docs.spec.ts
@@ -109,7 +109,7 @@ describe('website docs bindings', () => {
   });
 
   it('resolves canonical URLs against the production origin', () => {
-    expect(getCanonicalUrl('/docs/agent/guides/streaming')).toBe('https://cacheplane.ai/docs/agent/guides/streaming');
+    expect(getCanonicalUrl('/docs/agent/guides/streaming')).toBe('https://threadplane.ai/docs/agent/guides/streaming');
   });
 
   it('does not contain stale or broken internal docs links', () => {

--- a/apps/website/src/lib/site-metadata.ts
+++ b/apps/website/src/lib/site-metadata.ts
@@ -3,7 +3,7 @@ import { getAllSolutionSlugs } from './solutions-data';
 import { docsConfig } from './docs-config';
 import { getAllPosts } from './blog';
 
-export const SITE_ORIGIN = 'https://cacheplane.ai';
+export const SITE_ORIGIN = 'https://threadplane.ai';
 export const SITE_NAME = 'Agent UI for Angular';
 export const DEFAULT_SOCIAL_IMAGE = '/opengraph-image';
 

--- a/docs/gtm/icp.md
+++ b/docs/gtm/icp.md
@@ -1,4 +1,4 @@
-# ICP — Cacheplane
+# ICP — ThreadPlane
 
 > Operational doc. Edited by humans as we learn. The durable two-track ICP summary lives in [gtm.md §3](../../gtm.md).
 
@@ -16,7 +16,7 @@
 These are the signals to instrument first in Spec 1. Baseline rates between them populate this section quantitatively once `developer-funnel` ships.
 
 **Disqualifiers**
-- Greenfield app with no Angular constraint — Cacheplane is for teams that *must* stay on Angular.
+- Greenfield app with no Angular constraint — ThreadPlane is for teams that *must* stay on Angular.
 - Hobby/learning project — we welcome them, but they aren't the ICP for prioritization.
 
 **Where they hang out**

--- a/docs/gtm/messaging.md
+++ b/docs/gtm/messaging.md
@@ -1,10 +1,10 @@
-# Messaging — Cacheplane
+# Messaging — ThreadPlane
 
 > Operational doc. Hero copy, proof rows, comparison framing, launch lines. Edited by humans as we iterate. The durable category claim lives in [gtm.md §2](../../gtm.md).
 
 ## Positioning statement (durable)
 
-> For Angular teams building AI agents on LangGraph, AG-UI, or custom backends, Cacheplane is the open-source agent UI framework that turns streaming agent events into production-grade Angular experiences: chat, tool progress, approvals, threads, generative UI, fallbacks, observability, and tests. Unlike React-first agent UI stacks or raw streaming SDKs, Cacheplane is signal-native, DI-friendly, design-system-first, self-hostable, and built for enterprise Angular apps.
+> For Angular teams building AI agents on LangGraph, AG-UI, or custom backends, ThreadPlane is the open-source agent UI framework that turns streaming agent events into production-grade Angular experiences: chat, tool progress, approvals, threads, generative UI, fallbacks, observability, and tests. Unlike React-first agent UI stacks or raw streaming SDKs, ThreadPlane is signal-native, DI-friendly, design-system-first, self-hostable, and built for enterprise Angular apps.
 
 ## Hero (locked for Spec 2 to implement)
 
@@ -18,7 +18,7 @@
 
 **Proof row:** `MIT · Angular-native Signals · LangGraph + AG-UI · A2UI-compatible · Self-hostable · App telemetry off by default`
 
-**Subline under proof row:** *Not another backend agent runtime. Keep LangGraph, Genkit, Mastra, CrewAI, or your own service. Cacheplane solves the Angular UI layer.*
+**Subline under proof row:** *Not another backend agent runtime. Keep LangGraph, Genkit, Mastra, CrewAI, or your own service. ThreadPlane solves the Angular UI layer.*
 
 ## The five durable differentiation points
 
@@ -55,16 +55,16 @@ Hidden attribution fields (populated by URL params + referrer): `source_page`, `
 
 ## Comparison page framing (Spec 3)
 
-| Alternative           | Cacheplane positioning vs. them |
+| Alternative           | ThreadPlane positioning vs. them |
 |-----------------------|---------------------------------|
-| `@langchain/angular`  | "Use it for the stream. Use Cacheplane for the production Angular UI, design-system rendering, fallbacks, thread UX, testing, and enterprise patterns." |
-| CopilotKit            | "Broad agent frontend stack; Cacheplane is deeply Angular-native, signal/DI/design-system-first, optimized for enterprise Angular teams that don't want a React-first mental model." |
-| Hashbrown             | "Hashbrown is great for browser-running agents and LLM-driven frontend tools; Cacheplane is for LangGraph/AG-UI/A2UI-backed enterprise agent workflows with production chat, approvals, threads, observability, and runtime adapters." |
-| A2UI renderer         | "A2UI renderer support is table stakes; Cacheplane adds Angular app integration, fallback behavior, design-system registry patterns, thread/chat UX, and enterprise hardening." |
+| `@langchain/angular`  | "Use it for the stream. Use ThreadPlane for the production Angular UI, design-system rendering, fallbacks, thread UX, testing, and enterprise patterns." |
+| CopilotKit            | "Broad agent frontend stack; ThreadPlane is deeply Angular-native, signal/DI/design-system-first, optimized for enterprise Angular teams that don't want a React-first mental model." |
+| Hashbrown             | "Hashbrown is great for browser-running agents and LLM-driven frontend tools; ThreadPlane is for LangGraph/AG-UI/A2UI-backed enterprise agent workflows with production chat, approvals, threads, observability, and runtime adapters." |
+| A2UI renderer         | "A2UI renderer support is table stakes; ThreadPlane adds Angular app integration, fallback behavior, design-system registry patterns, thread/chat UX, and enterprise hardening." |
 
 ## Launch narrative (Spec 6 spine)
 
-> Angular teams are building agents, but the last mile is still messy: streaming state, tool progress, interrupts, threads, generated UI, fallbacks, and tests. React has mature examples. Backend agent frameworks have protocols. Angular teams need something that speaks Signals, DI, templates, standalone components, and enterprise design systems. Cacheplane is an MIT-licensed agent UI framework for Angular that connects LangGraph, AG-UI, A2UI, and custom backends to production-ready Angular surfaces.
+> Angular teams are building agents, but the last mile is still messy: streaming state, tool progress, interrupts, threads, generated UI, fallbacks, and tests. React has mature examples. Backend agent frameworks have protocols. Angular teams need something that speaks Signals, DI, templates, standalone components, and enterprise design systems. ThreadPlane is an MIT-licensed agent UI framework for Angular that connects LangGraph, AG-UI, A2UI, and custom backends to production-ready Angular surfaces.
 
 ## Avoid
 

--- a/docs/gtm/taxonomy.md
+++ b/docs/gtm/taxonomy.md
@@ -1,4 +1,4 @@
-# Event & Property Taxonomy — Cacheplane
+# Event & Property Taxonomy — ThreadPlane
 
 > Single source of truth for PostHog event names, properties, CTA ids, and surface ids. Implementation lands in `apps/website/src/lib/analytics/events.ts`, `apps/cockpit/src/lib/analytics/events.ts`, and `libs/telemetry/src/shared/events.ts`. Whenever those files change, this file changes.
 

--- a/gtm.md
+++ b/gtm.md
@@ -1,4 +1,4 @@
-# Cacheplane GTM Strategy
+# ThreadPlane GTM Strategy
 
 > Durable strategy. Hand-edited. Operational details live in `docs/gtm/`.
 > Workstream plans live in `docs/superpowers/specs/gtm/`.
@@ -6,7 +6,7 @@
 
 ## 1. What we are
 
-Cacheplane is the production agent UI framework for Angular teams. It turns LangGraph, AG-UI, A2UI, and custom agent streams into real Angular experiences — chat, threads, tool progress, human approvals, generative UI, fallbacks, observability, tests — without rewriting in React or adopting a proprietary cloud.
+ThreadPlane is the production agent UI framework for Angular teams. It turns LangGraph, AG-UI, A2UI, and custom agent streams into real Angular experiences — chat, threads, tool progress, human approvals, generative UI, fallbacks, observability, tests — without rewriting in React or adopting a proprietary cloud.
 
 ## 2. Category
 
@@ -14,7 +14,7 @@ Cacheplane is the production agent UI framework for Angular teams. It turns Lang
 - **Secondary (only after "Agent UI"):** Angular Agent UI Framework
 - **Do not use:** "Angular Agent Framework" (ambiguous with backend runtimes and coding agents), "Enterprise Angular agent framework" (reads sales-first).
 
-The category claim is the **Angular final mile**: official streaming SDKs (LangChain, AG-UI, A2UI) get events into Angular; Cacheplane turns those events into production-ready Angular experiences. We do not compete as a general agent UI framework. We do not compete with backend runtimes.
+The category claim is the **Angular final mile**: official streaming SDKs (LangChain, AG-UI, A2UI) get events into Angular; ThreadPlane turns those events into production-ready Angular experiences. We do not compete as a general agent UI framework. We do not compete with backend runtimes.
 
 ## 3. ICP
 

--- a/libs/ag-ui/README.md
+++ b/libs/ag-ui/README.md
@@ -59,8 +59,8 @@ Each citation object in the array supports `id`, `index`, `title`, `url`, `snipp
 
 ## Documentation
 
-- [Quickstart](https://cacheplane.ai/docs/agent/getting-started/quickstart)
-- [AG-UI adapter guide](https://cacheplane.ai/docs/chat/guides/writing-an-adapter)
+- [Quickstart](https://threadplane.ai/docs/agent/getting-started/quickstart)
+- [AG-UI adapter guide](https://threadplane.ai/docs/chat/guides/writing-an-adapter)
 - [AG-UI protocol](https://github.com/ag-ui-protocol/ag-ui)
 
 ## License

--- a/libs/chat/src/lib/provide-chat.spec.ts
+++ b/libs/chat/src/lib/provide-chat.spec.ts
@@ -60,7 +60,7 @@ describe('provideChat', () => {
     const warn = globalThis.console.warn as ReturnType<typeof vi.fn>;
     expect(
       warn.mock.calls.some((c) =>
-        String(c[0]).includes('[cacheplane] @ngaf/chat'),
+        String(c[0]).includes('[threadplane] @ngaf/chat'),
       ),
     ).toBe(true);
   });

--- a/libs/chat/src/lib/provide-chat.ts
+++ b/libs/chat/src/lib/provide-chat.ts
@@ -16,7 +16,7 @@ export interface ChatConfig {
   avatarLabel?: string;
   /** Shared assistant display name for consumers that read CHAT_CONFIG (default: "Assistant"). */
   assistantName?: string;
-  /** Signed license token from cacheplane.dev. Optional; omitted in dev. */
+  /** Signed license token from threadplane.ai. Optional; omitted in dev. */
   license?: string;
   /**
    * @internal

--- a/libs/design-tokens/src/lib/tokens.css
+++ b/libs/design-tokens/src/lib/tokens.css
@@ -1,7 +1,7 @@
 /**
  * Design Tokens — CSS Custom Properties
  *
- * Single source of truth for the @cacheplane design system.
+ * Single source of truth for the ThreadPlane design system.
  * Import this file in any app to get all tokens as CSS vars.
  *
  * Variable naming: --ds-{category}-{name}

--- a/libs/langgraph/README.md
+++ b/libs/langgraph/README.md
@@ -81,11 +81,11 @@ return new AIMessage({
 
 ## Documentation
 
-- [Quickstart](https://cacheplane.ai/docs/agent/getting-started/quickstart)
-- [`agent()` API reference](https://cacheplane.ai/docs/agent/api/agent)
-- [Human-in-the-loop / interrupts](https://cacheplane.ai/docs/agent/guides/interrupts)
-- [Thread persistence](https://cacheplane.ai/docs/agent/guides/persistence)
-- [Testing with `MockAgentTransport`](https://cacheplane.ai/docs/agent/guides/testing)
+- [Quickstart](https://threadplane.ai/docs/agent/getting-started/quickstart)
+- [`agent()` API reference](https://threadplane.ai/docs/agent/api/agent)
+- [Human-in-the-loop / interrupts](https://threadplane.ai/docs/agent/guides/interrupts)
+- [Thread persistence](https://threadplane.ai/docs/agent/guides/persistence)
+- [Testing with `MockAgentTransport`](https://threadplane.ai/docs/agent/guides/testing)
 
 ## License
 

--- a/libs/langgraph/src/lib/agent.provider.spec.ts
+++ b/libs/langgraph/src/lib/agent.provider.spec.ts
@@ -75,6 +75,6 @@ describe('provideAgent', () => {
     TestBed.inject(AGENT_CONFIG);
     await new Promise((r) => setTimeout(r, 0));
     const calls = warn.mock.calls.map((c) => String(c[0]));
-    expect(calls.some((m) => m.includes('[cacheplane] @ngaf/langgraph'))).toBe(true);
+    expect(calls.some((m) => m.includes('[threadplane] @ngaf/langgraph'))).toBe(true);
   });
 });

--- a/libs/langgraph/src/lib/agent.provider.ts
+++ b/libs/langgraph/src/lib/agent.provider.ts
@@ -18,7 +18,7 @@ export interface AgentConfig {
   apiUrl?:    string;
   /** Custom transport implementation. Defaults to {@link FetchStreamTransport}. */
   transport?: AgentTransport;
-  /** Signed license token from cacheplane.dev. Optional; omitted in dev. */
+  /** Signed license token from threadplane.ai. Optional; omitted in dev. */
   license?: string;
   /**
    * @internal

--- a/libs/licensing/README.md
+++ b/libs/licensing/README.md
@@ -1,6 +1,6 @@
 # @ngaf/licensing
 
-Offline Ed25519 license verification for the Cacheplane Angular framework
+Offline Ed25519 license verification for the ThreadPlane Angular framework
 libraries.
 
 ## Status
@@ -14,6 +14,6 @@ Private, pre-1.0. Consumed by `@ngaf/langgraph`, `@ngaf/render`, and
 - `evaluateLicense(result, { nowSec })` — returns one of
   `licensed | grace | expired | missing | tampered | noncommercial`.
 - `runLicenseCheck(options)` — runs verification and emits a single
-  `console.warn` with the `[cacheplane]` prefix when unlicensed.
+  `console.warn` with the `[threadplane]` prefix when unlicensed.
 - **Never throws from init** — every failure mode is reported via warn, never
   by throwing or blocking the host application's startup.

--- a/libs/licensing/src/lib/nag.spec.ts
+++ b/libs/licensing/src/lib/nag.spec.ts
@@ -27,9 +27,9 @@ describe('emitNag', () => {
     emitNag({ status: 'missing' }, { package: '@ngaf/langgraph', warn });
     expect(warn).toHaveBeenCalledTimes(1);
     const message = warn.mock.calls[0][0] as string;
-    expect(message).toContain('[cacheplane]');
+    expect(message).toContain('[threadplane]');
     expect(message).toContain('@ngaf/langgraph');
-    expect(message).toContain('cacheplane.dev/pricing');
+    expect(message).toContain('threadplane.ai/pricing');
   });
 
   it('warns differently for grace / expired / tampered', () => {

--- a/libs/licensing/src/lib/nag.ts
+++ b/libs/licensing/src/lib/nag.ts
@@ -12,13 +12,13 @@ const seen = new Set<string>();
 
 const MESSAGES: Record<string, string> = {
   missing:
-    'no license key detected. The library will keep running, but please get a license at https://cacheplane.dev/pricing',
+    'no license key detected. The library will keep running, but please get a license at https://threadplane.ai/pricing',
   grace:
-    'license is expired and within the 14-day grace window. Renew at https://cacheplane.dev/pricing',
+    'license is expired and within the 14-day grace window. Renew at https://threadplane.ai/pricing',
   expired:
-    'license is expired. The library will keep running, but please renew at https://cacheplane.dev/pricing',
+    'license is expired. The library will keep running, but please renew at https://threadplane.ai/pricing',
   tampered:
-    'license signature is invalid or malformed. Download a fresh key from https://cacheplane.dev/pricing',
+    'license signature is invalid or malformed. Download a fresh key from https://threadplane.ai/pricing',
 };
 
 export function emitNag(
@@ -34,7 +34,7 @@ export function emitNag(
   seen.add(key);
 
   const body = MESSAGES[status] ?? 'license check failed.';
-  warn(`[cacheplane] ${options.package}: ${body}`);
+  warn(`[threadplane] ${options.package}: ${body}`);
 }
 
 /** @internal testing hook only. */

--- a/libs/render/README.md
+++ b/libs/render/README.md
@@ -20,10 +20,10 @@ npm install @ngaf/render
 
 ## Documentation
 
-- [Quickstart](https://cacheplane.ai/docs/render/getting-started/quickstart)
-- [Component registry](https://cacheplane.ai/docs/render/guides/registry)
-- [Fallback patterns](https://cacheplane.ai/docs/render/guides/fallback)
-- [A2UI v1-compatible protocol](https://cacheplane.ai/docs/render/a2ui/overview)
+- [Quickstart](https://threadplane.ai/docs/render/getting-started/quickstart)
+- [Component registry](https://threadplane.ai/docs/render/guides/registry)
+- [Fallback patterns](https://threadplane.ai/docs/render/guides/fallback)
+- [A2UI v1-compatible protocol](https://threadplane.ai/docs/render/a2ui/overview)
 
 ## License
 

--- a/libs/render/src/lib/provide-render.spec.ts
+++ b/libs/render/src/lib/provide-render.spec.ts
@@ -51,7 +51,7 @@ describe('provideRender', () => {
     const warn = globalThis.console.warn as ReturnType<typeof vi.fn>;
     expect(
       warn.mock.calls.some((c) =>
-        String(c[0]).includes('[cacheplane] @ngaf/render'),
+        String(c[0]).includes('[threadplane] @ngaf/render'),
       ),
     ).toBe(true);
   });

--- a/libs/render/src/lib/render.types.ts
+++ b/libs/render/src/lib/render.types.ts
@@ -48,7 +48,7 @@ export interface RenderConfig {
   store?: StateStore;
   functions?: Record<string, ComputedFunction>;
   handlers?: Record<string, (params: Record<string, unknown>) => unknown | Promise<unknown>>;
-  /** Signed license token from cacheplane.dev. Optional; omitted in dev. */
+  /** Signed license token from threadplane.ai. Optional; omitted in dev. */
   license?: string;
   /**
    * @internal

--- a/libs/telemetry/README.md
+++ b/libs/telemetry/README.md
@@ -25,7 +25,7 @@ import { isTelemetryDisabled, sha256, getAnonId } from '@ngaf/telemetry';
 
 ## What this package is
 
-The single telemetry surface for `@ngaf/*`. It exists so we can answer "how is Cacheplane being used?" without instrumenting browser packages that ship to end-users.
+The single telemetry surface for `@ngaf/*`. It exists so we can answer "how is ThreadPlane being used?" without instrumenting browser packages that ship to end-users.
 
 ## What is and isn't telemetered
 
@@ -119,7 +119,7 @@ Enterprise users can redirect Node telemetry to their own ingest:
 NGAF_TELEMETRY_INGEST_URL=https://telemetry.acme-internal.example.com/api/ingest
 ```
 
-Default ingest (when env var is unset) is a thin proxy on the Cacheplane website (`https://cacheplane.ai/api/ingest`) that accepts the `@ngaf/telemetry` JSON payload and forwards `ngaf:*` events to our PostHog project without forwarding installer IP addresses. Source of the proxy lives in `apps/website/src/app/api/ingest/`.
+Default ingest (when env var is unset) is a thin proxy on the ThreadPlane website (`https://threadplane.ai/api/ingest`) that accepts the `@ngaf/telemetry` JSON payload and forwards `ngaf:*` events to our PostHog project without forwarding installer IP addresses. Source of the proxy lives in `apps/website/src/app/api/ingest/`.
 
 ## Verifying telemetry is silent
 

--- a/libs/telemetry/src/node/client.spec.ts
+++ b/libs/telemetry/src/node/client.spec.ts
@@ -71,10 +71,10 @@ describe('node client', () => {
     );
   });
 
-  test('capturePostinstall defaults to the live Cacheplane ingest proxy', async () => {
+  test('capturePostinstall defaults to the live ThreadPlane ingest proxy', async () => {
     delete process.env.NGAF_TELEMETRY_INGEST_URL;
     await capturePostinstall({ pkg: 'x', version: '1' });
-    expect(fetchMock.mock.calls[0][0]).toBe('https://cacheplane.ai/api/ingest');
+    expect(fetchMock.mock.calls[0][0]).toBe('https://threadplane.ai/api/ingest');
   });
 
   test('capturePostinstall sends sample_weight property', async () => {

--- a/libs/telemetry/src/node/client.ts
+++ b/libs/telemetry/src/node/client.ts
@@ -4,9 +4,9 @@ import { shouldSample } from '../shared/sample.js';
 import type { NgafNodeEvent } from '../shared/events.js';
 import { isProgrammaticallyDisabled } from './disable.js';
 
-const DEFAULT_INGEST = 'https://cacheplane.ai/api/ingest';
+const DEFAULT_INGEST = 'https://threadplane.ai/api/ingest';
 const REQUEST_TIMEOUT_MS = 3_000;
-// Public identifier accepted by the Cacheplane ingest proxy. The proxy re-keys
+// Public identifier accepted by the ThreadPlane ingest proxy. The proxy re-keys
 // server-side with the private PostHog token.
 const PUBLIC_INGEST_KEY = 'phc_public_cacheplane_telemetry';
 

--- a/libs/telemetry/src/shared/personal-email-domains.spec.ts
+++ b/libs/telemetry/src/shared/personal-email-domains.spec.ts
@@ -19,7 +19,7 @@ describe('personal email domains', () => {
 
   it('returns false for unknown domains and falsy inputs', () => {
     expect(isPersonalEmailDomain('acme.com')).toBe(false);
-    expect(isPersonalEmailDomain('cacheplane.ai')).toBe(false);
+    expect(isPersonalEmailDomain('threadplane.ai')).toBe(false);
     expect(isPersonalEmailDomain('')).toBe(false);
     expect(isPersonalEmailDomain(null)).toBe(false);
     expect(isPersonalEmailDomain(undefined)).toBe(false);

--- a/marketing/channels/README.md
+++ b/marketing/channels/README.md
@@ -1,6 +1,6 @@
 # @ngaf/marketing-channels
 
-Channel adapters for the Cacheplane marketing pipeline. One adapter per channel, all behind a single `ChannelAdapter` interface.
+Channel adapters for the ThreadPlane marketing pipeline. One adapter per channel, all behind a single `ChannelAdapter` interface.
 
 ## Implemented
 
@@ -20,7 +20,7 @@ import { getAdapter } from '@ngaf/marketing-channels';
 const x = getAdapter('x');
 const result = await x.post({
   channel: 'x',
-  text: 'Hello from Cacheplane.',
+  text: 'Hello from ThreadPlane.',
 });
 console.log(result.url);
 ```
@@ -51,7 +51,7 @@ Dev.to uses a single static API key.
 
 1. Sign in to Dev.to.
 2. **Settings** → **Extensions** → **DEV Community API Keys** → **Generate API Key**.
-   Name it `cacheplane-marketing` (or anything you like).
+   Name it `threadplane-marketing` (or anything you like).
 3. Copy the key into `.env`:
 
    ```

--- a/marketing/channels/scripts/smoke.ts
+++ b/marketing/channels/scripts/smoke.ts
@@ -67,13 +67,13 @@ function buildDevToDraft(): Draft {
       '',
       '## Why this exists',
       '',
-      'The Cacheplane marketing pipeline syndicates blog content to Dev.to. This run verifies the live wire works end-to-end.',
+      'The ThreadPlane marketing pipeline syndicates blog content to Dev.to. This run verifies the live wire works end-to-end.',
     ].join('\n'),
     article: {
       title: `Marketing Pipeline Smoke Test — ${stamp}`,
       tags: ['test'],
-      canonicalUrl: 'https://cacheplane.ai',
-      description: 'Automated smoke test of the Cacheplane marketing pipeline Dev.to adapter.',
+      canonicalUrl: 'https://threadplane.ai',
+      description: 'Automated smoke test of the ThreadPlane marketing pipeline Dev.to adapter.',
     },
   };
 }

--- a/marketing/channels/src/devto/metrics.spec.ts
+++ b/marketing/channels/src/devto/metrics.spec.ts
@@ -46,7 +46,7 @@ describe('fetchDevToMetrics', () => {
     );
     await fetchDevToMetrics(apiKey, '9');
     expect(receivedHeaders?.get('api-key')).toBe(apiKey);
-    expect(receivedHeaders?.get('user-agent')).toBe('cacheplane-marketing/1.0');
+    expect(receivedHeaders?.get('user-agent')).toBe('threadplane-marketing/1.0');
   });
 
   it('throws a clear error on 404', async () => {

--- a/marketing/channels/src/devto/metrics.ts
+++ b/marketing/channels/src/devto/metrics.ts
@@ -20,7 +20,7 @@ export async function fetchDevToMetrics(
       url: `https://dev.to/api/articles/${postId}`,
       headers: {
         'api-key': apiKey,
-        'User-Agent': 'cacheplane-marketing/1.0',
+        'User-Agent': 'threadplane-marketing/1.0',
       },
     });
   } catch (err) {

--- a/marketing/channels/src/devto/post.spec.ts
+++ b/marketing/channels/src/devto/post.spec.ts
@@ -18,7 +18,7 @@ function baseDraft(): Draft {
     article: {
       title: 'Hello',
       tags: ['angular', 'tutorial'],
-      canonicalUrl: 'https://cacheplane.ai/blog/hello',
+      canonicalUrl: 'https://threadplane.ai/blog/hello',
       description: 'A hello article.',
     },
   };
@@ -44,14 +44,14 @@ describe('postDevTo', () => {
 
     expect(receivedHeaders?.get('api-key')).toBe(apiKey);
     expect(receivedHeaders?.get('content-type')).toMatch(/application\/json/);
-    expect(receivedHeaders?.get('user-agent')).toBe('cacheplane-marketing/1.0');
+    expect(receivedHeaders?.get('user-agent')).toBe('threadplane-marketing/1.0');
     expect(receivedBody).toEqual({
       article: {
         title: 'Hello',
         body_markdown: '# Hello\n\nBody',
         published: true,
         tags: ['angular', 'tutorial'],
-        canonical_url: 'https://cacheplane.ai/blog/hello',
+        canonical_url: 'https://threadplane.ai/blog/hello',
         description: 'A hello article.',
       },
     });

--- a/marketing/channels/src/devto/post.ts
+++ b/marketing/channels/src/devto/post.ts
@@ -42,7 +42,7 @@ export async function postDevTo(apiKey: string, draft: Draft): Promise<PostResul
       headers: {
         'api-key': apiKey,
         'Content-Type': 'application/json',
-        'User-Agent': 'cacheplane-marketing/1.0',
+        'User-Agent': 'threadplane-marketing/1.0',
       },
       body: JSON.stringify({ article }),
       retryOn5xx: true,

--- a/marketing/channels/src/validation.spec.ts
+++ b/marketing/channels/src/validation.spec.ts
@@ -108,7 +108,7 @@ describe('validateDraft (Dev.to)', () => {
       article: {
         title: 'My Article',
         tags: ['angular', 'tutorial'],
-        canonicalUrl: 'https://cacheplane.ai/blog/my-article',
+        canonicalUrl: 'https://threadplane.ai/blog/my-article',
         description: 'A description.',
       },
     };

--- a/marketing/channels/src/x/auth-cli.ts
+++ b/marketing/channels/src/x/auth-cli.ts
@@ -58,7 +58,7 @@ async function main(): Promise<void> {
   authorizeUrl.searchParams.set('code_challenge', challenge);
   authorizeUrl.searchParams.set('code_challenge_method', 'S256');
 
-  process.stdout.write(`\nOpening browser to authorize Cacheplane marketing app...\n${authorizeUrl.toString()}\n\n`);
+  process.stdout.write(`\nOpening browser to authorize ThreadPlane marketing app...\n${authorizeUrl.toString()}\n\n`);
   openInBrowser(authorizeUrl.toString());
 
   const result = await new Promise<{ code: string }>((resolve, reject) => {

--- a/marketing/cowork/README.md
+++ b/marketing/cowork/README.md
@@ -1,6 +1,6 @@
-# Cacheplane GTM — Cowork skill
+# ThreadPlane GTM — Cowork skill
 
-A single Claude Cowork skill that operates Cacheplane's GTM motion: weekly PostHog snapshots, lead triage, workstream scaffolding, and "where are we?" status questions.
+A single Claude Cowork skill that operates ThreadPlane's GTM motion: weekly PostHog snapshots, lead triage, workstream scaffolding, and "where are we?" status questions.
 
 The skill is **project-local**. It isn't published to a marketplace. Install steps are manual and one-time per machine.
 

--- a/marketing/cowork/gtm/SKILL.md
+++ b/marketing/cowork/gtm/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: gtm
-description: Cacheplane GTM operator. Use to run weekly PostHog snapshots, draft the Notes section, triage inbound leads against the qualified-lead definition, scaffold new workstream specs, and answer "where are we?" questions by reading gtm.md plus the latest report. Invoke any time GTM motion work is happening or the weekly cadence fires.
+description: ThreadPlane GTM operator. Use to run weekly PostHog snapshots, draft the Notes section, triage inbound leads against the qualified-lead definition, scaffold new workstream specs, and answer "where are we?" questions by reading gtm.md plus the latest report. Invoke any time GTM motion work is happening or the weekly cadence fires.
 disable-model-invocation: false
 allowed-tools: Read, Edit, Write, Bash(npm run posthog:*), Bash(npm run gtm:*), Bash(gh pr *), Bash(git *), Glob, Grep
 ---
 
-# Cacheplane GTM operator
+# ThreadPlane GTM operator
 
-You are the GTM operator for Cacheplane. You own the operational layer of the GTM motion. Strategy decisions live in `gtm.md` and the per-workstream specs; you execute against them.
+You are the GTM operator for ThreadPlane. You own the operational layer of the GTM motion. Strategy decisions live in `gtm.md` and the per-workstream specs; you execute against them.
 
 ## What you own
 

--- a/marketing/cowork/marketing/SKILL.md
+++ b/marketing/cowork/marketing/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: marketing
 description: |
-  Cacheplane marketing pipeline operator. Reads `marketing/cowork/inbox/*.json`
+  ThreadPlane marketing pipeline operator. Reads `marketing/cowork/inbox/*.json`
   draft bundles, presents them for review in conversation, supports
   edit/approve/reject decisions, and dispatches approved drafts to channel
   adapters. Invoke when "drafts are waiting" or when the user wants to

--- a/scripts/ci-workflow.spec.mjs
+++ b/scripts/ci-workflow.spec.mjs
@@ -85,6 +85,24 @@ describe('CI workflow', () => {
     );
   });
 
+  it('runs production smoke against ThreadPlane domains', async () => {
+    const productionSmokeJob = await readProductionSmokeJob();
+
+    assert.match(productionSmokeJob, /BASE_URL:\s*https:\/\/cockpit\.threadplane\.ai/);
+    assert.match(productionSmokeJob, /EXAMPLES_URL:\s*https:\/\/examples\.threadplane\.ai/);
+    assert.match(productionSmokeJob, /DEMO_URL:\s*https:\/\/demo\.threadplane\.ai/);
+  });
+
+  it('binds Vercel deploys to the renamed ThreadPlane projects', async () => {
+    const deployJob = await readDeployJob();
+    const workflow = await readWorkflow();
+
+    assert.match(deployJob, /"projectName":"threadplane"/);
+    assert.match(deployJob, /"projectName":"threadplane-cockpit"/);
+    assert.match(deployJob, /"projectName":"threadplane-examples"/);
+    assert.match(workflow, /"projectName":"threadplane-demo"/);
+  });
+
   it('uses the read-only PostHog key for CI drift checks', async () => {
     const postHogSyncPlanJob = await readPostHogSyncPlanJob();
 

--- a/scripts/demo-middleware.ts
+++ b/scripts/demo-middleware.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 /**
  * Vercel Serverless Function proxy for the canonical-demo deployment
- * (demo.cacheplane.ai). Wraps the shared langgraph-proxy factory with:
+ * (demo.threadplane.ai). Wraps the shared langgraph-proxy factory with:
  *   - the rate-limit gate from scripts/rate-limit.ts (Phase 3)
  *   - CORS allowlist + body-byte cap from env (Phase 4)
  *
@@ -14,9 +14,9 @@
 import { createProxyHandler } from './langgraph-proxy';
 import { checkRateLimit } from './rate-limit';
 
-const DEFAULT_ALLOWED_ORIGINS = ['https://demo.cacheplane.ai'];
+const DEFAULT_ALLOWED_ORIGINS = ['https://demo.threadplane.ai'];
 const DEFAULT_MAX_BODY_BYTES = 8192;
-const DEFAULT_TELEMETRY_INGEST_URL = 'https://cacheplane.ai/api/ingest';
+const DEFAULT_TELEMETRY_INGEST_URL = 'https://threadplane.ai/api/ingest';
 
 const allowedOrigins = (() => {
   const raw = process.env['ALLOWED_ORIGINS'];

--- a/scripts/langgraph-proxy.spec.ts
+++ b/scripts/langgraph-proxy.spec.ts
@@ -51,7 +51,7 @@ describe('createProxyHandler', () => {
     );
     const handler = createProxyHandler({
       backendUrl: DEFAULT_BACKEND,
-      telemetryIngestUrl: 'https://cacheplane.ai/api/ingest',
+      telemetryIngestUrl: 'https://threadplane.ai/api/ingest',
     });
     const res = makeRes();
     const body = {
@@ -62,7 +62,7 @@ describe('createProxyHandler', () => {
 
     await handler({
       method: 'POST',
-      headers: { host: 'demo.cacheplane.ai', 'content-type': 'application/json' },
+      headers: { host: 'demo.threadplane.ai', 'content-type': 'application/json' },
       body,
       url: '/api/ingest',
       query: {},
@@ -70,7 +70,7 @@ describe('createProxyHandler', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, init] = fetchMock.mock.calls[0]!;
-    expect(url).toBe('https://cacheplane.ai/api/ingest');
+    expect(url).toBe('https://threadplane.ai/api/ingest');
     expect(init).toEqual(expect.objectContaining({
       method: 'POST',
       headers: { 'content-type': 'application/json' },
@@ -90,13 +90,13 @@ describe('createProxyHandler', () => {
     );
     const handler = createProxyHandler({
       backendUrl: DEFAULT_BACKEND,
-      telemetryIngestUrl: 'https://cacheplane.ai/api/ingest',
+      telemetryIngestUrl: 'https://threadplane.ai/api/ingest',
     });
     const res = makeRes();
 
     await handler({
       method: 'POST',
-      headers: { host: 'demo.cacheplane.ai', 'content-type': 'application/json' },
+      headers: { host: 'demo.threadplane.ai', 'content-type': 'application/json' },
       body: {
         event: 'ngaf:runtime_request_created',
         distinctId: 'browser:test',
@@ -139,7 +139,7 @@ describe('createProxyHandler', () => {
     );
     const handler = createProxyHandler({ backendUrl: DEFAULT_BACKEND });
     const res = makeRes();
-    await handler({ method: 'POST', headers: { 'content-type': 'application/json', host: 'demo.cacheplane.ai' }, body: { hello: 'world' }, url: '/api/threads', query: {} } as never, res as never);
+    await handler({ method: 'POST', headers: { 'content-type': 'application/json', host: 'demo.threadplane.ai' }, body: { hello: 'world' }, url: '/api/threads', query: {} } as never, res as never);
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [calledUrl, init] = fetchMock.mock.calls[0]!;
     expect(calledUrl).toBe(`${DEFAULT_BACKEND}/threads`);
@@ -156,7 +156,7 @@ describe('createProxyHandler', () => {
     );
     const handler = createProxyHandler({ backendUrl: DEFAULT_BACKEND });
     const res = makeRes();
-    await handler({ method: 'GET', headers: { host: 'demo.cacheplane.ai' }, body: undefined, url: '/api/threads/abc?[...path]=threads/abc&limit=10', query: {} } as never, res as never);
+    await handler({ method: 'GET', headers: { host: 'demo.threadplane.ai' }, body: undefined, url: '/api/threads/abc?[...path]=threads/abc&limit=10', query: {} } as never, res as never);
     expect(fetchMock.mock.calls[0]![0]).toBe(`${DEFAULT_BACKEND}/threads/abc?limit=10`);
   });
 
@@ -174,7 +174,7 @@ describe('createProxyHandler', () => {
     );
     const handler = createProxyHandler({ backendUrl: DEFAULT_BACKEND });
     const res = makeRes();
-    await handler({ method: 'POST', headers: { host: 'demo.cacheplane.ai' }, body: {}, url: '/api/threads/abc/runs/stream', query: {} } as never, res as never);
+    await handler({ method: 'POST', headers: { host: 'demo.threadplane.ai' }, body: {}, url: '/api/threads/abc/runs/stream', query: {} } as never, res as never);
     expect(res.setHeader).toHaveBeenCalledWith('content-type', 'text/event-stream');
     expect(res.write).toHaveBeenCalledTimes(2);
     expect(res.end).toHaveBeenCalledTimes(1);
@@ -184,7 +184,7 @@ describe('createProxyHandler', () => {
     vi.spyOn(global, 'fetch').mockRejectedValue(new Error('network down'));
     const handler = createProxyHandler({ backendUrl: DEFAULT_BACKEND });
     const res = makeRes();
-    await handler({ method: 'POST', headers: { host: 'demo.cacheplane.ai' }, body: {}, url: '/api/threads', query: {} } as never, res as never);
+    await handler({ method: 'POST', headers: { host: 'demo.threadplane.ai' }, body: {}, url: '/api/threads', query: {} } as never, res as never);
     expect(res._status).toBe(502);
     expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: 'Proxy error' }));
   });
@@ -196,8 +196,8 @@ describe('createProxyHandler', () => {
     const resolveBackend = vi.fn(() => 'https://override.example.com');
     const handler = createProxyHandler({ resolveBackend });
     const res = makeRes();
-    await handler({ method: 'GET', headers: { host: 'demo.cacheplane.ai', referer: 'https://demo.cacheplane.ai/' }, body: undefined, url: '/api/info', query: {} } as never, res as never);
-    expect(resolveBackend).toHaveBeenCalledWith('https://demo.cacheplane.ai/');
+    await handler({ method: 'GET', headers: { host: 'demo.threadplane.ai', referer: 'https://demo.threadplane.ai/' }, body: undefined, url: '/api/info', query: {} } as never, res as never);
+    expect(resolveBackend).toHaveBeenCalledWith('https://demo.threadplane.ai/');
     expect(fetchMock.mock.calls[0]![0]).toBe('https://override.example.com/info');
   });
 
@@ -208,7 +208,7 @@ describe('createProxyHandler', () => {
     const checkRateLimit = vi.fn();
     const handler = createProxyHandler({ backendUrl: DEFAULT_BACKEND, checkRateLimit });
     const res = makeRes();
-    await handler({ method: 'GET', headers: { host: 'demo.cacheplane.ai' }, body: undefined, url: '/api/info', query: {} } as never, res as never);
+    await handler({ method: 'GET', headers: { host: 'demo.threadplane.ai' }, body: undefined, url: '/api/info', query: {} } as never, res as never);
     expect(checkRateLimit).not.toHaveBeenCalled();
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
@@ -222,7 +222,7 @@ describe('createProxyHandler', () => {
     const res = makeRes();
     await handler({
       method: 'POST',
-      headers: { host: 'demo.cacheplane.ai', 'x-forwarded-for': '203.0.113.5' },
+      headers: { host: 'demo.threadplane.ai', 'x-forwarded-for': '203.0.113.5' },
       body: { assistant_id: 'chat' },
       url: '/api/threads/abc/runs/stream',
       query: {},
@@ -238,7 +238,7 @@ describe('createProxyHandler', () => {
     const res = makeRes();
     await handler({
       method: 'POST',
-      headers: { host: 'demo.cacheplane.ai', 'x-forwarded-for': '203.0.113.5' },
+      headers: { host: 'demo.threadplane.ai', 'x-forwarded-for': '203.0.113.5' },
       body: { assistant_id: 'chat' },
       url: '/api/threads/abc/runs/stream',
       query: {},
@@ -257,17 +257,17 @@ describe('createProxyHandler', () => {
     );
     const handler = createProxyHandler({
       backendUrl: DEFAULT_BACKEND,
-      allowedOrigins: ['https://demo.cacheplane.ai'],
+      allowedOrigins: ['https://demo.threadplane.ai'],
     });
     const res = makeRes();
     await handler({
       method: 'GET',
-      headers: { host: 'demo.cacheplane.ai', origin: 'https://demo.cacheplane.ai' },
+      headers: { host: 'demo.threadplane.ai', origin: 'https://demo.threadplane.ai' },
       body: undefined,
       url: '/api/info',
       query: {},
     } as never, res as never);
-    expect(res.setHeader).toHaveBeenCalledWith('access-control-allow-origin', 'https://demo.cacheplane.ai');
+    expect(res.setHeader).toHaveBeenCalledWith('access-control-allow-origin', 'https://demo.threadplane.ai');
     expect(res.setHeader).toHaveBeenCalledWith('vary', 'origin');
     expect(fetchMock).toHaveBeenCalled();
   });
@@ -276,12 +276,12 @@ describe('createProxyHandler', () => {
     const fetchMock = vi.spyOn(global, 'fetch');
     const handler = createProxyHandler({
       backendUrl: DEFAULT_BACKEND,
-      allowedOrigins: ['https://demo.cacheplane.ai'],
+      allowedOrigins: ['https://demo.threadplane.ai'],
     });
     const res = makeRes();
     await handler({
       method: 'GET',
-      headers: { host: 'demo.cacheplane.ai', origin: 'https://malicious.example' },
+      headers: { host: 'demo.threadplane.ai', origin: 'https://malicious.example' },
       body: undefined,
       url: '/api/info',
       query: {},
@@ -297,12 +297,12 @@ describe('createProxyHandler', () => {
     );
     const handler = createProxyHandler({
       backendUrl: DEFAULT_BACKEND,
-      allowedOrigins: ['https://demo.cacheplane.ai'],
+      allowedOrigins: ['https://demo.threadplane.ai'],
     });
     const res = makeRes();
     await handler({
       method: 'GET',
-      headers: { host: 'demo.cacheplane.ai' },
+      headers: { host: 'demo.threadplane.ai' },
       body: undefined,
       url: '/api/info',
       query: {},
@@ -316,18 +316,18 @@ describe('createProxyHandler', () => {
   it('OPTIONS preflight with allowed Origin returns 204 with echoed Origin', async () => {
     const handler = createProxyHandler({
       backendUrl: DEFAULT_BACKEND,
-      allowedOrigins: ['https://demo.cacheplane.ai'],
+      allowedOrigins: ['https://demo.threadplane.ai'],
     });
     const res = makeRes();
     await handler({
       method: 'OPTIONS',
-      headers: { origin: 'https://demo.cacheplane.ai' },
+      headers: { origin: 'https://demo.threadplane.ai' },
       body: undefined,
       url: '/api/info',
       query: {},
     } as never, res as never);
     expect(res._status).toBe(204);
-    expect(res.setHeader).toHaveBeenCalledWith('access-control-allow-origin', 'https://demo.cacheplane.ai');
+    expect(res.setHeader).toHaveBeenCalledWith('access-control-allow-origin', 'https://demo.threadplane.ai');
   });
 
   it('preserves wildcard CORS when allowedOrigins is undefined (legacy examples behavior)', async () => {
@@ -338,7 +338,7 @@ describe('createProxyHandler', () => {
     const res = makeRes();
     await handler({
       method: 'GET',
-      headers: { host: 'demo.cacheplane.ai', origin: 'https://anywhere.example' },
+      headers: { host: 'demo.threadplane.ai', origin: 'https://anywhere.example' },
       body: undefined,
       url: '/api/info',
       query: {},
@@ -355,7 +355,7 @@ describe('createProxyHandler', () => {
     const bigBody = { content: 'x'.repeat(200) };
     await handler({
       method: 'POST',
-      headers: { host: 'demo.cacheplane.ai', 'content-type': 'application/json' },
+      headers: { host: 'demo.threadplane.ai', 'content-type': 'application/json' },
       body: bigBody,
       url: '/api/threads',
       query: {},
@@ -375,7 +375,7 @@ describe('createProxyHandler', () => {
     await handler({
       method: 'POST',
       headers: {
-        host: 'demo.cacheplane.ai',
+        host: 'demo.threadplane.ai',
         'content-type': 'application/json',
         'content-length': '500',
       },
@@ -400,7 +400,7 @@ describe('createProxyHandler', () => {
     const res = makeRes();
     await handler({
       method: 'POST',
-      headers: { host: 'demo.cacheplane.ai', 'content-type': 'application/json', 'content-length': '999999' },
+      headers: { host: 'demo.threadplane.ai', 'content-type': 'application/json', 'content-length': '999999' },
       body: { content: 'x'.repeat(50000) },
       url: '/api/threads',
       query: {},

--- a/scripts/langgraph-proxy.ts
+++ b/scripts/langgraph-proxy.ts
@@ -46,7 +46,7 @@ export interface ProxyConfig {
   readonly checkRateLimit?: (ip: string) => Promise<{ allowed: boolean; retryAfterSec: number; count: number }>;
   /** Origins to allow via CORS. If undefined, legacy wildcard `*` behavior
    *  preserved (used by cockpit-examples). Each entry is a full origin
-   *  string, e.g. `https://demo.cacheplane.ai`. Match is exact-string. */
+   *  string, e.g. `https://demo.threadplane.ai`. Match is exact-string. */
   readonly allowedOrigins?: readonly string[];
   /** Maximum request body size in bytes. If undefined, no cap (legacy
    *  behavior). Checked against Content-Length first, falls back to


### PR DESCRIPTION
## Summary
- migrate public deployment domains and docs from CachePlane/ngai to ThreadPlane
- rename Vercel project references from cacheplane to threadplane
- preserve hello@cacheplane.ai as the email identity while moving app/site domains to threadplane.ai

## Verification
- npm ci
- npm run generate-agent-context
- npm run generate-api-docs
- node --test scripts/ci-workflow.spec.mjs
- npx vitest run scripts/langgraph-proxy.spec.ts apps/cockpit/scripts/deploy-smoke.spec.ts apps/minting-service/src/lib/email.spec.ts libs/licensing/src/lib/nag.spec.ts
- npx nx test telemetry langgraph chat render cockpit minting-service
- npx nx lint website minting-service
- npx nx build website cockpit
- git diff --check

## Deployment notes
- Vercel projects were renamed to threadplane variants.
- threadplane.ai, www.threadplane.ai, cockpit.threadplane.ai, examples.threadplane.ai, demo.threadplane.ai, and mint.threadplane.ai were added and verified.
- cacheplane.ai project-domain bindings were removed, but the cacheplane.ai DNS zone remains for email records.