### PR TITLE
fix(ci): minting health check URL — minting → mint subdomain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -636,7 +636,7 @@ jobs:
           npx vercel deploy --prebuilt --prod --yes --token=${{ secrets.VERCEL_TOKEN }}
       - name: Verify minting service health
         env:
-          MINTING_URL: https://minting.threadplane.ai
+          MINTING_URL: https://mint.threadplane.ai
         run: |
           for i in 1 2 3 4 5; do
             if curl -sf -o /dev/null "$MINTING_URL/api/health"; then


### PR DESCRIPTION
## Summary

Tiny correction to PR C (#510). The Vercel project \`threadplane-minting-service\` has \`mint.threadplane.ai\` (not \`minting.threadplane.ai\`) as its assigned domain — confirmed via Vercel API on this team. The post-deploy health check in \`ci.yml\` was hard-coded to the wrong subdomain.

One-line fix, one file changed.

## Test plan

- [x] \`grep mint\\.threadplane .github/workflows/ci.yml\` → 1 hit (the env line)
- [x] \`grep minting\\.threadplane .github/workflows/ci.yml\` → 0 hits
- [x] \`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"\` → ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)