### PR TITLE
chore(stripe): regenerate price IDs after subscription sync

### DIFF
--- a/pricing/tiers.generated.ts
+++ b/pricing/tiers.generated.ts
@@ -4,7 +4,7 @@ import type { TierSlug, BillingCycle } from './tiers.config';
 
 type BuyableSlug = Exclude<TierSlug, 'community' | 'enterprise'>;
 
-// Empty stub — run `STRIPE_SECRET_KEY=sk_... pnpm tsx scripts/stripe/sync-products.ts`
-// to populate. Until that runs, the checkout API returns a 503 with a helpful
-// message.
-export const STRIPE_PRICE_IDS: Partial<Record<BuyableSlug, Record<BillingCycle, string>>> = {};
+export const STRIPE_PRICE_IDS: Partial<Record<BuyableSlug, Record<BillingCycle, string>>> = {
+  developer_seat: { monthly: "price_1TapR1GYRsLErhxb83221xMU", annual: "price_1TapR1GYRsLErhxb67dc67h1" },
+  team: { monthly: "price_1TapR2GYRsLErhxbBbrJMLpk", annual: "price_1TapR2GYRsLErhxbYsWAkYuE" },
+};


### PR DESCRIPTION
## Summary
After PR #532, ran scripts/stripe/sync-products.ts against the live Stripe test-mode account. Created 4 recurring prices (monthly + annual × developer_seat + team) and archived the prior one-time prices. /api/checkout/session now has the IDs it needs to actually drive subscription checkout.

## Operational state (parallel to this PR)
- ✅ DB migration 0002 applied to minting Neon DB
- ✅ Webhook \`we_1TZcsHGYRsLErhxbdN2JTFTr\` enabled_events updated: \`customer.subscription.{created,updated,deleted}\` + \`invoice.paid\` + \`charge.refunded\` (dropped \`checkout.session.completed\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)