### PR TITLE
refactor(e2e): use @ngaf-internal/e2e-harness alias in cap specs

### DIFF
--- a/cockpit/chat/a2ui/angular/e2e/c-a2ui.spec.ts
+++ b/cockpit/chat/a2ui/angular/e2e/c-a2ui.spec.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { test, expect } from '@playwright/test';
-import { submitAndWaitForResponse } from '../../../../../libs/e2e-harness/src';
+import { submitAndWaitForResponse } from '@ngaf-internal/e2e-harness';
 
 test('c-a2ui: LAX-JFK prompt renders a2ui-surface with form spec', async ({ page }) => {
   await submitAndWaitForResponse(page, 'I want to fly LAX to JFK');

--- a/cockpit/chat/a2ui/angular/e2e/global-setup-impl.ts
+++ b/cockpit/chat/a2ui/angular/e2e/global-setup-impl.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { resolve } from 'node:path';
-import { createGlobalSetup } from '../../../../../libs/e2e-harness/src';
+import { createGlobalSetup } from '@ngaf-internal/e2e-harness';
 
 export default createGlobalSetup({
   langgraphCwd: 'cockpit/chat/a2ui/python',

--- a/cockpit/chat/a2ui/angular/e2e/tsconfig.json
+++ b/cockpit/chat/a2ui/angular/e2e/tsconfig.json
@@ -7,8 +7,25 @@
     "strict": true,
     "skipLibCheck": true,
     "noEmit": true,
-    "types": ["node"]
+    "types": [
+      "node"
+    ],
+    "baseUrl": "../../../../..",
+    "paths": {
+      "@ngaf-internal/e2e-harness": [
+        "libs/e2e-harness/src/index.ts"
+      ],
+      "@ngaf-internal/e2e-harness/global-teardown": [
+        "libs/e2e-harness/src/global-teardown.ts"
+      ]
+    }
   },
-  "include": ["**/*.ts"],
-  "exclude": ["node_modules", "test-results", "playwright-report"]
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "test-results",
+    "playwright-report"
+  ]
 }

--- a/cockpit/chat/generative-ui/angular/e2e/c-generative-ui.spec.ts
+++ b/cockpit/chat/generative-ui/angular/e2e/c-generative-ui.spec.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { test, expect } from '@playwright/test';
-import { submitAndWaitForResponse } from '../../../../../libs/e2e-harness/src';
+import { submitAndWaitForResponse } from '@ngaf-internal/e2e-harness';
 
 test('c-generative-ui: dashboard prompt renders chat-generative-ui surface', async ({ page }) => {
   await submitAndWaitForResponse(page, 'Show me a dashboard of airline operations.');

--- a/cockpit/chat/generative-ui/angular/e2e/global-setup-impl.ts
+++ b/cockpit/chat/generative-ui/angular/e2e/global-setup-impl.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { resolve } from 'node:path';
-import { createGlobalSetup } from '../../../../../libs/e2e-harness/src';
+import { createGlobalSetup } from '@ngaf-internal/e2e-harness';
 
 export default createGlobalSetup({
   langgraphCwd: 'cockpit/chat/generative-ui/python',

--- a/cockpit/chat/generative-ui/angular/e2e/tsconfig.json
+++ b/cockpit/chat/generative-ui/angular/e2e/tsconfig.json
@@ -7,8 +7,25 @@
     "strict": true,
     "skipLibCheck": true,
     "noEmit": true,
-    "types": ["node"]
+    "types": [
+      "node"
+    ],
+    "baseUrl": "../../../../..",
+    "paths": {
+      "@ngaf-internal/e2e-harness": [
+        "libs/e2e-harness/src/index.ts"
+      ],
+      "@ngaf-internal/e2e-harness/global-teardown": [
+        "libs/e2e-harness/src/global-teardown.ts"
+      ]
+    }
   },
-  "include": ["**/*.ts"],
-  "exclude": ["node_modules", "test-results", "playwright-report"]
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "test-results",
+    "playwright-report"
+  ]
 }

--- a/cockpit/chat/input/angular/e2e/c-input.spec.ts
+++ b/cockpit/chat/input/angular/e2e/c-input.spec.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { test, expect } from '@playwright/test';
-import { submitAndWaitForResponse } from '../../../../../libs/e2e-harness/src';
+import { submitAndWaitForResponse } from '@ngaf-internal/e2e-harness';
 
 const PROMPT = 'Hello';
 

--- a/cockpit/chat/input/angular/e2e/global-setup-impl.ts
+++ b/cockpit/chat/input/angular/e2e/global-setup-impl.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { resolve } from 'node:path';
-import { createGlobalSetup } from '../../../../../libs/e2e-harness/src';
+import { createGlobalSetup } from '@ngaf-internal/e2e-harness';
 
 export default createGlobalSetup({
   langgraphCwd: 'cockpit/chat/input/python',

--- a/cockpit/chat/input/angular/e2e/tsconfig.json
+++ b/cockpit/chat/input/angular/e2e/tsconfig.json
@@ -7,8 +7,25 @@
     "strict": true,
     "skipLibCheck": true,
     "noEmit": true,
-    "types": ["node"]
+    "types": [
+      "node"
+    ],
+    "baseUrl": "../../../../..",
+    "paths": {
+      "@ngaf-internal/e2e-harness": [
+        "libs/e2e-harness/src/index.ts"
+      ],
+      "@ngaf-internal/e2e-harness/global-teardown": [
+        "libs/e2e-harness/src/global-teardown.ts"
+      ]
+    }
   },
-  "include": ["**/*.ts"],
-  "exclude": ["node_modules", "test-results", "playwright-report"]
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "test-results",
+    "playwright-report"
+  ]
 }

--- a/cockpit/chat/interrupts/angular/e2e/c-interrupts.spec.ts
+++ b/cockpit/chat/interrupts/angular/e2e/c-interrupts.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test';
 import {
   sendPromptAndWaitForInterrupt,
   clickInterruptActionAndWaitFinal,
-} from '../../../../../libs/e2e-harness/src';
+} from '@ngaf-internal/e2e-harness';
 
 test('c-interrupts: confirm path books the flight via book_flight + resume("confirm")', async ({ page }) => {
   await sendPromptAndWaitForInterrupt(page, 'Book me on UA123.');

--- a/cockpit/chat/interrupts/angular/e2e/global-setup-impl.ts
+++ b/cockpit/chat/interrupts/angular/e2e/global-setup-impl.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { resolve } from 'node:path';
-import { createGlobalSetup } from '../../../../../libs/e2e-harness/src';
+import { createGlobalSetup } from '@ngaf-internal/e2e-harness';
 
 export default createGlobalSetup({
   // Per-cap cleanup PR: each chat cap runs its OWN standalone backend

--- a/cockpit/chat/interrupts/angular/e2e/tsconfig.json
+++ b/cockpit/chat/interrupts/angular/e2e/tsconfig.json
@@ -7,8 +7,25 @@
     "strict": true,
     "skipLibCheck": true,
     "noEmit": true,
-    "types": ["node"]
+    "types": [
+      "node"
+    ],
+    "baseUrl": "../../../../..",
+    "paths": {
+      "@ngaf-internal/e2e-harness": [
+        "libs/e2e-harness/src/index.ts"
+      ],
+      "@ngaf-internal/e2e-harness/global-teardown": [
+        "libs/e2e-harness/src/global-teardown.ts"
+      ]
+    }
   },
-  "include": ["**/*.ts"],
-  "exclude": ["node_modules", "test-results", "playwright-report"]
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "test-results",
+    "playwright-report"
+  ]
 }

--- a/cockpit/chat/messages/angular/e2e/c-messages.spec.ts
+++ b/cockpit/chat/messages/angular/e2e/c-messages.spec.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { test, expect } from '@playwright/test';
-import { submitAndWaitForResponse } from '../../../../../libs/e2e-harness/src';
+import { submitAndWaitForResponse } from '@ngaf-internal/e2e-harness';
 
 const PROMPT = 'Hello';
 

--- a/cockpit/chat/messages/angular/e2e/global-setup-impl.ts
+++ b/cockpit/chat/messages/angular/e2e/global-setup-impl.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { resolve } from 'node:path';
-import { createGlobalSetup } from '../../../../../libs/e2e-harness/src';
+import { createGlobalSetup } from '@ngaf-internal/e2e-harness';
 
 export default createGlobalSetup({
   langgraphCwd: 'cockpit/chat/messages/python',

--- a/cockpit/chat/messages/angular/e2e/tsconfig.json
+++ b/cockpit/chat/messages/angular/e2e/tsconfig.json
@@ -7,8 +7,25 @@
     "strict": true,
     "skipLibCheck": true,
     "noEmit": true,
-    "types": ["node"]
+    "types": [
+      "node"
+    ],
+    "baseUrl": "../../../../..",
+    "paths": {
+      "@ngaf-internal/e2e-harness": [
+        "libs/e2e-harness/src/index.ts"
+      ],
+      "@ngaf-internal/e2e-harness/global-teardown": [
+        "libs/e2e-harness/src/global-teardown.ts"
+      ]
+    }
   },
-  "include": ["**/*.ts"],
-  "exclude": ["node_modules", "test-results", "playwright-report"]
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "test-results",
+    "playwright-report"
+  ]
 }

