### PR TITLE
fix(examples-chat): collapse mode routes via UrlMatcher (unbreaks e2e + Vercel)

### DIFF
--- a/examples/chat/angular/src/app/app.routes.ts
+++ b/examples/chat/angular/src/app/app.routes.ts
@@ -1,12 +1,34 @@
 // SPDX-License-Identifier: MIT
-import { Routes } from '@angular/router';
+import { Routes, UrlMatcher, UrlSegment } from '@angular/router';
 
-// Each mode gets two route entries: a stateless `<mode>` and a
-// thread-scoped `<mode>/:threadId`. Angular Router doesn't support
-// `?`-style optional params, hence the duplication. DemoShell's
-// URL ↔ signal sync (see spec 2026-05-20-url-thread-routing-design.md)
-// reads `route.firstChild.paramMap.threadId` so both shapes feed the
-// same handler.
+/** Matcher factory: collapses `<mode>` and `<mode>/<threadId>` into a
+ *  single route entry. Two separate route entries (`embed` + `embed/:threadId`)
+ *  cause Angular to tear down + remount the mode component when navigating
+ *  from one to the other — which, post-PR-#500, was killing the in-flight
+ *  stream when the agent auto-created a thread mid-send and our
+ *  signal→URL effect navigated `/embed` → `/embed/<new-id>`.
+ *
+ *  This matcher recognises both URL shapes as the same route, so the
+ *  component instance survives the navigation.
+ *
+ *  Exported `posParams.threadId` is consumable via ActivatedRoute /
+ *  router.firstChild.paramMap if a consumer ever needs it; DemoShell
+ *  itself reads from `router.url` via `parseUrl()` and doesn't depend
+ *  on the param being plumbed through ActivatedRoute. */
+function modeMatcher(modeName: string): UrlMatcher {
+  return (segments: UrlSegment[]) => {
+    if (segments.length === 0) return null;
+    if (segments[0].path !== modeName) return null;
+    if (segments.length === 1) {
+      return { consumed: segments, posParams: {} };
+    }
+    if (segments.length === 2) {
+      return { consumed: segments, posParams: { threadId: segments[1] } };
+    }
+    return null;
+  };
+}
+
 export const routes: Routes = [
   { path: '', pathMatch: 'full', redirectTo: 'embed' },
   {
@@ -15,32 +37,17 @@ export const routes: Routes = [
       import('./shell/demo-shell.component').then((m) => m.DemoShell),
     children: [
       {
-        path: 'embed',
+        matcher: modeMatcher('embed'),
         loadComponent: () =>
           import('./modes/embed-mode.component').then((m) => m.EmbedMode),
       },
       {
-        path: 'embed/:threadId',
-        loadComponent: () =>
-          import('./modes/embed-mode.component').then((m) => m.EmbedMode),
-      },
-      {
-        path: 'popup',
+        matcher: modeMatcher('popup'),
         loadComponent: () =>
           import('./modes/popup-mode.component').then((m) => m.PopupMode),
       },
       {
-        path: 'popup/:threadId',
-        loadComponent: () =>
-          import('./modes/popup-mode.component').then((m) => m.PopupMode),
-      },
-      {
-        path: 'sidebar',
-        loadComponent: () =>
-          import('./modes/sidebar-mode.component').then((m) => m.SidebarMode),
-      },
-      {
-        path: 'sidebar/:threadId',
+        matcher: modeMatcher('sidebar'),
         loadComponent: () =>
           import('./modes/sidebar-mode.component').then((m) => m.SidebarMode),
       },


### PR DESCRIPTION
## Summary

#500 broke `examples/chat — e2e` and `Canonical demo → Vercel` on main. Investigation:

**Diagnosis:** #500 added two route entries per mode (`embed`, `embed/:threadId`, etc — six entries total). Navigating from `/embed` to `/embed/<id>` is a route **change** (different entry), which makes Angular tear down + remount the mode component — killing any active stream.

**Symptom:** e2e test `error-handling.spec.ts:5` and `keyboard-accessibility.spec.ts:29` both depend on sending a message and seeing the assistant message render. After #500, the agent auto-creates a thread mid-send → signal→URL effect fires `router.navigate('/embed/<new-id>')` → component remounts → stream dies → assistant message never arrives → test fails.

**Cascade:** `Canonical demo → Vercel` gates on e2e green, so prod has been stuck on the pre-#500 bundle since merge.

## Fix

Collapse the per-mode pair into one route entry via `UrlMatcher`. Both `/<mode>` and `/<mode>/<threadId>` now resolve to the same route, so the component instance survives the navigation and the stream keeps flowing.

## Test plan

- [x] `nx build examples-chat-angular` green
- [ ] CI green (especially `examples/chat — e2e`)
- [ ] Vercel deploy succeeds → prod bundle hash updates
- [ ] After deploy: drive Chrome through the four #500 flows again on prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)