### PR TITLE
ci: drop redundant Minting service deploy job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -789,42 +789,11 @@ jobs:
           });
           NODE
 
-  minting-deploy:
-    name: Minting service deploy
-    needs: [library]
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: actions/setup-node@v6.3.0
-        with:
-          node-version: 22
-          cache: npm
-      - run: npm ci
-      - name: Deploy minting service to Vercel (production)
-        working-directory: apps/minting-service
-        run: |
-          mkdir -p .vercel
-          cat > .vercel/project.json <<EOF
-          {"projectId":"${{ secrets.VERCEL_MINTING_PROJECT_ID }}","orgId":"${{ secrets.VERCEL_ORG_ID }}","projectName":"threadplane-minting-service"}
-          EOF
-          npx vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
-          npx vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
-          npx vercel deploy --prebuilt --prod --yes --token=${{ secrets.VERCEL_TOKEN }}
-      - name: Verify minting service health
-        env:
-          MINTING_URL: https://mint.threadplane.ai
-        run: |
-          for i in 1 2 3 4 5; do
-            if curl -sf -o /dev/null "$MINTING_URL/api/health"; then
-              echo "Minting service is healthy."
-              exit 0
-            fi
-            echo "Waiting for minting service; attempt $i/5..."
-            sleep 5
-          done
-          echo "::error::Minting service did not respond at $MINTING_URL/api/health"
-          exit 1
+  # Minting service deploys via Vercel's git integration on every push to main
+  # (configured in the Vercel project's git settings, not here). The previous
+  # manual `vercel deploy` step doubled the rootDirectory path and was always
+  # failing despite production being healthy. Dropped; rely on Vercel for the
+  # deploy itself.
 
   production-smoke:
     name: Production smoke


### PR DESCRIPTION
## Summary
The CI \`Minting service deploy\` job has been failing on every push to main since Vercel's project rootDirectory began including \`apps/minting-service\`. The action invoked \`vercel deploy --prebuilt\` from \`working-directory: apps/minting-service\`, doubling the path.

Vercel's git integration already auto-deploys the minting service on every main push — \`5066fad1\`, \`af84132b\`, ..., \`ea35d59b\` all show \`state: READY\` in the Vercel dashboard despite this job failing.

## Verify
- \`https://mint.threadplane.ai/api/health\` → \`{"ok":true}\`
- Latest minting deployment in Vercel: \`ea35d59\` / READY

🤖 Generated with [Claude Code](https://claude.com/claude-code)