### PR TITLE
Align adapter testing surfaces: symmetric provideFakeAgent + shared FakeAgentConfig

### DIFF
--- a/apps/website/content/docs/ag-ui/api/api-docs.json
+++ b/apps/website/content/docs/ag-ui/api/api-docs.json
@@ -403,32 +403,6 @@
     "examples": []
   },
   {
-    "name": "FakeAgentConfig",
-    "kind": "interface",
-    "description": "",
-    "properties": [
-      {
-        "name": "delayMs",
-        "type": "number",
-        "description": "Milliseconds between successive token emissions.",
-        "optional": true
-      },
-      {
-        "name": "reasoningTokens",
-        "type": "string[]",
-        "description": "Optional reasoning chunks emitted before the text reply.",
-        "optional": true
-      },
-      {
-        "name": "tokens",
-        "type": "string[]",
-        "description": "Tokens streamed back as the assistant reply.",
-        "optional": true
-      }
-    ],
-    "examples": []
-  },
-  {
     "name": "ToAgentOptions",
     "kind": "interface",
     "description": "",

--- a/apps/website/content/docs/ag-ui/guides/testing.mdx
+++ b/apps/website/content/docs/ag-ui/guides/testing.mdx
@@ -1,0 +1,76 @@
+# Testing
+
+`@threadplane/ag-ui` gives you two test doubles, smallest scope first:
+
+- **`provideFakeAgent()`** — a one-call fake backend that runs the real adapter pipeline and streams canned tokens. No server, no LLM.
+- **`mockAgent()`** (from `@threadplane/chat`) — a writable-signal mock for component/unit tests. The ag-ui agent _is_ the neutral `Agent` contract, so there is no ag-ui-specific mock — use the neutral one directly.
+
+See [Choosing an adapter → Testing](/docs/choosing-an-adapter#testing) for when to use each test double.
+
+## Fake backend: `provideFakeAgent()`
+
+`provideFakeAgent({ tokens, reasoningTokens, delayMs })` wires a fake backend into Angular DI in one call. It exercises the **real adapter pipeline** — `injectAgent()`, status transitions, message accumulation — but the wire events are canned, so there's no server and no LLM. Use it for adapter-integration tests, in-browser demos, and offline development.
+
+It drops in exactly where `provideAgent()` would go — the call shape matches the LangGraph adapter:
+
+<Tabs>
+<Tab label="app.config.ts">
+
+```typescript
+import { ApplicationConfig } from '@angular/core';
+import { provideFakeAgent } from '@threadplane/ag-ui';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideFakeAgent({ tokens: ['Hello'] }),
+  ],
+};
+```
+
+</Tab>
+<Tab label="chat.component.ts">
+
+```typescript
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChatComponent } from '@threadplane/chat';
+import { injectAgent } from '@threadplane/ag-ui';
+
+@Component({
+  selector: 'app-chat',
+  imports: [ChatComponent],
+  template: `<chat [agent]="agent" />`,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ChatHost {
+  protected readonly agent = injectAgent();
+}
+```
+
+</Tab>
+</Tabs>
+
+The component is byte-identical to production — only the provider changes. `FakeAgentConfig` (`{ tokens?, reasoningTokens?, delayMs? }`) lives in `@threadplane/chat/testing`:
+
+| Option | Type | Notes |
+| --- | --- | --- |
+| `tokens` | `string[]` | Emitted as streamed text deltas, in order. |
+| `reasoningTokens` | `string[]` | Emitted before text deltas to exercise reasoning UI. |
+| `delayMs` | `number` | Delay between streamed events. |
+
+For the underlying `FakeAgent` class and its canned event sequence, see [Fake Agent](/docs/ag-ui/guides/fake-agent).
+
+## Contract mock: `mockAgent()`
+
+For component and unit tests where you don't need a streaming pipeline at all, use the neutral `mockAgent(initial)` from `@threadplane/chat`. It returns an `Agent` whose state surface is exposed as **writable signals** — set state directly and assert your component reacts. Nothing is real.
+
+The ag-ui adapter exposes exactly the neutral `Agent` contract, so there is no ag-ui-specific mock — `mockAgent()` is the right tool.
+
+```typescript
+import { mockAgent } from '@threadplane/chat';
+
+const m = mockAgent({ status: 'running' });
+m.messages.set([{ role: 'assistant', content: 'Hello!' }]);
+
+expect(m.messages()[0].content).toBe('Hello!');
+expect(m.status()).toBe('running');
+```

--- a/apps/website/content/docs/chat/api/api-docs.json
+++ b/apps/website/content/docs/chat/api/api-docs.json
@@ -7184,6 +7184,32 @@
     "examples": []
   },
   {
+    "name": "FakeAgentConfig",
+    "kind": "interface",
+    "description": "Shared config for the adapters' `provideFakeAgent()` helpers\n(@threadplane/langgraph and @threadplane/ag-ui). Drives an in-process\nfake backend that streams a canned assistant reply.",
+    "properties": [
+      {
+        "name": "delayMs",
+        "type": "number",
+        "description": "Milliseconds between successive token emissions.",
+        "optional": true
+      },
+      {
+        "name": "reasoningTokens",
+        "type": "string[]",
+        "description": "Optional reasoning chunks emitted before the text reply.",
+        "optional": true
+      },
+      {
+        "name": "tokens",
+        "type": "string[]",
+        "description": "Assistant reply, streamed token-by-token.",
+        "optional": true
+      }
+    ],
+    "examples": []
+  },
+  {
     "name": "assertReasoningFixtureMessages",
     "kind": "function",
     "description": "Assertion — common to both adapters. Throws if the produced messages\ndon't match the shared expectation.",

--- a/apps/website/content/docs/choosing-an-adapter/index.mdx
+++ b/apps/website/content/docs/choosing-an-adapter/index.mdx
@@ -72,6 +72,18 @@ import { provideAgent as provideAgUiAgent } from '@threadplane/ag-ui';
 
 Each adapter uses its own private DI token internally, so providing both does not cause a runtime DI collision — but the developer ergonomics get awkward, and `<chat [agent]="agent" />` can only bind one Agent at a time. We recommend picking one adapter per app.
 
+## Testing
+
+Three layers of test doubles, smallest scope first:
+
+| Layer | Use | What's real | When |
+|---|---|---|---|
+| **Contract mock** | `mockAgent()` (chat) / `mockLangGraphAgent()` (langgraph) | nothing — you set `messages()`, `status()` directly | component/unit tests |
+| **Fake backend** | `provideFakeAgent({ tokens })` (both adapters) | the real adapter pipeline; canned wire events | adapter-integration tests, in-browser, no server |
+| **LLM fixture replay** | aimock (cockpit/examples e2e) | the whole stack incl. a real graph; only the LLM is replayed | full end-to-end |
+
+Reach for the smallest layer that covers your test. Don't stand up aimock when a `mockAgent` unit test suffices; don't hand-roll a transport when `provideFakeAgent` exists.
+
 ## Why two adapters?
 
 The `Agent` contract from `@threadplane/chat` is intentionally runtime-neutral. The two adapters exist because they bridge different on-the-wire protocols into that contract:

--- a/apps/website/content/docs/langgraph/api/api-docs.json
+++ b/apps/website/content/docs/langgraph/api/api-docs.json
@@ -30,6 +30,147 @@
     ]
   },
   {
+    "name": "FakeStreamTransport",
+    "kind": "class",
+    "description": "In-process AgentTransport that auto-streams a canned assistant reply.\n\nBacks `provideFakeAgent()`. Unlike `MockAgentTransport` (passive, driven\nmanually from specs), this transport emits its tokens automatically on\n`stream()`, then completes — suitable for offline demos and integration tests.\n\nNOT for production use.",
+    "params": [
+      {
+        "name": "config",
+        "type": "FakeAgentConfig",
+        "description": "",
+        "optional": false
+      }
+    ],
+    "examples": [],
+    "properties": [],
+    "methods": [
+      {
+        "name": "cancelRun",
+        "signature": "cancelRun(_threadId: string, _runId: string, _signal: AbortSignal)",
+        "description": "Optional: cancel a server-side run.",
+        "params": [
+          {
+            "name": "_threadId",
+            "type": "string",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "_runId",
+            "type": "string",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "_signal",
+            "type": "AbortSignal",
+            "description": "",
+            "optional": false
+          }
+        ]
+      },
+      {
+        "name": "createQueuedRun",
+        "signature": "createQueuedRun(_assistantId: string, threadId: string, payload: unknown, _signal: AbortSignal, options: LangGraphSubmitOptions)",
+        "description": "Optional: create a server-side queued run without joining it immediately.",
+        "params": [
+          {
+            "name": "_assistantId",
+            "type": "string",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "threadId",
+            "type": "string",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "payload",
+            "type": "unknown",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "_signal",
+            "type": "AbortSignal",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "options",
+            "type": "LangGraphSubmitOptions",
+            "description": "",
+            "optional": true
+          }
+        ]
+      },
+      {
+        "name": "getHistory",
+        "signature": "getHistory(_threadId: string, _signal: AbortSignal)",
+        "description": "Optional: load persisted checkpoint history for a thread.",
+        "params": [
+          {
+            "name": "_threadId",
+            "type": "string",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "_signal",
+            "type": "AbortSignal",
+            "description": "",
+            "optional": false
+          }
+        ]
+      },
+      {
+        "name": "joinStream",
+        "signature": "joinStream()",
+        "description": "Optional: join an already-started run without creating a new one.",
+        "params": []
+      },
+      {
+        "name": "stream",
+        "signature": "stream(_assistantId: string, _threadId: string | null, _payload: unknown, signal: AbortSignal, _options: LangGraphSubmitOptions)",
+        "description": "Open a streaming connection to an agent and yield events.",
+        "params": [
+          {
+            "name": "_assistantId",
+            "type": "string",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "_threadId",
+            "type": "string | null",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "_payload",
+            "type": "unknown",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "signal",
+            "type": "AbortSignal",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "_options",
+            "type": "LangGraphSubmitOptions",
+            "description": "",
+            "optional": true
+          }
+        ]
+      }
+    ]
+  },
+  {
     "name": "FetchStreamTransport",
     "kind": "class",
     "description": "Production transport that connects to a LangGraph Platform API via HTTP and SSE.\n\nCreates threads automatically if no threadId is provided, and streams events\nusing the LangGraph SDK client.",

--- a/apps/website/content/docs/langgraph/api/api-docs.json
+++ b/apps/website/content/docs/langgraph/api/api-docs.json
@@ -1503,8 +1503,14 @@
   {
     "name": "MockLangGraphAgent",
     "kind": "interface",
-    "description": "A LangGraphAgent mock with writable signals for easy test control.\n\nCast the result of `mockLangGraphAgent()` to this type to access\nwritable signals without unsafe casts in test files.",
+    "description": "A LangGraphAgent mock with writable signals for easy test control.\n\nBuilds on the runtime-neutral MockAgent from `@threadplane/chat`\n(which supplies the neutral `Agent`-contract writable signals plus\n`submit`/`stop`/`regenerate` call tracking) and layers the LangGraph-specific\nwritable signals on top.\n\nCast the result of `mockLangGraphAgent()` to this type to access\nwritable signals without unsafe casts in test files.",
     "properties": [
+      {
+        "name": "_internal",
+        "type": "object",
+        "description": "",
+        "optional": false
+      },
       {
         "name": "activeSubagents",
         "type": "WritableSignal<SubagentStreamRef[]>",
@@ -1692,6 +1698,12 @@
         "optional": false
       },
       {
+        "name": "stopCount",
+        "type": "number",
+        "description": "",
+        "optional": false
+      },
+      {
         "name": "subagents",
         "type": "WritableSignal<Map<string, Subagent>>",
         "description": "",
@@ -1701,6 +1713,12 @@
         "name": "submit",
         "type": "object",
         "description": "Submit input, resume commands, checkpoint forks, or other LangGraph run options.",
+        "optional": false
+      },
+      {
+        "name": "submitCalls",
+        "type": "object[]",
+        "description": "",
         "optional": false
       },
       {
@@ -2055,12 +2073,12 @@
   {
     "name": "mockLangGraphAgent",
     "kind": "function",
-    "description": "Creates a mock LangGraphAgent with writable signals for testing.\nControl state by writing to the returned writable signals directly.",
-    "signature": "mockLangGraphAgent(initial: object): MockLangGraphAgent<>",
+    "description": "Creates a mock LangGraphAgent with writable signals for testing.\nControl state by writing to the returned writable signals directly.\n\nNeutral `Agent`-contract signals come from mockAgent; LangGraph-specific\nsignals are declared here and layered on top.",
+    "signature": "mockLangGraphAgent(initial: MockAgentOptions & { hasValue?: boolean; isThreadLoading?: boolean; langGraphMessages?: BaseMessage<MessageStructure<MessageToolSet>, MessageType>[] }): MockLangGraphAgent<>",
     "params": [
       {
         "name": "initial",
-        "type": "object",
+        "type": "MockAgentOptions & { hasValue?: boolean; isThreadLoading?: boolean; langGraphMessages?: BaseMessage<MessageStructure<MessageToolSet>, MessageType>[] }",
         "description": "",
         "optional": false
       }
@@ -2080,6 +2098,25 @@
       {
         "name": "configOrFactory",
         "type": "AgentConfig<T, BagTemplate> | object",
+        "description": "",
+        "optional": false
+      }
+    ],
+    "returns": {
+      "type": "Provider[]",
+      "description": ""
+    },
+    "examples": []
+  },
+  {
+    "name": "provideFakeAgent",
+    "kind": "function",
+    "description": "Wire an in-process fake LangGraph agent into Angular DI.\n\nStreams a canned assistant reply (see FakeAgentConfig) with no backend —\nthe symmetric counterpart to @threadplane/ag-ui's provideFakeAgent(). For\nadvanced manual scripting (tool calls, interrupts, multi-batch), provide\nthe agent yourself with\n`provideAgent({ assistantId, transport: new MockAgentTransport(...) })`.",
+    "signature": "provideFakeAgent(config: FakeAgentConfig): Provider[]",
+    "params": [
+      {
+        "name": "config",
+        "type": "FakeAgentConfig",
         "description": "",
         "optional": false
       }

--- a/apps/website/content/docs/langgraph/guides/testing.mdx
+++ b/apps/website/content/docs/langgraph/guides/testing.mdx
@@ -1,9 +1,89 @@
 # Testing
 
-MockAgentTransport lets you test agent interactions deterministically without a running LangGraph server. Script exact event sequences, step through streaming lifecycles, and verify every signal transition in your Angular test specs.
+`@threadplane/langgraph` ships two purpose-built test doubles, plus an advanced manual-scripting transport for the rare cases that need it:
+
+- **`provideFakeAgent()`** — a one-call fake backend that runs the real adapter pipeline and streams canned tokens. No server, no LLM. Reach for this first.
+- **`mockLangGraphAgent()`** — a writable-signal mock for component/unit tests, where you set `messages()`, `status()`, etc. directly.
+- **`MockAgentTransport`** — an advanced escape hatch for hand-scripting exact wire event sequences (tool calls, interrupts, multi-batch lifecycles).
 
 <Callout type="tip" title="No flaky tests">
-MockAgentTransport eliminates network dependencies, timing issues, and server state. Every test run produces identical results. Your CI pipeline stays green.
+None of these touch the network, the LLM, or server state. Every test run produces identical results. Your CI pipeline stays green.
+</Callout>
+
+See [Choosing an adapter → Testing](/docs/choosing-an-adapter#testing) for when to use each test double.
+
+## Fake backend: `provideFakeAgent()`
+
+`provideFakeAgent({ tokens, reasoningTokens, delayMs })` wires a fake backend into Angular DI in one call. It exercises the **real adapter pipeline** — `injectAgent()`, status transitions, message accumulation — but the wire events are canned, so there's no server and no LLM. Use it for adapter-integration tests, in-browser demos, and offline development.
+
+It drops in exactly where `provideAgent()` would go:
+
+<Tabs>
+<Tab label="app.config.ts">
+
+```typescript
+import { ApplicationConfig } from '@angular/core';
+import { provideFakeAgent } from '@threadplane/langgraph';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideFakeAgent({ tokens: ['Hello', ' world'] }),
+  ],
+};
+```
+
+</Tab>
+<Tab label="chat.component.ts">
+
+```typescript
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChatComponent } from '@threadplane/chat';
+import { injectAgent } from '@threadplane/langgraph';
+
+@Component({
+  selector: 'app-chat',
+  imports: [ChatComponent],
+  template: `<chat [agent]="agent" />`,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ChatHost {
+  protected readonly agent = injectAgent();
+}
+```
+
+</Tab>
+</Tabs>
+
+The component is byte-identical to production — only the provider changes. `FakeAgentConfig` (`{ tokens?, reasoningTokens?, delayMs? }`) lives in `@threadplane/chat/testing`:
+
+| Option | Type | Notes |
+| --- | --- | --- |
+| `tokens` | `string[]` | Emitted as streamed text deltas, in order. |
+| `reasoningTokens` | `string[]` | Emitted before text deltas to exercise reasoning UI. |
+| `delayMs` | `number` | Delay between streamed events. |
+
+## Contract mock: `mockLangGraphAgent()`
+
+For component and unit tests where you don't need a streaming pipeline at all, `mockLangGraphAgent(initial)` returns a `LangGraphAgent` whose state surface is exposed as **writable signals**. Set state directly and assert your component reacts — nothing is real.
+
+```typescript
+import { mockLangGraphAgent } from '@threadplane/langgraph';
+
+const m = mockLangGraphAgent({ status: 'running' });
+m.messages.set([{ role: 'assistant', content: 'Hello!' }]);
+
+expect(m.messages()[0].content).toBe('Hello!');
+expect(m.status()).toBe('running');
+```
+
+`mockLangGraphAgent()` extends the neutral [`mockAgent()`](/docs/chat/api/mock-agent) from `@threadplane/chat` — it supplies the neutral `Agent`-contract writable signals (`messages`, `status`, `isLoading`, `error`, `interrupt`, …) plus `submit`/`stop` call tracking, then layers the LangGraph-specific signals (`langGraphMessages`, `branch`, `queue`, …) on top.
+
+## Advanced: `MockAgentTransport`
+
+Lead with `provideFakeAgent()` for the simple case. Reach for `MockAgentTransport` only when you need to hand-script exact wire event sequences — tool calls, interrupts, or multi-batch streaming lifecycles that the canned-token fake can't express.
+
+<Callout type="tip" title="No flaky tests">
+`MockAgentTransport` eliminates network dependencies, timing issues, and server state. Every test run produces identical results.
 </Callout>
 
 ## Python: Testing the Agent

--- a/apps/website/src/lib/docs-config.ts
+++ b/apps/website/src/lib/docs-config.ts
@@ -250,6 +250,7 @@ export const docsConfig: DocsLibrary[] = [
         pages: [
           { title: 'Fake Agent', slug: 'fake-agent', section: 'guides' },
           { title: 'Citations', slug: 'citations', section: 'guides' },
+          { title: 'Testing', slug: 'testing', section: 'guides' },
           { title: 'Troubleshooting', slug: 'troubleshooting', section: 'guides' },
         ],
       },

--- a/docs/superpowers/plans/2026-05-28-adapter-testing-surface-alignment.md
+++ b/docs/superpowers/plans/2026-05-28-adapter-testing-surface-alignment.md
@@ -1,0 +1,654 @@
+# Adapter Testing-Surface Alignment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give `@threadplane/langgraph` and `@threadplane/ag-ui` symmetric test doubles — a one-call `provideFakeAgent({tokens,…})` on both (shared `FakeAgentConfig`), and `mockLangGraphAgent` built on the neutral `mockAgent` — plus a test-double selection guide.
+
+**Architecture:** `FakeAgentConfig` becomes a single canonical type in `@threadplane/chat/testing`. langgraph gains a `provideFakeAgent` backed by a new **auto-emitting** `FakeStreamTransport` (the existing `MockAgentTransport` is passive/manual and stays the advanced escape hatch). `mockLangGraphAgent` is refactored to call chat's `mockAgent()` for the shared neutral signal bag, layering LangGraph-specific writable signals on top. Docs get a three-layer test-double selection table. No backwards-compat / re-exports — breaking changes accepted. Uniform patch bump `0.0.48 → 0.0.49` across all publishable libs.
+
+**Tech Stack:** Nx monorepo · Angular 20 (libs) · Vitest + Angular TestBed · MDX (docs).
+
+**Reference spec:** [docs/superpowers/specs/2026-05-28-adapter-testing-surface-alignment-design.md](../specs/2026-05-28-adapter-testing-surface-alignment-design.md)
+
+> **Spec refinement (internal-only):** The spec's §2b says langgraph `provideFakeAgent` wraps `new MockAgentTransport(script)`. During planning we confirmed `MockAgentTransport` is **passive** — its `stream()` waits for manual `emit()`/`nextBatch()` and won't auto-stream a constructor script. So `provideFakeAgent` is instead backed by a new **auto-emitting** `FakeStreamTransport` (parallels ag-ui's auto-emitting `FakeAgent`). The public API (`provideFakeAgent({tokens, reasoningTokens, delayMs})` and its behavior) is identical to the spec; only the private backing transport differs.
+
+---
+
+## File structure
+
+- **Create** `libs/chat/testing/fake-agent-config.ts` — the canonical `FakeAgentConfig` interface.
+- **Modify** `libs/chat/testing/public-api.ts` — export `FakeAgentConfig`.
+- **Modify** `libs/ag-ui/src/lib/testing/provide-fake-agent.ts` — delete local `FakeAgentConfig`, import from `@threadplane/chat/testing`.
+- **Modify** `libs/ag-ui/src/public-api.ts` — stop exporting `FakeAgentConfig` (no re-export).
+- **Create** `libs/langgraph/src/lib/testing/fake-stream.transport.ts` — auto-emitting `FakeStreamTransport implements AgentTransport`.
+- **Create** `libs/langgraph/src/lib/testing/provide-fake-agent.ts` — `provideFakeAgent(config)`.
+- **Modify** `libs/langgraph/src/public-api.ts` — export `provideFakeAgent`.
+- **Modify** `libs/langgraph/src/lib/testing/mock-langgraph-agent.ts` — refactor to extend chat's `mockAgent`.
+- **Docs:** `apps/website/content/docs/langgraph/guides/testing.mdx`, `apps/website/content/docs/ag-ui/guides/testing.mdx`, `apps/website/content/docs/choosing-an-adapter/index.mdx`, `libs/langgraph/README.md`, `libs/ag-ui/README.md`.
+- **Version:** all seven publishable `libs/*/package.json`.
+
+---
+
+## Task 1: Canonical `FakeAgentConfig` in `@threadplane/chat/testing`
+
+**Files:**
+- Create: `libs/chat/testing/fake-agent-config.ts`
+- Modify: `libs/chat/testing/public-api.ts`
+
+- [ ] **Step 1: Create the type**
+
+```ts
+// libs/chat/testing/fake-agent-config.ts
+// SPDX-License-Identifier: MIT
+
+/**
+ * Shared config for the adapters' `provideFakeAgent()` helpers
+ * (@threadplane/langgraph and @threadplane/ag-ui). Drives an in-process
+ * fake backend that streams a canned assistant reply.
+ */
+export interface FakeAgentConfig {
+  /** Assistant reply, streamed token-by-token. */
+  tokens?: string[];
+  /** Optional reasoning chunks emitted before the text reply. */
+  reasoningTokens?: string[];
+  /** Milliseconds between successive token emissions. */
+  delayMs?: number;
+}
+```
+
+- [ ] **Step 2: Export it**
+
+In `libs/chat/testing/public-api.ts`, add:
+
+```ts
+export type { FakeAgentConfig } from './fake-agent-config';
+```
+
+- [ ] **Step 3: Build chat**
+
+Run: `npx nx build chat`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add libs/chat/testing/fake-agent-config.ts libs/chat/testing/public-api.ts
+git commit -m "feat(chat): add shared FakeAgentConfig to chat/testing"
+```
+
+## Task 2: ag-ui imports `FakeAgentConfig` from chat/testing
+
+**Files:**
+- Modify: `libs/ag-ui/src/lib/testing/provide-fake-agent.ts`
+- Modify: `libs/ag-ui/src/public-api.ts`
+
+- [ ] **Step 1: Replace the local interface with an import**
+
+In `libs/ag-ui/src/lib/testing/provide-fake-agent.ts`, delete the local `export interface FakeAgentConfig { … }` block and add at the top (with the other imports):
+
+```ts
+import type { FakeAgentConfig } from '@threadplane/chat/testing';
+```
+
+Keep the rest of the file (the `provideFakeAgent` function and its `FakeAgent` usage) unchanged — it already references `FakeAgentConfig` by name.
+
+- [ ] **Step 2: Remove the `FakeAgentConfig` re-export from ag-ui public-api**
+
+In `libs/ag-ui/src/public-api.ts`, delete the line:
+
+```ts
+export type { FakeAgentConfig } from './lib/testing/provide-fake-agent';
+```
+
+Keep `provideAgent`, `injectAgent`, `AgentConfig`, `provideFakeAgent`, `FakeAgent`, `toAgent`, `bridgeCitationsState`.
+
+- [ ] **Step 3: Run ag-ui tests + build**
+
+Run: `npx nx run-many -t test build --projects=ag-ui`
+Expected: PASS (existing `provide-fake-agent.spec.ts` still green — it constructs `provideFakeAgent({tokens,…})` which is unchanged).
+
+- [ ] **Step 4: Confirm `@threadplane/chat/testing` resolves from ag-ui**
+
+If the build fails on the deep import path, check `libs/ag-ui/tsconfig*.json` / root `tsconfig.base.json` `paths` for a `@threadplane/chat/testing` entry. The `generate-api-docs.ts` config already lists `libs/chat/testing/public-api.ts` as an entry point, so the path mapping should exist; if not, add it mirroring the `@threadplane/chat` mapping with a `/testing` suffix pointing at `libs/chat/testing/public-api.ts`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add libs/ag-ui/src/lib/testing/provide-fake-agent.ts libs/ag-ui/src/public-api.ts
+git commit -m "refactor(ag-ui): import shared FakeAgentConfig from chat/testing"
+```
+
+## Task 3: langgraph auto-emitting `FakeStreamTransport`
+
+**Files:**
+- Create: `libs/langgraph/src/lib/testing/fake-stream.transport.ts`
+- Create: `libs/langgraph/src/lib/testing/fake-stream.transport.spec.ts`
+
+The transport implements `AgentTransport` (same interface `MockAgentTransport` implements) but its `stream()` **auto-emits** synthesized events with `delayMs` spacing, then completes. The canonical streaming event shape (from `agent.fn.spec.ts`) is `{ type: 'messages', messages: [{ id, type: 'ai', content }] }`, where `content` is the cumulative text so far.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// libs/langgraph/src/lib/testing/fake-stream.transport.spec.ts
+// SPDX-License-Identifier: MIT
+import { describe, it, expect } from 'vitest';
+import { FakeStreamTransport } from './fake-stream.transport';
+import type { StreamEvent } from '../agent.types';
+
+async function collect(transport: FakeStreamTransport): Promise<StreamEvent[]> {
+  const out: StreamEvent[] = [];
+  const ac = new AbortController();
+  for await (const ev of transport.stream('a', null, {}, ac.signal)) {
+    out.push(ev);
+  }
+  return out;
+}
+
+describe('FakeStreamTransport', () => {
+  it('auto-streams tokens as cumulative assistant message events', async () => {
+    const transport = new FakeStreamTransport({ tokens: ['Hello', ' world'], delayMs: 0 });
+    const events = await collect(transport);
+    // Last message event carries the full concatenated reply.
+    const messageEvents = events.filter((e) => e.type === 'messages');
+    expect(messageEvents.length).toBeGreaterThan(0);
+    const last = messageEvents[messageEvents.length - 1] as StreamEvent & {
+      messages: Array<{ type: string; content: string }>;
+    };
+    expect(last.messages[0].type).toBe('ai');
+    expect(last.messages[0].content).toBe('Hello world');
+  });
+
+  it('completes (stream ends) after emitting all tokens', async () => {
+    const transport = new FakeStreamTransport({ tokens: ['x'], delayMs: 0 });
+    const events = await collect(transport);
+    // collect() only resolves if the async iterator completes.
+    expect(events.length).toBeGreaterThan(0);
+  });
+
+  it('uses default tokens when none provided', async () => {
+    const transport = new FakeStreamTransport({ delayMs: 0 });
+    const events = await collect(transport);
+    expect(events.length).toBeGreaterThan(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx nx test langgraph -- --testFile=fake-stream.transport.spec.ts` (or `npx nx test langgraph` and locate the file)
+Expected: FAIL — "Cannot find module './fake-stream.transport'".
+
+- [ ] **Step 3: Implement the transport**
+
+```ts
+// libs/langgraph/src/lib/testing/fake-stream.transport.ts
+// SPDX-License-Identifier: MIT
+import type {
+  AgentQueueEntry,
+  AgentTransport,
+  LangGraphSubmitOptions,
+  StreamEvent,
+} from '../agent.types';
+import type { ThreadState } from '@langchain/langgraph-sdk';
+import type { FakeAgentConfig } from '@threadplane/chat/testing';
+
+const DEFAULT_TOKENS = ['Hello', ' from', ' the', ' fake', ' LangGraph', ' agent.'];
+
+/**
+ * In-process AgentTransport that auto-streams a canned assistant reply.
+ *
+ * Backs `provideFakeAgent()`. Unlike `MockAgentTransport` (which is passive and
+ * driven manually from specs), this transport emits its tokens automatically on
+ * `stream()`, then completes — suitable for offline demos and integration tests.
+ *
+ * NOT for production use.
+ */
+export class FakeStreamTransport implements AgentTransport {
+  private readonly tokens: string[];
+  private readonly reasoningTokens: string[];
+  private readonly delayMs: number;
+
+  constructor(config: FakeAgentConfig = {}) {
+    this.tokens = config.tokens ?? DEFAULT_TOKENS;
+    this.reasoningTokens = config.reasoningTokens ?? [];
+    this.delayMs = config.delayMs ?? 0;
+  }
+
+  async *stream(
+    _assistantId: string,
+    _threadId: string | null,
+    _payload: unknown,
+    signal: AbortSignal,
+    _options?: LangGraphSubmitOptions,
+  ): AsyncIterable<StreamEvent> {
+    const id = 'fake-ai-1';
+
+    // Reasoning chunks first, if any. Cumulative content on additional_kwargs
+    // mirrors how the adapter surfaces reasoning; see reasoning-fixture.ts for
+    // the canonical shape and adjust if a richer event type is required.
+    let reasoning = '';
+    for (const chunk of this.reasoningTokens) {
+      if (signal.aborted) return;
+      reasoning += chunk;
+      yield {
+        type: 'messages',
+        messages: [
+          { id, type: 'ai', content: '', additional_kwargs: { reasoning_content: reasoning } },
+        ],
+      } as unknown as StreamEvent;
+      if (this.delayMs > 0) await delay(this.delayMs);
+    }
+
+    // Assistant text reply, cumulative.
+    let content = '';
+    for (const tok of this.tokens) {
+      if (signal.aborted) return;
+      content += tok;
+      yield {
+        type: 'messages',
+        messages: [{ id, type: 'ai', content }],
+      } as unknown as StreamEvent;
+      if (this.delayMs > 0) await delay(this.delayMs);
+    }
+  }
+
+  async createQueuedRun(
+    _assistantId: string,
+    threadId: string,
+    payload: unknown,
+    _signal: AbortSignal,
+    options?: LangGraphSubmitOptions,
+  ): Promise<AgentQueueEntry> {
+    return {
+      id: 'fake-queued-run',
+      threadId,
+      values: payload,
+      options: { ...options, multitaskStrategy: 'enqueue' },
+      createdAt: new Date(),
+    };
+  }
+
+  async cancelRun(_threadId: string, _runId: string, _signal: AbortSignal): Promise<void> {}
+
+  async getHistory(_threadId: string, _signal: AbortSignal): Promise<ThreadState[]> {
+    return [];
+  }
+
+  async *joinStream(): AsyncIterable<StreamEvent> {
+    // No queued-run replay in the fake.
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+```
+
+Note: the `as unknown as StreamEvent` casts cover the inline message-literal shape (the same `{ id, type: 'ai', content }` literal used in `agent.fn.spec.ts:464`). If `AgentTransport`'s method signatures differ from what's shown (e.g. additional required methods), read the `AgentTransport` interface in `agent.types.ts` and `MockAgentTransport` for the exact contract, and implement every required member — `MockAgentTransport` is the reference for the full method set.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx nx test langgraph`
+Expected: the three `FakeStreamTransport` tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add libs/langgraph/src/lib/testing/fake-stream.transport.ts libs/langgraph/src/lib/testing/fake-stream.transport.spec.ts
+git commit -m "feat(langgraph): add auto-emitting FakeStreamTransport for provideFakeAgent"
+```
+
+## Task 4: langgraph `provideFakeAgent`
+
+**Files:**
+- Create: `libs/langgraph/src/lib/testing/provide-fake-agent.ts`
+- Create: `libs/langgraph/src/lib/testing/provide-fake-agent.spec.ts`
+- Modify: `libs/langgraph/src/public-api.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// libs/langgraph/src/lib/testing/provide-fake-agent.spec.ts
+// SPDX-License-Identifier: MIT
+import { describe, it, expect } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { provideFakeAgent } from './provide-fake-agent';
+import { injectAgent } from '../inject-agent';
+
+describe('provideFakeAgent (langgraph)', () => {
+  it('provides an agent that streams the canned tokens into messages()', async () => {
+    TestBed.configureTestingModule({
+      providers: [provideFakeAgent({ tokens: ['Hi', ' there'], delayMs: 0 })],
+    });
+    const agent = TestBed.runInInjectionContext(() => injectAgent());
+    await TestBed.runInInjectionContext(async () => {
+      await agent.submit({ message: 'hello' });
+    });
+    // Let the auto-emit stream flush.
+    await new Promise((r) => setTimeout(r, 20));
+    const msgs = agent.messages();
+    const assistant = msgs.find((m) => m.role === 'assistant');
+    expect(assistant?.content).toContain('Hi there');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx nx test langgraph`
+Expected: FAIL — "Cannot find module './provide-fake-agent'".
+
+- [ ] **Step 3: Implement `provideFakeAgent`**
+
+```ts
+// libs/langgraph/src/lib/testing/provide-fake-agent.ts
+// SPDX-License-Identifier: MIT
+import { type Provider } from '@angular/core';
+import type { FakeAgentConfig } from '@threadplane/chat/testing';
+import { provideAgent } from '../agent.provider';
+import { FakeStreamTransport } from './fake-stream.transport';
+
+/**
+ * Wire an in-process fake LangGraph agent into Angular DI.
+ *
+ * Streams a canned assistant reply (see FakeAgentConfig) with no backend —
+ * the symmetric counterpart to @threadplane/ag-ui's provideFakeAgent(). For
+ * advanced manual scripting (tool calls, interrupts, multi-batch), provide
+ * the agent yourself with `provideAgent({ transport: new MockAgentTransport(...) })`.
+ */
+export function provideFakeAgent(config: FakeAgentConfig = {}): Provider[] {
+  return provideAgent({
+    assistantId: 'fake',
+    transport: new FakeStreamTransport(config),
+  });
+}
+```
+
+(`provideAgent` returns `Provider[]`; return it directly.)
+
+- [ ] **Step 4: Export from public-api**
+
+In `libs/langgraph/src/public-api.ts`, near the other testing exports (after `mockLangGraphAgent`), add:
+
+```ts
+export { provideFakeAgent } from './lib/testing/provide-fake-agent';
+```
+
+- [ ] **Step 5: Run test + build**
+
+Run: `npx nx run-many -t test build --projects=langgraph`
+Expected: PASS. If the streamed assistant message doesn't appear in `messages()`, inspect the `messages`-event shape the adapter expects (compare to `agent.fn.spec.ts:462-469`) and adjust `FakeStreamTransport`'s emitted literal — the test is the gate.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add libs/langgraph/src/lib/testing/provide-fake-agent.ts libs/langgraph/src/lib/testing/provide-fake-agent.spec.ts libs/langgraph/src/public-api.ts
+git commit -m "feat(langgraph): add provideFakeAgent mirroring ag-ui"
+```
+
+## Task 5: Refactor `mockLangGraphAgent` to extend `mockAgent`
+
+**Files:**
+- Modify: `libs/langgraph/src/lib/testing/mock-langgraph-agent.ts`
+
+The neutral writable signals (`messages`, `status`, `isLoading`, `error`, `toolCalls`, `state`, `interrupt`, `subagents`, `history`, lifecycle stub, `events$`, `submit`/`stop`/`regenerate` + `submitCalls`/`stopCount`) come from chat's `mockAgent`. `mockLangGraphAgent` calls it (forcing `withInterrupt`/`withSubagents`/`history` on, since `MockLangGraphAgent` declares them non-optional), then layers the LangGraph-specific writable signals.
+
+- [ ] **Step 1: Read the current file end-to-end**
+
+Read `libs/chat/src/lib/testing/mock-agent.ts` (the base: `mockAgent`, `MockAgent`, `MockAgentOptions`) and the full current `libs/langgraph/src/lib/testing/mock-langgraph-agent.ts` to enumerate which signals are neutral (delegate to `mockAgent`) vs LangGraph-specific (keep).
+
+- [ ] **Step 2: Change the `MockLangGraphAgent` type to extend `MockAgent`**
+
+```ts
+import type { MockAgent, MockAgentOptions } from '@threadplane/chat';
+
+/**
+ * A LangGraphAgent mock with writable signals for easy test control.
+ * Extends the neutral MockAgent (from @threadplane/chat) with the
+ * LangGraph-specific writable signals.
+ */
+export interface MockLangGraphAgent extends MockAgent, LangGraphAgent<any, any> {
+  // LangGraph-specific writable signals (neutral ones come from MockAgent):
+  langGraphMessages: WritableSignal<BaseMessage[]>;
+  hasValue: WritableSignal<boolean>;
+  value: WritableSignal<any>;
+  langGraphInterrupts: WritableSignal<Interrupt<any>[]>;
+  langGraphToolCalls: WritableSignal<ToolCallWithResult[]>;
+  toolProgress: WritableSignal<ToolProgress[]>;
+  queue: WritableSignal<AgentQueue>;
+  branch: WritableSignal<string>;
+  langGraphHistory: WritableSignal<ThreadState<any>[]>;
+  experimentalBranchTree: WritableSignal<AgentBranchTree<any>>;
+  isThreadLoading: WritableSignal<boolean>;
+  activeSubagents: WritableSignal<SubagentStreamRef[]>;
+  customEvents: WritableSignal<CustomStreamEvent[]>;
+}
+```
+
+(If `MockAgent` + `LangGraphAgent` have conflicting member variance, prefer `extends MockAgent` and re-declare any LangGraph members that need a writable type — the existing file already lists the full set, so this is a reconciliation, not new design. Resolve type conflicts by keeping the `WritableSignal<…>` declarations.)
+
+- [ ] **Step 3: Rewrite `mockLangGraphAgent` to delegate the neutral bag to `mockAgent`**
+
+```ts
+import { mockAgent } from '@threadplane/chat';
+
+export function mockLangGraphAgent(
+  initial: MockAgentOptions & {
+    langGraphMessages?: BaseMessage[];
+    isThreadLoading?: boolean;
+    hasValue?: boolean;
+  } = {},
+): MockLangGraphAgent {
+  const base = mockAgent({
+    ...initial,
+    withInterrupt: true,
+    withSubagents: true,
+    history: initial.history ?? [],
+  });
+
+  // LangGraph-specific writable signals.
+  const langGraphMessages = signal<BaseMessage[]>(initial.langGraphMessages ?? []);
+  const hasValue = signal<boolean>(initial.hasValue ?? false);
+  const value = signal<any>(undefined);
+  const langGraphInterrupts = signal<Interrupt<any>[]>([]);
+  const langGraphToolCalls = signal<ToolCallWithResult[]>([]);
+  const toolProgress = signal<ToolProgress[]>([]);
+  const queue = signal<AgentQueue>(/* existing default from current file */ undefined as unknown as AgentQueue);
+  const branch = signal<string>('');
+  const langGraphHistory = signal<ThreadState<any>[]>([]);
+  const experimentalBranchTree = signal<AgentBranchTree<any>>(/* existing default */ undefined as unknown as AgentBranchTree<any>);
+  const isThreadLoading = signal<boolean>(initial.isThreadLoading ?? false);
+  const activeSubagents = signal<SubagentStreamRef[]>([]);
+  const customEvents = signal<CustomStreamEvent[]>([]);
+
+  return {
+    ...base,
+    langGraphMessages,
+    hasValue,
+    value,
+    langGraphInterrupts,
+    langGraphToolCalls,
+    toolProgress,
+    queue,
+    branch,
+    langGraphHistory,
+    experimentalBranchTree,
+    isThreadLoading,
+    activeSubagents,
+    customEvents,
+  } as MockLangGraphAgent;
+}
+```
+
+Use the **exact default values** for `queue` and `experimentalBranchTree` from the current file (don't invent them — copy the existing initializers). The current file's `initial` parameter fields and per-signal defaults are the source of truth; preserve them so existing callers behave identically.
+
+- [ ] **Step 4: Run the langgraph suite**
+
+Run: `npx nx test langgraph`
+Expected: PASS — **all existing specs that consume `mockLangGraphAgent` must remain green**. This is the regression gate.
+
+- [ ] **Step 5: Add a spec asserting the neutral-shape relationship**
+
+Append to an existing mock spec (or create `mock-langgraph-agent.spec.ts` if none):
+
+```ts
+import { mockLangGraphAgent } from './mock-langgraph-agent';
+
+describe('mockLangGraphAgent extends mockAgent', () => {
+  it('exposes the neutral MockAgent writable signals', () => {
+    const m = mockLangGraphAgent({ status: 'running' });
+    expect(m.status()).toBe('running');     // neutral signal, set via mockAgent
+    m.messages.set([]);                     // writable neutral signal
+    expect(m.submitCalls).toEqual([]);      // neutral submit tracking
+    // LangGraph-specific signal still present:
+    m.branch.set('main');
+    expect(m.branch()).toBe('main');
+  });
+});
+```
+
+- [ ] **Step 6: Run + build**
+
+Run: `npx nx run-many -t test build --projects=langgraph`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add libs/langgraph/src/lib/testing/mock-langgraph-agent.ts libs/langgraph/src/lib/testing/mock-langgraph-agent.spec.ts
+git commit -m "refactor(langgraph): mockLangGraphAgent extends neutral mockAgent"
+```
+
+## Task 6: Docs — testing guides + selection table + READMEs
+
+**Files:**
+- Modify: `apps/website/content/docs/langgraph/guides/testing.mdx`
+- Create/Modify: `apps/website/content/docs/ag-ui/guides/testing.mdx`
+- Modify: `apps/website/content/docs/choosing-an-adapter/index.mdx`
+- Modify: `libs/langgraph/README.md`, `libs/ag-ui/README.md`
+
+- [ ] **Step 1: Add the test-double selection table to Choosing-an-adapter**
+
+In `apps/website/content/docs/choosing-an-adapter/index.mdx`, add a `## Testing` section with this table:
+
+```markdown
+## Testing
+
+Three layers of test doubles, smallest scope first:
+
+| Layer | Use | What's real | When |
+|---|---|---|---|
+| **Contract mock** | `mockAgent()` (chat) / `mockLangGraphAgent()` (langgraph) | nothing — you set `messages()`, `status()` directly | component/unit tests |
+| **Fake backend** | `provideFakeAgent({ tokens })` (both adapters) | the real adapter pipeline; canned wire events | adapter-integration tests, in-browser, no server |
+| **LLM fixture replay** | aimock (cockpit/examples e2e) | the whole stack incl. a real graph; only the LLM is replayed | full end-to-end |
+
+Reach for the smallest layer that covers your test. Don't stand up aimock when a `mockAgent` unit test suffices; don't hand-roll a transport when `provideFakeAgent` exists.
+```
+
+- [ ] **Step 2: Update the langgraph testing guide**
+
+In `apps/website/content/docs/langgraph/guides/testing.mdx`, document:
+- `provideFakeAgent({ tokens, reasoningTokens, delayMs })` — one-call fake backend; show `provideFakeAgent({ tokens: ['Hello', ' world'] })` in `app.config.ts` then `injectAgent()`.
+- `mockLangGraphAgent(initial)` — writable-signal mock (extends the neutral `mockAgent`); show setting `m.messages.set([...])` / `m.status.set('running')` in a component test.
+- A link to the selection table: `See [Choosing an adapter → Testing](/docs/choosing-an-adapter#testing).`
+Replace any references to manually constructing `MockAgentTransport` for the simple case with `provideFakeAgent`; keep `MockAgentTransport` documented as the advanced manual-scripting escape hatch.
+
+- [ ] **Step 3: Create/update the ag-ui testing guide**
+
+`apps/website/content/docs/ag-ui/guides/testing.mdx` — if it doesn't exist, create it and add it to `apps/website/src/lib/docs-config.ts` under the `ag-ui` library's guides section (mirror an existing guide entry). Document:
+- `provideFakeAgent({ tokens, reasoningTokens, delayMs })` — same call shape as langgraph.
+- Using the neutral `mockAgent()` from `@threadplane/chat` for component tests (ag-ui's agent is the neutral contract — no ag-ui-specific mock needed).
+- Link to the selection table.
+
+- [ ] **Step 4: Add Testing subsections to both lib READMEs**
+
+`libs/langgraph/README.md` and `libs/ag-ui/README.md` — add a short `## Testing` subsection:
+
+````markdown
+## Testing
+
+```ts
+// Fake backend — streams canned tokens, no server:
+import { provideFakeAgent } from '@threadplane/langgraph'; // or '@threadplane/ag-ui'
+providers: [provideFakeAgent({ tokens: ['Hello', ' world'] })];
+```
+
+For component/unit tests, use the writable-signal mock: `mockLangGraphAgent()`
+(langgraph) or `mockAgent()` from `@threadplane/chat` (ag-ui). See
+[Choosing an adapter → Testing](https://threadplane.ai/docs/choosing-an-adapter#testing).
+````
+
+(Use `@threadplane/ag-ui` and `mockAgent()` in the ag-ui README.)
+
+- [ ] **Step 5: Build the website**
+
+Run: `npx nx build website`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/website/content/docs/ apps/website/src/lib/docs-config.ts libs/langgraph/README.md libs/ag-ui/README.md
+git commit -m "docs: testing guides + test-double selection table"
+```
+
+## Task 7: Uniform version bump + final verification
+
+**Files:**
+- Modify: all seven `libs/{chat,langgraph,ag-ui,render,a2ui,licensing,telemetry}/package.json`
+
+- [ ] **Step 1: Bump every publishable lib `0.0.48` → `0.0.49`**
+
+```bash
+for lib in chat langgraph ag-ui render a2ui licensing telemetry; do
+  sed -i '' 's/"version": "0.0.48"/"version": "0.0.49"/' "libs/$lib/package.json"
+done
+```
+
+- [ ] **Step 2: Verify uniform versions**
+
+Run: `node scripts/verify-release-versions.mjs`
+Expected: `Release group "publishable" is atomic at 0.0.49: …` (exit 0).
+
+- [ ] **Step 3: Full affected verification**
+
+Run: `npx nx run-many -t lint test build --projects=chat,langgraph,ag-ui,website`
+Expected: all green.
+
+- [ ] **Step 4: Confirm no stale local `FakeAgentConfig` definition remains**
+
+Run: `git grep -n "interface FakeAgentConfig" -- libs/`
+Expected: exactly one hit — `libs/chat/testing/fake-agent-config.ts`.
+
+- [ ] **Step 5: Confirm symmetric public surface**
+
+Run: `git grep -n "provideFakeAgent" -- libs/langgraph/src/public-api.ts libs/ag-ui/src/public-api.ts`
+Expected: both adapters export `provideFakeAgent`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add libs/*/package.json
+git commit -m "chore: bump publishable libs to 0.0.49 for testing-surface alignment"
+```
+
+---
+
+## Final verification matrix
+
+| Check | Command | Expected |
+|---|---|---|
+| Shared config single source | `git grep -n "interface FakeAgentConfig" -- libs/` | one hit (chat/testing) |
+| Symmetric provider | `git grep -n "provideFakeAgent" -- libs/*/src/public-api.ts` | langgraph + ag-ui both export it |
+| langgraph mock extends neutral | `mockLangGraphAgent()` test asserts neutral `MockAgent` signals present | PASS |
+| Uniform versions | `node scripts/verify-release-versions.mjs` | atomic at 0.0.49 |
+| Build/test/lint | `npx nx run-many -t lint test build --projects=chat,langgraph,ag-ui,website` | all green |
+| Docs build | `npx nx build website` | PASS |
+
+## Risk reminders
+
+- **`MockAgentTransport` is passive** — do not wire `provideFakeAgent` through it. Use the new auto-emitting `FakeStreamTransport`.
+- **`mockLangGraphAgent` regression gate**: every existing spec consuming it must stay green after the refactor. Copy the current per-signal default values verbatim (especially `queue`, `experimentalBranchTree`).
+- **Uniform version bump** across all seven publishable libs, or CI's `verify-release-versions.mjs` fails (`feedback_uniform_publishable_versions.md`).
+- **No re-exports** — moved `FakeAgentConfig` is imported from `@threadplane/chat/testing`; breaking import changes are accepted.
+- **`@threadplane/chat/testing` path mapping** must resolve from both adapter libs (Task 2 Step 4).

--- a/docs/superpowers/specs/2026-05-28-adapter-testing-surface-alignment-design.md
+++ b/docs/superpowers/specs/2026-05-28-adapter-testing-surface-alignment-design.md
@@ -1,0 +1,140 @@
+# Adapter Testing-Surface Alignment
+
+**Status:** Design — ready for plan
+**Date:** 2026-05-28
+**Owner:** Brian Love
+
+## Background
+
+The agent→langgraph rename (PR #556) gave `@threadplane/langgraph` and `@threadplane/ag-ui` a symmetric *wiring* surface (`provideAgent` / `injectAgent` / `AgentConfig`). Their **testing** surfaces were intentionally left asymmetric and are this phase's subject.
+
+There are three layers of test doubles in the framework, each for a different test scope:
+
+| Layer | Test double | What's real | What's faked | Scope |
+|---|---|---|---|---|
+| **1. Contract** | `mockAgent` (chat) / `mockLangGraphAgent` (langgraph) | nothing | the whole `Agent` (writable signals) | component/unit — set `messages()`, assert render |
+| **2. Wire/transport** | `provideFakeAgent` / `FakeAgent` (ag-ui), `MockAgentTransport` (langgraph) | the real adapter pipeline (reducers, signal wiring) | the backend (canned wire events) | adapter-integration, in-browser, no server |
+| **3. LLM provider** | aimock (`libs/e2e-harness`, `@copilotkit/aimock` `LLMock`) | Angular app + real `langgraph dev` + real Python graph + real adapter | only the nondeterministic LLM (OpenAI fixtures) | full Playwright e2e |
+
+**aimock (layer 3) is out of scope and needs no alignment.** It's graph/backend-side and adapter-agnostic — it replays OpenAI calls for whatever Python graph runs, indifferent to which frontend adapter is used. Its fixture format (OpenAI chat-completions matching) must NOT be unified with layer-2 token configs (LangGraph/AG-UI wire events) — different protocols, different process boundaries.
+
+This phase aligns **layers 1 and 2** across the two adapters.
+
+## Current state and gaps
+
+| | Layer 2 — fake-backend | Layer 1 — writable-signal mock |
+|---|---|---|
+| **chat** (neutral) | — | `mockAgent()` / `MockAgent` / `MockAgentOptions` — exists, in `@threadplane/chat` **main** public-api |
+| **langgraph** | `MockAgentTransport` (low-level `StreamEvent[][]` script; no one-call helper) | `mockLangGraphAgent()` / `MockLangGraphAgent` — **independent reimplementation**, does not use `mockAgent` |
+| **ag-ui** | `provideFakeAgent({tokens, reasoningTokens, delayMs})` + `FakeAgent` + **local** `FakeAgentConfig` | — (consumers can use chat's `mockAgent`) |
+
+Three gaps:
+
+1. langgraph has no one-call fake-backend provider (consumers hand-assemble `provideAgent({ transport: new MockAgentTransport(script) })`).
+2. `FakeAgentConfig` is ag-ui-local, not shared, so the two adapters' fake-backend configs aren't a single type.
+3. `mockLangGraphAgent` duplicates the ~40-signal neutral bag instead of extending `mockAgent`.
+
+## Goals
+
+1. Both adapters expose a one-call `provideFakeAgent(config: FakeAgentConfig)` with the **same** `{tokens, reasoningTokens, delayMs}` config.
+2. `FakeAgentConfig` is a single canonical type owned by `@threadplane/chat/testing`.
+3. `mockLangGraphAgent` is built on the neutral `mockAgent`, eliminating the duplicated signal bag.
+4. A "which test double for which scope" selection table is documented so users pick the right layer.
+
+## Non-goals
+
+- Any change to aimock (layer 3) or its fixtures.
+- A separate `mockAgUiAgent` — ag-ui's `Agent` *is* the neutral contract, so ag-ui consumers use `mockAgent` directly.
+- Backwards compatibility / deprecation shims. Breaking changes are accepted; **no re-exports** for moved symbols.
+- Unifying `provideFakeAgent` token config with aimock fixture format.
+
+## Design
+
+### 2a. Shared `FakeAgentConfig` in `@threadplane/chat/testing`
+
+```ts
+// libs/chat/testing/fake-agent-config.ts  (exported from chat/testing/public-api.ts)
+export interface FakeAgentConfig {
+  /** Assistant reply, streamed token-by-token. */
+  tokens?: string[];
+  /** Optional reasoning chunks emitted before the text reply. */
+  reasoningTokens?: string[];
+  /** Milliseconds between successive token emissions. */
+  delayMs?: number;
+}
+```
+
+ag-ui's local `FakeAgentConfig` (in `libs/ag-ui/src/lib/testing/provide-fake-agent.ts`) is **deleted**. ag-ui imports `FakeAgentConfig` from `@threadplane/chat/testing` and does **not** re-export it. Consumers that referenced `FakeAgentConfig` from `@threadplane/ag-ui` now import it from `@threadplane/chat/testing` (breaking — accepted).
+
+### 2b. langgraph `provideFakeAgent(config: FakeAgentConfig)` (new)
+
+A one-call helper mirroring ag-ui's. It synthesizes a `StreamEvent[][]` script that streams `reasoningTokens` (if any) then `tokens` as a single assistant message with `delayMs` spacing, and returns:
+
+```ts
+provideAgent({ assistantId: 'fake', transport: new MockAgentTransport(synthesizedScript) })
+```
+
+- Imports `FakeAgentConfig` from `@threadplane/chat/testing` (no re-export).
+- Exported from `libs/langgraph/src/public-api.ts`.
+- The raw `provideAgent({ transport: new MockAgentTransport(scriptedBatches) })` path remains the **advanced escape hatch** for tests needing tool calls, interrupts, or multi-batch scripting.
+- The synthesized script must produce wire events that the langgraph adapter's reducers translate into `messages()` (assistant text) and, when `reasoningTokens` are present, the reasoning surface — matching how `MockAgentTransport` events already flow. Exact `StreamEvent` shapes are determined by reading `MockAgentTransport`'s existing event handling during implementation.
+
+### 2c. `mockLangGraphAgent` extends `mockAgent` (refactor)
+
+`mockLangGraphAgent(initial)` calls chat's `mockAgent(initial)` to obtain the shared neutral writable signals (`messages`, `status`, `isLoading`, `error`, `toolCalls`, `interrupt`, `subagents`, `history`, `state`, lifecycle stub, `events$`), then layers the LangGraph-specific writable signals on top: `langGraphMessages`, `langGraphInterrupts`, `langGraphToolCalls`, `toolProgress`, `queue`, `branch`, `langGraphHistory`, `experimentalBranchTree`, `isThreadLoading`, `activeSubagents`, `customEvents`, `hasValue`, `value`.
+
+- `MockLangGraphAgent extends MockAgent` (the chat type), adding the LangGraph-specific writable signals.
+- The neutral signals are created by `mockAgent`, not re-declared.
+- `mockAgent`'s `MockAgentOptions` is the base of `mockLangGraphAgent`'s `initial` parameter; LangGraph-only initial fields (e.g. `langGraphMessages`, `isThreadLoading`) extend it.
+- Existing langgraph component/spec tests that consume `mockLangGraphAgent` must pass unchanged.
+
+### 2d. ag-ui writable-signal mock — none added
+
+ag-ui's adapter produces the neutral `Agent` contract, so ag-ui consumers use `mockAgent()` from `@threadplane/chat` directly for component/unit tests. Documented in the ag-ui testing guide; no `mockAgUiAgent` is added.
+
+### Resulting symmetry
+
+| | Layer 2 — fake-backend | Layer 1 — writable-signal mock |
+|---|---|---|
+| langgraph | `provideFakeAgent({tokens, …})` | `mockLangGraphAgent()` (extends `mockAgent`) |
+| ag-ui | `provideFakeAgent({tokens, …})` | `mockAgent()` (from chat, neutral) |
+
+Same `provideFakeAgent({tokens, reasoningTokens, delayMs})` call shape on both adapters, backed by one shared `FakeAgentConfig`.
+
+## Documentation
+
+- **`apps/website/content/docs/langgraph/guides/testing.mdx`** (exists): document `provideFakeAgent({tokens})` (layer 2) and `mockLangGraphAgent()` (layer 1, extends `mockAgent`).
+- **`apps/website/content/docs/ag-ui/guides/testing.mdx`**: create if absent; document `provideFakeAgent({tokens})` and using neutral `mockAgent()` for component tests.
+- **Test-double selection table** (the three-layer pyramid from Background): canonical copy added as a new "Testing" section on the existing **Choosing-an-adapter** page (`apps/website/content/docs/choosing-an-adapter/index.mdx`) — it's already adapter-neutral and the natural home for cross-adapter guidance. Both adapter testing guides link to it rather than duplicating it. Guidance: don't reach for aimock when a `mockAgent` unit test suffices; don't hand-roll transport mocks when `provideFakeAgent` exists.
+- **Lib READMEs** (`libs/langgraph/README.md`, `libs/ag-ui/README.md`): short "Testing" subsection — `provideFakeAgent({tokens})` plus a one-liner pointing at neutral `mockAgent` for unit tests.
+
+## Testing (TDD)
+
+- **chat:** `FakeAgentConfig` is a type (no runtime test). `mockAgent` keeps existing coverage; add an assertion only if its source is touched.
+- **langgraph:** new `provideFakeAgent` spec — TestBed-provide it, `injectAgent()`, drive the fake stream, assert `messages()`/`status()` reflect the canned tokens, including `reasoningTokens` ordering and `delayMs` spacing. Refactored `mockLangGraphAgent` — existing specs pass unchanged; add a spec asserting the returned object satisfies the neutral `MockAgent` shape.
+- **ag-ui:** existing `provide-fake-agent.spec.ts` passes after the `FakeAgentConfig` import move.
+
+## Versioning
+
+Additive new exports plus one internal refactor → **patch** bump, applied **uniformly** across all publishable libs `0.0.48 → 0.0.49` (per the uniform-version CI gate enforced by `scripts/verify-release-versions.mjs`: chat, langgraph, ag-ui, render, a2ui, licensing, telemetry).
+
+## Phasing (one PR, ordered commits)
+
+1. **chat** — add `FakeAgentConfig` to `chat/testing`.
+2. **ag-ui** — delete local `FakeAgentConfig`, import from chat/testing; specs green.
+3. **langgraph** — add `provideFakeAgent` + spec; refactor `mockLangGraphAgent` to extend `mockAgent` + specs green.
+4. **docs** — testing guides, selection-table page + cross-links, README testing subsections.
+5. **versioning + verification** — uniform bump to `0.0.49`; `nx run-many -t lint test build` green for chat, langgraph, ag-ui, website.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Synthesized `StreamEvent` shapes in langgraph `provideFakeAgent` don't match what the adapter reducers expect | Implementation reads `MockAgentTransport`'s existing event handling + an existing transport-driven spec to mirror the exact event shapes; the new spec asserts `messages()` actually populates. |
+| `mockLangGraphAgent` refactor changes behavior relied on by existing component tests | Existing specs are the regression gate — they must pass unchanged. No public signal removed; only the construction is rerouted through `mockAgent`. |
+| Moving `FakeAgentConfig` breaks external imports | Accepted (no backwards-compat requirement). Consumers re-point to `@threadplane/chat/testing`. |
+| Forgetting the uniform version bump | Codified in `feedback_uniform_publishable_versions.md`; verify with `node scripts/verify-release-versions.mjs`. |
+
+## Open decisions
+
+None. All decisions captured above were approved during brainstorming.

--- a/libs/a2ui/package.json
+++ b/libs/a2ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/a2ui",
-  "version": "0.0.48",
+  "version": "0.0.49",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/ag-ui/README.md
+++ b/libs/ag-ui/README.md
@@ -112,9 +112,20 @@ Example state shape:
 
 Each citation supports `id`, `index`, `title`, `url`, `snippet`, and custom `extra` fields. The message ID key matches the corresponding message in the chat history.
 
-### Testing
+---
 
-`FakeAgent` is a test-only `AbstractAgent` implementation. `provideFakeAgent(config?)` registers it in the Angular injector so unit tests run without a live AG-UI backend.
+## Testing
+
+```ts
+// Fake backend — streams canned tokens, no server:
+import { provideFakeAgent } from '@threadplane/ag-ui';
+providers: [provideFakeAgent({ tokens: ['Hello', ' world'] })];
+```
+
+For component/unit tests, use the neutral writable-signal mock `mockAgent()`
+from `@threadplane/chat` — the ag-ui agent _is_ the neutral `Agent` contract,
+so there is no adapter-specific mock. See
+[Choosing an adapter → Testing](https://threadplane.ai/docs/choosing-an-adapter#testing).
 
 ---
 

--- a/libs/ag-ui/package.json
+++ b/libs/ag-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/ag-ui",
-  "version": "0.0.48",
+  "version": "0.0.49",
   "description": "AG-UI protocol adapter for @threadplane/chat — works with any AG-UI-compatible backend.",
   "keywords": ["angular", "ag-ui", "agent", "adapter", "threadplane"],
   "peerDependencies": {

--- a/libs/ag-ui/src/lib/testing/provide-fake-agent.ts
+++ b/libs/ag-ui/src/lib/testing/provide-fake-agent.ts
@@ -1,18 +1,10 @@
 // libs/ag-ui/src/lib/testing/provide-fake-agent.ts
 // SPDX-License-Identifier: MIT
 import { type Provider } from '@angular/core';
+import type { FakeAgentConfig } from '@threadplane/chat/testing';
 import { AGENT } from '../provide-agent';
 import { toAgent } from '../to-agent';
 import { FakeAgent } from './fake-agent';
-
-export interface FakeAgentConfig {
-  /** Tokens streamed back as the assistant reply. */
-  tokens?: string[];
-  /** Optional reasoning chunks emitted before the text reply. */
-  reasoningTokens?: string[];
-  /** Milliseconds between successive token emissions. */
-  delayMs?: number;
-}
 
 /**
  * Registers an in-process FakeAgent under AGENT.

--- a/libs/ag-ui/src/public-api.ts
+++ b/libs/ag-ui/src/public-api.ts
@@ -5,7 +5,6 @@ export { provideAgent, injectAgent } from './lib/provide-agent';
 export type { AgentConfig } from './lib/provide-agent';
 export { FakeAgent } from './lib/testing/fake-agent';
 export { provideFakeAgent } from './lib/testing/provide-fake-agent';
-export type { FakeAgentConfig } from './lib/testing/provide-fake-agent';
 
 // Citation state bridge
 export { bridgeCitationsState } from './lib/bridge-citations-state';

--- a/libs/chat/package.json
+++ b/libs/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/chat",
-  "version": "0.0.48",
+  "version": "0.0.49",
   "exports": {
     "./chat.css": "./chat.css",
     "./themes/default-dark.css": "./themes/default-dark.css",

--- a/libs/chat/testing/fake-agent-config.ts
+++ b/libs/chat/testing/fake-agent-config.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+
+/**
+ * Shared config for the adapters' `provideFakeAgent()` helpers
+ * (@threadplane/langgraph and @threadplane/ag-ui). Drives an in-process
+ * fake backend that streams a canned assistant reply.
+ */
+export interface FakeAgentConfig {
+  /** Assistant reply, streamed token-by-token. */
+  tokens?: string[];
+  /** Optional reasoning chunks emitted before the text reply. */
+  reasoningTokens?: string[];
+  /** Milliseconds between successive token emissions. */
+  delayMs?: number;
+}

--- a/libs/chat/testing/public-api.ts
+++ b/libs/chat/testing/public-api.ts
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: MIT
+export type { FakeAgentConfig } from './fake-agent-config';
 export { runAgentConformance } from './agent-conformance';
 export { runAgentWithHistoryConformance } from './agent-with-history-conformance';
 export {

--- a/libs/langgraph/README.md
+++ b/libs/langgraph/README.md
@@ -174,13 +174,23 @@ const citations = extractCitations(message);
 
 `Citation` is a type from `@threadplane/chat`; `CitationsResolverService` and `provideChat` also live there.
 
-## Reliability
-
-**Testing.** `MockAgentTransport` is a deterministic in-memory transport that replays scripted stream events. The rule is: swap the transport, never mock `injectAgent()` itself. `mockLangGraphAgent(options?)` is a convenience factory for unit tests.
+## Testing
 
 ```ts
-import { MockAgentTransport, mockLangGraphAgent } from '@threadplane/langgraph';
+// Fake backend — streams canned tokens, no server:
+import { provideFakeAgent } from '@threadplane/langgraph';
+providers: [provideFakeAgent({ tokens: ['Hello', ' world'] })];
 ```
+
+For component/unit tests, use the writable-signal mock `mockLangGraphAgent()`
+(it extends the neutral `mockAgent` from `@threadplane/chat`). See
+[Choosing an adapter → Testing](https://threadplane.ai/docs/choosing-an-adapter#testing).
+
+Need to hand-script exact wire events (tool calls, interrupts, multi-batch
+lifecycles)? `MockAgentTransport` is the advanced escape hatch — swap the
+transport, never mock `injectAgent()` itself.
+
+## Reliability
 
 **Runtime-neutral contract.** `LangGraphAgent` implements the `Agent` contract from `@threadplane/chat`. Components that depend only on that contract are portable across adapters (`@threadplane/ag-ui`, future adapters) without modification.
 

--- a/libs/langgraph/package.json
+++ b/libs/langgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/langgraph",
-  "version": "0.0.48",
+  "version": "0.0.49",
   "description": "LangGraph adapter for @threadplane/chat — Angular bindings for LangGraph Platform.",
   "keywords": ["angular", "langgraph", "langchain", "agent", "adapter", "threadplane"],
   "peerDependencies": {

--- a/libs/langgraph/src/lib/testing/fake-stream.transport.spec.ts
+++ b/libs/langgraph/src/lib/testing/fake-stream.transport.spec.ts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+import { describe, it, expect } from 'vitest';
+import { FakeStreamTransport } from './fake-stream.transport';
+import type { StreamEvent } from '../agent.types';
+
+async function collect(transport: FakeStreamTransport): Promise<StreamEvent[]> {
+  const out: StreamEvent[] = [];
+  const ac = new AbortController();
+  for await (const ev of transport.stream('a', null, {}, ac.signal)) {
+    out.push(ev);
+  }
+  return out;
+}
+
+describe('FakeStreamTransport', () => {
+  it('auto-streams tokens as cumulative assistant message events', async () => {
+    const transport = new FakeStreamTransport({ tokens: ['Hello', ' world'], delayMs: 0 });
+    const events = await collect(transport);
+    const messageEvents = events.filter((e) => e.type === 'messages');
+    expect(messageEvents.length).toBeGreaterThan(0);
+    const last = messageEvents[messageEvents.length - 1] as StreamEvent & {
+      messages: Array<{ type: string; content: string }>;
+    };
+    expect(last.messages[0].type).toBe('ai');
+    expect(last.messages[0].content).toBe('Hello world');
+  });
+
+  it('completes (stream ends) after emitting all tokens', async () => {
+    const transport = new FakeStreamTransport({ tokens: ['x'], delayMs: 0 });
+    const events = await collect(transport);
+    expect(events.length).toBeGreaterThan(0);
+  });
+
+  it('uses default tokens when none provided', async () => {
+    const transport = new FakeStreamTransport({ delayMs: 0 });
+    const events = await collect(transport);
+    expect(events.length).toBeGreaterThan(0);
+  });
+});

--- a/libs/langgraph/src/lib/testing/fake-stream.transport.ts
+++ b/libs/langgraph/src/lib/testing/fake-stream.transport.ts
@@ -80,13 +80,19 @@ export class FakeStreamTransport implements AgentTransport {
     };
   }
 
-  async cancelRun(_threadId: string, _runId: string, _signal: AbortSignal): Promise<void> {}
+  async cancelRun(_threadId: string, _runId: string, _signal: AbortSignal): Promise<void> {
+    // No-op: the fake has no real runs to cancel.
+    return;
+  }
 
   async getHistory(_threadId: string, _signal: AbortSignal): Promise<ThreadState[]> {
     return [];
   }
 
-  async *joinStream(): AsyncIterable<StreamEvent> {}
+  async *joinStream(): AsyncIterable<StreamEvent> {
+    // No queued-run replay in the fake; yields nothing.
+    yield* [];
+  }
 }
 
 function delay(ms: number): Promise<void> {

--- a/libs/langgraph/src/lib/testing/fake-stream.transport.ts
+++ b/libs/langgraph/src/lib/testing/fake-stream.transport.ts
@@ -27,7 +27,9 @@ export class FakeStreamTransport implements AgentTransport {
   constructor(config: FakeAgentConfig = {}) {
     this.tokens = config.tokens ?? DEFAULT_TOKENS;
     this.reasoningTokens = config.reasoningTokens ?? [];
-    this.delayMs = config.delayMs ?? 0;
+    // Default 60ms matches @threadplane/ag-ui's FakeAgent so both adapters'
+    // provideFakeAgent() stream at the same cadence for the same config.
+    this.delayMs = config.delayMs ?? 60;
   }
 
   async *stream(

--- a/libs/langgraph/src/lib/testing/fake-stream.transport.ts
+++ b/libs/langgraph/src/lib/testing/fake-stream.transport.ts
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+import type {
+  AgentQueueEntry,
+  AgentTransport,
+  LangGraphSubmitOptions,
+  StreamEvent,
+} from '../agent.types';
+import type { ThreadState } from '@langchain/langgraph-sdk';
+import type { FakeAgentConfig } from '@threadplane/chat/testing';
+
+const DEFAULT_TOKENS = ['Hello', ' from', ' the', ' fake', ' LangGraph', ' agent.'];
+
+/**
+ * In-process AgentTransport that auto-streams a canned assistant reply.
+ *
+ * Backs `provideFakeAgent()`. Unlike `MockAgentTransport` (passive, driven
+ * manually from specs), this transport emits its tokens automatically on
+ * `stream()`, then completes — suitable for offline demos and integration tests.
+ *
+ * NOT for production use.
+ */
+export class FakeStreamTransport implements AgentTransport {
+  private readonly tokens: string[];
+  private readonly reasoningTokens: string[];
+  private readonly delayMs: number;
+
+  constructor(config: FakeAgentConfig = {}) {
+    this.tokens = config.tokens ?? DEFAULT_TOKENS;
+    this.reasoningTokens = config.reasoningTokens ?? [];
+    this.delayMs = config.delayMs ?? 0;
+  }
+
+  async *stream(
+    _assistantId: string,
+    _threadId: string | null,
+    _payload: unknown,
+    signal: AbortSignal,
+    _options?: LangGraphSubmitOptions,
+  ): AsyncIterable<StreamEvent> {
+    const id = 'fake-ai-1';
+
+    let reasoning = '';
+    for (const chunk of this.reasoningTokens) {
+      if (signal.aborted) return;
+      reasoning += chunk;
+      yield {
+        type: 'messages',
+        messages: [
+          { id, type: 'ai', content: '', additional_kwargs: { reasoning_content: reasoning } },
+        ],
+      } as unknown as StreamEvent;
+      if (this.delayMs > 0) await delay(this.delayMs);
+    }
+
+    let content = '';
+    for (const tok of this.tokens) {
+      if (signal.aborted) return;
+      content += tok;
+      yield {
+        type: 'messages',
+        messages: [{ id, type: 'ai', content }],
+      } as unknown as StreamEvent;
+      if (this.delayMs > 0) await delay(this.delayMs);
+    }
+  }
+
+  async createQueuedRun(
+    _assistantId: string,
+    threadId: string,
+    payload: unknown,
+    _signal: AbortSignal,
+    options?: LangGraphSubmitOptions,
+  ): Promise<AgentQueueEntry> {
+    return {
+      id: 'fake-queued-run',
+      threadId,
+      values: payload,
+      options: { ...options, multitaskStrategy: 'enqueue' },
+      createdAt: new Date(),
+    };
+  }
+
+  async cancelRun(_threadId: string, _runId: string, _signal: AbortSignal): Promise<void> {}
+
+  async getHistory(_threadId: string, _signal: AbortSignal): Promise<ThreadState[]> {
+    return [];
+  }
+
+  async *joinStream(): AsyncIterable<StreamEvent> {}
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/libs/langgraph/src/lib/testing/mock-langgraph-agent.spec.ts
+++ b/libs/langgraph/src/lib/testing/mock-langgraph-agent.spec.ts
@@ -85,3 +85,14 @@ describe('mockLangGraphAgent', () => {
     expect(typeof ref.langGraphHistory).toBe('function');
   });
 });
+
+describe('mockLangGraphAgent extends mockAgent', () => {
+  it('exposes the neutral MockAgent writable signals', () => {
+    const m = mockLangGraphAgent({ status: 'running' });
+    expect(m.status()).toBe('running');   // neutral signal set via mockAgent opts
+    m.messages.set([]);                    // writable neutral signal
+    expect(m.submitCalls).toEqual([]);     // neutral submit tracking
+    m.branch.set('main');                  // LangGraph-specific signal still present
+    expect(m.branch()).toBe('main');
+  });
+});

--- a/libs/langgraph/src/lib/testing/mock-langgraph-agent.ts
+++ b/libs/langgraph/src/lib/testing/mock-langgraph-agent.ts
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
 import { computed, signal, WritableSignal } from '@angular/core';
-import { Subject } from 'rxjs';
 import type {
   LangGraphAgent,
   SubagentStreamRef,
@@ -13,43 +12,60 @@ import type {
 import type { ToolProgress, ToolCallWithResult } from '@langchain/langgraph-sdk';
 import type { BaseMessage, AIMessage as CoreAIMessage } from '@langchain/core/messages';
 import type { MessageMetadata } from '@langchain/langgraph-sdk/ui';
+import { mockAgent } from '@threadplane/chat';
 import type {
-  AgentStatus,
+  MockAgent,
+  MockAgentOptions,
   AgentInterrupt,
   AgentCheckpoint,
+  AgentStatus,
   Message,
   Subagent,
   ToolCall,
-  AgentEvent,
 } from '@threadplane/chat';
 
 /**
  * A LangGraphAgent mock with writable signals for easy test control.
  *
+ * Builds on the runtime-neutral {@link MockAgent} from `@threadplane/chat`
+ * (which supplies the neutral `Agent`-contract writable signals plus
+ * `submit`/`stop`/`regenerate` call tracking) and layers the LangGraph-specific
+ * writable signals on top.
+ *
  * Cast the result of `mockLangGraphAgent()` to this type to access
  * writable signals without unsafe casts in test files.
  */
 export interface MockLangGraphAgent extends LangGraphAgent<any, any> {
-  // Writable versions of signals for direct test mutation
+  // Neutral writable signals — re-declared writable. (Dual-extends of MockAgent
+  // and LangGraphAgent is impossible because they declare incompatible
+  // `lifecycle` shapes, so we extend LangGraphAgent and layer the MockAgent
+  // call-tracking surface explicitly below.)
   messages: WritableSignal<Message[]>;
-  langGraphMessages: WritableSignal<BaseMessage[]>;
   status: WritableSignal<AgentStatus>;
   isLoading: WritableSignal<boolean>;
   error: WritableSignal<unknown>;
+  toolCalls: WritableSignal<ToolCall[]>;
+  interrupt: WritableSignal<AgentInterrupt | undefined>;
+  subagents: WritableSignal<Map<string, Subagent>>;
+  history: WritableSignal<AgentCheckpoint[]>;
+
+  // MockAgent call-tracking surface (delegated to mockAgent at runtime).
+  submitCalls: MockAgent['submitCalls'];
+  stopCount: MockAgent['stopCount'];
+  _internal: MockAgent['_internal'];
+
+  // LangGraph-specific writable signals.
+  langGraphMessages: WritableSignal<BaseMessage[]>;
   hasValue: WritableSignal<boolean>;
   value: WritableSignal<any>;
-  interrupt: WritableSignal<AgentInterrupt | undefined>;
   langGraphInterrupts: WritableSignal<Interrupt<any>[]>;
-  toolCalls: WritableSignal<ToolCall[]>;
   langGraphToolCalls: WritableSignal<ToolCallWithResult[]>;
   toolProgress: WritableSignal<ToolProgress[]>;
   queue: WritableSignal<AgentQueue>;
   branch: WritableSignal<string>;
-  history: WritableSignal<AgentCheckpoint[]>;
   langGraphHistory: WritableSignal<ThreadState<any>[]>;
   experimentalBranchTree: WritableSignal<AgentBranchTree<any>>;
   isThreadLoading: WritableSignal<boolean>;
-  subagents: WritableSignal<Map<string, Subagent>>;
   activeSubagents: WritableSignal<SubagentStreamRef[]>;
   customEvents: WritableSignal<CustomStreamEvent[]>;
 }
@@ -57,28 +73,29 @@ export interface MockLangGraphAgent extends LangGraphAgent<any, any> {
 /**
  * Creates a mock LangGraphAgent with writable signals for testing.
  * Control state by writing to the returned writable signals directly.
+ *
+ * Neutral `Agent`-contract signals come from {@link mockAgent}; LangGraph-specific
+ * signals are declared here and layered on top.
  */
 export function mockLangGraphAgent(
-  initial: {
-    messages?: Message[];
+  initial: MockAgentOptions & {
     langGraphMessages?: BaseMessage[];
-    status?: AgentStatus;
-    isLoading?: boolean;
-    error?: unknown;
     hasValue?: boolean;
     isThreadLoading?: boolean;
   } = {}
 ): MockLangGraphAgent {
-  const messages$ = signal<Message[]>(initial.messages ?? []);
+  const base = mockAgent({
+    ...initial,
+    withInterrupt: true,
+    withSubagents: true,
+    history: initial.history ?? [],
+  });
+
+  // ── LangGraph-specific writable signals (defaults copied verbatim) ────────
   const langGraphMessages$ = signal<BaseMessage[]>(initial.langGraphMessages ?? []);
-  const status$ = signal<AgentStatus>(initial.status ?? 'idle');
-  const isLoading$ = signal<boolean>(initial.isLoading ?? false);
-  const error$ = signal<unknown>(initial.error ?? null);
   const hasValue$ = signal<boolean>(initial.hasValue ?? false);
   const value$ = signal<any>(null);
-  const interrupt$ = signal<AgentInterrupt | undefined>(undefined);
   const langGraphInterrupts$ = signal<Interrupt<any>[]>([]);
-  const toolCalls$ = signal<ToolCall[]>([]);
   const langGraphToolCalls$ = signal<ToolCallWithResult[]>([]);
   const toolProgress$ = signal<ToolProgress[]>([]);
   const queue$ = signal<AgentQueue>({
@@ -88,36 +105,23 @@ export function mockLangGraphAgent(
     clear: async () => undefined,
   });
   const branch$ = signal<string>('');
-  const history$ = signal<AgentCheckpoint[]>([]);
   const langGraphHistory$ = signal<ThreadState<any>[]>([]);
   const experimentalBranchTree$ = signal<AgentBranchTree<any>>({ type: 'sequence', items: [] });
   const isThreadLoading$ = signal<boolean>(initial.isThreadLoading ?? false);
-  const subagents$ = signal<Map<string, Subagent>>(new Map());
   const activeSubagents$ = signal<SubagentStreamRef[]>([]);
   const customEvents$ = signal<CustomStreamEvent[]>([]);
 
+  // `state` derives from the raw LangGraph value (preserves current behavior).
   const state$ = computed<Record<string, unknown>>(() => {
     const v = value$();
     return v && typeof v === 'object' ? (v as Record<string, unknown>) : {};
   });
 
-  const eventsSubject = new Subject<AgentEvent>();
-
   const mock: MockLangGraphAgent = {
-    // ── AgentWithHistory (runtime-neutral surface) ────────────────────────
-    messages: messages$,
-    status: status$,
-    isLoading: isLoading$,
-    error: error$,
-    toolCalls: toolCalls$,
-    state: state$,
-    interrupt: interrupt$,
-    subagents: subagents$,
-    events$: eventsSubject.asObservable(),
-    history: history$,
-    submit: (_input: any, _opts?: any) => Promise.resolve(),
-    stop: () => Promise.resolve(),
-    regenerate: (_assistantMessageIndex: number) => Promise.resolve(),
+    ...base,
+
+    // ── Neutral surface: override `state` to derive from the LangGraph value ─
+    state: state$ as never,
 
     // ── Raw LangGraph signals ─────────────────────────────────────────────
     langGraphMessages: langGraphMessages$,
@@ -170,7 +174,7 @@ export function mockLangGraphAgent(
       toolCallStartedAt:   signal<number | null>(null),
       toolCallCompletedAt: signal<number | null>(null),
     },
-  };
+  } as MockLangGraphAgent;
 
   return mock;
 }

--- a/libs/langgraph/src/lib/testing/provide-fake-agent.spec.ts
+++ b/libs/langgraph/src/lib/testing/provide-fake-agent.spec.ts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+import { describe, it, expect } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { provideFakeAgent } from './provide-fake-agent';
+import { injectAgent } from '../inject-agent';
+
+describe('provideFakeAgent (langgraph)', () => {
+  it('provides an agent that streams the canned tokens into messages()', async () => {
+    TestBed.configureTestingModule({
+      providers: [provideFakeAgent({ tokens: ['Hi', ' there'], delayMs: 0 })],
+    });
+    const agent = TestBed.runInInjectionContext(() => injectAgent());
+    await TestBed.runInInjectionContext(async () => {
+      await agent.submit({ message: 'hello' });
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    const msgs = agent.messages();
+    const assistant = msgs.find((m) => m.role === 'assistant');
+    expect(assistant?.content).toContain('Hi there');
+  });
+});

--- a/libs/langgraph/src/lib/testing/provide-fake-agent.ts
+++ b/libs/langgraph/src/lib/testing/provide-fake-agent.ts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+import { type Provider } from '@angular/core';
+import type { FakeAgentConfig } from '@threadplane/chat/testing';
+import { provideAgent } from '../agent.provider';
+import { FakeStreamTransport } from './fake-stream.transport';
+
+/**
+ * Wire an in-process fake LangGraph agent into Angular DI.
+ *
+ * Streams a canned assistant reply (see FakeAgentConfig) with no backend —
+ * the symmetric counterpart to @threadplane/ag-ui's provideFakeAgent(). For
+ * advanced manual scripting (tool calls, interrupts, multi-batch), provide
+ * the agent yourself with
+ * `provideAgent({ assistantId, transport: new MockAgentTransport(...) })`.
+ */
+export function provideFakeAgent(config: FakeAgentConfig = {}): Provider[] {
+  return provideAgent({
+    assistantId: 'fake',
+    transport: new FakeStreamTransport(config),
+  });
+}

--- a/libs/langgraph/src/public-api.ts
+++ b/libs/langgraph/src/public-api.ts
@@ -42,6 +42,7 @@ export { FetchStreamTransport } from './lib/transport/fetch-stream.transport';
 // Mock test utility for LangGraph agent
 export { mockLangGraphAgent } from './lib/testing/mock-langgraph-agent';
 export type { MockLangGraphAgent } from './lib/testing/mock-langgraph-agent';
+export { provideFakeAgent } from './lib/testing/provide-fake-agent';
 
 // Citation normalizer — useful for advanced consumers building custom adapters
 // or bridging non-LangGraph message shapes into ngaf Citation[].

--- a/libs/langgraph/src/public-api.ts
+++ b/libs/langgraph/src/public-api.ts
@@ -43,6 +43,9 @@ export { FetchStreamTransport } from './lib/transport/fetch-stream.transport';
 export { mockLangGraphAgent } from './lib/testing/mock-langgraph-agent';
 export type { MockLangGraphAgent } from './lib/testing/mock-langgraph-agent';
 export { provideFakeAgent } from './lib/testing/provide-fake-agent';
+// Low-level auto-emitting fake transport backing provideFakeAgent — exported
+// for advanced manual wiring (parity with @threadplane/ag-ui's FakeAgent).
+export { FakeStreamTransport } from './lib/testing/fake-stream.transport';
 
 // Citation normalizer — useful for advanced consumers building custom adapters
 // or bridging non-LangGraph message shapes into ngaf Citation[].

--- a/libs/licensing/package.json
+++ b/libs/licensing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/licensing",
-  "version": "0.0.48",
+  "version": "0.0.49",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/render/package.json
+++ b/libs/render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/render",
-  "version": "0.0.48",
+  "version": "0.0.49",
   "peerDependencies": {
     "@angular/core": "^20.0.0 || ^21.0.0",
     "@angular/common": "^20.0.0 || ^21.0.0",

--- a/libs/telemetry/package.json
+++ b/libs/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/telemetry",
-  "version": "0.0.48",
+  "version": "0.0.49",
   "license": "MIT",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

Phase 2 follow-up to the agent→langgraph rename: aligns the two adapters' **test doubles** so they're symmetric.

- **Shared `FakeAgentConfig`** (`{tokens?, reasoningTokens?, delayMs?}`) now lives in `@threadplane/chat/testing`. ag-ui's local copy is deleted; both adapters import the one canonical type. (Breaking: import `FakeAgentConfig` from `@threadplane/chat/testing`, not `@threadplane/ag-ui`.)
- **`@threadplane/langgraph` gains `provideFakeAgent({tokens,…})`** — a one-call fake backend mirroring ag-ui's, backed by a new auto-emitting `FakeStreamTransport` (the passive `MockAgentTransport` stays the advanced manual-scripting escape hatch). Default `delayMs: 60` matches ag-ui.
- **`mockLangGraphAgent` now delegates to chat's neutral `mockAgent()`** for the shared writable-signal bag, layering only the LangGraph-specific signals. No duplicated signal bag; existing consumers unchanged.
- **ag-ui adds no adapter-specific mock** — its agent is the neutral contract, so consumers use `mockAgent()` from `@threadplane/chat` directly.
- **Docs:** a three-layer test-double selection table on the Choosing-an-adapter page (contract mock → fake backend → aimock e2e), updated langgraph testing guide, new ag-ui testing guide, README Testing sections.
- Uniform **`0.0.49`** bump across all seven publishable libs.

aimock (full-e2e LLM fixture replay) is a separate, lower layer and intentionally untouched.

Resulting symmetry — same `provideFakeAgent({tokens})` on both adapters; `mockLangGraphAgent()` / `mockAgent()` for component tests.

Spec/plan: `docs/superpowers/specs/2026-05-28-adapter-testing-surface-alignment-design.md`, `docs/superpowers/plans/2026-05-28-adapter-testing-surface-alignment.md`.

## Test plan
- [x] `nx run-many -t lint test build --projects=chat,langgraph,ag-ui,website` green
- [x] langgraph suite 180 passing (incl. new FakeStreamTransport, provideFakeAgent, mockLangGraphAgent-extends-mockAgent specs); ag-ui specs green after FakeAgentConfig import move
- [x] `node scripts/verify-release-versions.mjs` atomic at 0.0.49
- [x] Final whole-diff code review: approved
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)