### PR TITLE
fix(website): consistent navbar→eyebrow spacing on pricing + blog heroes

### DIFF
--- a/apps/website/src/app/blog/page.tsx
+++ b/apps/website/src/app/blog/page.tsx
@@ -35,7 +35,7 @@ export default async function BlogIndexPage({ searchParams }: Props) {
 
   return (
     <div style={{ paddingTop: 80, background: tokens.surfaces.canvas, minHeight: '100vh' }}>
-      <div style={{ maxWidth: 960, margin: '0 auto', padding: '64px 24px' }}>
+      <div style={{ maxWidth: 960, margin: '0 auto', padding: '35px 24px 64px' }}>
         <header style={{ marginBottom: 32 }}>
           <Eyebrow tone="accent" style={{ marginBottom: 16 }}>
             Blog

--- a/apps/website/src/app/pricing/page.tsx
+++ b/apps/website/src/app/pricing/page.tsx
@@ -20,7 +20,7 @@ export const metadata = createPageMetadata({
 export default function PricingPage() {
   return (
     <>
-      <Section surface="canvas" tight ariaLabelledBy="pricing-heading">
+      <Section surface="canvas" ariaLabelledBy="pricing-heading">
         <Container>
           <div style={{ textAlign: 'center', maxWidth: 760, margin: '0 auto' }}>
             <Eyebrow tone="accent" style={{ marginBottom: 16 }}>Pricing</Eyebrow>


### PR DESCRIPTION
## Summary

Audited every non-docs hero/header (via Chrome MCP, gap = eyebrow top − navbar bottom @1440px). 11/13 pages were a consistent **34px**; two outliers fixed:

| Page | Before | After |
|---|---|---|
| /pricing | **−1px** (eyebrow *behind* navbar) | 34px |
| /blog | **63px** (~2×) | 34px |

**Root causes:**
- `/pricing` — hero `<Section>` had `tight`, applying `sectionYTight` (80px), which is *less* than the 81px fixed navbar, so the "Pricing" eyebrow rendered underneath it. Dropped `tight` → inherits `sectionY` (115.2px = navbar + 34px).
- `/blog` — bespoke hero layout stacked outer `paddingTop:80` + inner `64px` top = 144px. Reduced the inner top padding to 35 (sides/bottom unchanged).

All other pages (home, ag-ui, langgraph, render, chat, pilot-to-prod, solutions, solutions/[slug], contact, thanks) were already at 34px and untouched.

## Test plan

- [x] Re-measured both pages in Chrome after the fix → both 34px
- [ ] CI green