### PR TITLE
fix(cockpit): aimock fixtures for refund interrupts e2e

### DIFF
--- a/cockpit/langgraph/interrupts/angular/e2e/fixtures/interrupts.json
+++ b/cockpit/langgraph/interrupts/angular/e2e/fixtures/interrupts.json
@@ -1,11 +1,35 @@
 {
   "fixtures": [
     {
-      "match": {
-        "userMessage": "Hello"
-      },
+      "match": { "responseFormat": "json_schema", "userMessage": "cus_a8x2k" },
       "response": {
-        "content": "Hello! How can I help you today? Please approve this response to continue."
+        "content": {
+          "customer_id": "cus_a8x2k",
+          "amount": 47.5,
+          "reason": "Customer was charged twice for the same order."
+        }
+      }
+    },
+    {
+      "match": { "responseFormat": "json_schema", "userMessage": "cus_z19fp" },
+      "response": {
+        "content": {
+          "customer_id": "cus_z19fp",
+          "amount": 129.0,
+          "reason": "Chargeback opened for unrecognized activity."
+        }
+      }
+    },
+    {
+      "match": { "systemMessage": "Refund Authorization Assistant", "userMessage": "cus_a8x2k" },
+      "response": {
+        "content": "Understood — a $47.50 refund to cus_a8x2k for a duplicate charge. Pausing for operator approval; no refund is issued until a human reviews and approves."
+      }
+    },
+    {
+      "match": { "systemMessage": "Refund Authorization Assistant", "userMessage": "cus_z19fp" },
+      "response": {
+        "content": "Understood — a $129.00 refund to cus_z19fp for a chargeback. Pausing for operator approval; no refund is issued until a human reviews and approves."
       }
     }
   ]


### PR DESCRIPTION
## Summary

Fixes the red `Cockpit — e2e (cockpit-langgraph-interrupts-angular)` job on main.

**Root cause:** the refund rewrite (#553) added two LLM calls per turn in `draft_refund` — a structured-output extractor and a plain-text acknowledgement — but the e2e fixture file still only had the old generic `"Hello"` entry. Both calls hit the aimock replay proxy with no matching fixture → `404 No fixture matched` at `graph.py:54`.

**Fix (fixtures only — no harness change):**
- The extractor uses `chat.completions.parse` with `response_format: { type: "json_schema", name: "RefundDraft" }` (verified empirically — `with_structured_output` routes through the structured-outputs path). Matched via `responseFormat: "json_schema"`; response returns `content` as a JSON object, which aimock stringifies for the parser.
- The acknowledgement is a plain-text call matched on the refund system prompt.
- Both welcome suggestions covered (`cus_a8x2k` $47.50, `cus_z19fp` $129.00).

aimock already supports structured-output fixtures (`match.responseFormat`, JSON `content`), so no `libs/e2e-harness` change was needed.

## Test plan

- [x] Verified locally against `@copilotkit/aimock`: extractor returns `RefundDraft(customer_id=cus_a8x2k, amount=47.5, …)`, ack returns text
- [ ] `Cockpit — e2e (cockpit-langgraph-interrupts-angular)` green in CI