### PR TITLE
fix cockpit content asset tracing

### DIFF
--- a/apps/cockpit/next.config.ts
+++ b/apps/cockpit/next.config.ts
@@ -1,8 +1,21 @@
 import { composePlugins, withNx } from '@nx/next';
 import type { WithNxOptions } from '@nx/next/plugins/with-nx';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const cockpitAppDir = dirname(fileURLToPath(import.meta.url));
 
 export const nextConfig: WithNxOptions = {
   nx: {},
+  outputFileTracingRoot: join(cockpitAppDir, '../..'),
+  outputFileTracingIncludes: {
+    '/*': [
+      '../../cockpit/**/*.md',
+      '../../cockpit/**/*.py',
+      '../../cockpit/**/*.ts',
+      '../../nx.json',
+    ],
+  },
   skipTrailingSlashRedirect: true,
   rewrites: async () => [
     {


### PR DESCRIPTION
## Summary
- Include cockpit runtime content assets in Next output file tracing for production deployments.
- Trace from the monorepo root so server-side content bundle reads can find example code, prompts, docs, backend source, and nx.json.

## Root Cause
The cockpit server reads example content from `cockpit/**` with `fs` at request/render time. The production deployment trace was rooted at the Next app, so files outside `apps/cockpit` were omitted from the Vercel bundle and the Code, Docs, and API panes rendered empty or missing content.

## Verification
- `npx tsx --tsconfig=apps/cockpit/tsconfig.json -e '<content bundle audit>'`
- `npx nx test cockpit`
- `npx nx build cockpit --skip-nx-cache`
- Verified `dist/apps/cockpit/.next/server/app/[...slug]/page.js.nft.json` includes representative code, backend, docs, prompt, and `nx.json` entries.
