### PR TITLE
fix(chat): suppress duplicate typing-indicator while bubble streams; add c-a2ui welcome chips

### DIFF
--- a/apps/website/content/docs/chat/api/api-docs.json
+++ b/apps/website/content/docs/chat/api/api-docs.json
@@ -1576,6 +1576,12 @@
         "optional": false
       },
       {
+        "name": "currentAssistantStreaming",
+        "type": "Signal<boolean>",
+        "description": "True iff there's a current (last-index) assistant message that's\nstill streaming. The bubble's own caret already signals loading;\nwe suppress the floor typing-indicator in that case so the user\ndoesn't see two loading affordances at once.\n\nMatches the same `streaming + current` condition the bubble uses\nto enable `.chat-message__caret`:\n  `agent().isLoading() && i === agent().messages().length - 1`\n  `i === agent().messages().length - 1`\n\nRestricted to assistant role because the caret only renders on\nassistant bubbles (`:host([data-role=\"assistant\"][data-current=...\n ][data-streaming=...])`).",
+        "optional": false
+      },
+      {
         "name": "forkRequested",
         "type": "OutputEmitterRef<string>",
         "description": "Bubbled from chat-message gutter markers when the user requests a checkpoint fork.",

--- a/cockpit/chat/a2ui/angular/src/app/a2ui.component.ts
+++ b/cockpit/chat/a2ui/angular/src/app/a2ui.component.ts
@@ -1,17 +1,32 @@
 // SPDX-License-Identifier: MIT
 import { Component } from '@angular/core';
-import { ChatComponent, a2uiBasicCatalog } from '@ngaf/chat';
+import { ChatComponent, ChatWelcomeSuggestionComponent, a2uiBasicCatalog } from '@ngaf/chat';
 import { ExampleChatLayoutComponent } from '@ngaf/example-layouts';
 import { agent } from '@ngaf/langgraph';
 import { environment } from '../environments/environment';
 
+const WELCOME_SUGGESTIONS = [
+  { label: 'LAX → JFK',          value: 'I want to fly LAX to JFK' },
+  { label: 'SFO → SEA',          value: 'I want to fly SFO to SEA' },
+] as const;
+
 @Component({
   selector: 'app-a2ui',
   standalone: true,
-  imports: [ChatComponent, ExampleChatLayoutComponent],
+  imports: [ChatComponent, ChatWelcomeSuggestionComponent, ExampleChatLayoutComponent],
   template: `
     <example-chat-layout>
-      <chat main [agent]="agent" [views]="catalog" class="flex-1 min-w-0" />
+      <chat main [agent]="agent" [views]="catalog" class="flex-1 min-w-0">
+        <div chatWelcomeSuggestions>
+          @for (s of suggestions; track s.value) {
+            <chat-welcome-suggestion
+              [label]="s.label"
+              [value]="s.value"
+              (selected)="send($event)"
+            />
+          }
+        </div>
+      </chat>
     </example-chat-layout>
   `,
 })
@@ -21,4 +36,9 @@ export class A2uiComponent {
     assistantId: environment.a2uiAssistantId,
   });
   protected readonly catalog = a2uiBasicCatalog();
+  protected readonly suggestions = WELCOME_SUGGESTIONS;
+
+  protected send(text: string): void {
+    void this.agent.submit({ message: text });
+  }
 }

