### PR TITLE
fix(chat-welcome): apply suggestions gap one level down for wrapped chips

### DIFF
--- a/libs/chat/src/lib/styles/chat-welcome.styles.ts
+++ b/libs/chat/src/lib/styles/chat-welcome.styles.ts
@@ -55,6 +55,17 @@ export const CHAT_WELCOME_STYLES = `
     gap: 8px;
     margin-top: 4px;
   }
+  /* Consumers commonly project chips wrapped in a single <div
+     chatWelcomeSuggestions> element. In that case the slot's flex gap
+     applies between divs (one of them) — not between the chips inside.
+     Apply the same flex layout one level down so the chips actually
+     get spacing. Safe no-op when chips are projected directly. */
+  .chat-welcome__suggestions > div {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 8px;
+  }
   .chat-welcome__suggestions:empty { display: none; }
 `;
 


### PR DESCRIPTION
## Summary
The chat welcome screen's suggestion chips had no visible gap between them on c-a2ui (and a subtle one on c-generative-ui).

Root cause: \`.chat-welcome__suggestions\` is \`display: flex; gap: 8px\`, but every consumer projects chips wrapped in a single \`<div chatWelcomeSuggestions>\` — so the slot's flex gap fires between exactly zero pairs of divs (there's only one), and the chips inside that div sit flush.

## Fix
Add a one-level-deeper CSS rule: \`.chat-welcome__suggestions > div\` also gets \`display: flex; gap: 8px\`. Safe no-op when consumers project chips directly without a wrapper div.

## Files
- \`libs/chat/src/lib/styles/chat-welcome.styles.ts\` — one new CSS rule

## Test plan
- [x] \`npx nx run chat:build\` / \`chat:test\` — green
- [x] \`npx nx run cockpit-chat-a2ui-angular:build\` — green
- [x] Chrome MCP smoke locally: c-a2ui welcome chips now show a clear 8px gap (\`LAX → JFK\` and \`SFO → SEA\` no longer touch)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)