--- a/cockpit/chat/subagents/angular/e2e/c-subagents.spec.ts
+++ b/cockpit/chat/subagents/angular/e2e/c-subagents.spec.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { test, expect } from '@playwright/test';
-import { submitAndWaitForResponse } from '../../../../../libs/e2e-harness/src';
+import { submitAndWaitForResponse } from '@ngaf-internal/e2e-harness';
 
 const PROMPT = 'Plan a trip from LAX to JFK';
 

--- a/cockpit/chat/subagents/angular/e2e/global-setup-impl.ts
+++ b/cockpit/chat/subagents/angular/e2e/global-setup-impl.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { resolve } from 'node:path';
-import { createGlobalSetup } from '../../../../../libs/e2e-harness/src';
+import { createGlobalSetup } from '@ngaf-internal/e2e-harness';
 
 export default createGlobalSetup({
   // Per-cap cleanup PR: each chat cap runs its OWN standalone backend

--- a/cockpit/chat/subagents/angular/e2e/tsconfig.json
+++ b/cockpit/chat/subagents/angular/e2e/tsconfig.json
@@ -7,8 +7,25 @@
     "strict": true,
     "skipLibCheck": true,
     "noEmit": true,
-    "types": ["node"]
+    "types": [
+      "node"
+    ],
+    "baseUrl": "../../../../..",
+    "paths": {
+      "@ngaf-internal/e2e-harness": [
+        "libs/e2e-harness/src/index.ts"
+      ],
+      "@ngaf-internal/e2e-harness/global-teardown": [
+        "libs/e2e-harness/src/global-teardown.ts"
+      ]
+    }
   },
-  "include": ["**/*.ts"],
-  "exclude": ["node_modules", "test-results", "playwright-report"]
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "test-results",
+    "playwright-report"
+  ]
 }

--- a/cockpit/chat/theming/angular/e2e/c-theming.spec.ts
+++ b/cockpit/chat/theming/angular/e2e/c-theming.spec.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { test, expect } from '@playwright/test';
-import { submitAndWaitForResponse } from '../../../../../libs/e2e-harness/src';
+import { submitAndWaitForResponse } from '@ngaf-internal/e2e-harness';
 
 const PROMPT = 'Hello';
 

