### PR TITLE
chore(minting): TEMP smoke debug — surface 500 error in response body

### DIFF
--- a/apps/minting-service/handlers/stripe-webhook.ts
+++ b/apps/minting-service/handlers/stripe-webhook.ts
@@ -71,8 +71,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse): 
     await handleEvent(event, deps);
     res.status(200).json({ received: true });
   } catch (err) {
+    const msg = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
+    const stack = err instanceof Error ? (err.stack ?? '').split('\n').slice(0, 5).join(' | ') : '';
     console.error('webhook handler error', { eventId: event.id, type: event.type, err });
-    res.status(500).send('internal error');
+    // TEMP smoke diagnostic — surface error class + message + first stack frames so
+    // we can read it via curl/Stripe Dashboard delivery body. Revert after smoke.
+    res.status(500).send(`internal error: ${msg}\n${stack}`);
   } finally {
     await db.close();
   }


### PR DESCRIPTION
Diagnostic patch for active smoke test. The minting webhook handler is hitting 500 but with an empty body (Vercel substitution or process death). This change appends the caught error class + message + first 5 stack frames into the 500 response body so we can read what's actually throwing via Stripe Dashboard's webhook delivery view or a direct curl.

**Will be reverted immediately after the smoke isolates the failure.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)