### PR TITLE
revert(minting): drop temp webhook 500 diagnostic

### DIFF
--- a/apps/minting-service/handlers/stripe-webhook.ts
+++ b/apps/minting-service/handlers/stripe-webhook.ts
@@ -71,23 +71,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse): 
     await handleEvent(event, deps);
     res.status(200).json({ received: true });
   } catch (err) {
-    const describe = (e: unknown): string => {
-      if (!(e instanceof Error)) return String(e);
-      const props = ['code', 'severity', 'detail', 'hint', 'where', 'schema_name', 'table_name', 'constraint_name', 'routine']
-        .map((k) => {
-          const v = (e as unknown as Record<string, unknown>)[k];
-          return v === undefined ? null : `${k}=${String(v)}`;
-        })
-        .filter((s): s is string => s !== null)
-        .join(' ');
-      const stack = (e.stack ?? '').split('\n').slice(0, 8).join(' | ');
-      return `${e.name}: ${e.message}${props ? ` [${props}]` : ''}\n  ${stack}`;
-    };
-    const top = describe(err);
-    const cause = err instanceof Error && err.cause ? `\nCAUSE: ${describe(err.cause)}` : '';
     console.error('webhook handler error', { eventId: event.id, type: event.type, err });
-    // TEMP smoke diagnostic — surface error class + message + cause chain + PG fields.
-    res.status(500).send(`internal error: ${top}${cause}`);
+    res.status(500).send('internal error');
   } finally {
     await db.close();
   }


### PR DESCRIPTION
## Summary
- Reverts the verbose error body added in #520 and extended in #522
- End-to-end smoke passed; root cause was the Neon integration shadowing `DATABASE_URL`, fixed in #525

🤖 Generated with [Claude Code](https://claude.com/claude-code)