### PR TITLE
debug(langgraph): add console.debug to LangGraphThreadsAdapter.refresh()

### DIFF
--- a/apps/website/content/docs/agent/api/api-docs.json
+++ b/apps/website/content/docs/agent/api/api-docs.json
@@ -331,7 +331,7 @@
       {
         "name": "refresh",
         "signature": "refresh()",
-        "description": "Fetch the latest thread list from the server. Failures are\n logged via `console.error` (not swallowed silently — silent\n catches have masked prod issues in the past).",
+        "description": "Fetch the latest thread list from the server. Failures are\n logged via `console.error` (not swallowed silently — silent\n catches have masked prod issues in the past).\n\n Invocation and resolution are logged at `console.debug` so prod\n inspection can distinguish \"never called\" from \"called but\n resolved empty\" from \"called and threw.\" This was prompted by a\n demo.threadplane.ai cold-load bug where the sidenav stayed empty\n with no visible signal. Tighten the log volume if it becomes\n noisy.",
         "params": []
       },
       {

--- a/libs/langgraph/src/lib/threads/threads-adapter.ts
+++ b/libs/langgraph/src/lib/threads/threads-adapter.ts
@@ -78,10 +78,19 @@ export class LangGraphThreadsAdapter {
 
   /** Fetch the latest thread list from the server. Failures are
    *  logged via `console.error` (not swallowed silently — silent
-   *  catches have masked prod issues in the past). */
+   *  catches have masked prod issues in the past).
+   *
+   *  Invocation and resolution are logged at `console.debug` so prod
+   *  inspection can distinguish "never called" from "called but
+   *  resolved empty" from "called and threw." This was prompted by a
+   *  demo.threadplane.ai cold-load bug where the sidenav stayed empty
+   *  with no visible signal. Tighten the log volume if it becomes
+   *  noisy. */
   async refresh(): Promise<void> {
+    console.debug('[LangGraphThreadsAdapter.refresh] invoked');
     try {
       const list = await this.client.threads.search({ limit: 50 });
+      console.debug('[LangGraphThreadsAdapter.refresh] resolved', list.length);
       const mapped = list.map((t) => this.toThread(t));
       this._threads.set(
         mapped


### PR DESCRIPTION
## Summary

PR #488 already replaced the silent catch with `console.error` in the new shared adapter. This adds the complementary `console.debug` calls on invoke + resolve so prod can distinguish:
- "never called" (effect not firing)
- "called but resolved empty"
- "called and threw" (already covered by console.error from #488)

## Why

Production demo (`demo.threadplane.ai/embed`) shows empty sidenav on cold load even though `/api/threads/search` returns 50 threads when poked from the page console. After deploy + reload, presence/absence of `[LangGraphThreadsAdapter.refresh] invoked` tells us whether the effect even fires.

## Test plan

- [x] `vitest run threads-adapter` — 7/7 pass
- [ ] CI green
- [ ] After merge + deploy: check console on cold-load of `demo.threadplane.ai/embed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)