### PR TITLE
fix(website): mobile hygiene — sidebar breakpoint + layout viewport constraint

### DIFF
--- a/apps/website/src/app/global.css
+++ b/apps/website/src/app/global.css
@@ -5,6 +5,10 @@
   box-sizing: border-box;
 }
 
+html {
+  overflow-x: hidden;
+}
+
 body {
   background-color: var(--color-bg);
   color: var(--color-text-primary);
@@ -12,6 +16,14 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   overflow-x: hidden;
+}
+
+/* Code blocks scroll internally; never expand the layout viewport. */
+pre, code {
+  max-width: 100%;
+}
+pre {
+  overflow-x: auto;
 }
 
 /* Long unbreakable tokens (e.g. package names like @threadplane/chat,

--- a/apps/website/src/components/docs/DocsSidebar.tsx
+++ b/apps/website/src/components/docs/DocsSidebar.tsx
@@ -168,7 +168,7 @@ export function DocsSidebar({ activeLibrary, activeSection, activeSlug }: Props)
 
   return (
     <aside
-      className="w-64 shrink-0 py-6 overflow-y-auto hidden md:block"
+      className="w-64 shrink-0 py-6 overflow-y-auto hidden lg:block"
       style={{
         borderRight: `1px solid ${tokens.surfaces.border}`,
         background: tokens.surfaces.surface,


### PR DESCRIPTION
Two related mobile-hygiene fixes from the prod audit + Chrome MCP DOM inspection:

**1. Docs sidebar reveal pushed to `lg:block`**
Audit flagged the sidebar as 500–925% viewport-height sticky on 768px tablet. Pushing from `md:block` to `lg:block` hides it for tablet/narrow-desktop. The mobile nav's docs tab already covers navigation at <lg.

**2. Layout viewport constraint (real overflow fix)**
Chrome MCP confirmed PR #547's `body { overflow-x: hidden }` is live in prod, but the audit's overflow numbers persist because on mobile, when child content (code blocks, wide grids) exceeds device-width, browsers *expand the layout viewport*. The fixed nav then renders at that expanded width — the hamburger ends up clipped offscreen.

Added:
- `html { overflow-x: hidden }` — anchors layout viewport to visual viewport, so `position: fixed` elements stay aligned.
- `pre { max-width: 100%; overflow-x: auto }` as a universal rule (was already on `.shiki` and `.docs-prose pre`; this catches any other pre in landing components without those classes).

## Test plan
- [ ] Mobile audit re-run shows overflow drop to ~0px across the 8 previously-overflowing routes
- [ ] Hamburger button visible and tappable at 360px width on / and /ag-ui
- [ ] /docs at 768px — full-width article, no sidebar
- [ ] /docs at ≥1024px — sidebar unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)