### PR TITLE
fix(graph): use SDK in-process ASGI transport for thread metadata writes

### DIFF
--- a/cockpit/chat/a2ui/python/src/graph.py
+++ b/cockpit/chat/a2ui/python/src/graph.py
@@ -782,7 +782,11 @@ async def generate_title(state: MessagesState, config) -> dict:
     thread_id = (config.get("configurable") or {}).get("thread_id")
     if not thread_id:
         return {}
-    sdk_url = os.environ.get("LANGGRAPH_API_URL", "http://localhost:2024")
+    # url=None lets the SDK use its in-process ASGI transport when the
+    # call originates from inside a LangGraph server graph (always the
+    # case here). The old fallback to localhost:2024 forced an HTTP
+    # round-trip that fails on the prod runtime container. See PR #493.
+    sdk_url = os.environ.get("LANGGRAPH_API_URL")
     try:
         client = get_client(url=sdk_url)
         thread = await client.threads.get(thread_id)

--- a/cockpit/chat/threads/python/src/graph.py
+++ b/cockpit/chat/threads/python/src/graph.py
@@ -44,7 +44,12 @@ async def generate_title(state: MessagesState, config) -> dict:
     thread_id = (config.get("configurable") or {}).get("thread_id")
     if not thread_id:
         return {}
-    sdk_url = os.environ.get("LANGGRAPH_API_URL", "http://localhost:2024")
+    # url=None lets the SDK use its in-process ASGI transport when the
+    # call originates from inside a LangGraph server graph (always the
+    # case here). The old fallback to localhost:2024 forced an HTTP
+    # round-trip that fails on the prod runtime container. See PR #492
+    # for the diagnosis trail.
+    sdk_url = os.environ.get("LANGGRAPH_API_URL")
     try:
         client = get_client(url=sdk_url)
         thread = await client.threads.get(thread_id)

--- a/examples/chat/python/src/graph.py
+++ b/examples/chat/python/src/graph.py
@@ -97,7 +97,15 @@ async def _maybe_write_thread_title(state: "State", config: RunnableConfig) -> d
     """
     global _threads_client
     thread_id = (config.get("configurable") or {}).get("thread_id")
-    sdk_url = os.environ.get("LANGGRAPH_API_URL", "http://localhost:2024")
+    # url=None lets the SDK use its in-process ASGI transport when the
+    # call originates from inside a LangGraph server graph (which is
+    # always the case here). The old fallback to http://localhost:2024
+    # PREVENTED that path: it always forced an HTTP round-trip to a
+    # port that doesn't exist on the prod runtime container (it does
+    # locally because `langgraph dev` listens on 2024 — which is why
+    # this only broke in prod). LANGGRAPH_API_URL is only honoured
+    # when explicitly set, e.g. for cross-process callbacks.
+    sdk_url = os.environ.get("LANGGRAPH_API_URL")
     if not isinstance(thread_id, str) or not thread_id:
         return {"skipped": "no thread_id in config"}
 


### PR DESCRIPTION
## Root cause (diagnosed via PR #492's @traceable wrapper)

```json
{
  "error_type": "ConnectError",
  "error_message": "All connection attempts failed",
  "sdk_url": "http://localhost:2024",
  "thread_id": "019e4768-143b-7f73-8da2-55c9657d478d"
}
```

The Python helper was calling `get_client(url='http://localhost:2024')` whenever `LANGGRAPH_API_URL` was unset, then HTTP-calling back into the runtime. In local dev this accidentally works because `langgraph dev` listens on 2024. On the prod runtime container the server is on a different port — every title write threw `ConnectError`, the bare `except` swallowed it, every prod thread showed "Untitled."

## Fix

Pass `url=os.environ.get("LANGGRAPH_API_URL")` (no fallback). When `None`, the SDK uses its **in-process ASGI transport** — the canonical path for graph-to-server self-calls. From the SDK docstring:

> If `None`, the client first attempts an in-process connection via ASGI transport. ... This only works if the client is used from within the Agent server.

Applies to:
- `examples/chat/python` (the demo where the bug surfaced)
- `cockpit/chat/threads/python` (same anti-pattern; would've failed on prod for the same reason)

## Verification

PR #492's `@traceable` instrumentation stays. After merge + deploy, a probe should produce a LangSmith run with `outputs.wrote_title: "<title slice>"` instead of the ConnectError.

## Test plan

- [x] Both graphs compile + import (`from src.graph import graph`)
- [ ] CI green
- [ ] After merge + deploy: probe → LangSmith run shows `wrote_title`, `/api/threads/<id>.metadata.title` populated, sidenav row shows the title (not "Untitled")
- [ ] If the verification probe still fails, the @traceable output will tell us what changed

## Trail

- #486 — frontend debug logs (proved refresh works)
- #491 — Python print() logs (couldn't see them via API)
- #492 — @traceable wrapper (surfaced ConnectError + sdk_url)
- **#493 (this PR)** — root-cause fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)