### PR TITLE
ci(perf): cockpit-examples-build builds only affected caps on PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,12 +153,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v6.3.0
         with:
           node-version: 22
           cache: npm
       - run: npm ci
-      - run: npx nx run-many -t build --projects='cockpit-*-angular' --skip-nx-cache
+      - name: Build cockpit examples (affected on PR, all on push)
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            npx nx run-many -t build --projects='cockpit-*-angular' --skip-nx-cache
+          else
+            BASE="${{ github.event.pull_request.base.sha }}"
+            HEAD="${{ github.event.pull_request.head.sha }}"
+            AFFECTED=$(npx nx show projects --affected --base="$BASE" --head="$HEAD" \
+              | grep -E '^cockpit-.*-angular$' | paste -sd, - || true)
+            if [ -z "$AFFECTED" ]; then
+              echo "No affected cockpit angular projects; nothing to build."
+            else
+              echo "Building affected: $AFFECTED"
+              npx nx run-many -t build --projects="$AFFECTED" --skip-nx-cache
+            fi
+          fi
 
   cockpit-smoke:
     name: Cockpit — representative capability smoke


### PR DESCRIPTION
## Summary

`cockpit-examples-build` ran `nx run-many --projects='cockpit-*-angular'` on every PR — building all 32 cockpit angular projects (~5m28s) regardless of what changed.

Now:
- **PR**: builds only the `cockpit-*-angular` projects nx considers affected (base..head). 1-cap PR → 1 build; libs/chat fanout → all 32; docs-only → fast no-op.
- **push to main**: unchanged full build of all 32 (pre-deploy safety net).

This is a production `nx build`, distinct from cockpit-e2e's `nx serve` (dev-server) — not redundant, so the job stays; it just scopes its work on PRs. Adds `fetch-depth: 0` to checkout (required for nx affected base..head).

## Test plan

- [x] YAML lint clean
- [ ] This PR (touches only ci.yml → 0 affected cockpit caps) → build step is a fast no-op
- [ ] A future cap-touching PR → builds only that cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)