--- a/libs/chat/src/lib/compositions/chat/chat.component.ts
+++ b/libs/chat/src/lib/compositions/chat/chat.component.ts
@@ -255,7 +255,12 @@ export function isPinned(
               </ng-template>
             </chat-message-list>
 
-            @if (pinned()) {
+            <!-- Suppress the floor typing-indicator while the current
+                 assistant bubble is streaming: its own caret is already
+                 the loading affordance. Showing both reads as visual
+                 noise rather than richer feedback. See
+                 currentAssistantStreaming() on the component class. -->
+            @if (pinned() && !currentAssistantStreaming()) {
               <chat-typing-indicator [agent]="agent()" />
             }
           </div>
@@ -394,6 +399,29 @@ export class ChatComponent {
   protected readonly pinned = signal<boolean>(true);
   private programmaticScrollCount = 0;
   private static readonly PIN_TOLERANCE_PX = 150;
+
+  /**
+   * True iff there's a current (last-index) assistant message that's
+   * still streaming. The bubble's own caret already signals loading;
+   * we suppress the floor typing-indicator in that case so the user
+   * doesn't see two loading affordances at once.
+   *
+   * Matches the same `streaming + current` condition the bubble uses
+   * to enable `.chat-message__caret`:
+   *   `agent().isLoading() && i === agent().messages().length - 1`
+   *   `i === agent().messages().length - 1`
+   *
+   * Restricted to assistant role because the caret only renders on
+   * assistant bubbles (`:host([data-role="assistant"][data-current=...
+   *  ][data-streaming=...])`).
+   */
+  protected readonly currentAssistantStreaming = computed(() => {
+    if (!this.agent().isLoading()) return false;
+    const msgs = this.agent().messages();
+    if (msgs.length === 0) return false;
+    const last = msgs[msgs.length - 1];
+    return last?.role === 'assistant';
+  });
 
   constructor() {
     // Inject the chat lib's root CSS custom properties (--ngaf-chat-bg,


### PR DESCRIPTION
## Summary
Two related demo-polish fixes uncovered while testing the modify-search prefill (PR #454) locally.

### 1. Double loading affordance
During every assistant turn, users saw BOTH the AI bubble's pulsing caret (`.chat-message__caret`) AND the floor `<chat-typing-indicator>` simultaneously. Both communicate the same thing — "agent is working" — and showing two reads as visual noise rather than richer feedback.

**Fix:** new `currentAssistantStreaming()` computed on `ChatComponent` returns true when the latest message is an assistant message AND the agent is loading — exactly the condition under which the bubble caret renders. The `@if (pinned())` guard on the typing indicator now also requires `!currentAssistantStreaming()`, so the caret and the dots no longer overlap.

The typing indicator still appears in its original spot when there's no streaming assistant bubble yet (the moment between user submit and the first AI message append) — so the "I sent something" feedback isn't lost.

### 2. c-a2ui had no welcome chips
The other cockpit chat caps (`generative-ui`, `interrupts`, `subagents`, `tool-calls`) ship two suggestion chips so a first-time visitor doesn't have to type anything to see the demo. `c-a2ui` shipped none — visitors landed on a blank `'How can I help?'` screen with no hint that they should type a booking prompt.

**Fix:** add `'LAX → JFK'` and `'SFO → SEA'` chips matching the existing pattern.

## Files
- `cockpit/chat/a2ui/angular/src/app/a2ui.component.ts` — add welcome chips
- `libs/chat/src/lib/compositions/chat/chat.component.ts` — suppress typing-indicator when current AI bubble is streaming

## Test plan
- [x] `npx nx run chat:build` — green (includes the regression test asserting no `<chat-genui-skeleton>` in this composition)
- [x] `npx nx run chat:test` — green
- [x] `npx nx run cockpit-chat-a2ui-angular:build` — green
- [x] Chrome MCP smoke: c-a2ui welcome screen shows both chips; clicking 'LAX → JFK' fires the prompt; during the ~15-20s gpt-5 structured-output wait the user sees exactly one loading affordance (the bubble caret), not two; form renders correctly
- [ ] CI

## Not in scope
- The 10-30s "void" before c-a2ui's `build_form` renders anything (because gpt-5 structured-output doesn't stream tokens) is a separate, larger issue. The chat-lib has a `<chat-genui-skeleton>` primitive but it's deliberately not mounted in `chat.component.ts` (there's a spec regression test enforcing this — the skeleton was moved out of the bubble intending to land in an outer slot that was never built). Worth a separate spec.
- The LLM occasionally picks the wrong destination from a prompt like "LAX to JFK" (sets Destination=LAX). Build-form prompt-engineering issue, not a chat-lib concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)