### PR TITLE
test(website): add retries: CI ? 2 : 0 to playwright config

### DIFF
--- a/apps/website/playwright.config.ts
+++ b/apps/website/playwright.config.ts
@@ -10,6 +10,9 @@ const reuseExistingServer = process.env['PLAYWRIGHT_REUSE_EXISTING_SERVER'] === 
 export default defineConfig({
   testDir: './e2e',
   fullyParallel: true,
+  // Match the cockpit configs: 2 retries on CI to absorb transient Next.js
+  // dev-server startup flake; 0 locally for fast feedback.
+  retries: process.env['CI'] ? 2 : 0,
   use: {
     baseURL,
   },


### PR DESCRIPTION
## Summary
Adds \`retries: process.env['CI'] ? 2 : 0\` to \`apps/website/playwright.config.ts\` to align with all cockpit cap configs. Absorbs transient Next.js dev-server startup flake; local runs keep retries=0 for fast feedback.

Identified during the post-Task-#4 e2e audit (item #3 in the recommended task ordering).

## Test plan
- [ ] CI \`Website — e2e\` gate passes.
- [ ] Future transient flakes self-recover without re-running CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)