### PR TITLE
diag(minting): include err.cause + PG fields in webhook 500

### DIFF
--- a/apps/minting-service/handlers/stripe-webhook.ts
+++ b/apps/minting-service/handlers/stripe-webhook.ts
@@ -71,12 +71,23 @@ export default async function handler(req: VercelRequest, res: VercelResponse): 
     await handleEvent(event, deps);
     res.status(200).json({ received: true });
   } catch (err) {
-    const msg = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
-    const stack = err instanceof Error ? (err.stack ?? '').split('\n').slice(0, 5).join(' | ') : '';
+    const describe = (e: unknown): string => {
+      if (!(e instanceof Error)) return String(e);
+      const props = ['code', 'severity', 'detail', 'hint', 'where', 'schema_name', 'table_name', 'constraint_name', 'routine']
+        .map((k) => {
+          const v = (e as unknown as Record<string, unknown>)[k];
+          return v === undefined ? null : `${k}=${String(v)}`;
+        })
+        .filter((s): s is string => s !== null)
+        .join(' ');
+      const stack = (e.stack ?? '').split('\n').slice(0, 8).join(' | ');
+      return `${e.name}: ${e.message}${props ? ` [${props}]` : ''}\n  ${stack}`;
+    };
+    const top = describe(err);
+    const cause = err instanceof Error && err.cause ? `\nCAUSE: ${describe(err.cause)}` : '';
     console.error('webhook handler error', { eventId: event.id, type: event.type, err });
-    // TEMP smoke diagnostic — surface error class + message + first stack frames so
-    // we can read it via curl/Stripe Dashboard delivery body. Revert after smoke.
-    res.status(500).send(`internal error: ${msg}\n${stack}`);
+    // TEMP smoke diagnostic — surface error class + message + cause chain + PG fields.
+    res.status(500).send(`internal error: ${top}${cause}`);
   } finally {
     await db.close();
   }


### PR DESCRIPTION
## Summary
- Extends the temporary smoke diagnostic added in #520 to unwrap `err.cause` and surface postgres-js PG fields (code, severity, detail, hint, etc.)
- Needed because the current 500 body only shows `"Failed query: insert into processed_events ..."` — the underlying driver error is hidden under `err.cause`

## Why
End-to-end smoke is currently 500ing on the first DB write. Local query against the same `processed_events` table succeeds and schema is correct, so the cause is likely a connection-level error (SSL, auth, or pooler) only visible in the wrapped cause.

## Test plan
- [ ] Merge → Vercel auto-deploy
- [ ] Resend the failing Stripe event from dashboard
- [ ] Capture the now-fuller 500 body to identify root cause
- [ ] Revert this + #520 patches in a follow-up after smoke is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)