### PR TITLE
chore(minting): drop unused LICENSE_DEFAULT_TTL_DAYS

### DIFF
--- a/apps/minting-service/handlers/stripe-webhook.ts
+++ b/apps/minting-service/handlers/stripe-webhook.ts
@@ -67,7 +67,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse): 
     privateKeyHex: env.LICENSE_SIGNING_PRIVATE_KEY_HEX,
     resendApiKey: env.RESEND_API_KEY,
     emailFrom: env.EMAIL_FROM,
-    defaultTtlDays: env.LICENSE_DEFAULT_TTL_DAYS,
   };
 
   try {

--- a/apps/minting-service/src/lib/env.spec.ts
+++ b/apps/minting-service/src/lib/env.spec.ts
@@ -27,7 +27,7 @@ describe('loadEnv', () => {
     const { loadEnv } = await import('./env.js');
     const env = loadEnv();
     expect(env.STRIPE_SECRET_KEY).toBe('sk_test_xxx');
-    expect(env.LICENSE_DEFAULT_TTL_DAYS).toBe(365);
+    expect(env.LICENSE_SIGNING_PRIVATE_KEY_HEX).toHaveLength(64);
   });
 
   it('throws with a list of all missing vars', async () => {
@@ -48,10 +48,4 @@ describe('loadEnv', () => {
     expect(() => loadEnv()).toThrow(/64 hex chars/);
   });
 
-  it('accepts a custom LICENSE_DEFAULT_TTL_DAYS', async () => {
-    setEnv({ ...REQUIRED, LICENSE_DEFAULT_TTL_DAYS: '30' });
-    const { loadEnv } = await import('./env.js');
-    const env = loadEnv();
-    expect(env.LICENSE_DEFAULT_TTL_DAYS).toBe(30);
-  });
 });

--- a/apps/minting-service/src/lib/env.ts
+++ b/apps/minting-service/src/lib/env.ts
@@ -15,7 +15,6 @@ export interface Env {
   RESEND_API_KEY: string;
   EMAIL_FROM: string;
   LICENSE_SIGNING_PRIVATE_KEY_HEX: string;
-  LICENSE_DEFAULT_TTL_DAYS: number;
 }
 
 export function loadEnv(): Env {
@@ -36,6 +35,5 @@ export function loadEnv(): Env {
     RESEND_API_KEY: process.env['RESEND_API_KEY']!,
     EMAIL_FROM: process.env['EMAIL_FROM']!,
     LICENSE_SIGNING_PRIVATE_KEY_HEX: keyHex,
-    LICENSE_DEFAULT_TTL_DAYS: Number(process.env['LICENSE_DEFAULT_TTL_DAYS'] ?? 365),
   };
 }

--- a/apps/minting-service/src/lib/handlers.spec.ts
+++ b/apps/minting-service/src/lib/handlers.spec.ts
@@ -26,7 +26,6 @@ function makeDeps(overrides: Partial<HandlerDeps> = {}): HandlerDeps {
     privateKeyHex: 'a'.repeat(64),
     resendApiKey: 're_test',
     emailFrom: 'noreply@example.com',
-    defaultTtlDays: 365,
     ...overrides,
   };
 }

--- a/apps/minting-service/src/lib/handlers.ts
+++ b/apps/minting-service/src/lib/handlers.ts
@@ -37,7 +37,6 @@ export interface HandlerDeps {
   privateKeyHex: string;
   resendApiKey: string;
   emailFrom: string;
-  defaultTtlDays: number;
 }
 
 export async function handleEvent(event: Stripe.Event, deps: HandlerDeps): Promise<void> {


### PR DESCRIPTION
## Summary
Under subscriptions, every license's \`expiresAt\` comes from \`item.current_period_end\`. The fallback fixed TTL has no callers, so the env var and the HandlerDeps field were dead code.

## Test plan
- [x] minting-service tests pass
- [ ] Drop LICENSE_DEFAULT_TTL_DAYS from the Vercel project env (operational, after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)