### PR TITLE
test(examples-chat): fix no_fixture_match for contact-form welcome chip

### DIFF
--- a/examples/chat/angular/e2e/fixtures/contact-form.json
+++ b/examples/chat/angular/e2e/fixtures/contact-form.json
@@ -1,0 +1,119 @@
+{
+  "fixtures": [
+    {
+      "match": {
+        "userMessage": "contact form"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "name": "render_a2ui_surface",
+            "arguments": {
+              "envelopes": [
+                {
+                  "surfaceUpdate": {
+                    "surfaceId": "contact-form",
+                    "components": [
+                      {
+                        "id": "root",
+                        "component": {
+                          "Column": {
+                            "children": {
+                              "explicitList": [
+                                "form-title",
+                                "name-field",
+                                "email-field",
+                                "subject-field",
+                                "message-field",
+                                "send-button"
+                              ]
+                            },
+                            "alignment": "start"
+                          }
+                        }
+                      },
+                      {
+                        "id": "form-title",
+                        "component": {
+                          "Text": {
+                            "text": { "literalString": "Contact Us" },
+                            "usageHint": "h1"
+                          }
+                        }
+                      },
+                      {
+                        "id": "name-field",
+                        "component": {
+                          "TextField": {
+                            "label": { "literalString": "Name" },
+                            "text": { "literalString": "" },
+                            "textFieldType": "shortText"
+                          }
+                        }
+                      },
+                      {
+                        "id": "email-field",
+                        "component": {
+                          "TextField": {
+                            "label": { "literalString": "Email address" },
+                            "text": { "literalString": "" },
+                            "textFieldType": "shortText"
+                          }
+                        }
+                      },
+                      {
+                        "id": "subject-field",
+                        "component": {
+                          "TextField": {
+                            "label": { "literalString": "Subject" },
+                            "text": { "literalString": "" },
+                            "textFieldType": "shortText"
+                          }
+                        }
+                      },
+                      {
+                        "id": "message-field",
+                        "component": {
+                          "TextField": {
+                            "label": { "literalString": "Message" },
+                            "text": { "literalString": "" },
+                            "textFieldType": "longText"
+                          }
+                        }
+                      },
+                      {
+                        "id": "send-button",
+                        "component": {
+                          "Button": {
+                            "child": "send-text",
+                            "action": {
+                              "name": "submit_contact"
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "id": "send-text",
+                        "component": {
+                          "Text": {
+                            "text": { "literalString": "Send" }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "beginRendering": {
+                    "surfaceId": "contact-form",
+                    "root": "root"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Eliminates the recurring \`No fixture matched\` / \`Background run failed\` cascade in the langgraph backend log during every \`examples/chat — e2e\` CI run.

Root cause: \`lifecycle.spec.ts:61\` ('selecting a welcome suggestion submits and clears welcome state') clicks the 'Demo: render a contact form' welcome chip, which sends the full chip value as the LLM prompt:

> *Show me a contact form with fields for name, email address, subject, and a multi-line message, plus a Send button.*

No fixture matched this prompt. The test passed (it doesn't await the assistant response), but the langgraph backend kept retrying and emitting 404 tracebacks into the log on every run.

## Fix
Add a fixture matching the substring \`'contact form'\` (aimock's \`userMessage\` matching is includes-based) that returns a \`render_a2ui_surface\` tool call building the requested contact-form spec (name / email / subject / message + Send button) — modeled directly on the existing \`a2ui-surface.json\` (feedback form).

## Why a fixture instead of changing the test
- The test specifically validates the chip-click user affordance — short-circuiting it (typing the chip label instead of clicking) would defeat the test's purpose.
- aimock's substring match keeps the fixture key tight (\`'contact form'\`) so it won't shadow existing fixtures or accidentally match unrelated future prompts.

## Test plan
- [x] \`pnpm nx e2e examples-chat-angular --grep \"selecting a welcome suggestion\"\` — green; langgraph log shows \`Background run succeeded\` (was: 4 lines of 404 tracebacks)
- [x] Full \`pnpm nx e2e examples-chat-angular\` — no fixture-related regressions; pre-existing local flakes (error-handling, markdown-surfaces, regenerate, send-receive) unchanged
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)