--- a/cockpit/chat/theming/angular/e2e/global-setup-impl.ts
+++ b/cockpit/chat/theming/angular/e2e/global-setup-impl.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { resolve } from 'node:path';
-import { createGlobalSetup } from '../../../../../libs/e2e-harness/src';
+import { createGlobalSetup } from '@ngaf-internal/e2e-harness';
 
 export default createGlobalSetup({
   langgraphCwd: 'cockpit/chat/theming/python',

--- a/cockpit/chat/theming/angular/e2e/tsconfig.json
+++ b/cockpit/chat/theming/angular/e2e/tsconfig.json
@@ -7,8 +7,25 @@
     "strict": true,
     "skipLibCheck": true,
     "noEmit": true,
-    "types": ["node"]
+    "types": [
+      "node"
+    ],
+    "baseUrl": "../../../../..",
+    "paths": {
+      "@ngaf-internal/e2e-harness": [
+        "libs/e2e-harness/src/index.ts"
+      ],
+      "@ngaf-internal/e2e-harness/global-teardown": [
+        "libs/e2e-harness/src/global-teardown.ts"
+      ]
+    }
   },
-  "include": ["**/*.ts"],
-  "exclude": ["node_modules", "test-results", "playwright-report"]
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "test-results",
+    "playwright-report"
+  ]
 }

--- a/cockpit/chat/threads/angular/e2e/c-threads.spec.ts
+++ b/cockpit/chat/threads/angular/e2e/c-threads.spec.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { test, expect } from '@playwright/test';
-import { submitAndWaitForResponse } from '../../../../../libs/e2e-harness/src';
+import { submitAndWaitForResponse } from '@ngaf-internal/e2e-harness';
 
 const PROMPT = 'Hello';
 

--- a/cockpit/chat/threads/angular/e2e/global-setup-impl.ts
+++ b/cockpit/chat/threads/angular/e2e/global-setup-impl.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { resolve } from 'node:path';
-import { createGlobalSetup } from '../../../../../libs/e2e-harness/src';
+import { createGlobalSetup } from '@ngaf-internal/e2e-harness';
 
 export default createGlobalSetup({
   langgraphCwd: 'cockpit/chat/threads/python',

--- a/cockpit/chat/threads/angular/e2e/tsconfig.json
+++ b/cockpit/chat/threads/angular/e2e/tsconfig.json
@@ -7,8 +7,25 @@
     "strict": true,
     "skipLibCheck": true,
     "noEmit": true,
-    "types": ["node"]
+    "types": [
+      "node"
+    ],
+    "baseUrl": "../../../../..",
+    "paths": {
+      "@ngaf-internal/e2e-harness": [
+        "libs/e2e-harness/src/index.ts"
+      ],
+      "@ngaf-internal/e2e-harness/global-teardown": [
+        "libs/e2e-harness/src/global-teardown.ts"
+      ]
+    }
   },
-  "include": ["**/*.ts"],
-  "exclude": ["node_modules", "test-results", "playwright-report"]
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "test-results",
+    "playwright-report"
+  ]
 }

--- a/cockpit/chat/timeline/angular/e2e/c-timeline.spec.ts
+++ b/cockpit/chat/timeline/angular/e2e/c-timeline.spec.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { test, expect } from '@playwright/test';
-import { submitAndWaitForResponse } from '../../../../../libs/e2e-harness/src';
+import { submitAndWaitForResponse } from '@ngaf-internal/e2e-harness';
 
 const PROMPT = 'Hello';
 

--- a/cockpit/chat/timeline/angular/e2e/global-setup-impl.ts
+++ b/cockpit/chat/timeline/angular/e2e/global-setup-impl.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { resolve } from 'node:path';
-import { createGlobalSetup } from '../../../../../libs/e2e-harness/src';
+import { createGlobalSetup } from '@ngaf-internal/e2e-harness';
 
 export default createGlobalSetup({
   langgraphCwd: 'cockpit/chat/timeline/python',

--- a/cockpit/chat/timeline/angular/e2e/tsconfig.json
+++ b/cockpit/chat/timeline/angular/e2e/tsconfig.json
@@ -7,8 +7,25 @@
     "strict": true,
     "skipLibCheck": true,
     "noEmit": true,
-    "types": ["node"]
+    "types": [
+      "node"
+    ],
+    "baseUrl": "../../../../..",
+    "paths": {
+      "@ngaf-internal/e2e-harness": [
+        "libs/e2e-harness/src/index.ts"
+      ],
+      "@ngaf-internal/e2e-harness/global-teardown": [
+        "libs/e2e-harness/src/global-teardown.ts"
+      ]
+    }
   },
-  "include": ["**/*.ts"],
-  "exclude": ["node_modules", "test-results", "playwright-report"]
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "test-results",
+    "playwright-report"
+  ]
 }

--- a/cockpit/chat/tool-calls/angular/e2e/c-tool-calls.spec.ts
+++ b/cockpit/chat/tool-calls/angular/e2e/c-tool-calls.spec.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { test, expect } from '@playwright/test';
-import { submitAndWaitForResponse } from '../../../../../libs/e2e-harness/src';
+import { submitAndWaitForResponse } from '@ngaf-internal/e2e-harness';
 
 const PROMPT = "What's the status of UA123?";
 

--- a/cockpit/chat/tool-calls/angular/e2e/global-setup-impl.ts
+++ b/cockpit/chat/tool-calls/angular/e2e/global-setup-impl.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { resolve } from 'node:path';
-import { createGlobalSetup } from '../../../../../libs/e2e-harness/src';
+import { createGlobalSetup } from '@ngaf-internal/e2e-harness';
 
 export default createGlobalSetup({
   // Per-cap cleanup PR: each chat cap runs its OWN standalone backend

--- a/cockpit/chat/tool-calls/angular/e2e/tsconfig.json
+++ b/cockpit/chat/tool-calls/angular/e2e/tsconfig.json
@@ -7,8 +7,25 @@
     "strict": true,
     "skipLibCheck": true,
     "noEmit": true,
-    "types": ["node"]
+    "types": [
+      "node"
+    ],
+    "baseUrl": "../../../../..",
+    "paths": {
+      "@ngaf-internal/e2e-harness": [
+        "libs/e2e-harness/src/index.ts"
+      ],
+      "@ngaf-internal/e2e-harness/global-teardown": [
+        "libs/e2e-harness/src/global-teardown.ts"
+      ]
+    }
   },
-  "include": ["**/*.ts"],
-  "exclude": ["node_modules", "test-results", "playwright-report"]
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "test-results",
+    "playwright-report"
+  ]
 }

