### PR TITLE
ci: add examples-chat-e2e-summary aggregator job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,6 +274,20 @@ jobs:
             examples/chat/angular/e2e/test-results/
           retention-days: 7
 
+  examples-chat-e2e-summary:
+    name: "examples/chat — e2e"
+    needs: [ci-scope, examples-chat-e2e]
+    if: always() && (github.event_name == 'push' || needs.ci-scope.outputs.examples_chat == 'true')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Aggregate matrix outcome
+        run: |
+          if [[ "${{ needs.examples-chat-e2e.result }}" != "success" ]]; then
+            echo "Matrix outcome: ${{ needs.examples-chat-e2e.result }}"
+            exit 1
+          fi
+          echo "All examples-chat-e2e matrix expansions passed."
+
   cockpit-e2e:
     name: "Cockpit — e2e (${{ matrix.cap.angular }})"
     needs: ci-scope


### PR DESCRIPTION
## Summary

PR #521 sharded the singular `examples/chat — e2e` job into a 4-way matrix. The singular check name is no longer reported — anything referencing it externally (status badges, branch protection rules, deploy gates that read by name) sees a missing context.

This mirrors the existing `cockpit-e2e-summary` pattern (ci.yml:334-345): a no-op aggregator job named `examples/chat — e2e` that gates on the matrix's aggregated result. Restores the singular check name without undoing the sharding.

## Test plan

- [ ] On this PR, both the matrix shards (`examples/chat — e2e (N/4)`) AND the summary (`examples/chat — e2e`) report success
- [ ] On main, the singular `examples/chat — e2e` check appears alongside the 4 shard checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)