### PR TITLE
Fix shared deployment smoke assistant ids

### DIFF
--- a/apps/cockpit/src/lib/verify-shared-deployment.spec.ts
+++ b/apps/cockpit/src/lib/verify-shared-deployment.spec.ts
@@ -7,7 +7,7 @@ import {
 
 describe('verify-shared-deployment', () => {
   it('allows the two-pass planning graph more time than single-response smoke assistants', () => {
-    expect(getSmokeAssistantStreamTimeoutMs('planning')).toBe(90000);
+    expect(getSmokeAssistantStreamTimeoutMs('da-planning')).toBe(90000);
     expect(getSmokeAssistantStreamTimeoutMs('streaming')).toBe(
       DEFAULT_SMOKE_ASSISTANT_STREAM_TIMEOUT_MS,
     );

--- a/scripts/verify-shared-deployment.ts
+++ b/scripts/verify-shared-deployment.ts
@@ -22,8 +22,8 @@ const REQUIRED_URL_KEYS = [
 const SMOKE_ASSISTANT_IDS = [
   'streaming',
   'deployment-runtime',
-  'planning',
-  'filesystem',
+  'da-planning',
+  'da-filesystem',
   'c-generative-ui',
   'c-a2ui',
   'chat',
@@ -37,7 +37,7 @@ export const DEFAULT_SMOKE_ASSISTANT_STREAM_TIMEOUT_MS = 30000;
 const SMOKE_ASSISTANT_STREAM_TIMEOUT_MS: Partial<Record<SmokeAssistantId, number>> = {
   // The planning graph intentionally performs two model calls: one to create
   // structured plan state, then one to execute the plan and answer.
-  planning: 90000,
+  'da-planning': 90000,
   // UI graph assistants can include extra model/tool work before the first AI
   // stream event, and CI has observed them occasionally crossing 30s.
   'c-generative-ui': 90000,


### PR DESCRIPTION
## Summary
- smoke deep-agents planning/filesystem using registered LangGraph assistant ids
- keep deployment URL route keys unchanged
- update verifier timeout coverage for da-planning

## Test Plan
- npx vitest run --config vite.config.mts apps/cockpit/src/lib/verify-shared-deployment.spec.ts
- set -a; source /Users/blove/repos/angular-agent-framework/.env; set +a; npx tsx scripts/verify-shared-deployment.ts