--- a/cockpit/deep-agents/filesystem/angular/e2e/da-filesystem.spec.ts
+++ b/cockpit/deep-agents/filesystem/angular/e2e/da-filesystem.spec.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { test, expect } from '@playwright/test';
-import { submitAndWaitForResponse } from '../../../../../libs/e2e-harness/src';
+import { submitAndWaitForResponse } from '@ngaf-internal/e2e-harness';
 
 test('da-filesystem: hello prompt produces assistant turn', async ({ page }) => {
   const bubble = await submitAndWaitForResponse(page, 'Hello');

--- a/cockpit/deep-agents/filesystem/angular/e2e/global-setup-impl.ts
+++ b/cockpit/deep-agents/filesystem/angular/e2e/global-setup-impl.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { resolve } from 'node:path';
-import { createGlobalSetup } from '../../../../../libs/e2e-harness/src';
+import { createGlobalSetup } from '@ngaf-internal/e2e-harness';
 
 export default createGlobalSetup({
   langgraphCwd: 'cockpit/deep-agents/filesystem/python',

--- a/cockpit/deep-agents/filesystem/angular/e2e/tsconfig.json
+++ b/cockpit/deep-agents/filesystem/angular/e2e/tsconfig.json
@@ -7,8 +7,25 @@
     "strict": true,
     "skipLibCheck": true,
     "noEmit": true,
-    "types": ["node"]
+    "types": [
+      "node"
+    ],
+    "baseUrl": "../../../../..",
+    "paths": {
+      "@ngaf-internal/e2e-harness": [
+        "libs/e2e-harness/src/index.ts"
+      ],
+      "@ngaf-internal/e2e-harness/global-teardown": [
+        "libs/e2e-harness/src/global-teardown.ts"
+      ]
+    }
   },
-  "include": ["**/*.ts"],
-  "exclude": ["node_modules", "test-results", "playwright-report"]
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "test-results",
+    "playwright-report"
+  ]
 }

--- a/cockpit/deep-agents/memory/angular/e2e/da-memory.spec.ts
+++ b/cockpit/deep-agents/memory/angular/e2e/da-memory.spec.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { test, expect } from '@playwright/test';
-import { submitAndWaitForResponse } from '../../../../../libs/e2e-harness/src';
+import { submitAndWaitForResponse } from '@ngaf-internal/e2e-harness';
 
 test('da-memory: hello prompt produces assistant turn', async ({ page }) => {
   const bubble = await submitAndWaitForResponse(page, 'Hello');

--- a/cockpit/deep-agents/memory/angular/e2e/global-setup-impl.ts
+++ b/cockpit/deep-agents/memory/angular/e2e/global-setup-impl.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { resolve } from 'node:path';
-import { createGlobalSetup } from '../../../../../libs/e2e-harness/src';
+import { createGlobalSetup } from '@ngaf-internal/e2e-harness';
 
 export default createGlobalSetup({
   langgraphCwd: 'cockpit/deep-agents/memory/python',

--- a/cockpit/deep-agents/memory/angular/e2e/tsconfig.json
+++ b/cockpit/deep-agents/memory/angular/e2e/tsconfig.json
@@ -7,8 +7,25 @@
     "strict": true,
     "skipLibCheck": true,
     "noEmit": true,
-    "types": ["node"]
+    "types": [
+      "node"
+    ],
+    "baseUrl": "../../../../..",
+    "paths": {
+      "@ngaf-internal/e2e-harness": [
+        "libs/e2e-harness/src/index.ts"
+      ],
+      "@ngaf-internal/e2e-harness/global-teardown": [
+        "libs/e2e-harness/src/global-teardown.ts"
+      ]
+    }
   },
-  "include": ["**/*.ts"],
-  "exclude": ["node_modules", "test-results", "playwright-report"]
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "test-results",
+    "playwright-report"
+  ]
 }

--- a/cockpit/deep-agents/planning/angular/e2e/da-planning.spec.ts
+++ b/cockpit/deep-agents/planning/angular/e2e/da-planning.spec.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { test, expect } from '@playwright/test';
-import { submitAndWaitForResponse } from '../../../../../libs/e2e-harness/src';
+import { submitAndWaitForResponse } from '@ngaf-internal/e2e-harness';
 
 test('da-planning: hello prompt produces assistant turn', async ({ page }) => {
   const bubble = await submitAndWaitForResponse(page, 'Hello');

--- a/cockpit/deep-agents/planning/angular/e2e/global-setup-impl.ts
+++ b/cockpit/deep-agents/planning/angular/e2e/global-setup-impl.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { resolve } from 'node:path';
-import { createGlobalSetup } from '../../../../../libs/e2e-harness/src';
+import { createGlobalSetup } from '@ngaf-internal/e2e-harness';
 
 export default createGlobalSetup({
   langgraphCwd: 'cockpit/deep-agents/planning/python',

--- a/cockpit/deep-agents/planning/angular/e2e/tsconfig.json
+++ b/cockpit/deep-agents/planning/angular/e2e/tsconfig.json
@@ -7,8 +7,25 @@
     "strict": true,
     "skipLibCheck": true,
     "noEmit": true,
-    "types": ["node"]
+    "types": [
+      "node"
+    ],
+    "baseUrl": "../../../../..",
+    "paths": {
+      "@ngaf-internal/e2e-harness": [
+        "libs/e2e-harness/src/index.ts"
+      ],
+      "@ngaf-internal/e2e-harness/global-teardown": [
+        "libs/e2e-harness/src/global-teardown.ts"
+      ]
+    }
   },
-  "include": ["**/*.ts"],
-  "exclude": ["node_modules", "test-results", "playwright-report"]
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "test-results",
+    "playwright-report"
+  ]
 }

--- a/cockpit/deep-agents/sandboxes/angular/e2e/da-sandboxes.spec.ts
+++ b/cockpit/deep-agents/sandboxes/angular/e2e/da-sandboxes.spec.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { test, expect } from '@playwright/test';
-import { submitAndWaitForResponse } from '../../../../../libs/e2e-harness/src';
+import { submitAndWaitForResponse } from '@ngaf-internal/e2e-harness';
 
 test('da-sandboxes: hello prompt produces assistant turn', async ({ page }) => {
   const bubble = await submitAndWaitForResponse(page, 'Hello');

--- a/cockpit/deep-agents/sandboxes/angular/e2e/global-setup-impl.ts
+++ b/cockpit/deep-agents/sandboxes/angular/e2e/global-setup-impl.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { resolve } from 'node:path';
-import { createGlobalSetup } from '../../../../../libs/e2e-harness/src';
+import { createGlobalSetup } from '@ngaf-internal/e2e-harness';
 
 export default createGlobalSetup({
   langgraphCwd: 'cockpit/deep-agents/sandboxes/python',

--- a/cockpit/deep-agents/sandboxes/angular/e2e/tsconfig.json
+++ b/cockpit/deep-agents/sandboxes/angular/e2e/tsconfig.json
@@ -7,8 +7,25 @@
     "strict": true,
     "skipLibCheck": true,
     "noEmit": true,
-    "types": ["node"]
+    "types": [
+      "node"
+    ],
+    "baseUrl": "../../../../..",
+    "paths": {
+      "@ngaf-internal/e2e-harness": [
+        "libs/e2e-harness/src/index.ts"
+      ],
+      "@ngaf-internal/e2e-harness/global-teardown": [
+        "libs/e2e-harness/src/global-teardown.ts"
+      ]
+    }
   },
-  "include": ["**/*.ts"],
-  "exclude": ["node_modules", "test-results", "playwright-report"]
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "test-results",
+    "playwright-report"
+  ]
 }

--- a/cockpit/deep-agents/skills/angular/e2e/da-skills.spec.ts
+++ b/cockpit/deep-agents/skills/angular/e2e/da-skills.spec.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { test, expect } from '@playwright/test';
-import { submitAndWaitForResponse } from '../../../../../libs/e2e-harness/src';
+import { submitAndWaitForResponse } from '@ngaf-internal/e2e-harness';
 
 test('da-skills: hello prompt produces assistant turn', async ({ page }) => {
   const bubble = await submitAndWaitForResponse(page, 'Hello');

--- a/cockpit/deep-agents/skills/angular/e2e/global-setup-impl.ts
+++ b/cockpit/deep-agents/skills/angular/e2e/global-setup-impl.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { resolve } from 'node:path';
-import { createGlobalSetup } from '../../../../../libs/e2e-harness/src';
+import { createGlobalSetup } from '@ngaf-internal/e2e-harness';
 
 export default createGlobalSetup({
   langgraphCwd: 'cockpit/deep-agents/skills/python',

--- a/cockpit/deep-agents/skills/angular/e2e/tsconfig.json
+++ b/cockpit/deep-agents/skills/angular/e2e/tsconfig.json
@@ -7,8 +7,25 @@
     "strict": true,
     "skipLibCheck": true,
     "noEmit": true,
-    "types": ["node"]
+    "types": [
+      "node"
+    ],
+    "baseUrl": "../../../../..",
+    "paths": {
+      "@ngaf-internal/e2e-harness": [
+        "libs/e2e-harness/src/index.ts"
+      ],
+      "@ngaf-internal/e2e-harness/global-teardown": [
+        "libs/e2e-harness/src/global-teardown.ts"
+      ]
+    }
   },
-  "include": ["**/*.ts"],
-  "exclude": ["node_modules", "test-results", "playwright-report"]
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "test-results",
+    "playwright-report"
+  ]
 }

--- a/cockpit/deep-agents/subagents/angular/e2e/da-subagents.spec.ts
+++ b/cockpit/deep-agents/subagents/angular/e2e/da-subagents.spec.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { test, expect } from '@playwright/test';
-import { submitAndWaitForResponse } from '../../../../../libs/e2e-harness/src';
+import { submitAndWaitForResponse } from '@ngaf-internal/e2e-harness';
 
 test('da-subagents: hello prompt produces assistant turn', async ({ page }) => {
   const bubble = await submitAndWaitForResponse(page, 'Hello');

--- a/cockpit/deep-agents/subagents/angular/e2e/global-setup-impl.ts
+++ b/cockpit/deep-agents/subagents/angular/e2e/global-setup-impl.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { resolve } from 'node:path';
-import { createGlobalSetup } from '../../../../../libs/e2e-harness/src';
+import { createGlobalSetup } from '@ngaf-internal/e2e-harness';
 
 export default createGlobalSetup({
   langgraphCwd: 'cockpit/deep-agents/subagents/python',

--- a/cockpit/deep-agents/subagents/angular/e2e/tsconfig.json
+++ b/cockpit/deep-agents/subagents/angular/e2e/tsconfig.json
@@ -7,8 +7,25 @@
     "strict": true,
     "skipLibCheck": true,
     "noEmit": true,
-    "types": ["node"]
+    "types": [
+      "node"
+    ],
+    "baseUrl": "../../../../..",
+    "paths": {
+      "@ngaf-internal/e2e-harness": [
+        "libs/e2e-harness/src/index.ts"
+      ],
+      "@ngaf-internal/e2e-harness/global-teardown": [
+        "libs/e2e-harness/src/global-teardown.ts"
+      ]
+    }
   },
-  "include": ["**/*.ts"],
-  "exclude": ["node_modules", "test-results", "playwright-report"]
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "test-results",
+    "playwright-report"
+  ]
 }

--- a/cockpit/langgraph/deployment-runtime/angular/e2e/deployment-runtime.spec.ts
+++ b/cockpit/langgraph/deployment-runtime/angular/e2e/deployment-runtime.spec.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { test, expect } from '@playwright/test';
-import { submitAndWaitForResponse } from '../../../../../libs/e2e-harness/src';
+import { submitAndWaitForResponse } from '@ngaf-internal/e2e-harness';
 
 test('deployment-runtime: hello prompt produces assistant turn', async ({ page }) => {
   const bubble = await submitAndWaitForResponse(page, 'Hello');

--- a/cockpit/langgraph/deployment-runtime/angular/e2e/global-setup-impl.ts
+++ b/cockpit/langgraph/deployment-runtime/angular/e2e/global-setup-impl.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { resolve } from 'node:path';
-import { createGlobalSetup } from '../../../../../libs/e2e-harness/src';
+import { createGlobalSetup } from '@ngaf-internal/e2e-harness';
 
 export default createGlobalSetup({
   langgraphCwd: 'cockpit/langgraph/deployment-runtime/python',

--- a/cockpit/langgraph/deployment-runtime/angular/e2e/tsconfig.json
+++ b/cockpit/langgraph/deployment-runtime/angular/e2e/tsconfig.json
@@ -7,8 +7,25 @@
     "strict": true,
     "skipLibCheck": true,
     "noEmit": true,
-    "types": ["node"]
+    "types": [
+      "node"
+    ],
+    "baseUrl": "../../../../..",
+    "paths": {
+      "@ngaf-internal/e2e-harness": [
+        "libs/e2e-harness/src/index.ts"
+      ],
+      "@ngaf-internal/e2e-harness/global-teardown": [
+        "libs/e2e-harness/src/global-teardown.ts"
+      ]
+    }
   },
-  "include": ["**/*.ts"],
-  "exclude": ["node_modules", "test-results", "playwright-report"]
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "test-results",
+    "playwright-report"
+  ]
 }

--- a/cockpit/langgraph/durable-execution/angular/e2e/durable-execution.spec.ts
+++ b/cockpit/langgraph/durable-execution/angular/e2e/durable-execution.spec.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { test, expect } from '@playwright/test';
-import { submitAndWaitForResponse } from '../../../../../libs/e2e-harness/src';
+import { submitAndWaitForResponse } from '@ngaf-internal/e2e-harness';
 
 test('durable-execution: hello prompt produces assistant turn', async ({ page }) => {
   const bubble = await submitAndWaitForResponse(page, 'Hello');

--- a/cockpit/langgraph/durable-execution/angular/e2e/global-setup-impl.ts
+++ b/cockpit/langgraph/durable-execution/angular/e2e/global-setup-impl.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { resolve } from 'node:path';
-import { createGlobalSetup } from '../../../../../libs/e2e-harness/src';
+import { createGlobalSetup } from '@ngaf-internal/e2e-harness';
 
 export default createGlobalSetup({
   langgraphCwd: 'cockpit/langgraph/durable-execution/python',

--- a/cockpit/langgraph/durable-execution/angular/e2e/tsconfig.json
+++ b/cockpit/langgraph/durable-execution/angular/e2e/tsconfig.json
@@ -7,8 +7,25 @@
     "strict": true,
     "skipLibCheck": true,
     "noEmit": true,
-    "types": ["node"]
+    "types": [
+      "node"
+    ],
+    "baseUrl": "../../../../..",
+    "paths": {
+      "@ngaf-internal/e2e-harness": [
+        "libs/e2e-harness/src/index.ts"
+      ],
+      "@ngaf-internal/e2e-harness/global-teardown": [
+        "libs/e2e-harness/src/global-teardown.ts"
+      ]
+    }
   },
-  "include": ["**/*.ts"],
-  "exclude": ["node_modules", "test-results", "playwright-report"]
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "test-results",
+    "playwright-report"
+  ]
 }

--- a/cockpit/langgraph/interrupts/angular/e2e/global-setup-impl.ts
+++ b/cockpit/langgraph/interrupts/angular/e2e/global-setup-impl.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { resolve } from 'node:path';
-import { createGlobalSetup } from '../../../../../libs/e2e-harness/src';
+import { createGlobalSetup } from '@ngaf-internal/e2e-harness';
 
 export default createGlobalSetup({
   langgraphCwd: 'cockpit/langgraph/interrupts/python',

--- a/cockpit/langgraph/interrupts/angular/e2e/interrupts.spec.ts
+++ b/cockpit/langgraph/interrupts/angular/e2e/interrupts.spec.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { test, expect } from '@playwright/test';
-import { submitAndWaitForResponse } from '../../../../../libs/e2e-harness/src';
+import { submitAndWaitForResponse } from '@ngaf-internal/e2e-harness';
 
 test('interrupts: hello prompt produces assistant turn', async ({ page }) => {
   const bubble = await submitAndWaitForResponse(page, 'Hello');

--- a/cockpit/langgraph/interrupts/angular/e2e/tsconfig.json
+++ b/cockpit/langgraph/interrupts/angular/e2e/tsconfig.json
@@ -7,8 +7,25 @@
     "strict": true,
     "skipLibCheck": true,
     "noEmit": true,
-    "types": ["node"]
+    "types": [
+      "node"
+    ],
+    "baseUrl": "../../../../..",
+    "paths": {
+      "@ngaf-internal/e2e-harness": [
+        "libs/e2e-harness/src/index.ts"
+      ],
+      "@ngaf-internal/e2e-harness/global-teardown": [
+        "libs/e2e-harness/src/global-teardown.ts"
+      ]
+    }
   },
-  "include": ["**/*.ts"],
-  "exclude": ["node_modules", "test-results", "playwright-report"]
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "test-results",
+    "playwright-report"
+  ]
 }

--- a/cockpit/langgraph/memory/angular/e2e/global-setup-impl.ts
+++ b/cockpit/langgraph/memory/angular/e2e/global-setup-impl.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { resolve } from 'node:path';
-import { createGlobalSetup } from '../../../../../libs/e2e-harness/src';
+import { createGlobalSetup } from '@ngaf-internal/e2e-harness';
 
 export default createGlobalSetup({
   langgraphCwd: 'cockpit/langgraph/memory/python',

--- a/cockpit/langgraph/memory/angular/e2e/memory.spec.ts
+++ b/cockpit/langgraph/memory/angular/e2e/memory.spec.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { test, expect } from '@playwright/test';
-import { submitAndWaitForResponse } from '../../../../../libs/e2e-harness/src';
+import { submitAndWaitForResponse } from '@ngaf-internal/e2e-harness';
 
 test('memory: hello prompt produces assistant turn', async ({ page }) => {
   const bubble = await submitAndWaitForResponse(page, 'Hello');

--- a/cockpit/langgraph/memory/angular/e2e/tsconfig.json
+++ b/cockpit/langgraph/memory/angular/e2e/tsconfig.json
@@ -7,8 +7,25 @@
     "strict": true,
     "skipLibCheck": true,
     "noEmit": true,
-    "types": ["node"]
+    "types": [
+      "node"
+    ],
+    "baseUrl": "../../../../..",
+    "paths": {
+      "@ngaf-internal/e2e-harness": [
+        "libs/e2e-harness/src/index.ts"
+      ],
+      "@ngaf-internal/e2e-harness/global-teardown": [
+        "libs/e2e-harness/src/global-teardown.ts"
+      ]
+    }
   },
-  "include": ["**/*.ts"],
-  "exclude": ["node_modules", "test-results", "playwright-report"]
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "test-results",
+    "playwright-report"
+  ]
 }

--- a/cockpit/langgraph/persistence/angular/e2e/global-setup-impl.ts
+++ b/cockpit/langgraph/persistence/angular/e2e/global-setup-impl.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { resolve } from 'node:path';
-import { createGlobalSetup } from '../../../../../libs/e2e-harness/src';
+import { createGlobalSetup } from '@ngaf-internal/e2e-harness';
 
 export default createGlobalSetup({
   langgraphCwd: 'cockpit/langgraph/persistence/python',

--- a/cockpit/langgraph/persistence/angular/e2e/persistence.spec.ts
+++ b/cockpit/langgraph/persistence/angular/e2e/persistence.spec.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { test, expect } from '@playwright/test';
-import { submitAndWaitForResponse } from '../../../../../libs/e2e-harness/src';
+import { submitAndWaitForResponse } from '@ngaf-internal/e2e-harness';
 
 test('persistence: hello prompt produces assistant turn', async ({ page }) => {
   const bubble = await submitAndWaitForResponse(page, 'Hello');

--- a/cockpit/langgraph/persistence/angular/e2e/tsconfig.json
+++ b/cockpit/langgraph/persistence/angular/e2e/tsconfig.json
@@ -7,8 +7,25 @@
     "strict": true,
     "skipLibCheck": true,
     "noEmit": true,
-    "types": ["node"]
+    "types": [
+      "node"
+    ],
+    "baseUrl": "../../../../..",
+    "paths": {
+      "@ngaf-internal/e2e-harness": [
+        "libs/e2e-harness/src/index.ts"
+      ],
+      "@ngaf-internal/e2e-harness/global-teardown": [
+        "libs/e2e-harness/src/global-teardown.ts"
+      ]
+    }
   },
-  "include": ["**/*.ts"],
-  "exclude": ["node_modules", "test-results", "playwright-report"]
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "test-results",
+    "playwright-report"
+  ]
 }

--- a/cockpit/langgraph/streaming/angular/e2e/global-setup-impl.ts
+++ b/cockpit/langgraph/streaming/angular/e2e/global-setup-impl.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { resolve } from 'node:path';
-import { createGlobalSetup } from '../../../../../libs/e2e-harness/src';
+import { createGlobalSetup } from '@ngaf-internal/e2e-harness';
 
 export default createGlobalSetup({
   langgraphCwd: 'cockpit/langgraph/streaming/python',

--- a/cockpit/langgraph/streaming/angular/e2e/streaming.spec.ts
+++ b/cockpit/langgraph/streaming/angular/e2e/streaming.spec.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { test, expect } from '@playwright/test';
-import { submitAndWaitForResponse } from '../../../../../libs/e2e-harness/src';
+import { submitAndWaitForResponse } from '@ngaf-internal/e2e-harness';
 
 test('streaming: assistant text from the mocked LLM renders in the cockpit chat composition', async ({ page }) => {
   const bubble = await submitAndWaitForResponse(

--- a/cockpit/langgraph/streaming/angular/e2e/tsconfig.json
+++ b/cockpit/langgraph/streaming/angular/e2e/tsconfig.json
@@ -7,8 +7,25 @@
     "strict": true,
     "skipLibCheck": true,
     "noEmit": true,
-    "types": ["node"]
+    "types": [
+      "node"
+    ],
+    "baseUrl": "../../../../..",
+    "paths": {
+      "@ngaf-internal/e2e-harness": [
+        "libs/e2e-harness/src/index.ts"
+      ],
+      "@ngaf-internal/e2e-harness/global-teardown": [
+        "libs/e2e-harness/src/global-teardown.ts"
+      ]
+    }
   },
-  "include": ["**/*.ts"],
-  "exclude": ["node_modules", "test-results", "playwright-report"]
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "test-results",
+    "playwright-report"
+  ]
 }

--- a/cockpit/langgraph/subgraphs/angular/e2e/global-setup-impl.ts
+++ b/cockpit/langgraph/subgraphs/angular/e2e/global-setup-impl.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { resolve } from 'node:path';
-import { createGlobalSetup } from '../../../../../libs/e2e-harness/src';
+import { createGlobalSetup } from '@ngaf-internal/e2e-harness';
 
 export default createGlobalSetup({
   langgraphCwd: 'cockpit/langgraph/subgraphs/python',

--- a/cockpit/langgraph/subgraphs/angular/e2e/subgraphs.spec.ts
+++ b/cockpit/langgraph/subgraphs/angular/e2e/subgraphs.spec.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { test, expect } from '@playwright/test';
-import { submitAndWaitForResponse } from '../../../../../libs/e2e-harness/src';
+import { submitAndWaitForResponse } from '@ngaf-internal/e2e-harness';
 
 test('subgraphs: hello prompt produces assistant turn', async ({ page }) => {
   const bubble = await submitAndWaitForResponse(page, 'Hello');

--- a/cockpit/langgraph/subgraphs/angular/e2e/tsconfig.json
+++ b/cockpit/langgraph/subgraphs/angular/e2e/tsconfig.json
@@ -7,8 +7,25 @@
     "strict": true,
     "skipLibCheck": true,
     "noEmit": true,
-    "types": ["node"]
+    "types": [
+      "node"
+    ],
+    "baseUrl": "../../../../..",
+    "paths": {
+      "@ngaf-internal/e2e-harness": [
+        "libs/e2e-harness/src/index.ts"
+      ],
+      "@ngaf-internal/e2e-harness/global-teardown": [
+        "libs/e2e-harness/src/global-teardown.ts"
+      ]
+    }
   },
-  "include": ["**/*.ts"],
-  "exclude": ["node_modules", "test-results", "playwright-report"]
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "test-results",
+    "playwright-report"
+  ]
 }

--- a/cockpit/langgraph/time-travel/angular/e2e/global-setup-impl.ts
+++ b/cockpit/langgraph/time-travel/angular/e2e/global-setup-impl.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { resolve } from 'node:path';
-import { createGlobalSetup } from '../../../../../libs/e2e-harness/src';
+import { createGlobalSetup } from '@ngaf-internal/e2e-harness';
 
 export default createGlobalSetup({
   langgraphCwd: 'cockpit/langgraph/time-travel/python',

--- a/cockpit/langgraph/time-travel/angular/e2e/time-travel.spec.ts
+++ b/cockpit/langgraph/time-travel/angular/e2e/time-travel.spec.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { test, expect } from '@playwright/test';
-import { submitAndWaitForResponse } from '../../../../../libs/e2e-harness/src';
+import { submitAndWaitForResponse } from '@ngaf-internal/e2e-harness';
 
 test('time-travel: hello prompt produces assistant turn', async ({ page }) => {
   const bubble = await submitAndWaitForResponse(page, 'Hello');

--- a/cockpit/langgraph/time-travel/angular/e2e/tsconfig.json
+++ b/cockpit/langgraph/time-travel/angular/e2e/tsconfig.json
@@ -7,8 +7,25 @@
     "strict": true,
     "skipLibCheck": true,
     "noEmit": true,
-    "types": ["node"]
+    "types": [
+      "node"
+    ],
+    "baseUrl": "../../../../..",
+    "paths": {
+      "@ngaf-internal/e2e-harness": [
+        "libs/e2e-harness/src/index.ts"
+      ],
+      "@ngaf-internal/e2e-harness/global-teardown": [
+        "libs/e2e-harness/src/global-teardown.ts"
+      ]
+    }
   },
-  "include": ["**/*.ts"],
-  "exclude": ["node_modules", "test-results", "playwright-report"]
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "test-results",
+    "playwright-report"
+  ]
 }

--- a/examples/chat/angular/e2e/tsconfig.json
+++ b/examples/chat/angular/e2e/tsconfig.json
@@ -8,8 +8,25 @@
     "skipLibCheck": true,
     "allowImportingTsExtensions": false,
     "noEmit": true,
-    "types": ["node"]
+    "types": [
+      "node"
+    ],
+    "baseUrl": "../../../../..",
+    "paths": {
+      "@ngaf-internal/e2e-harness": [
+        "libs/e2e-harness/src/index.ts"
+      ],
+      "@ngaf-internal/e2e-harness/global-teardown": [
+        "libs/e2e-harness/src/global-teardown.ts"
+      ]
+    }
   },
-  "include": ["**/*.ts"],
-  "exclude": ["node_modules", "test-results", "playwright-report"]
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "test-results",
+    "playwright-report"
+  ]
 }


### PR DESCRIPTION
## Summary

- Replaces `../../../../../libs/e2e-harness/src` relative imports with the `@ngaf-internal/e2e-harness` path alias across all 25 cap e2e suites (24 cockpit + examples/chat).
- Wires the alias into each cap's e2e `tsconfig.json` via local `baseUrl` + `paths` (rather than extending `tsconfig.base.json`) to keep Playwright's compilation surface minimal.
- 48 spec/setup imports rewritten. The 24 `require.resolve(...globalTeardown)` calls in `playwright.config.ts` stay as relative paths — tsconfig-paths doesn't apply at Node runtime.

## Test plan

- [ ] CI: `Cockpit — e2e (*)` matrix all green
- [ ] CI: `examples/chat — e2e` green
- [ ] No new lint failures
- [ ] `npx tsc --noEmit` in each e2e dir resolves the alias

🤖 Generated with [Claude Code](https://claude.com/claude-code)