### PR TITLE
fix(tests): resolve two pre-existing main CI failures

### DIFF
--- a/apps/website/e2e/website.spec.ts
+++ b/apps/website/e2e/website.spec.ts
@@ -29,8 +29,16 @@ test('pricing page shows plan cards', async ({ page }) => {
 
 test('pricing page lead form validates required fields', async ({ page }) => {
   await page.goto('/pricing');
-  await page.click('button[type="submit"]');
-  await expect(page.locator('form').first()).toBeVisible();
+  // The pricing page also has Stripe-checkout submit buttons in
+  // PricingGrid; scope to the LeadForm's "Get in touch" button so this
+  // test exercises the lead form (not the checkout flow which would
+  // POST to /api/checkout/session and require Stripe to be configured).
+  const leadForm = page
+    .locator('form')
+    .filter({ has: page.getByRole('button', { name: /get in touch/i }) })
+    .first();
+  await leadForm.getByRole('button', { name: /get in touch/i }).click();
+  await expect(leadForm).toBeVisible();
 });
 
 test('contact page submits a lead payload and renders success state', async ({ page }) => {

--- a/libs/langgraph/src/lib/agent.provider.spec.ts
+++ b/libs/langgraph/src/lib/agent.provider.spec.ts
@@ -40,7 +40,7 @@ describe('provideAgent', () => {
     const token = await signLicense(
       {
         sub: 'cus_test',
-        tier: 'developer-seat',
+        tier: 'developer_seat',
         iat: 1_700_000_000,
         exp: 2_000_000_000,
         seats: 1,


### PR DESCRIPTION
## Summary

Two unrelated test failures had been red on main since recent merges:

1. **Library — lint / test / build** failing on `langgraph:test` — `agent.provider.spec.ts` used legacy tier slug `'developer-seat'` (hyphen). PR #516 renamed the `LicenseTier` union to underscored slugs (`'developer_seat'`). Token was rejected as malformed → nag fired → test failed.

2. **Website — e2e** failing on "pricing page lead form validates required fields" — bare `page.click('button[type="submit"]')` was picking the first submit button, which after PR #508 became a Stripe checkout button (POSTs to `/api/checkout/session` which 500s without `STRIPE_SECRET_KEY`). Scoped to the LeadForm via the "Get in touch" button text.

## Test plan

- [x] `npx vitest run agent.provider` locally — 4/4 passing
- [ ] Website-e2e on this PR — green
- [ ] Library on this PR — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)