### PR TITLE
fix(minting): rename DATABASE_URL → MINTING_DATABASE_URL

### DIFF
--- a/apps/minting-service/src/lib/env.spec.ts
+++ b/apps/minting-service/src/lib/env.spec.ts
@@ -2,7 +2,7 @@
 const REQUIRED = {
   STRIPE_SECRET_KEY: 'sk_test_xxx',
   STRIPE_WEBHOOK_SECRET: 'whsec_xxx',
-  DATABASE_URL: 'postgres://u:p@h:5432/d',
+  MINTING_DATABASE_URL: 'postgres://u:p@h:5432/d',
   RESEND_API_KEY: 're_xxx',
   EMAIL_FROM: 'a@b.c',
   LICENSE_SIGNING_PRIVATE_KEY_HEX: 'a'.repeat(64),
@@ -31,9 +31,9 @@ describe('loadEnv', () => {
   });
 
   it('throws with a list of all missing vars', async () => {
-    setEnv({ ...REQUIRED, STRIPE_SECRET_KEY: undefined, DATABASE_URL: undefined });
+    setEnv({ ...REQUIRED, STRIPE_SECRET_KEY: undefined, MINTING_DATABASE_URL: undefined });
     const { loadEnv } = await import('./env.js');
-    expect(() => loadEnv()).toThrow(/STRIPE_SECRET_KEY.*DATABASE_URL|DATABASE_URL.*STRIPE_SECRET_KEY/);
+    expect(() => loadEnv()).toThrow(/STRIPE_SECRET_KEY.*MINTING_DATABASE_URL|MINTING_DATABASE_URL.*STRIPE_SECRET_KEY/);
   });
 
   it('throws when private key hex is the wrong length', async () => {

--- a/apps/minting-service/src/lib/env.ts
+++ b/apps/minting-service/src/lib/env.ts
@@ -2,7 +2,7 @@
 const REQUIRED_VARS = [
   'STRIPE_SECRET_KEY',
   'STRIPE_WEBHOOK_SECRET',
-  'DATABASE_URL',
+  'MINTING_DATABASE_URL',
   'RESEND_API_KEY',
   'EMAIL_FROM',
   'LICENSE_SIGNING_PRIVATE_KEY_HEX',
@@ -32,7 +32,7 @@ export function loadEnv(): Env {
   return {
     STRIPE_SECRET_KEY: process.env['STRIPE_SECRET_KEY']!,
     STRIPE_WEBHOOK_SECRET: process.env['STRIPE_WEBHOOK_SECRET']!,
-    DATABASE_URL: process.env['DATABASE_URL']!,
+    DATABASE_URL: process.env['MINTING_DATABASE_URL']!,
     RESEND_API_KEY: process.env['RESEND_API_KEY']!,
     EMAIL_FROM: process.env['EMAIL_FROM']!,
     LICENSE_SIGNING_PRIVATE_KEY_HEX: keyHex,


### PR DESCRIPTION
## Summary
- Avoids the Neon Vercel integration's runtime override of `DATABASE_URL`, which always points at the default `neondb` database
- Minting service connects to a distinct `minting` database (separate schema for `processed_events`, `licenses`) — using a non-conflicting var name prevents shadowing

## Why
End-to-end smoke kept failing with `relation "processed_events" does not exist`. Diagnostics confirmed Vercel was injecting `DATABASE_URL=postgres://.../neondb` at runtime even though the project-level env was set to `postgres://.../minting`. The Neon integration ships its own `DATABASE_URL`, `DATABASE_URL_UNPOOLED`, `POSTGRES_URL`, etc., and those win.

## Run-book
After merge, set `MINTING_DATABASE_URL` on the `threadplane-minting-service` Vercel project (production + preview) to the pooled connection string for the `minting` database. The legacy `DATABASE_URL` can stay or be removed; it's no longer read.

## Test plan
- [x] Unit: env.spec.ts updated and passing locally
- [ ] Smoke: complete a fresh Checkout session post-deploy and confirm `processed_events` + `licenses` rows insert

🤖 Generated with [Claude Code](https://claude.com/claude-code)