### PR TITLE
docs: align licensing env-var name on THREADPLANE_LICENSE

### DIFF
--- a/apps/website/content/docs/licensing/guides/ci-and-offline.mdx
+++ b/apps/website/content/docs/licensing/guides/ci-and-offline.mdx
@@ -9,13 +9,13 @@ No network call is needed to know whether a token is signed correctly.
 For CI builds, treat the license token like any other secret:
 
 ```bash
-NGAF_LICENSE=... npm test
+THREADPLANE_LICENSE=... npm test
 ```
 
 Then pass it through `provideChat()`.
 
 ```ts
-provideChat({ license: process.env['NGAF_LICENSE'] });
+provideChat({ license: process.env['THREADPLANE_LICENSE'] });
 ```
 
 If you call `runLicenseCheck()` directly, inject the current time only when you need deterministic tests:

--- a/apps/website/content/docs/licensing/guides/setup.mdx
+++ b/apps/website/content/docs/licensing/guides/setup.mdx
@@ -23,7 +23,7 @@ import {
 
 const status = await runLicenseCheck({
   package: '@ngaf/example',
-  token: process.env.NGAF_LICENSE,
+  token: process.env.THREADPLANE_LICENSE,
   publicKey: LICENSE_PUBLIC_KEY,
   isNoncommercial: inferNoncommercial(),
 });


### PR DESCRIPTION
## Summary
\`/docs/licensing/guides/setup.mdx\` and \`ci-and-offline.mdx\` still referenced \`NGAF_LICENSE\`; the chat README and \`/docs/chat/getting-started/installation\` already use \`THREADPLANE_LICENSE\`. Aligning on a single name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)