### PR TITLE
Sidebar mode: enable pushContent so the panel pushes content left

### DIFF
--- a/examples/chat/angular/src/app/modes/sidebar-mode.component.ts
+++ b/examples/chat/angular/src/app/modes/sidebar-mode.component.ts
@@ -11,44 +11,47 @@ import { WelcomeSuggestionsComponent } from './welcome-suggestions.component';
   imports: [ChatSidebarComponent, WelcomeSuggestionsComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <div class="sidebar-mode__background">
-      <p class="sidebar-mode__hint">
-        Use the launcher (right edge) to dismiss or re-open the chat panel.
-      </p>
-    </div>
     <chat-sidebar
       [agent]="agent"
       [views]="catalog"
       [modelOptions]="shell.modelOptions()"
       [selectedModel]="shell.model()"
       [open]="true"
+      [pushContent]="true"
       (selectedModelChange)="shell.onModelChange($event)"
       (replayRequested)="shell.onTimelineReplay($event)"
       (forkRequested)="shell.onTimelineFork($event)"
     >
+      <div class="sidebar-mode__background">
+        <p class="sidebar-mode__hint">
+          Use the launcher (right edge) to dismiss or re-open the chat panel.
+        </p>
+      </div>
       <welcome-suggestions chatWelcomeSuggestions (selected)="send($event)" />
     </chat-sidebar>
   `,
   styles: [`
-    /* chat-sidebar's visible chrome is position: fixed (panel + launcher),
-     * so its host element doesn't need to take layout space. Use
-     * display: contents on the host to drop it from the flow, and let
-     * the sibling .sidebar-mode__background fill the visible area. */
     :host { display: block; flex: 1; min-height: 0; position: relative; }
+    /* Projected into chat-sidebar's default content slot so [pushContent]
+     * applies its right-margin push to this background when the panel
+     * opens. Sized to fill the visible area below the toolbar. */
     .sidebar-mode__background {
       display: grid;
       place-items: center;
-      height: 100%;
+      min-height: calc(100dvh - var(--demo-toolbar-height, 51px));
       color: #8a92a3;
       font-size: 14px;
     }
-    :host ::ng-deep > chat-sidebar { display: contents; }
-    /* The chat-sidebar default content slot (.chat-sidebar__content) is
-     * meant for the consumer's page content when chat-sidebar is in
-     * push mode. The demo uses .sidebar-mode__background instead, so
-     * hide the default content slot — its min-height: 100vh would
-     * otherwise stack below the background and overflow the page. */
-    :host ::ng-deep .chat-sidebar__content { display: none; }
+    /* chat-sidebar's default content slot sets min-height: 100vh which,
+     * combined with the demo's flex column, would otherwise overflow the
+     * page. The background div above provides the visible "page" so we
+     * cap the chat-sidebar__content height to the available space. */
+    :host ::ng-deep .chat-sidebar__content {
+      /* Important: lib sets min-height: 100vh on this slot which would
+       * push the page 51px below the viewport in our flex column under
+       * the 51px toolbar. Override here. */
+      min-height: 0 !important;
+    }
   `],
 })
 export class SidebarMode {


### PR DESCRIPTION
## Summary
- chat-sidebar already supports \`[pushContent]\`: when true and \`open\`, the lib applies \`margin-right: 28rem\` to its default content slot. Setting \`[pushContent]="true"\` in sidebar-mode now pushes the page background left of the panel rather than overlaying.
- Restructured sidebar-mode to project the \`.sidebar-mode__background\` div INTO chat-sidebar's default \`<ng-content>\` slot (was a sibling). Now the push margin actually applies to it.
- Background height switched from \`height: 100%\` to \`min-height: calc(100dvh - var(--demo-toolbar-height, 51px))\` so the area below the toolbar is filled exactly.
- Override \`min-height: 0 !important\` on \`.chat-sidebar__content\` to defeat the lib's \`min-height: 100vh\` (would push content 51px past viewport in our flex column under the top toolbar).

Demo-only change. No lib touched.

## Test plan
- [x] Local chrome-mcp: panel open → \`data-push: "true"\`, \`data-open: "true"\`, \`.chat-sidebar__content\` margin-right 448px (= 28rem), background bgRight 1352 ≈ panelLeft 1351 (content cleanly bounded), pageOverflow 0
- [ ] Canonical demo redeploys on demo.threadplane.ai

🤖 Generated with [Claude Code](https://claude.com/claude-code)