### PR TITLE
fix(chat): rename chat-sidenav-scrim output close → dismiss

### DIFF
--- a/apps/website/content/docs/chat/api/api-docs.json
+++ b/apps/website/content/docs/chat/api/api-docs.json
@@ -3414,12 +3414,12 @@
   {
     "name": "ChatSidenavScrimComponent",
     "kind": "class",
-    "description": "Backdrop scrim for chat-sidenav's drawer mode, rendered as a sibling of\n<chat-sidenav> so its z-index sits cleanly between the page content\nand the drawer host (escapes the drawer host's stacking context).\n\nUsage:\n  <chat-sidenav-scrim [open]=\"drawerOpen()\" (close)=\"drawerOpen.set(false)\" />\n  <chat-sidenav [(open)]=\"drawerOpen\" ...></chat-sidenav>",
+    "description": "Backdrop scrim for chat-sidenav's drawer mode, rendered as a sibling of\n<chat-sidenav> so its z-index sits cleanly between the page content\nand the drawer host (escapes the drawer host's stacking context).\n\nUsage:\n  <chat-sidenav-scrim [open]=\"drawerOpen()\" (dismiss)=\"drawerOpen.set(false)\" />\n  <chat-sidenav [(open)]=\"drawerOpen\" ...></chat-sidenav>",
     "params": [],
     "examples": [],
     "properties": [
       {
-        "name": "close",
+        "name": "dismiss",
         "type": "OutputEmitterRef<void>",
         "description": "Fires when the user clicks the backdrop.",
         "optional": false

--- a/examples/chat/angular/src/app/shell/demo-shell.component.html
+++ b/examples/chat/angular/src/app/shell/demo-shell.component.html
@@ -60,7 +60,7 @@
 
   <chat-sidenav-scrim
     [open]="sidenavMode() === 'drawer' && drawerOpen()"
-    (close)="drawerOpen.set(false)"
+    (dismiss)="drawerOpen.set(false)"
   />
   <chat-sidenav
     [threads]="visibleThreads()"

--- a/libs/chat/src/lib/primitives/chat-sidenav-scrim/chat-sidenav-scrim.component.spec.ts
+++ b/libs/chat/src/lib/primitives/chat-sidenav-scrim/chat-sidenav-scrim.component.spec.ts
@@ -24,13 +24,13 @@ describe('ChatSidenavScrimComponent', () => {
     expect(btn.getAttribute('aria-label')).toBe('Close conversations');
   });
 
-  it('emits (close) on click', () => {
+  it('emits (dismiss) on click', () => {
     fx.componentRef.setInput('open', true);
     fx.detectChanges();
-    let closed = false;
-    fx.componentInstance.close.subscribe(() => { closed = true; });
+    let dismissed = false;
+    fx.componentInstance.dismiss.subscribe(() => { dismissed = true; });
     const btn = fx.nativeElement.querySelector('button.chat-sidenav-scrim__button') as HTMLButtonElement;
     btn.click();
-    expect(closed).toBe(true);
+    expect(dismissed).toBe(true);
   });
 });

--- a/libs/chat/src/lib/primitives/chat-sidenav-scrim/chat-sidenav-scrim.component.ts
+++ b/libs/chat/src/lib/primitives/chat-sidenav-scrim/chat-sidenav-scrim.component.ts
@@ -8,7 +8,7 @@ import { ChangeDetectionStrategy, Component, input, output } from '@angular/core
  * and the drawer host (escapes the drawer host's stacking context).
  *
  * Usage:
- *   <chat-sidenav-scrim [open]="drawerOpen()" (close)="drawerOpen.set(false)" />
+ *   <chat-sidenav-scrim [open]="drawerOpen()" (dismiss)="drawerOpen.set(false)" />
  *   <chat-sidenav [(open)]="drawerOpen" ...></chat-sidenav>
  */
 @Component({
@@ -21,7 +21,7 @@ import { ChangeDetectionStrategy, Component, input, output } from '@angular/core
         type="button"
         class="chat-sidenav-scrim__button"
         aria-label="Close conversations"
-        (click)="close.emit()"
+        (click)="dismiss.emit()"
       ></button>
     }
   `,
@@ -44,5 +44,5 @@ export class ChatSidenavScrimComponent {
   /** When true, render the backdrop button covering the viewport. */
   readonly open = input<boolean>(false);
   /** Fires when the user clicks the backdrop. */
-  readonly close = output<void>();
+  readonly dismiss = output<void>();
 }


### PR DESCRIPTION
## Summary

- Renames `ChatSidenavScrimComponent`'s `close` output to `dismiss`.
- `close` is a standard DOM event name, which trips `@angular-eslint/no-output-native` and was the lone error failing `Library — lint / test / build` after PR #477.
- Updates the only consumer (the chat demo shell template) and the component spec + docstring.

3 files, 8 insertions, 8 deletions.

## Test plan

- [x] `npx nx run chat:lint` → success (was failing on the `close` output).
- [ ] CI: full Library lint/test/build to confirm green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)