### PR TITLE
fix(chat-checkpoint-marker): close hover-bridge gap so Rewind/Fork stay reachable

### DIFF
--- a/libs/chat/src/lib/primitives/chat-checkpoint-marker/chat-checkpoint-marker.component.ts
+++ b/libs/chat/src/lib/primitives/chat-checkpoint-marker/chat-checkpoint-marker.component.ts
@@ -52,6 +52,20 @@ import { CHAT_HOST_TOKENS } from '../../styles/chat-tokens';
       font-size: 11px;
       z-index: 5;
     }
+    /* Invisible hover-bridge: a 10px-wide pseudo-element bridges the visual
+       gap between the 10px dot and the pill (which sits at left:18px). Without
+       it, the user's cursor crosses 8px of dead space while moving toward the
+       pill — neither dot nor pill is hovered during that traversal, and the
+       pill flickers off before the cursor reaches it. The bridge is created
+       on the pill itself so the same :hover chain keeps the pill open. */
+    .chat-checkpoint-marker__pill::before {
+      content: '';
+      position: absolute;
+      left: -10px;
+      top: 0;
+      bottom: 0;
+      width: 10px;
+    }
     .chat-checkpoint-marker__dot:hover + .chat-checkpoint-marker__pill,
     .chat-checkpoint-marker__dot:focus-visible + .chat-checkpoint-marker__pill,
     .chat-checkpoint-marker__pill:hover {


### PR DESCRIPTION
## Summary
The Rewind / Fork pill on checkpoint markers (visible on hover of the gutter dot) was unclickable: the pill would flicker out before the cursor reached it.

## Root cause
The pill is positioned at \`left: 18px\` from the 10px-wide dot, with a pure-CSS \`:hover\` toggle. The 8px gap between dot's right edge and pill's left edge is dead space — neither element is hovered during traversal, so the pill hides immediately when the cursor leaves the dot.

## Fix
Add a 10px-wide invisible \`::before\` pseudo-element on the pill that extends leftward to meet the dot. The cursor stays inside the pill's hover region for the whole traversal.

- No JS, no behavioral change
- Coarse-pointer (touch) path unaffected — that uses a tap-driven \`data-open\` toggle

## Files
- \`libs/chat/src/lib/primitives/chat-checkpoint-marker/chat-checkpoint-marker.component.ts\` — one CSS rule (8 lines)

## Test plan
- [x] \`npx nx run chat:build\` / \`chat:test\` — green
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)