### PR TITLE
test(examples-chat): pin no-nav-loop invariant

### DIFF
--- a/examples/chat/angular/src/app/shell/demo-shell.component.spec.ts
+++ b/examples/chat/angular/src/app/shell/demo-shell.component.spec.ts
@@ -1,7 +1,7 @@
 import { signal } from '@angular/core';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { TestBed } from '@angular/core/testing';
-import { provideRouter, Router } from '@angular/router';
+import { provideRouter, Router, NavigationEnd } from '@angular/router';
 import { LangGraphThreadsAdapter } from '@ngaf/langgraph';
 import { DemoShell } from './demo-shell.component';
 
@@ -214,6 +214,38 @@ describe('DemoShell — URL thread sync', () => {
       threadIdSignal: { (): string | null };
     };
     expect(cmp.threadIdSignal()).toBe('url-thread');
+  });
+
+  it('does not re-navigate when hydrating from URL (no nav-loop)', async () => {
+    // Regression guard for the URL↔signal sync invariant that every PR
+    // in the routing chain (#500/#504/#514/#518/#527) was dancing
+    // around: when the URL→signal effect hydrates `threadIdSignal`
+    // from `/embed/<id>`, the subsequent signal→URL effect must see
+    // signal === urlId and short-circuit (compare-and-set guard).
+    // Without that guard we'd loop: URL → signal → router.navigate →
+    // URL again, observable as extra NavigationEnd events.
+    const router = TestBed.inject(Router);
+    await router.navigateByUrl('/embed/no-loop-thread');
+
+    // Subscribe BEFORE createComponent so we capture any NavigationEnd
+    // events the component's effects might emit. The initial nav above
+    // already fired before we subscribed, so it doesn't count.
+    const navEnds: string[] = [];
+    const sub = router.events.subscribe((e) => {
+      if (e instanceof NavigationEnd) navEnds.push(e.urlAfterRedirects);
+    });
+
+    const fx = TestBed.createComponent(DemoShell);
+    fx.detectChanges();
+    sub.unsubscribe();
+
+    const cmp = fx.componentInstance as unknown as {
+      threadIdSignal: { (): string | null };
+    };
+    expect(cmp.threadIdSignal()).toBe('no-loop-thread');
+    // Zero NavigationEnd events — the signal→URL effect short-circuited
+    // because signal already matched urlState (compare-and-set guard).
+    expect(navEnds).toEqual([]);
   });
 });
 

--- a/examples/chat/angular/src/app/shell/demo-shell.component.spec.ts
+++ b/examples/chat/angular/src/app/shell/demo-shell.component.spec.ts
@@ -1,5 +1,5 @@
 import { signal } from '@angular/core';
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { TestBed } from '@angular/core/testing';
 import { provideRouter, Router, NavigationEnd } from '@angular/router';
 import { LangGraphThreadsAdapter } from '@ngaf/langgraph';


### PR DESCRIPTION
## Summary

Adds a regression guard for the URL↔signal sync invariant that every PR in the routing chain (#500/#504/#514/#518/#527) was dancing around: when the URL→signal effect hydrates `threadIdSignal` from `/embed/<id>`, the signal→URL effect MUST see signal===urlId and short-circuit. Without the guard we'd loop:

```
URL → signal → router.navigate → URL → signal → ...
```

The test asserts zero NavigationEnd events fire between initial `navigateByUrl` and end of `detectChanges` — proving the compare-and-set guard at `demo-shell.component.ts` (signal→URL effect) does its job.

## Follow-up: Minting service Vercel deploy

Unrelated to this PR but worth flagging: the `Minting service deploy` job has been red on the last 4 main runs. Error:
```
The provided path "~/work/.../apps/minting-service/apps/minting-service" does not exist
```

The Vercel project for minting-service has its **Root Directory** set to `apps/minting-service` in the Vercel dashboard. The workflow runs `vercel pull` from `working-directory: apps/minting-service`, so Vercel computes the root as `<cwd>/<configured-root>` and the path doubles.

**Fix (Vercel dashboard, no code change required):** set the project's Root Directory to empty/blank.

## Test plan

- [x] 33/33 examples-chat-angular unit tests passing locally (18 in demo-shell.spec, +1 new)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)