### PR TITLE
fix(cockpit-chat): render messages in c-messages + c-input primitive demos

### DIFF
--- a/cockpit/chat/input/angular/src/app/input.component.ts
+++ b/cockpit/chat/input/angular/src/app/input.component.ts
@@ -1,7 +1,13 @@
 // SPDX-License-Identifier: MIT
 import { Component, computed } from '@angular/core';
-import { ChatInputComponent as ChatInputPrimitive } from '@ngaf/chat';
-import { ChatMessageListComponent } from '@ngaf/chat';
+import {
+  ChatInputComponent as ChatInputPrimitive,
+  ChatMessageListComponent,
+  ChatMessageComponent,
+  ChatStreamingMdComponent,
+  MessageTemplateDirective,
+  messageContent,
+} from '@ngaf/chat';
 import { ExampleChatLayoutComponent } from '@ngaf/example-layouts';
 import { agent } from '@ngaf/langgraph';
 import { environment } from '../environments/environment';
@@ -10,11 +16,23 @@ import { environment } from '../environments/environment';
  * InputComponent showcases ChatInputComponent features including
  * keyboard handling, disabled state, and custom placeholder.
  * A sidebar displays the current input state.
+ *
+ * ChatMessageListComponent renders nothing on its own — it discovers
+ * projected `<ng-template chatMessageTemplate="...">` blocks via
+ * contentChildren. Templates are projected here so the conversation
+ * surface actually displays user + assistant turns.
  */
 @Component({
   selector: 'app-input',
   standalone: true,
-  imports: [ChatInputPrimitive, ChatMessageListComponent, ExampleChatLayoutComponent],
+  imports: [
+    ChatInputPrimitive,
+    ChatMessageListComponent,
+    ChatMessageComponent,
+    ChatStreamingMdComponent,
+    MessageTemplateDirective,
+    ExampleChatLayoutComponent,
+  ],
   template: `
     <example-chat-layout sidebarWidth="w-72">
       <div main class="flex-1 flex flex-col min-w-0">
@@ -22,7 +40,27 @@ import { environment } from '../environments/environment';
           <h1 class="text-sm font-semibold" style="color: var(--ngaf-chat-text);">Chat Input Demo</h1>
         </header>
         <div class="flex-1 overflow-y-auto">
-          <chat-message-list [agent]="agent" />
+          <chat-message-list [agent]="agent">
+            <ng-template chatMessageTemplate="human" let-message>
+              <chat-message [role]="'user'">{{ messageContent(message) }}</chat-message>
+            </ng-template>
+            <ng-template chatMessageTemplate="ai" let-message let-i="index">
+              <chat-message
+                [role]="'assistant'"
+                [streaming]="agent.isLoading() && i === agent.messages().length - 1"
+                [current]="i === agent.messages().length - 1"
+              >
+                <chat-streaming-md
+                  [content]="messageContent(message)"
+                  [streaming]="agent.isLoading() && i === agent.messages().length - 1"
+                />
+              </chat-message>
+            </ng-template>
+            <ng-template chatMessageTemplate="tool" let-message><!-- hidden --></ng-template>
+            <ng-template chatMessageTemplate="system" let-message>
+              <chat-message [role]="'system'">{{ messageContent(message) }}</chat-message>
+            </ng-template>
+          </chat-message-list>
         </div>
         <div class="px-4 py-2" style="background: var(--ngaf-chat-bg);">
           <chat-input [agent]="agent" placeholder="Try typing here..." (submitted)="submitMessage($event)" />
@@ -59,6 +97,7 @@ export class InputComponent {
 
   protected readonly streamStatus = computed(() => this.agent.status());
   protected readonly isLoading = computed(() => this.agent.isLoading());
+  protected readonly messageContent = messageContent;
 
   submitMessage(content: string) {
     this.agent.submit({ message: content });

--- a/cockpit/chat/messages/angular/src/app/messages.component.ts
+++ b/cockpit/chat/messages/angular/src/app/messages.component.ts
@@ -4,6 +4,10 @@ import {
   ChatMessageListComponent,
   ChatInputComponent,
   ChatTypingIndicatorComponent,
+  ChatMessageComponent,
+  ChatStreamingMdComponent,
+  MessageTemplateDirective,
+  messageContent,
 } from '@ngaf/chat';
 import { ExampleChatLayoutComponent } from '@ngaf/example-layouts';
 import { agent } from '@ngaf/langgraph';
@@ -15,11 +19,25 @@ import { environment } from '../environments/environment';
  * Uses ChatMessageListComponent, ChatInputComponent, and ChatTypingIndicatorComponent
  * individually rather than the composed ChatComponent, giving full control
  * over layout and message rendering.
+ *
+ * ChatMessageListComponent renders nothing on its own — it discovers
+ * projected `<ng-template chatMessageTemplate="...">` blocks via
+ * contentChildren and uses them per message type. The composed `<chat>`
+ * component provides default templates internally; primitive consumers
+ * must project them explicitly.
  */
 @Component({
   selector: 'app-messages',
   standalone: true,
-  imports: [ChatMessageListComponent, ChatInputComponent, ChatTypingIndicatorComponent, ExampleChatLayoutComponent],
+  imports: [
+    ChatMessageListComponent,
+    ChatInputComponent,
+    ChatTypingIndicatorComponent,
+    ChatMessageComponent,
+    ChatStreamingMdComponent,
+    MessageTemplateDirective,
+    ExampleChatLayoutComponent,
+  ],
   template: `
     <example-chat-layout sidebarWidth="w-72">
       <div main class="flex-1 flex flex-col min-w-0">
@@ -27,7 +45,27 @@ import { environment } from '../environments/environment';
           <h1 class="text-sm font-semibold" style="color: var(--ngaf-chat-text);">Chat Messages Primitives</h1>
         </header>
         <div class="flex-1 overflow-y-auto">
-          <chat-message-list [agent]="agent" />
+          <chat-message-list [agent]="agent">
+            <ng-template chatMessageTemplate="human" let-message>
+              <chat-message [role]="'user'">{{ messageContent(message) }}</chat-message>
+            </ng-template>
+            <ng-template chatMessageTemplate="ai" let-message let-i="index">
+              <chat-message
+                [role]="'assistant'"
+                [streaming]="agent.isLoading() && i === agent.messages().length - 1"
+                [current]="i === agent.messages().length - 1"
+              >
+                <chat-streaming-md
+                  [content]="messageContent(message)"
+                  [streaming]="agent.isLoading() && i === agent.messages().length - 1"
+                />
+              </chat-message>
+            </ng-template>
+            <ng-template chatMessageTemplate="tool" let-message><!-- hidden --></ng-template>
+            <ng-template chatMessageTemplate="system" let-message>
+              <chat-message [role]="'system'">{{ messageContent(message) }}</chat-message>
+            </ng-template>
+          </chat-message-list>
         </div>
         <div class="px-4 py-2" style="background: var(--ngaf-chat-bg);">
           <chat-typing-indicator [agent]="agent" />
@@ -51,6 +89,8 @@ export class MessagesComponent {
     apiUrl: environment.langGraphApiUrl,
     assistantId: environment.streamingAssistantId,
   });
+
+  protected readonly messageContent = messageContent;
 
   submitMessage(content: string) {
     this.agent.submit({ message: content });


### PR DESCRIPTION
## Summary
Both c-messages and c-input use \`<chat-message-list [agent]=\"agent\" />\` standalone (intentionally, per their docstrings — to demonstrate primitive usage without the composed \`<chat>\` wrapper). But \`ChatMessageListComponent\`'s template is purely \`@for + findTemplate(...)\` over messages — it discovers projected \`<ng-template chatMessageTemplate=\"...\">\` blocks via \`contentChildren\`. With none projected, every \`findTemplate\` returns undefined → nothing renders.

This was a production bug: the demos couldn't actually display messages. Confirmed via PR #462 e2e attempt where langgraph completed successfully but no assistant bubble ever appeared in the DOM.

## Fix
Project the minimal four \`ng-template chatMessageTemplate\` blocks (human, ai, tool, system) — matching the defaults the composed \`<chat>\` component provides internally. Templates use the same public primitives (\`ChatMessageComponent\`, \`ChatStreamingMdComponent\`) so the demos still showcase the intended \"compose primitives without the composition wrapper\" pattern.

## Unblocks
- Task #4 (c-messages aimock e2e pilot — PR #462 closed pending this fix).
- Any documentation/site demos that link to these cap pages.

## Test plan
- [ ] CI Cockpit — build / test (component builds clean).
- [ ] CI Cockpit — build all examples (both demos build).
- [ ] Reviewer: open \`npx nx serve cockpit-chat-messages-angular\` locally; send \"hello\" → user + assistant bubbles render (was: silent failure).
- [ ] Reviewer: open \`npx nx serve cockpit-chat-input-angular\` locally; same check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)