### PR TITLE
Code mode: file tree with responsive collapse

### DIFF
--- a/apps/cockpit/src/app/cockpit.css
+++ b/apps/cockpit/src/app/cockpit.css
@@ -260,3 +260,15 @@ pre.shiki {
   color: var(--ds-text-primary);
   border-left-color: var(--ds-accent);
 }
+
+/* Tab close (×) on Code-mode tabs */
+.cockpit-tab-trigger { display: inline-flex; align-items: center; gap: 0.4rem; }
+.cockpit-tab-trigger__close {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 0.95rem; height: 0.95rem; border-radius: 0.2rem;
+  color: var(--ds-text-muted); font-size: 0.85rem; line-height: 1;
+  opacity: 0; cursor: pointer;
+}
+.cockpit-tab-trigger:hover .cockpit-tab-trigger__close,
+.cockpit-tab-trigger[data-state="active"] .cockpit-tab-trigger__close { opacity: 1; }
+.cockpit-tab-trigger__close:hover { background: var(--ds-accent-surface); color: var(--ds-text-primary); }

--- a/apps/cockpit/src/app/cockpit.css
+++ b/apps/cockpit/src/app/cockpit.css
@@ -238,7 +238,6 @@ pre.shiki {
 /* Code-mode file tree */
 .cockpit-file-tree { list-style: none; padding: 0; margin: 0; font-size: 12px; line-height: 1.7; }
 .cockpit-file-tree ul { list-style: none; padding: 0; margin: 0; }
-.cockpit-file-tree__file-row { display: flex; align-items: center; }
 .cockpit-file-tree__file,
 .cockpit-file-tree__folder {
   display: flex; align-items: center; gap: 0.4rem; flex: 1; min-width: 0;

--- a/apps/cockpit/src/app/cockpit.css
+++ b/apps/cockpit/src/app/cockpit.css
@@ -205,13 +205,16 @@ pre.shiki {
   font-size: 0.75rem;
 }
 
-/* Shared prose layer — docs + api */
+/* Shared prose layer — docs + api + code mode content */
 .cockpit-prose {
   max-width: 42rem;
+  margin-inline: auto;
   font-size: 0.9rem;
   line-height: 1.7;
   color: var(--ds-text-secondary);
 }
+.cockpit-prose--wide { max-width: 48rem; }
+.cockpit-prose--code { max-width: 56rem; }
 .cockpit-prose h1, .cockpit-prose h2, .cockpit-prose h3 {
   font-family: var(--font-garamond), var(--ds-font-serif);
   color: var(--ds-text-primary);

--- a/apps/cockpit/src/app/cockpit.css
+++ b/apps/cockpit/src/app/cockpit.css
@@ -234,3 +234,30 @@ pre.shiki {
 .cockpit-prose table.params { border-collapse: collapse; margin: 0.5rem 0; }
 .cockpit-prose table.params th { font-family: var(--font-mono), monospace; font-size: 0.6rem; letter-spacing: 0.06em; text-transform: uppercase; padding-bottom: 0.5rem; border-bottom: 1px solid var(--ds-border); }
 .cockpit-prose table.params td { padding: 0.5rem 0.75rem 0.5rem 0; border-bottom: 1px solid var(--ds-border); }
+
+/* Code-mode file tree */
+.cockpit-file-tree { list-style: none; padding: 0; margin: 0; font-size: 12px; line-height: 1.7; }
+.cockpit-file-tree ul { list-style: none; padding: 0; margin: 0; }
+.cockpit-file-tree__file-row { display: flex; align-items: center; }
+.cockpit-file-tree__file,
+.cockpit-file-tree__folder {
+  display: flex; align-items: center; gap: 0.4rem; flex: 1; min-width: 0;
+  padding: 3px 0.75rem 3px 0.75rem; background: transparent; border: 0; text-align: left; cursor: pointer;
+  color: var(--ds-text-secondary); font-family: var(--font-mono), "JetBrains Mono", monospace; font-size: 12px;
+  border-left: 2px solid transparent; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.cockpit-file-tree__folder { color: var(--ds-text-muted); display: flex; align-items: center; }
+.cockpit-file-tree__caret { font-size: 9px; color: var(--ds-text-muted); width: 0.65rem; flex-shrink: 0; }
+.cockpit-file-tree__label { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.cockpit-file-tree__chip {
+  font-family: var(--font-mono), monospace; font-size: 9px;
+  padding: 1px 5px; border-radius: 3px; margin-right: 0.5rem; flex-shrink: 0;
+  background: var(--ds-accent-surface); color: var(--ds-accent);
+  opacity: 0.85;
+}
+.cockpit-file-tree__file:hover { color: var(--ds-text-primary); }
+.cockpit-file-tree__file[aria-current="true"] {
+  background: var(--ds-accent-surface);
+  color: var(--ds-text-primary);
+  border-left-color: var(--ds-accent);
+}

--- a/apps/cockpit/src/components/api-mode/api-mode.tsx
+++ b/apps/cockpit/src/components/api-mode/api-mode.tsx
@@ -130,8 +130,8 @@ export function ApiMode({ docSections, hasCodeFiles = false }: ApiModeProps) {
   const pySections = docSections.filter((s) => s.language === 'python');
 
   return (
-    <section aria-label="API mode" className="h-full overflow-auto py-4 px-4 md:px-8">
-      <div className="cockpit-prose" style={{ maxWidth: '48rem' }}>
+    <section aria-label="API mode" className="h-full overflow-auto py-6 px-4 md:px-8">
+      <div className="cockpit-prose cockpit-prose--wide">
         {tsSections.length > 0 ? (
           <div>
             <h3

--- a/apps/cockpit/src/components/code-mode/code-mode.spec.tsx
+++ b/apps/cockpit/src/components/code-mode/code-mode.spec.tsx
@@ -245,6 +245,45 @@ describe('CodeMode', () => {
     expect(container.textContent).toContain('Select a file from the tree');
   });
 
+  it('closes a tab when Enter is pressed on the close button', () => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    act(() => {
+      root!.render(
+        <CodeMode
+          entryTitle="Planning"
+          codeAssetPaths={['src/a.ts', 'src/b.ts']}
+          backendAssetPaths={[]}
+          codeFiles={{
+            'src/a.ts': '<pre class="shiki"><code>a</code></pre>',
+            'src/b.ts': '<pre class="shiki"><code>b</code></pre>',
+          }}
+          promptFiles={{}}
+        />,
+      );
+    });
+
+    // The first tab (a.ts) is active by default; its close span is focusable.
+    const closeBtn = container.querySelector(
+      '[role="tab"][data-state="active"] [data-tab-close]',
+    ) as HTMLElement;
+    expect(closeBtn).not.toBeNull();
+    expect(closeBtn.getAttribute('tabindex')).toBe('0');
+
+    act(() => {
+      closeBtn.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }),
+      );
+    });
+
+    const tabs = Array.from(container.querySelectorAll('[role="tab"]')).map((t) =>
+      (t.textContent ?? '').replace(/×/g, '').trim(),
+    );
+    expect(tabs).toEqual(['b.ts']);
+  });
+
   it('fires cockpit:code_copied when the Copy button is clicked', () => {
     container = document.createElement('div');
     document.body.appendChild(container);

--- a/apps/cockpit/src/components/code-mode/code-mode.spec.tsx
+++ b/apps/cockpit/src/components/code-mode/code-mode.spec.tsx
@@ -52,7 +52,7 @@ describe('CodeMode', () => {
     expect(container.textContent).toContain('export default function Page() {}');
 
     const tabs = Array.from(container.querySelectorAll('[role="tab"]'));
-    expect(tabs.map((tab) => tab.textContent)).toEqual(['page.tsx', 'index.ts']);
+    expect(tabs.map((tab) => (tab.textContent ?? '').replace(/×/g, '').trim())).toEqual(['page.tsx', 'index.ts']);
 
     act(() => {
       (tabs[1] as HTMLElement).dispatchEvent(
@@ -105,12 +105,12 @@ describe('CodeMode', () => {
     });
 
     const tabs = Array.from(container.querySelectorAll('[role="tab"]'));
-    const tabLabels = tabs.map((tab) => tab.textContent);
+    const tabLabels = tabs.map((tab) => (tab.textContent ?? '').replace(/×/g, '').trim());
     expect(tabLabels).toContain('app.tsx');
     expect(tabLabels).toContain('system.md');
 
     act(() => {
-      const promptTab = tabs.find((tab) => tab.textContent === 'system.md') as HTMLElement;
+      const promptTab = tabs.find((tab) => (tab.textContent ?? '').replace(/×/g, '').trim() === 'system.md') as HTMLElement;
       promptTab.dispatchEvent(
         new MouseEvent('mousedown', { bubbles: true, cancelable: true, button: 0 })
       );
@@ -139,11 +139,11 @@ describe('CodeMode', () => {
       );
     });
 
-    const tabLabels = Array.from(container.querySelectorAll('[role="tab"]')).map((t) => t.textContent);
+    const tabLabels = Array.from(container.querySelectorAll('[role="tab"]')).map((t) => (t.textContent ?? '').replace(/×/g, '').trim());
     expect(tabLabels).toEqual(['a.ts', 'graph.py', 'p.md']);
 
     const active = container.querySelector('[role="tab"][data-state="active"]');
-    expect(active?.textContent).toBe('a.ts');
+    expect((active?.textContent ?? '').replace(/×/g, '').trim()).toBe('a.ts');
   });
 
   it('opens a closed file and activates it when the tree row is clicked', () => {
@@ -176,7 +176,73 @@ describe('CodeMode', () => {
     act(() => { bRow.click(); });
 
     const active = container.querySelector('[role="tab"][data-state="active"]');
-    expect(active?.textContent).toBe('b.ts');
+    expect((active?.textContent ?? '').replace(/×/g, '').trim()).toBe('b.ts');
+  });
+
+  it('closes a tab and activates its left neighbor', () => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    act(() => {
+      root!.render(
+        <CodeMode
+          entryTitle="Planning"
+          codeAssetPaths={['src/a.ts', 'src/b.ts', 'src/c.ts']}
+          backendAssetPaths={[]}
+          codeFiles={{
+            'src/a.ts': '<pre class="shiki"><code>a</code></pre>',
+            'src/b.ts': '<pre class="shiki"><code>b</code></pre>',
+            'src/c.ts': '<pre class="shiki"><code>c</code></pre>',
+          }}
+          promptFiles={{}}
+        />,
+      );
+    });
+
+    // Activate b.ts, then close it.
+    const bTab = Array.from(container.querySelectorAll('[role="tab"]')).find(
+      (el) => el.textContent?.startsWith('b.ts'),
+    ) as HTMLElement;
+    act(() => {
+      bTab.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true, button: 0 }));
+    });
+
+    const closeBtn = container.querySelector('[role="tab"][data-state="active"] [data-tab-close]') as HTMLElement;
+    expect(closeBtn).not.toBeNull();
+    act(() => { closeBtn.click(); });
+
+    const tabs = Array.from(container.querySelectorAll('[role="tab"]')).map((t) =>
+      (t.textContent ?? '').replace(/×/g, '').trim(),
+    );
+    expect(tabs).toEqual(['a.ts', 'c.ts']);
+
+    const active = container.querySelector('[role="tab"][data-state="active"]');
+    expect((active?.textContent ?? '').startsWith('a.ts')).toBe(true);
+  });
+
+  it('shows the empty state after the last tab is closed', () => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    act(() => {
+      root!.render(
+        <CodeMode
+          entryTitle="Planning"
+          codeAssetPaths={['src/only.ts']}
+          backendAssetPaths={[]}
+          codeFiles={{ 'src/only.ts': '<pre class="shiki"><code>x</code></pre>' }}
+          promptFiles={{}}
+        />,
+      );
+    });
+
+    const closeBtn = container.querySelector('[role="tab"] [data-tab-close]') as HTMLElement;
+    act(() => { closeBtn.click(); });
+
+    expect(container.querySelectorAll('[role="tab"]')).toHaveLength(0);
+    expect(container.textContent).toContain('Select a file from the tree');
   });
 
   it('fires cockpit:code_copied when the Copy button is clicked', () => {

--- a/apps/cockpit/src/components/code-mode/code-mode.spec.tsx
+++ b/apps/cockpit/src/components/code-mode/code-mode.spec.tsx
@@ -119,6 +119,33 @@ describe('CodeMode', () => {
     expect(container.textContent).toContain('You are a helpful assistant.');
   });
 
+  it('pre-opens all code, backend, and prompt files as tabs with the first code file active', () => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    act(() => {
+      root!.render(
+        <CodeMode
+          entryTitle="Planning"
+          codeAssetPaths={['src/a.ts']}
+          backendAssetPaths={['backend/graph.py']}
+          codeFiles={{
+            'src/a.ts': '<pre class="shiki"><code>a</code></pre>',
+            'backend/graph.py': '<pre class="shiki"><code>g</code></pre>',
+          }}
+          promptFiles={{ 'prompts/p.md': 'hello' }}
+        />,
+      );
+    });
+
+    const tabLabels = Array.from(container.querySelectorAll('[role="tab"]')).map((t) => t.textContent);
+    expect(tabLabels).toEqual(['a.ts', 'graph.py', 'p.md']);
+
+    const active = container.querySelector('[role="tab"][data-state="active"]');
+    expect(active?.textContent).toBe('a.ts');
+  });
+
   it('fires cockpit:code_copied when the Copy button is clicked', () => {
     container = document.createElement('div');
     document.body.appendChild(container);

--- a/apps/cockpit/src/components/code-mode/code-mode.spec.tsx
+++ b/apps/cockpit/src/components/code-mode/code-mode.spec.tsx
@@ -146,6 +146,39 @@ describe('CodeMode', () => {
     expect(active?.textContent).toBe('a.ts');
   });
 
+  it('opens a closed file and activates it when the tree row is clicked', () => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    act(() => {
+      root!.render(
+        <CodeMode
+          entryTitle="Planning"
+          codeAssetPaths={['src/a.ts', 'src/b.ts']}
+          backendAssetPaths={[]}
+          codeFiles={{
+            'src/a.ts': '<pre class="shiki"><code>a</code></pre>',
+            'src/b.ts': '<pre class="shiki"><code>b</code></pre>',
+          }}
+          promptFiles={{}}
+        />,
+      );
+    });
+
+    // Locate the tree row for b.ts and click it. Since FT5 has both files pre-opened,
+    // this verifies the tree-click path even before FT6 introduces close behaviour.
+    const bRow = Array.from(container.querySelectorAll('[data-file-row]')).find(
+      (el) => el.querySelector('[data-file-label]')?.textContent === 'b.ts',
+    ) as HTMLElement;
+    expect(bRow).toBeDefined();
+
+    act(() => { bRow.click(); });
+
+    const active = container.querySelector('[role="tab"][data-state="active"]');
+    expect(active?.textContent).toBe('b.ts');
+  });
+
   it('fires cockpit:code_copied when the Copy button is clicked', () => {
     container = document.createElement('div');
     document.body.appendChild(container);

--- a/apps/cockpit/src/components/code-mode/code-mode.tsx
+++ b/apps/cockpit/src/components/code-mode/code-mode.tsx
@@ -85,7 +85,7 @@ export function CodeMode({ entryTitle, codeAssetPaths, backendAssetPaths, codeFi
         // Activate the left neighbor; if the closed tab was leftmost (idx 0),
         // the new leftmost (next[0]) becomes active.
         const neighborIdx = Math.max(0, idx - 1);
-        return next[neighborIdx] ?? next[0];
+        return next[neighborIdx];
       });
       return next;
     });
@@ -112,63 +112,75 @@ export function CodeMode({ entryTitle, codeAssetPaths, backendAssetPaths, codeFi
       </aside>
 
       <div className="flex flex-col h-full min-w-0">
-        <Tabs
-          value={activePath ?? undefined}
-          onValueChange={(v) => setActivePath(v)}
-          className="flex flex-col h-full"
-        >
-          <TabsList className="shrink-0">
-            {openPaths.map((path) => (
-              <TabsTrigger
-                key={path}
-                value={path}
-                className={
-                  isPromptPath(path)
-                    ? 'text-[var(--ds-accent)]/70 data-[state=active]:text-[var(--ds-accent)] cockpit-tab-trigger'
-                    : 'cockpit-tab-trigger'
-                }
-              >
-                <span>{getTabLabel(path)}</span>
-                <span
-                  role="button"
-                  aria-label={`Close ${getTabLabel(path)}`}
-                  data-tab-close
-                  onPointerDown={(e) => { e.stopPropagation(); }}
-                  onClick={(e) => { e.stopPropagation(); handleClose(path); }}
-                  className="cockpit-tab-trigger__close"
-                >×</span>
-              </TabsTrigger>
-            ))}
-          </TabsList>
-
-          {openPaths.filter((p) => !isPromptPath(p)).map((path) => (
-            <TabsContent key={path} value={path} className="flex-1 overflow-auto py-6 px-4 md:px-8">
-              <div className="cockpit-prose cockpit-prose--code">
-                <CodeFileContent path={path} content={codeFiles[path]} capability={capability} />
-              </div>
-            </TabsContent>
-          ))}
-
-          {openPaths.filter(isPromptPath).map((path) => {
-            const content = promptFiles[path];
-            return (
-              <TabsContent key={path} value={path} className="flex-1 overflow-auto py-6 px-4 md:px-8">
-                <div className="cockpit-prose cockpit-prose--code">
-                  {content ? (
-                    <pre className="font-mono text-sm whitespace-pre-wrap">{content}</pre>
-                  ) : (
-                    <p className="text-sm text-[var(--ds-text-muted)]">No content for {getTabLabel(path)}</p>
-                  )}
-                </div>
-              </TabsContent>
-            );
-          })}
-        </Tabs>
-        {activePath === null ? (
+        {openPaths.length === 0 || activePath === null ? (
           <div className="flex-1 grid place-items-center text-sm text-[var(--ds-text-muted)] px-4 text-center">
             <p>Select a file from the tree to begin.</p>
           </div>
-        ) : null}
+        ) : (
+          <Tabs
+            value={activePath}
+            onValueChange={(v) => setActivePath(v)}
+            className="flex flex-col h-full"
+          >
+            <TabsList className="shrink-0">
+              {openPaths.map((path) => {
+                const label = getTabLabel(path);
+                return (
+                  <TabsTrigger
+                    key={path}
+                    value={path}
+                    className={
+                      isPromptPath(path)
+                        ? 'text-[var(--ds-accent)]/70 data-[state=active]:text-[var(--ds-accent)] cockpit-tab-trigger'
+                        : 'cockpit-tab-trigger'
+                    }
+                  >
+                    <span>{label}</span>
+                    <span
+                      role="button"
+                      tabIndex={0}
+                      aria-label={`Close ${label}`}
+                      data-tab-close
+                      onPointerDown={(e) => { e.stopPropagation(); }}
+                      onClick={(e) => { e.stopPropagation(); handleClose(path); }}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          handleClose(path);
+                        }
+                      }}
+                      className="cockpit-tab-trigger__close"
+                    >×</span>
+                  </TabsTrigger>
+                );
+              })}
+            </TabsList>
+
+            {openPaths.filter((p) => !isPromptPath(p)).map((path) => (
+              <TabsContent key={path} value={path} className="flex-1 overflow-auto py-6 px-4 md:px-8">
+                <div className="cockpit-prose cockpit-prose--code">
+                  <CodeFileContent path={path} content={codeFiles[path]} capability={capability} />
+                </div>
+              </TabsContent>
+            ))}
+
+            {openPaths.filter(isPromptPath).map((path) => {
+              const content = promptFiles[path];
+              return (
+                <TabsContent key={path} value={path} className="flex-1 overflow-auto py-6 px-4 md:px-8">
+                  <div className="cockpit-prose cockpit-prose--code">
+                    {content ? (
+                      <pre className="font-mono text-sm whitespace-pre-wrap">{content}</pre>
+                    ) : (
+                      <p className="text-sm text-[var(--ds-text-muted)]">No content for {getTabLabel(path)}</p>
+                    )}
+                  </div>
+                </TabsContent>
+              );
+            })}
+          </Tabs>
+        )}
       </div>
     </section>
   );

--- a/apps/cockpit/src/components/code-mode/code-mode.tsx
+++ b/apps/cockpit/src/components/code-mode/code-mode.tsx
@@ -53,8 +53,20 @@ function CodeFileContent({
 }
 
 export function CodeMode({ entryTitle, codeAssetPaths, backendAssetPaths, codeFiles, promptFiles, capability }: CodeModeProps) {
-  const promptPaths = Object.keys(promptFiles);
-  const allPaths = [...codeAssetPaths, ...backendAssetPaths, ...promptPaths];
+  const promptPaths = React.useMemo(() => Object.keys(promptFiles), [promptFiles]);
+  const allPaths = React.useMemo(
+    () => [...codeAssetPaths, ...backendAssetPaths, ...promptPaths],
+    [codeAssetPaths, backendAssetPaths, promptPaths],
+  );
+
+  const [openPaths, setOpenPaths] = React.useState<readonly string[]>(allPaths);
+  const [activePath, setActivePath] = React.useState<string | null>(allPaths[0] ?? null);
+
+  // If the capability changes (allPaths changes identity), reset open + active.
+  React.useEffect(() => {
+    setOpenPaths(allPaths);
+    setActivePath(allPaths[0] ?? null);
+  }, [allPaths]);
 
   if (allPaths.length === 0) {
     return (
@@ -64,30 +76,32 @@ export function CodeMode({ entryTitle, codeAssetPaths, backendAssetPaths, codeFi
     );
   }
 
-  const defaultPath = codeAssetPaths[0] ?? backendAssetPaths[0] ?? promptPaths[0];
+  const isPromptPath = (path: string) => promptPaths.includes(path);
 
   return (
     <section aria-label="Code mode" className="h-full flex flex-col">
-      <Tabs defaultValue={defaultPath} className="flex flex-col h-full">
+      <Tabs
+        value={activePath ?? undefined}
+        onValueChange={(v) => setActivePath(v)}
+        className="flex flex-col h-full"
+      >
         <TabsList className="shrink-0">
-          {codeAssetPaths.map((path) => (
-            <TabsTrigger key={path} value={path}>
-              {getTabLabel(path)}
-            </TabsTrigger>
-          ))}
-          {backendAssetPaths.map((path) => (
-            <TabsTrigger key={path} value={path}>
-              {getTabLabel(path)}
-            </TabsTrigger>
-          ))}
-          {promptPaths.map((path) => (
-            <TabsTrigger key={path} value={path} className="text-[var(--ds-accent)]/70 data-[state=active]:text-[var(--ds-accent)]">
+          {openPaths.map((path) => (
+            <TabsTrigger
+              key={path}
+              value={path}
+              className={
+                isPromptPath(path)
+                  ? 'text-[var(--ds-accent)]/70 data-[state=active]:text-[var(--ds-accent)]'
+                  : undefined
+              }
+            >
               {getTabLabel(path)}
             </TabsTrigger>
           ))}
         </TabsList>
 
-        {[...codeAssetPaths, ...backendAssetPaths].map((path) => (
+        {openPaths.filter((p) => !isPromptPath(p)).map((path) => (
           <TabsContent key={path} value={path} className="flex-1 overflow-auto py-6 px-4 md:px-8">
             <div className="cockpit-prose cockpit-prose--code">
               <CodeFileContent path={path} content={codeFiles[path]} capability={capability} />
@@ -95,7 +109,7 @@ export function CodeMode({ entryTitle, codeAssetPaths, backendAssetPaths, codeFi
           </TabsContent>
         ))}
 
-        {promptPaths.map((path) => {
+        {openPaths.filter(isPromptPath).map((path) => {
           const content = promptFiles[path];
           return (
             <TabsContent key={path} value={path} className="flex-1 overflow-auto py-6 px-4 md:px-8">

--- a/apps/cockpit/src/components/code-mode/code-mode.tsx
+++ b/apps/cockpit/src/components/code-mode/code-mode.tsx
@@ -74,6 +74,23 @@ export function CodeMode({ entryTitle, codeAssetPaths, backendAssetPaths, codeFi
     setActivePath(path);
   }, []);
 
+  const handleClose = React.useCallback((path: string) => {
+    setOpenPaths((prev) => {
+      const idx = prev.indexOf(path);
+      if (idx < 0) return prev;
+      const next = prev.filter((p) => p !== path);
+      setActivePath((current) => {
+        if (current !== path) return current;
+        if (next.length === 0) return null;
+        // Activate the left neighbor; if the closed tab was leftmost (idx 0),
+        // the new leftmost (next[0]) becomes active.
+        const neighborIdx = Math.max(0, idx - 1);
+        return next[neighborIdx] ?? next[0];
+      });
+      return next;
+    });
+  }, []);
+
   if (allPaths.length === 0) {
     return (
       <section aria-label="Code mode" className="grid place-items-center h-full text-[var(--ds-text-muted)] text-sm">
@@ -107,11 +124,19 @@ export function CodeMode({ entryTitle, codeAssetPaths, backendAssetPaths, codeFi
                 value={path}
                 className={
                   isPromptPath(path)
-                    ? 'text-[var(--ds-accent)]/70 data-[state=active]:text-[var(--ds-accent)]'
-                    : undefined
+                    ? 'text-[var(--ds-accent)]/70 data-[state=active]:text-[var(--ds-accent)] cockpit-tab-trigger'
+                    : 'cockpit-tab-trigger'
                 }
               >
-                {getTabLabel(path)}
+                <span>{getTabLabel(path)}</span>
+                <span
+                  role="button"
+                  aria-label={`Close ${getTabLabel(path)}`}
+                  data-tab-close
+                  onPointerDown={(e) => { e.stopPropagation(); }}
+                  onClick={(e) => { e.stopPropagation(); handleClose(path); }}
+                  className="cockpit-tab-trigger__close"
+                >×</span>
               </TabsTrigger>
             ))}
           </TabsList>
@@ -139,6 +164,11 @@ export function CodeMode({ entryTitle, codeAssetPaths, backendAssetPaths, codeFi
             );
           })}
         </Tabs>
+        {activePath === null ? (
+          <div className="flex-1 grid place-items-center text-sm text-[var(--ds-text-muted)] px-4 text-center">
+            <p>Select a file from the tree to begin.</p>
+          </div>
+        ) : null}
       </div>
     </section>
   );

--- a/apps/cockpit/src/components/code-mode/code-mode.tsx
+++ b/apps/cockpit/src/components/code-mode/code-mode.tsx
@@ -88,7 +88,8 @@ export function CodeMode({ entryTitle, codeAssetPaths, backendAssetPaths, codeFi
     <section aria-label="Code mode" className="h-full lg:grid lg:grid-cols-[220px_1fr] lg:overflow-hidden">
       <aside
         aria-label="File tree"
-        className="hidden lg:block lg:overflow-y-auto border-r border-[var(--ds-border)] bg-[var(--ds-surface-tinted)]/40"
+        className="hidden lg:block lg:overflow-y-auto border-r border-[var(--ds-border)]"
+        style={{ background: 'color-mix(in srgb, var(--ds-surface-tinted) 40%, transparent)' }}
       >
         <FileTree paths={allPaths} activePath={activePath} onSelect={handleSelect} />
       </aside>

--- a/apps/cockpit/src/components/code-mode/code-mode.tsx
+++ b/apps/cockpit/src/components/code-mode/code-mode.tsx
@@ -64,6 +64,7 @@ export function CodeMode({ entryTitle, codeAssetPaths, backendAssetPaths, codeFi
   const [activePath, setActivePath] = React.useState<string | null>(allPaths[0] ?? null);
 
   const [treeCollapsed, setTreeCollapsed] = React.useState(false);
+  const [mounted, setMounted] = React.useState(false);
 
   React.useEffect(() => {
     try {
@@ -71,8 +72,12 @@ export function CodeMode({ entryTitle, codeAssetPaths, backendAssetPaths, codeFi
         setTreeCollapsed(true);
       }
     } catch {
-      /* localStorage unavailable — leave default */
+      /* ignore */
     }
+    // Mark mounted on next animation frame so the localStorage state lands BEFORE
+    // the transition class is applied — no animated collapse on hard reload.
+    const id = requestAnimationFrame(() => setMounted(true));
+    return () => cancelAnimationFrame(id);
   }, []);
 
   const toggleTreeCollapsed = React.useCallback(() => {
@@ -128,10 +133,10 @@ export function CodeMode({ entryTitle, codeAssetPaths, backendAssetPaths, codeFi
   const isPromptPath = (path: string) => promptPaths.includes(path);
 
   return (
-    <section aria-label="Code mode" className={`h-full lg:grid lg:overflow-hidden ${treeCollapsed ? 'lg:grid-cols-[0_1fr]' : 'lg:grid-cols-[220px_1fr]'}`}>
+    <section aria-label="Code mode" className="h-full lg:flex lg:overflow-hidden">
       <aside
         aria-label="File tree"
-        className={`hidden lg:flex lg:flex-col border-r border-[var(--ds-border)] transition-[width] duration-200 ${treeCollapsed ? 'lg:w-0 lg:overflow-hidden lg:border-r-0' : 'lg:w-[220px] lg:overflow-y-auto'}`}
+        className={`hidden lg:flex lg:flex-col flex-none overflow-hidden border-r border-[var(--ds-border)] ${mounted ? 'transition-[width] duration-200' : ''} ${treeCollapsed ? 'lg:w-0 lg:border-r-0' : 'lg:w-[220px]'}`}
         style={{ background: 'color-mix(in srgb, var(--ds-surface-tinted) 40%, transparent)' }}
       >
         <div className="flex items-center justify-between px-2 py-1.5 border-b border-[var(--ds-border)]" style={{ background: 'color-mix(in srgb, var(--ds-surface-tinted) 70%, transparent)' }}>
@@ -146,7 +151,7 @@ export function CodeMode({ entryTitle, codeAssetPaths, backendAssetPaths, codeFi
         <FileTree paths={allPaths} activePath={activePath} onSelect={handleSelect} />
       </aside>
 
-      <div className="flex flex-col h-full min-w-0">
+      <div className="flex flex-col h-full min-w-0 flex-1">
         {treeCollapsed ? (
           <button
             type="button"

--- a/apps/cockpit/src/components/code-mode/code-mode.tsx
+++ b/apps/cockpit/src/components/code-mode/code-mode.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { track } from '../../lib/analytics/client';
+import { FileTree } from './file-tree';
 
 interface CodeModeProps {
   entryTitle: string;
@@ -68,6 +69,11 @@ export function CodeMode({ entryTitle, codeAssetPaths, backendAssetPaths, codeFi
     setActivePath(allPaths[0] ?? null);
   }, [allPaths]);
 
+  const handleSelect = React.useCallback((path: string) => {
+    setOpenPaths((prev) => (prev.includes(path) ? prev : [...prev, path]));
+    setActivePath(path);
+  }, []);
+
   if (allPaths.length === 0) {
     return (
       <section aria-label="Code mode" className="grid place-items-center h-full text-[var(--ds-text-muted)] text-sm">
@@ -79,51 +85,60 @@ export function CodeMode({ entryTitle, codeAssetPaths, backendAssetPaths, codeFi
   const isPromptPath = (path: string) => promptPaths.includes(path);
 
   return (
-    <section aria-label="Code mode" className="h-full flex flex-col">
-      <Tabs
-        value={activePath ?? undefined}
-        onValueChange={(v) => setActivePath(v)}
-        className="flex flex-col h-full"
+    <section aria-label="Code mode" className="h-full lg:grid lg:grid-cols-[220px_1fr] lg:overflow-hidden">
+      <aside
+        aria-label="File tree"
+        className="hidden lg:block lg:overflow-y-auto border-r border-[var(--ds-border)] bg-[var(--ds-surface-tinted)]/40"
       >
-        <TabsList className="shrink-0">
-          {openPaths.map((path) => (
-            <TabsTrigger
-              key={path}
-              value={path}
-              className={
-                isPromptPath(path)
-                  ? 'text-[var(--ds-accent)]/70 data-[state=active]:text-[var(--ds-accent)]'
-                  : undefined
-              }
-            >
-              {getTabLabel(path)}
-            </TabsTrigger>
-          ))}
-        </TabsList>
+        <FileTree paths={allPaths} activePath={activePath} onSelect={handleSelect} />
+      </aside>
 
-        {openPaths.filter((p) => !isPromptPath(p)).map((path) => (
-          <TabsContent key={path} value={path} className="flex-1 overflow-auto py-6 px-4 md:px-8">
-            <div className="cockpit-prose cockpit-prose--code">
-              <CodeFileContent path={path} content={codeFiles[path]} capability={capability} />
-            </div>
-          </TabsContent>
-        ))}
+      <div className="flex flex-col h-full min-w-0">
+        <Tabs
+          value={activePath ?? undefined}
+          onValueChange={(v) => setActivePath(v)}
+          className="flex flex-col h-full"
+        >
+          <TabsList className="shrink-0">
+            {openPaths.map((path) => (
+              <TabsTrigger
+                key={path}
+                value={path}
+                className={
+                  isPromptPath(path)
+                    ? 'text-[var(--ds-accent)]/70 data-[state=active]:text-[var(--ds-accent)]'
+                    : undefined
+                }
+              >
+                {getTabLabel(path)}
+              </TabsTrigger>
+            ))}
+          </TabsList>
 
-        {openPaths.filter(isPromptPath).map((path) => {
-          const content = promptFiles[path];
-          return (
+          {openPaths.filter((p) => !isPromptPath(p)).map((path) => (
             <TabsContent key={path} value={path} className="flex-1 overflow-auto py-6 px-4 md:px-8">
               <div className="cockpit-prose cockpit-prose--code">
-                {content ? (
-                  <pre className="font-mono text-sm whitespace-pre-wrap">{content}</pre>
-                ) : (
-                  <p className="text-sm text-[var(--ds-text-muted)]">No content for {getTabLabel(path)}</p>
-                )}
+                <CodeFileContent path={path} content={codeFiles[path]} capability={capability} />
               </div>
             </TabsContent>
-          );
-        })}
-      </Tabs>
+          ))}
+
+          {openPaths.filter(isPromptPath).map((path) => {
+            const content = promptFiles[path];
+            return (
+              <TabsContent key={path} value={path} className="flex-1 overflow-auto py-6 px-4 md:px-8">
+                <div className="cockpit-prose cockpit-prose--code">
+                  {content ? (
+                    <pre className="font-mono text-sm whitespace-pre-wrap">{content}</pre>
+                  ) : (
+                    <p className="text-sm text-[var(--ds-text-muted)]">No content for {getTabLabel(path)}</p>
+                  )}
+                </div>
+              </TabsContent>
+            );
+          })}
+        </Tabs>
+      </div>
     </section>
   );
 }

--- a/apps/cockpit/src/components/code-mode/code-mode.tsx
+++ b/apps/cockpit/src/components/code-mode/code-mode.tsx
@@ -63,6 +63,32 @@ export function CodeMode({ entryTitle, codeAssetPaths, backendAssetPaths, codeFi
   const [openPaths, setOpenPaths] = React.useState<readonly string[]>(allPaths);
   const [activePath, setActivePath] = React.useState<string | null>(allPaths[0] ?? null);
 
+  const [treeCollapsed, setTreeCollapsed] = React.useState(false);
+
+  React.useEffect(() => {
+    try {
+      if (typeof window !== 'undefined' && window.localStorage.getItem('cockpit:codeTree:collapsed') === '1') {
+        setTreeCollapsed(true);
+      }
+    } catch {
+      /* localStorage unavailable — leave default */
+    }
+  }, []);
+
+  const toggleTreeCollapsed = React.useCallback(() => {
+    setTreeCollapsed((prev) => {
+      const next = !prev;
+      try {
+        if (typeof window !== 'undefined') {
+          window.localStorage.setItem('cockpit:codeTree:collapsed', next ? '1' : '0');
+        }
+      } catch {
+        /* ignore */
+      }
+      return next;
+    });
+  }, []);
+
   // If the capability changes (allPaths changes identity), reset open + active.
   React.useEffect(() => {
     setOpenPaths(allPaths);
@@ -102,16 +128,33 @@ export function CodeMode({ entryTitle, codeAssetPaths, backendAssetPaths, codeFi
   const isPromptPath = (path: string) => promptPaths.includes(path);
 
   return (
-    <section aria-label="Code mode" className="h-full lg:grid lg:grid-cols-[220px_1fr] lg:overflow-hidden">
+    <section aria-label="Code mode" className={`h-full lg:grid lg:overflow-hidden ${treeCollapsed ? 'lg:grid-cols-[0_1fr]' : 'lg:grid-cols-[220px_1fr]'}`}>
       <aside
         aria-label="File tree"
-        className="hidden lg:block lg:overflow-y-auto border-r border-[var(--ds-border)]"
+        className={`hidden lg:flex lg:flex-col border-r border-[var(--ds-border)] transition-[width] duration-200 ${treeCollapsed ? 'lg:w-0 lg:overflow-hidden lg:border-r-0' : 'lg:w-[220px] lg:overflow-y-auto'}`}
         style={{ background: 'color-mix(in srgb, var(--ds-surface-tinted) 40%, transparent)' }}
       >
+        <div className="flex items-center justify-between px-2 py-1.5 border-b border-[var(--ds-border)]" style={{ background: 'color-mix(in srgb, var(--ds-surface-tinted) 70%, transparent)' }}>
+          <span className="font-mono text-[10px] uppercase tracking-wide text-[var(--ds-text-muted)] pl-1">Files</span>
+          <button
+            type="button"
+            aria-label="Collapse file tree"
+            onClick={toggleTreeCollapsed}
+            className="text-[var(--ds-text-muted)] hover:text-[var(--ds-text-primary)] px-1.5 py-0.5 rounded"
+          >‹</button>
+        </div>
         <FileTree paths={allPaths} activePath={activePath} onSelect={handleSelect} />
       </aside>
 
       <div className="flex flex-col h-full min-w-0">
+        {treeCollapsed ? (
+          <button
+            type="button"
+            aria-label="Expand file tree"
+            onClick={toggleTreeCollapsed}
+            className="hidden lg:flex shrink-0 items-center justify-center w-7 self-start mt-1 ml-1 rounded text-[var(--ds-accent)] hover:bg-[var(--ds-accent-surface)]"
+          >›</button>
+        ) : null}
         {openPaths.length === 0 || activePath === null ? (
           <div className="flex-1 grid place-items-center text-sm text-[var(--ds-text-muted)] px-4 text-center">
             <p>Select a file from the tree to begin.</p>

--- a/apps/cockpit/src/components/code-mode/code-mode.tsx
+++ b/apps/cockpit/src/components/code-mode/code-mode.tsx
@@ -88,20 +88,24 @@ export function CodeMode({ entryTitle, codeAssetPaths, backendAssetPaths, codeFi
         </TabsList>
 
         {[...codeAssetPaths, ...backendAssetPaths].map((path) => (
-          <TabsContent key={path} value={path} className="flex-1 overflow-auto">
-            <CodeFileContent path={path} content={codeFiles[path]} capability={capability} />
+          <TabsContent key={path} value={path} className="flex-1 overflow-auto py-6 px-4 md:px-8">
+            <div className="cockpit-prose cockpit-prose--code">
+              <CodeFileContent path={path} content={codeFiles[path]} capability={capability} />
+            </div>
           </TabsContent>
         ))}
 
         {promptPaths.map((path) => {
           const content = promptFiles[path];
           return (
-            <TabsContent key={path} value={path} className="flex-1 overflow-auto mt-4">
-              {content ? (
-                <pre className="font-mono text-sm whitespace-pre-wrap">{content}</pre>
-              ) : (
-                <p className="text-sm text-[var(--ds-text-muted)]">No content for {getTabLabel(path)}</p>
-              )}
+            <TabsContent key={path} value={path} className="flex-1 overflow-auto py-6 px-4 md:px-8">
+              <div className="cockpit-prose cockpit-prose--code">
+                {content ? (
+                  <pre className="font-mono text-sm whitespace-pre-wrap">{content}</pre>
+                ) : (
+                  <p className="text-sm text-[var(--ds-text-muted)]">No content for {getTabLabel(path)}</p>
+                )}
+              </div>
             </TabsContent>
           );
         })}

--- a/apps/cockpit/src/components/code-mode/file-tree.spec.tsx
+++ b/apps/cockpit/src/components/code-mode/file-tree.spec.tsx
@@ -1,0 +1,88 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { FileTree } from './file-tree';
+
+describe('FileTree', () => {
+  let container: HTMLDivElement | undefined;
+  let root: ReturnType<typeof createRoot> | undefined;
+
+  afterEach(() => {
+    act(() => { root?.unmount(); });
+    container?.remove();
+    vi.clearAllMocks();
+  });
+
+  function render(node: React.ReactElement) {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => { root!.render(node); });
+  }
+
+  it('renders a file row for every path', () => {
+    const onSelect = vi.fn();
+    render(
+      <FileTree
+        paths={['angular/src/app/planning.component.ts', 'python/src/graph.py', 'prompts/planning.md']}
+        activePath={null}
+        onSelect={onSelect}
+      />
+    );
+
+    const labels = Array.from(container!.querySelectorAll('[data-file-row]')).map((el) => el.textContent);
+    expect(labels).toContain('planning.component.ts');
+    expect(labels).toContain('graph.py');
+    expect(labels).toContain('planning.md');
+  });
+
+  it('marks the active file row with aria-current="true"', () => {
+    render(
+      <FileTree
+        paths={['a.ts', 'b.py']}
+        activePath="b.py"
+        onSelect={() => {}}
+      />
+    );
+
+    const active = container!.querySelector('[data-file-row][aria-current="true"]');
+    expect(active?.textContent).toBe('b.py');
+  });
+
+  it('emits onSelect with the file path when a file row is clicked', () => {
+    const onSelect = vi.fn();
+    render(
+      <FileTree
+        paths={['angular/src/app/planning.component.ts']}
+        activePath={null}
+        onSelect={onSelect}
+      />
+    );
+
+    const row = container!.querySelector('[data-file-row]') as HTMLElement;
+    act(() => { row.click(); });
+
+    expect(onSelect).toHaveBeenCalledWith('angular/src/app/planning.component.ts');
+  });
+
+  it('collapses a folder when its header is clicked and hides its children', () => {
+    render(
+      <FileTree
+        paths={['angular/src/app/planning.component.ts', 'angular/src/app/app.config.ts']}
+        activePath={null}
+        onSelect={() => {}}
+      />
+    );
+
+    // Folder "angular/src/app" is the only top-level row (compact-merged).
+    const folder = container!.querySelector('[data-folder-row]') as HTMLElement;
+    expect(folder.textContent).toContain('angular/src/app');
+    expect(container!.querySelectorAll('[data-file-row]')).toHaveLength(2);
+
+    act(() => { folder.click(); });
+
+    expect(container!.querySelectorAll('[data-file-row]')).toHaveLength(0);
+  });
+});

--- a/apps/cockpit/src/components/code-mode/file-tree.spec.tsx
+++ b/apps/cockpit/src/components/code-mode/file-tree.spec.tsx
@@ -32,7 +32,7 @@ describe('FileTree', () => {
       />
     );
 
-    const labels = Array.from(container!.querySelectorAll('[data-file-row]')).map((el) => el.textContent);
+    const labels = Array.from(container!.querySelectorAll('[data-file-label]')).map((el) => el.textContent);
     expect(labels).toContain('planning.component.ts');
     expect(labels).toContain('graph.py');
     expect(labels).toContain('planning.md');
@@ -48,7 +48,7 @@ describe('FileTree', () => {
     );
 
     const active = container!.querySelector('[data-file-row][aria-current="true"]');
-    expect(active?.textContent).toBe('b.py');
+    expect(active?.querySelector('[data-file-label]')?.textContent).toBe('b.py');
   });
 
   it('emits onSelect with the file path when a file row is clicked', () => {

--- a/apps/cockpit/src/components/code-mode/file-tree.tsx
+++ b/apps/cockpit/src/components/code-mode/file-tree.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import React from 'react';
+import { buildTree, type FolderNode, type TreeNode } from './file-tree.utils';
+
+interface FileTreeProps {
+  paths: readonly string[];
+  activePath: string | null;
+  onSelect: (path: string) => void;
+}
+
+function langChip(label: string): string | null {
+  const dot = label.lastIndexOf('.');
+  if (dot <= 0) return null;
+  return label.slice(dot + 1).toUpperCase();
+}
+
+export function FileTree({ paths, activePath, onSelect }: FileTreeProps) {
+  const tree = React.useMemo(() => buildTree(paths), [paths]);
+  const [collapsedFolders, setCollapsedFolders] = React.useState<ReadonlySet<string>>(() => new Set());
+
+  const toggleFolder = React.useCallback((id: string) => {
+    setCollapsedFolders((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  return (
+    <ul className="cockpit-file-tree" role="tree">
+      {tree.map((node, i) => (
+        <Node
+          key={`${i}-${node.label}`}
+          node={node}
+          depth={0}
+          folderId={node.label}
+          activePath={activePath}
+          collapsedFolders={collapsedFolders}
+          onToggleFolder={toggleFolder}
+          onSelect={onSelect}
+        />
+      ))}
+    </ul>
+  );
+}
+
+interface NodeProps {
+  node: TreeNode;
+  depth: number;
+  folderId: string;
+  activePath: string | null;
+  collapsedFolders: ReadonlySet<string>;
+  onToggleFolder: (id: string) => void;
+  onSelect: (path: string) => void;
+}
+
+function Node({ node, depth, folderId, activePath, collapsedFolders, onToggleFolder, onSelect }: NodeProps) {
+  if (node.kind === 'file') {
+    const chip = langChip(node.label);
+    const isActive = activePath === node.path;
+    return (
+      <li className="cockpit-file-tree__file-row">
+        <button
+          type="button"
+          data-file-row
+          aria-current={isActive ? 'true' : undefined}
+          onClick={() => onSelect(node.path)}
+          className="cockpit-file-tree__file"
+          style={{ paddingLeft: `${0.75 + depth * 0.75}rem` }}
+        >
+          {node.label}
+        </button>
+        {chip ? <span className="cockpit-file-tree__chip" aria-hidden="true">{chip}</span> : null}
+      </li>
+    );
+  }
+
+  const folder = node as FolderNode;
+  const isCollapsed = collapsedFolders.has(folderId);
+  return (
+    <li>
+      <button
+        type="button"
+        data-folder-row
+        aria-expanded={!isCollapsed}
+        onClick={() => onToggleFolder(folderId)}
+        className="cockpit-file-tree__folder"
+        style={{ paddingLeft: `${0.5 + depth * 0.75}rem` }}
+      >
+        <span className="cockpit-file-tree__caret" aria-hidden="true">{isCollapsed ? '▸' : '▾'}</span>
+        <span className="cockpit-file-tree__label">{folder.label}</span>
+      </button>
+      {!isCollapsed ? (
+        <ul>
+          {folder.children.map((child, i) => (
+            <Node
+              key={`${i}-${child.label}`}
+              node={child}
+              depth={depth + 1}
+              folderId={`${folderId}/${child.label}`}
+              activePath={activePath}
+              collapsedFolders={collapsedFolders}
+              onToggleFolder={onToggleFolder}
+              onSelect={onSelect}
+            />
+          ))}
+        </ul>
+      ) : null}
+    </li>
+  );
+}

--- a/apps/cockpit/src/components/code-mode/file-tree.tsx
+++ b/apps/cockpit/src/components/code-mode/file-tree.tsx
@@ -29,7 +29,7 @@ export function FileTree({ paths, activePath, onSelect }: FileTreeProps) {
   }, []);
 
   return (
-    <ul className="cockpit-file-tree" role="tree">
+    <ul className="cockpit-file-tree">
       {tree.map((node, i) => (
         <Node
           key={`${i}-${node.label}`}
@@ -61,7 +61,7 @@ function Node({ node, depth, folderId, activePath, collapsedFolders, onToggleFol
     const chip = langChip(node.label);
     const isActive = activePath === node.path;
     return (
-      <li className="cockpit-file-tree__file-row">
+      <li>
         <button
           type="button"
           data-file-row
@@ -70,9 +70,9 @@ function Node({ node, depth, folderId, activePath, collapsedFolders, onToggleFol
           className="cockpit-file-tree__file"
           style={{ paddingLeft: `${0.75 + depth * 0.75}rem` }}
         >
-          {node.label}
+          <span className="cockpit-file-tree__label" data-file-label>{node.label}</span>
+          {chip ? <span className="cockpit-file-tree__chip" aria-hidden="true">{chip}</span> : null}
         </button>
-        {chip ? <span className="cockpit-file-tree__chip" aria-hidden="true">{chip}</span> : null}
       </li>
     );
   }

--- a/apps/cockpit/src/components/code-mode/file-tree.utils.spec.ts
+++ b/apps/cockpit/src/components/code-mode/file-tree.utils.spec.ts
@@ -19,7 +19,8 @@ describe('buildTree', () => {
       'cockpit/planning/python/graph.py',
     ]);
     // common prefix "cockpit/planning/" is removed; "angular" and "python" become top-level folders
-    expect(tree.map((n) => (n.kind === 'folder' ? n.label : n.label))).toEqual(['angular', 'python']);
+    expect(tree.map((n) => n.kind)).toEqual(['folder', 'folder']);
+    expect(tree.map((n) => n.label)).toEqual(['angular', 'python']);
   });
 
   it('compacts single-child folder chains into one row', () => {
@@ -27,8 +28,8 @@ describe('buildTree', () => {
       'angular/src/app/planning.component.ts',
       'angular/src/app/app.config.ts',
     ]);
-    // angular > src > app each have one child folder beneath them on the way down;
-    // they merge into a single "angular/src/app" folder row.
+    // angular and src each have a single sub-folder; app has two files,
+    // so the merge produces one "angular/src/app" folder row.
     expect(tree).toHaveLength(1);
     expect(tree[0]).toMatchObject({ kind: 'folder', label: 'angular/src/app' });
     expect((tree[0] as { children: TreeNode[] }).children.map((c) => c.label).sort()).toEqual([
@@ -56,5 +57,17 @@ describe('buildTree', () => {
       { kind: 'file', path: 'a.ts', label: 'a.ts' },
       { kind: 'file', path: 'b.py', label: 'b.py' },
     ]);
+  });
+
+  it('normalizes leading and trailing slashes in paths', () => {
+    const tree = buildTree(['/angular/src/app/foo.ts', 'angular/src/app/bar.ts']);
+    expect(tree).toHaveLength(1);
+    const folder = tree[0] as { kind: 'folder'; label: string; children: TreeNode[] };
+    expect(folder.kind).toBe('folder');
+    expect(folder.label).toBe('angular/src/app');
+    expect(folder.children.map((c) => c.label).sort()).toEqual(['bar.ts', 'foo.ts']);
+    // FileNode.path must not retain the stripped leading slash
+    const foo = folder.children.find((c) => c.label === 'foo.ts') as { path: string };
+    expect(foo.path).toBe('angular/src/app/foo.ts');
   });
 });

--- a/apps/cockpit/src/components/code-mode/file-tree.utils.spec.ts
+++ b/apps/cockpit/src/components/code-mode/file-tree.utils.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { buildTree, type TreeNode } from './file-tree.utils';
+
+describe('buildTree', () => {
+  it('returns an empty array when no paths are given', () => {
+    expect(buildTree([])).toEqual([]);
+  });
+
+  it('returns a flat list of file nodes when there are no folders after trimming', () => {
+    const tree = buildTree(['planning.md']);
+    expect(tree).toEqual<TreeNode[]>([
+      { kind: 'file', path: 'planning.md', label: 'planning.md' },
+    ]);
+  });
+
+  it('strips the common directory prefix shared by all paths', () => {
+    const tree = buildTree([
+      'cockpit/planning/angular/app.config.ts',
+      'cockpit/planning/python/graph.py',
+    ]);
+    // common prefix "cockpit/planning/" is removed; "angular" and "python" become top-level folders
+    expect(tree.map((n) => (n.kind === 'folder' ? n.label : n.label))).toEqual(['angular', 'python']);
+  });
+
+  it('compacts single-child folder chains into one row', () => {
+    const tree = buildTree([
+      'angular/src/app/planning.component.ts',
+      'angular/src/app/app.config.ts',
+    ]);
+    // angular > src > app each have one child folder beneath them on the way down;
+    // they merge into a single "angular/src/app" folder row.
+    expect(tree).toHaveLength(1);
+    expect(tree[0]).toMatchObject({ kind: 'folder', label: 'angular/src/app' });
+    expect((tree[0] as { children: TreeNode[] }).children.map((c) => c.label).sort()).toEqual([
+      'app.config.ts',
+      'planning.component.ts',
+    ]);
+  });
+
+  it('keeps a folder distinct from its children when it has both a file and a subfolder', () => {
+    const tree = buildTree([
+      'angular/src/app/planning.component.ts',
+      'angular/src/app/views/plan-checklist.component.ts',
+    ]);
+    // angular/src/app contains a file AND a "views" subfolder → does not merge with "views"
+    const top = tree[0] as { kind: 'folder'; label: string; children: TreeNode[] };
+    expect(top.label).toBe('angular/src/app');
+    expect(top.children).toHaveLength(2);
+    const labels = top.children.map((c) => c.label).sort();
+    expect(labels).toEqual(['planning.component.ts', 'views']);
+  });
+
+  it('renders all files flat when no common prefix and only one segment each', () => {
+    const tree = buildTree(['a.ts', 'b.py']);
+    expect(tree).toEqual<TreeNode[]>([
+      { kind: 'file', path: 'a.ts', label: 'a.ts' },
+      { kind: 'file', path: 'b.py', label: 'b.py' },
+    ]);
+  });
+});

--- a/apps/cockpit/src/components/code-mode/file-tree.utils.ts
+++ b/apps/cockpit/src/components/code-mode/file-tree.utils.ts
@@ -49,8 +49,12 @@ function peelPrefix(nodes: TreeNode[]): TreeNode[] {
 }
 
 export function buildTree(paths: readonly string[]): TreeNode[] {
-  if (paths.length === 0) return [];
+  const normalized = paths
+    .map((p) => p.replace(/^\/+/, '').replace(/\/+$/, ''))
+    .filter((p) => p.length > 0);
+  if (normalized.length === 0) return [];
+
   const root: FolderNode = { kind: 'folder', label: '', children: [] };
-  paths.forEach((p) => insert(root, p.split('/'), p));
+  normalized.forEach((p) => insert(root, p.split('/'), p));
   return peelPrefix(compact(root.children));
 }

--- a/apps/cockpit/src/components/code-mode/file-tree.utils.ts
+++ b/apps/cockpit/src/components/code-mode/file-tree.utils.ts
@@ -1,0 +1,56 @@
+export type FileNode = { kind: 'file'; path: string; label: string };
+export type FolderNode = { kind: 'folder'; label: string; children: TreeNode[] };
+export type TreeNode = FileNode | FolderNode;
+
+
+function insert(root: FolderNode, segments: string[], fullPath: string): void {
+  let node = root;
+  for (let i = 0; i < segments.length - 1; i++) {
+    const seg = segments[i];
+    let child = node.children.find((c): c is FolderNode => c.kind === 'folder' && c.label === seg);
+    if (!child) {
+      child = { kind: 'folder', label: seg, children: [] };
+      node.children.push(child);
+    }
+    node = child;
+  }
+  const filename = segments[segments.length - 1];
+  node.children.push({ kind: 'file', path: fullPath, label: filename });
+}
+
+function compact(nodes: TreeNode[]): TreeNode[] {
+  return nodes.map((node) => {
+    if (node.kind === 'file') return node;
+    let folder = node;
+    // Merge while this folder has exactly one child AND that child is a folder.
+    while (folder.children.length === 1 && folder.children[0].kind === 'folder') {
+      const only = folder.children[0];
+      folder = { kind: 'folder', label: `${folder.label}/${only.label}`, children: only.children };
+    }
+    return { ...folder, children: compact(folder.children) };
+  });
+}
+
+/** Peel off a single top-level compacted folder when it is a pure "namespace"
+ *  node — i.e. it has exactly one top-level item, that item is a folder, and
+ *  every one of its direct children is also a folder (no files at that level).
+ *  This implements the common-directory-prefix trimming: a shared root that
+ *  only contains sub-folders is invisible; one that contains files is shown. */
+function peelPrefix(nodes: TreeNode[]): TreeNode[] {
+  if (
+    nodes.length === 1 &&
+    nodes[0].kind === 'folder' &&
+    nodes[0].children.length > 0 &&
+    nodes[0].children.every((c) => c.kind === 'folder')
+  ) {
+    return peelPrefix(nodes[0].children);
+  }
+  return nodes;
+}
+
+export function buildTree(paths: readonly string[]): TreeNode[] {
+  if (paths.length === 0) return [];
+  const root: FolderNode = { kind: 'folder', label: '', children: [] };
+  paths.forEach((p) => insert(root, p.split('/'), p));
+  return peelPrefix(compact(root.children));
+}

--- a/docs/superpowers/plans/2026-06-03-code-mode-file-tree.md
+++ b/docs/superpowers/plans/2026-06-03-code-mode-file-tree.md
@@ -1,0 +1,1169 @@
+# Code Mode File Tree — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a VS Code / Zed–style file tree on the left of the Code-mode tab strip at `lg:` widths, with all files pre-opened as tabs, tree-click activates/opens, tab close (×), and a persisted collapse toggle.
+
+**Architecture:** New pure-presentational `FileTree` component fed by a pure `buildTree(paths)` helper (TDD-friendly, no DOM). `CodeMode` migrates from Radix `Tabs.defaultValue` to explicit `openPaths` + `activePath` state and adds the responsive `lg:grid` layout with a collapse toggle persisted via `localStorage`. Zero new dependencies; all colors via existing `--ds-*` tokens; below `lg:` the layout falls back to today's tabs-only Code mode.
+
+**Tech Stack:** React, Tailwind v4 (CSS-based, no config file), Radix `Tabs`, Vitest + jsdom (tests use `createRoot`/`act` for interactive components, `renderToStaticMarkup` for pure-presentational ones — see the repo's existing specs).
+
+**Spec:** `docs/superpowers/specs/2026-06-03-code-mode-file-tree-design.md`
+
+**Conventions:**
+- Run a single test file with `npx nx test cockpit -- <relative-spec-path>`; full suite with `npx nx test cockpit`.
+- TS path alias `@/components/...` resolves to `apps/cockpit/src/components/...`.
+- Commit after each task.
+
+---
+
+## File map
+
+| File | Change | Responsibility |
+|------|--------|----------------|
+| `apps/cockpit/src/app/cockpit.css` | Modify | Add `.cockpit-prose--wide` / `.cockpit-prose--code` width modifiers + `margin-inline: auto`; add file-tree styles in Task 4. |
+| `apps/cockpit/src/components/api-mode/api-mode.tsx` | Modify (Task 1) | Use `.cockpit-prose--wide` class instead of inline `maxWidth`; outer `py-4` → `py-6`. |
+| `apps/cockpit/src/components/code-mode/code-mode.tsx` | Modify | Task 1: add `.cockpit-prose--code` wrapper + outer padding. Tasks 3, 5, 6: state migration, FileTree integration, close + collapse. |
+| `apps/cockpit/src/components/code-mode/code-mode.spec.tsx` | Modify (Tasks 3, 5, 6) | Add assertions for new state semantics + close + last-tab-close empty state. |
+| `apps/cockpit/src/components/code-mode/file-tree.utils.ts` | **NEW** (Task 2) | Pure `buildTree(paths)` returning a discriminated `FileNode | FolderNode` tree; common-prefix trimming + compact folder chains. |
+| `apps/cockpit/src/components/code-mode/file-tree.utils.spec.ts` | **NEW** (Task 2) | TDD spec for `buildTree`. |
+| `apps/cockpit/src/components/code-mode/file-tree.tsx` | **NEW** (Task 4) | Pure presentational tree: props `{ paths, activePath, onSelect }`. Owns folder-collapse state internally. |
+| `apps/cockpit/src/components/code-mode/file-tree.spec.tsx` | **NEW** (Task 4) | TDD spec for `FileTree`: rendering, click → onSelect, folder header toggles. |
+
+---
+
+## Task 1: Land the unified prose-width + Code-mode padding wrapper
+
+This brings already-staged-in-working-tree CSS/component improvements onto the branch as a clean commit. They are referenced by the spec ("the `.cockpit-prose--code` 56rem wrapper") and need to land before the file tree work. Also reverts a local-only `next.config.ts` hack and the working-tree `node_modules` symlink from the prior dev-server session.
+
+**Files:**
+- Modify: `apps/cockpit/src/app/cockpit.css`
+- Modify: `apps/cockpit/src/components/api-mode/api-mode.tsx`
+- Modify: `apps/cockpit/src/components/code-mode/code-mode.tsx`
+- Revert (do NOT commit): `apps/cockpit/next.config.ts` (local-only Turbopack root hack), `node_modules` symlink
+
+- [ ] **Step 1: Revert local-only changes**
+
+```bash
+git checkout -- apps/cockpit/next.config.ts
+rm -f node_modules
+```
+
+If `node_modules` was a real directory (not a symlink) and `rm -f` doesn't work, leave it: it's already in `.gitignore`.
+
+- [ ] **Step 2: Confirm the three legitimate changes are in place**
+
+Run: `git diff --stat apps/cockpit/src/app/cockpit.css apps/cockpit/src/components/api-mode/api-mode.tsx apps/cockpit/src/components/code-mode/code-mode.tsx`
+Expected: all three files show modifications. If `cockpit.css` does not contain `.cockpit-prose--wide`, apply the edit in Step 3; same for the other two if missing.
+
+- [ ] **Step 3: Apply (or verify) the cockpit.css additions**
+
+In `apps/cockpit/src/app/cockpit.css`, the `.cockpit-prose` block should read:
+
+```css
+/* Shared prose layer — docs + api + code mode content */
+.cockpit-prose {
+  max-width: 42rem;
+  margin-inline: auto;
+  font-size: 0.9rem;
+  line-height: 1.7;
+  color: var(--ds-text-secondary);
+}
+.cockpit-prose--wide { max-width: 48rem; }
+.cockpit-prose--code { max-width: 56rem; }
+```
+
+(The original block had no `margin-inline` and no modifier classes; add both.)
+
+- [ ] **Step 4: Apply (or verify) the api-mode change**
+
+In `apps/cockpit/src/components/api-mode/api-mode.tsx`, the outer `<section>` of the non-empty case should read:
+
+```tsx
+<section aria-label="API mode" className="h-full overflow-auto py-6 px-4 md:px-8">
+  <div className="cockpit-prose cockpit-prose--wide">
+```
+
+(Changes from `py-4` to `py-6`; replaces `style={{ maxWidth: '48rem' }}` with the modifier class.)
+
+- [ ] **Step 5: Apply (or verify) the code-mode change**
+
+In `apps/cockpit/src/components/code-mode/code-mode.tsx`, both `TabsContent` panels (code/backend files and prompt files) should wrap their children in `.cockpit-prose.cockpit-prose--code` and have the outer padding `py-6 px-4 md:px-8`. The code-asset panel:
+
+```tsx
+{[...codeAssetPaths, ...backendAssetPaths].map((path) => (
+  <TabsContent key={path} value={path} className="flex-1 overflow-auto py-6 px-4 md:px-8">
+    <div className="cockpit-prose cockpit-prose--code">
+      <CodeFileContent path={path} content={codeFiles[path]} capability={capability} />
+    </div>
+  </TabsContent>
+))}
+```
+
+And the prompt panel mirrors it (same outer className, same wrapper, prompt `<pre>` or fallback `<p>` inside).
+
+- [ ] **Step 6: Run tests**
+
+Run: `npx nx test cockpit`
+Expected: PASS. (Class additions are purely additive; no spec asserts on the inline `maxWidth` or the outer `py-4`.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/cockpit/src/app/cockpit.css apps/cockpit/src/components/api-mode/api-mode.tsx apps/cockpit/src/components/code-mode/code-mode.tsx
+git commit -m "refactor(cockpit): unified prose width modifiers + code-mode padding wrapper"
+```
+
+---
+
+## Task 2: `buildTree` utility (TDD)
+
+A pure function that turns a flat list of file paths into a tree with common-prefix trimming and **compact folder chains** (single-child folder chains merged into one row, matching the spec's example). This is the only logic that needs unit tests in isolation; the rest of the tree work is presentation.
+
+**Files:**
+- Create: `apps/cockpit/src/components/code-mode/file-tree.utils.ts`
+- Create: `apps/cockpit/src/components/code-mode/file-tree.utils.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+`apps/cockpit/src/components/code-mode/file-tree.utils.spec.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { buildTree, type TreeNode } from './file-tree.utils';
+
+describe('buildTree', () => {
+  it('returns an empty array when no paths are given', () => {
+    expect(buildTree([])).toEqual([]);
+  });
+
+  it('returns a flat list of file nodes when there are no folders after trimming', () => {
+    const tree = buildTree(['planning.md']);
+    expect(tree).toEqual<TreeNode[]>([
+      { kind: 'file', path: 'planning.md', label: 'planning.md' },
+    ]);
+  });
+
+  it('strips the common directory prefix shared by all paths', () => {
+    const tree = buildTree([
+      'cockpit/planning/angular/app.config.ts',
+      'cockpit/planning/python/graph.py',
+    ]);
+    // common prefix "cockpit/planning/" is removed; "angular" and "python" become top-level folders
+    expect(tree.map((n) => (n.kind === 'folder' ? n.label : n.label))).toEqual(['angular', 'python']);
+  });
+
+  it('compacts single-child folder chains into one row', () => {
+    const tree = buildTree([
+      'angular/src/app/planning.component.ts',
+      'angular/src/app/app.config.ts',
+    ]);
+    // angular > src > app each have one child folder beneath them on the way down;
+    // they merge into a single "angular/src/app" folder row.
+    expect(tree).toHaveLength(1);
+    expect(tree[0]).toMatchObject({ kind: 'folder', label: 'angular/src/app' });
+    expect((tree[0] as { children: TreeNode[] }).children.map((c) => c.label).sort()).toEqual([
+      'app.config.ts',
+      'planning.component.ts',
+    ]);
+  });
+
+  it('keeps a folder distinct from its children when it has both a file and a subfolder', () => {
+    const tree = buildTree([
+      'angular/src/app/planning.component.ts',
+      'angular/src/app/views/plan-checklist.component.ts',
+    ]);
+    // angular/src/app contains a file AND a "views" subfolder → does not merge with "views"
+    const top = tree[0] as { kind: 'folder'; label: string; children: TreeNode[] };
+    expect(top.label).toBe('angular/src/app');
+    expect(top.children).toHaveLength(2);
+    const labels = top.children.map((c) => c.label).sort();
+    expect(labels).toEqual(['planning.component.ts', 'views']);
+  });
+
+  it('renders all files flat when no common prefix and only one segment each', () => {
+    const tree = buildTree(['a.ts', 'b.py']);
+    expect(tree).toEqual<TreeNode[]>([
+      { kind: 'file', path: 'a.ts', label: 'a.ts' },
+      { kind: 'file', path: 'b.py', label: 'b.py' },
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx nx test cockpit -- src/components/code-mode/file-tree.utils.spec.ts`
+Expected: FAIL — cannot resolve `./file-tree.utils`.
+
+- [ ] **Step 3: Implement `buildTree`**
+
+`apps/cockpit/src/components/code-mode/file-tree.utils.ts`:
+
+```ts
+export type FileNode = { kind: 'file'; path: string; label: string };
+export type FolderNode = { kind: 'folder'; label: string; children: TreeNode[] };
+export type TreeNode = FileNode | FolderNode;
+
+function commonPrefixSegments(paths: readonly string[]): string[] {
+  if (paths.length === 0) return [];
+  const splits = paths.map((p) => p.split('/'));
+  const first = splits[0];
+  const common: string[] = [];
+  for (let i = 0; i < first.length - 1; i++) {
+    const seg = first[i];
+    if (splits.every((parts) => parts[i] === seg)) common.push(seg);
+    else break;
+  }
+  return common;
+}
+
+function insert(root: FolderNode, segments: string[], fullPath: string): void {
+  let node = root;
+  for (let i = 0; i < segments.length - 1; i++) {
+    const seg = segments[i];
+    let child = node.children.find((c): c is FolderNode => c.kind === 'folder' && c.label === seg);
+    if (!child) {
+      child = { kind: 'folder', label: seg, children: [] };
+      node.children.push(child);
+    }
+    node = child;
+  }
+  const filename = segments[segments.length - 1];
+  node.children.push({ kind: 'file', path: fullPath, label: filename });
+}
+
+function compact(nodes: TreeNode[]): TreeNode[] {
+  return nodes.map((node) => {
+    if (node.kind === 'file') return node;
+    let folder = node;
+    // Merge while this folder has exactly one child AND that child is a folder.
+    while (folder.children.length === 1 && folder.children[0].kind === 'folder') {
+      const only = folder.children[0];
+      folder = { kind: 'folder', label: `${folder.label}/${only.label}`, children: only.children };
+    }
+    return { ...folder, children: compact(folder.children) };
+  });
+}
+
+export function buildTree(paths: readonly string[]): TreeNode[] {
+  if (paths.length === 0) return [];
+  const prefix = commonPrefixSegments(paths);
+  const trimmed = paths.map((p) => p.split('/').slice(prefix.length));
+  const root: FolderNode = { kind: 'folder', label: '', children: [] };
+  trimmed.forEach((segments, i) => insert(root, segments, paths[i]));
+  return compact(root.children);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx nx test cockpit -- src/components/code-mode/file-tree.utils.spec.ts`
+Expected: PASS — all 6 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/cockpit/src/components/code-mode/file-tree.utils.ts apps/cockpit/src/components/code-mode/file-tree.utils.spec.ts
+git commit -m "feat(cockpit): add buildTree utility for Code-mode file tree"
+```
+
+---
+
+## Task 3: `CodeMode` state migration (no UX change yet)
+
+Replace Radix `Tabs.defaultValue` with explicit `openPaths` + `activePath` state in `CodeMode`. No visible behavior change in this task — same files render, same active file, just with the state model that the file tree needs in Task 5.
+
+**Files:**
+- Modify: `apps/cockpit/src/components/code-mode/code-mode.tsx`
+- Modify: `apps/cockpit/src/components/code-mode/code-mode.spec.tsx`
+
+- [ ] **Step 1: Add a regression test that activating a tab via state change still works**
+
+In `apps/cockpit/src/components/code-mode/code-mode.spec.tsx`, append this new `it` block inside the existing `describe('CodeMode', …)`:
+
+```tsx
+it('pre-opens all code, backend, and prompt files as tabs with the first code file active', () => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+
+  act(() => {
+    root!.render(
+      <CodeMode
+        entryTitle="Planning"
+        codeAssetPaths={['src/a.ts']}
+        backendAssetPaths={['backend/graph.py']}
+        codeFiles={{
+          'src/a.ts': '<pre class="shiki"><code>a</code></pre>',
+          'backend/graph.py': '<pre class="shiki"><code>g</code></pre>',
+        }}
+        promptFiles={{ 'prompts/p.md': 'hello' }}
+      />,
+    );
+  });
+
+  const tabLabels = Array.from(container.querySelectorAll('[role="tab"]')).map((t) => t.textContent);
+  expect(tabLabels).toEqual(['a.ts', 'graph.py', 'p.md']);
+
+  // The first code file is active.
+  const active = container.querySelector('[role="tab"][data-state="active"]');
+  expect(active?.textContent).toBe('a.ts');
+});
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `npx nx test cockpit -- src/components/code-mode/code-mode.spec.tsx`
+Expected: PASS for both this new test and the four existing ones. (Current behavior already satisfies the assertion — this is a regression guard for the upcoming state change.)
+
+- [ ] **Step 3: Migrate to explicit `openPaths` + `activePath` state**
+
+In `apps/cockpit/src/components/code-mode/code-mode.tsx`, replace the body of `CodeMode` (everything from `export function CodeMode(...)` through the closing `}`) with:
+
+```tsx
+export function CodeMode({ entryTitle, codeAssetPaths, backendAssetPaths, codeFiles, promptFiles, capability }: CodeModeProps) {
+  const promptPaths = React.useMemo(() => Object.keys(promptFiles), [promptFiles]);
+  const allPaths = React.useMemo(
+    () => [...codeAssetPaths, ...backendAssetPaths, ...promptPaths],
+    [codeAssetPaths, backendAssetPaths, promptPaths],
+  );
+
+  const [openPaths, setOpenPaths] = React.useState<readonly string[]>(allPaths);
+  const [activePath, setActivePath] = React.useState<string | null>(allPaths[0] ?? null);
+
+  // If the capability changes (allPaths changes identity), reset open + active.
+  React.useEffect(() => {
+    setOpenPaths(allPaths);
+    setActivePath(allPaths[0] ?? null);
+  }, [allPaths]);
+
+  if (allPaths.length === 0) {
+    return (
+      <section aria-label="Code mode" className="grid place-items-center h-full text-[var(--ds-text-muted)] text-sm">
+        <p>No files available for {entryTitle}.</p>
+      </section>
+    );
+  }
+
+  const isPromptPath = (path: string) => promptPaths.includes(path);
+
+  return (
+    <section aria-label="Code mode" className="h-full flex flex-col">
+      <Tabs
+        value={activePath ?? undefined}
+        onValueChange={(v) => setActivePath(v)}
+        className="flex flex-col h-full"
+      >
+        <TabsList className="shrink-0">
+          {openPaths.map((path) => (
+            <TabsTrigger
+              key={path}
+              value={path}
+              className={
+                isPromptPath(path)
+                  ? 'text-[var(--ds-accent)]/70 data-[state=active]:text-[var(--ds-accent)]'
+                  : undefined
+              }
+            >
+              {getTabLabel(path)}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+
+        {openPaths.filter((p) => !isPromptPath(p)).map((path) => (
+          <TabsContent key={path} value={path} className="flex-1 overflow-auto py-6 px-4 md:px-8">
+            <div className="cockpit-prose cockpit-prose--code">
+              <CodeFileContent path={path} content={codeFiles[path]} capability={capability} />
+            </div>
+          </TabsContent>
+        ))}
+
+        {openPaths.filter(isPromptPath).map((path) => {
+          const content = promptFiles[path];
+          return (
+            <TabsContent key={path} value={path} className="flex-1 overflow-auto py-6 px-4 md:px-8">
+              <div className="cockpit-prose cockpit-prose--code">
+                {content ? (
+                  <pre className="font-mono text-sm whitespace-pre-wrap">{content}</pre>
+                ) : (
+                  <p className="text-sm text-[var(--ds-text-muted)]">No content for {getTabLabel(path)}</p>
+                )}
+              </div>
+            </TabsContent>
+          );
+        })}
+      </Tabs>
+    </section>
+  );
+}
+```
+
+(Key differences vs today: drop `Tabs.defaultValue`, use controlled `value` + `onValueChange`; render tabs from `openPaths` instead of separate `codeAssetPaths`/`backendAssetPaths`/`promptPaths` arrays; reset state when `allPaths` identity changes. The `TabsList`, `CodeFileContent`, and prompt-render markup stay identical to today.)
+
+- [ ] **Step 4: Run all code-mode tests**
+
+Run: `npx nx test cockpit -- src/components/code-mode/code-mode.spec.tsx`
+Expected: PASS — the new test and all four existing ones (Shiki HTML render, fallback, prompt tabs, Copy analytics).
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `npx nx test cockpit`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/cockpit/src/components/code-mode/code-mode.tsx apps/cockpit/src/components/code-mode/code-mode.spec.tsx
+git commit -m "refactor(cockpit): controlled openPaths + activePath state in CodeMode"
+```
+
+---
+
+## Task 4: `FileTree` presentational component (TDD)
+
+A pure-presentational component that renders the output of `buildTree` with folder-collapse interaction. No file-system access, no localStorage — just `{ paths, activePath, onSelect }` props.
+
+**Files:**
+- Create: `apps/cockpit/src/components/code-mode/file-tree.tsx`
+- Create: `apps/cockpit/src/components/code-mode/file-tree.spec.tsx`
+- Modify: `apps/cockpit/src/app/cockpit.css` (file-tree styles)
+
+- [ ] **Step 1: Write the failing test**
+
+`apps/cockpit/src/components/code-mode/file-tree.spec.tsx`:
+
+```tsx
+/** @vitest-environment jsdom */
+import React from 'react';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { FileTree } from './file-tree';
+
+describe('FileTree', () => {
+  let container: HTMLDivElement | undefined;
+  let root: ReturnType<typeof createRoot> | undefined;
+
+  afterEach(() => {
+    act(() => { root?.unmount(); });
+    container?.remove();
+    vi.clearAllMocks();
+  });
+
+  function render(node: React.ReactElement) {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => { root!.render(node); });
+  }
+
+  it('renders a file row for every path', () => {
+    const onSelect = vi.fn();
+    render(
+      <FileTree
+        paths={['angular/src/app/planning.component.ts', 'python/src/graph.py', 'prompts/planning.md']}
+        activePath={null}
+        onSelect={onSelect}
+      />
+    );
+
+    const labels = Array.from(container!.querySelectorAll('[data-file-row]')).map((el) => el.textContent);
+    expect(labels).toContain('planning.component.ts');
+    expect(labels).toContain('graph.py');
+    expect(labels).toContain('planning.md');
+  });
+
+  it('marks the active file row with aria-current="true"', () => {
+    render(
+      <FileTree
+        paths={['a.ts', 'b.py']}
+        activePath="b.py"
+        onSelect={() => {}}
+      />
+    );
+
+    const active = container!.querySelector('[data-file-row][aria-current="true"]');
+    expect(active?.textContent).toBe('b.py');
+  });
+
+  it('emits onSelect with the file path when a file row is clicked', () => {
+    const onSelect = vi.fn();
+    render(
+      <FileTree
+        paths={['angular/src/app/planning.component.ts']}
+        activePath={null}
+        onSelect={onSelect}
+      />
+    );
+
+    const row = container!.querySelector('[data-file-row]') as HTMLElement;
+    act(() => { row.click(); });
+
+    expect(onSelect).toHaveBeenCalledWith('angular/src/app/planning.component.ts');
+  });
+
+  it('collapses a folder when its header is clicked and hides its children', () => {
+    render(
+      <FileTree
+        paths={['angular/src/app/planning.component.ts', 'angular/src/app/app.config.ts']}
+        activePath={null}
+        onSelect={() => {}}
+      />
+    );
+
+    // Folder "angular/src/app" is the only top-level row (compact-merged).
+    const folder = container!.querySelector('[data-folder-row]') as HTMLElement;
+    expect(folder.textContent).toContain('angular/src/app');
+    expect(container!.querySelectorAll('[data-file-row]')).toHaveLength(2);
+
+    act(() => { folder.click(); });
+
+    expect(container!.querySelectorAll('[data-file-row]')).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx nx test cockpit -- src/components/code-mode/file-tree.spec.tsx`
+Expected: FAIL — cannot resolve `./file-tree`.
+
+- [ ] **Step 3: Implement `FileTree`**
+
+`apps/cockpit/src/components/code-mode/file-tree.tsx`:
+
+```tsx
+'use client';
+
+import React from 'react';
+import { buildTree, type FolderNode, type TreeNode } from './file-tree.utils';
+
+interface FileTreeProps {
+  paths: readonly string[];
+  activePath: string | null;
+  onSelect: (path: string) => void;
+}
+
+function langChip(label: string): string | null {
+  const dot = label.lastIndexOf('.');
+  if (dot <= 0) return null;
+  return label.slice(dot + 1).toUpperCase();
+}
+
+export function FileTree({ paths, activePath, onSelect }: FileTreeProps) {
+  const tree = React.useMemo(() => buildTree(paths), [paths]);
+  const [collapsedFolders, setCollapsedFolders] = React.useState<ReadonlySet<string>>(() => new Set());
+
+  const toggleFolder = React.useCallback((id: string) => {
+    setCollapsedFolders((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  return (
+    <ul className="cockpit-file-tree" role="tree">
+      {tree.map((node, i) => (
+        <Node
+          key={`${i}-${node.label}`}
+          node={node}
+          depth={0}
+          folderId={node.label}
+          activePath={activePath}
+          collapsedFolders={collapsedFolders}
+          onToggleFolder={toggleFolder}
+          onSelect={onSelect}
+        />
+      ))}
+    </ul>
+  );
+}
+
+interface NodeProps {
+  node: TreeNode;
+  depth: number;
+  folderId: string;
+  activePath: string | null;
+  collapsedFolders: ReadonlySet<string>;
+  onToggleFolder: (id: string) => void;
+  onSelect: (path: string) => void;
+}
+
+function Node({ node, depth, folderId, activePath, collapsedFolders, onToggleFolder, onSelect }: NodeProps) {
+  if (node.kind === 'file') {
+    const chip = langChip(node.label);
+    const isActive = activePath === node.path;
+    return (
+      <li>
+        <button
+          type="button"
+          data-file-row
+          aria-current={isActive ? 'true' : undefined}
+          onClick={() => onSelect(node.path)}
+          className="cockpit-file-tree__file"
+          style={{ paddingLeft: `${0.75 + depth * 0.75}rem` }}
+        >
+          <span className="cockpit-file-tree__label">{node.label}</span>
+          {chip ? <span className="cockpit-file-tree__chip">{chip}</span> : null}
+        </button>
+      </li>
+    );
+  }
+
+  const folder = node as FolderNode;
+  const isCollapsed = collapsedFolders.has(folderId);
+  return (
+    <li>
+      <button
+        type="button"
+        data-folder-row
+        aria-expanded={!isCollapsed}
+        onClick={() => onToggleFolder(folderId)}
+        className="cockpit-file-tree__folder"
+        style={{ paddingLeft: `${0.5 + depth * 0.75}rem` }}
+      >
+        <span className="cockpit-file-tree__caret" aria-hidden="true">{isCollapsed ? '▸' : '▾'}</span>
+        <span className="cockpit-file-tree__label">{folder.label}</span>
+      </button>
+      {!isCollapsed ? (
+        <ul>
+          {folder.children.map((child, i) => (
+            <Node
+              key={`${i}-${child.label}`}
+              node={child}
+              depth={depth + 1}
+              folderId={`${folderId}/${child.label}`}
+              activePath={activePath}
+              collapsedFolders={collapsedFolders}
+              onToggleFolder={onToggleFolder}
+              onSelect={onSelect}
+            />
+          ))}
+        </ul>
+      ) : null}
+    </li>
+  );
+}
+```
+
+- [ ] **Step 4: Add tree styles to cockpit.css**
+
+Append to `apps/cockpit/src/app/cockpit.css`:
+
+```css
+/* Code-mode file tree */
+.cockpit-file-tree { list-style: none; padding: 0; margin: 0; font-size: 12px; line-height: 1.7; }
+.cockpit-file-tree ul { list-style: none; padding: 0; margin: 0; }
+.cockpit-file-tree__file,
+.cockpit-file-tree__folder {
+  display: flex; align-items: center; gap: 0.4rem; width: 100%;
+  padding: 3px 0.75rem 3px 0.75rem; background: transparent; border: 0; text-align: left; cursor: pointer;
+  color: var(--ds-text-secondary); font-family: var(--font-mono), "JetBrains Mono", monospace; font-size: 12px;
+  border-left: 2px solid transparent;
+}
+.cockpit-file-tree__folder { color: var(--ds-text-muted); }
+.cockpit-file-tree__caret { font-size: 9px; color: var(--ds-text-muted); width: 0.65rem; }
+.cockpit-file-tree__label { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.cockpit-file-tree__chip {
+  font-family: var(--font-mono), monospace; font-size: 9px;
+  padding: 1px 5px; border-radius: 3px;
+  background: var(--ds-accent-surface); color: var(--ds-accent);
+  opacity: 0.85;
+}
+.cockpit-file-tree__file:hover { color: var(--ds-text-primary); }
+.cockpit-file-tree__file[aria-current="true"] {
+  background: var(--ds-accent-surface);
+  color: var(--ds-text-primary);
+  border-left-color: var(--ds-accent);
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npx nx test cockpit -- src/components/code-mode/file-tree.spec.tsx`
+Expected: PASS — all 4 tests.
+
+- [ ] **Step 6: Run the full suite**
+
+Run: `npx nx test cockpit`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/cockpit/src/components/code-mode/file-tree.tsx apps/cockpit/src/components/code-mode/file-tree.spec.tsx apps/cockpit/src/app/cockpit.css
+git commit -m "feat(cockpit): FileTree component with folder collapse and active row"
+```
+
+---
+
+## Task 5: Mount `FileTree` in Code mode with responsive layout
+
+Place the tree to the left of the tab strip at `lg:` widths, hidden below. Wire `onSelect` to the existing `openPaths`/`activePath` handlers (activates if already open, opens if not).
+
+**Files:**
+- Modify: `apps/cockpit/src/components/code-mode/code-mode.tsx`
+- Modify: `apps/cockpit/src/components/code-mode/code-mode.spec.tsx`
+
+- [ ] **Step 1: Write the failing test (tree-click opens a not-yet-open file)**
+
+Append inside the existing `describe('CodeMode', …)` in `code-mode.spec.tsx`:
+
+```tsx
+it('opens a closed file and activates it when the tree row is clicked', () => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+
+  act(() => {
+    root!.render(
+      <CodeMode
+        entryTitle="Planning"
+        codeAssetPaths={['src/a.ts', 'src/b.ts']}
+        backendAssetPaths={[]}
+        codeFiles={{
+          'src/a.ts': '<pre class="shiki"><code>a</code></pre>',
+          'src/b.ts': '<pre class="shiki"><code>b</code></pre>',
+        }}
+        promptFiles={{}}
+      />,
+    );
+  });
+
+  // Simulate the close (×) behaviour landing in Task 6 by directly removing the tab from state via the tree:
+  // for now, just assert that clicking the tree row for b.ts activates b.ts (which is already open).
+  const bRow = Array.from(container.querySelectorAll('[data-file-row]')).find(
+    (el) => el.textContent === 'b.ts',
+  ) as HTMLElement;
+  expect(bRow).toBeDefined();
+
+  act(() => { bRow.click(); });
+
+  const active = container.querySelector('[role="tab"][data-state="active"]');
+  expect(active?.textContent).toBe('b.ts');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx nx test cockpit -- src/components/code-mode/code-mode.spec.tsx`
+Expected: FAIL — no `[data-file-row]` element rendered (FileTree not yet mounted in CodeMode).
+
+- [ ] **Step 3: Mount `FileTree` in `CodeMode`**
+
+In `apps/cockpit/src/components/code-mode/code-mode.tsx`:
+
+Add the FileTree import near the top:
+```tsx
+import { FileTree } from './file-tree';
+```
+
+Add the select handler inside `CodeMode` (right after the existing `useEffect` reset):
+
+```tsx
+const handleSelect = React.useCallback((path: string) => {
+  setOpenPaths((prev) => (prev.includes(path) ? prev : [...prev, path]));
+  setActivePath(path);
+}, []);
+```
+
+Replace the outer `<section aria-label="Code mode" className="h-full flex flex-col">` opening tag and its single `<Tabs>` child with a responsive split:
+
+```tsx
+return (
+  <section aria-label="Code mode" className="h-full lg:grid lg:grid-cols-[220px_1fr] lg:overflow-hidden">
+    <aside
+      aria-label="File tree"
+      className="hidden lg:block lg:overflow-y-auto border-r border-[var(--ds-border)] bg-[var(--ds-surface-tinted)]/40"
+    >
+      <FileTree paths={allPaths} activePath={activePath} onSelect={handleSelect} />
+    </aside>
+
+    <div className="flex flex-col h-full min-w-0">
+      <Tabs
+        value={activePath ?? undefined}
+        onValueChange={(v) => setActivePath(v)}
+        className="flex flex-col h-full"
+      >
+        {/* existing TabsList + TabsContent panels go here unchanged */}
+      </Tabs>
+    </div>
+  </section>
+);
+```
+
+The TabsList + TabsContent panels are unchanged from Task 3 — just moved inside the new `<div className="flex flex-col h-full min-w-0">` wrapper.
+
+- [ ] **Step 4: Run the updated spec**
+
+Run: `npx nx test cockpit -- src/components/code-mode/code-mode.spec.tsx`
+Expected: PASS — the new tree-click test and all earlier ones.
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `npx nx test cockpit`
+Expected: PASS.
+
+- [ ] **Step 6: Browser verify**
+
+Reload the cockpit Code mode at a viewport ≥1024px. The tree appears left of the tabs; clicking a tree row activates the matching tab. Resize below 1024px → tree disappears, tabs span full width. Toggle theme — colors flip correctly.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/cockpit/src/components/code-mode/code-mode.tsx apps/cockpit/src/components/code-mode/code-mode.spec.tsx
+git commit -m "feat(cockpit): mount FileTree in Code mode with lg: responsive split"
+```
+
+---
+
+## Task 6: Tab close (×) + last-tab empty state
+
+Add a close button to each tab trigger (visible on hover); closing removes the path from `openPaths` and activates the left neighbor (or the new leftmost if the closed tab was first). When the last tab closes, the content area shows a "select a file from the tree" empty state.
+
+**Files:**
+- Modify: `apps/cockpit/src/components/code-mode/code-mode.tsx`
+- Modify: `apps/cockpit/src/components/code-mode/code-mode.spec.tsx`
+- Modify: `apps/cockpit/src/app/cockpit.css` (close-button styles)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append inside `describe('CodeMode', …)`:
+
+```tsx
+it('closes a tab and activates its left neighbor', () => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+
+  act(() => {
+    root!.render(
+      <CodeMode
+        entryTitle="Planning"
+        codeAssetPaths={['src/a.ts', 'src/b.ts', 'src/c.ts']}
+        backendAssetPaths={[]}
+        codeFiles={{
+          'src/a.ts': '<pre class="shiki"><code>a</code></pre>',
+          'src/b.ts': '<pre class="shiki"><code>b</code></pre>',
+          'src/c.ts': '<pre class="shiki"><code>c</code></pre>',
+        }}
+        promptFiles={{}}
+      />,
+    );
+  });
+
+  // Activate b.ts, then close it.
+  const bTab = Array.from(container.querySelectorAll('[role="tab"]')).find(
+    (el) => el.textContent?.startsWith('b.ts'),
+  ) as HTMLElement;
+  act(() => {
+    bTab.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true, button: 0 }));
+  });
+
+  const closeBtn = container.querySelector('[role="tab"][data-state="active"] [data-tab-close]') as HTMLElement;
+  expect(closeBtn).not.toBeNull();
+  act(() => { closeBtn.click(); });
+
+  const tabs = Array.from(container.querySelectorAll('[role="tab"]')).map((t) =>
+    (t.textContent ?? '').replace(/×/g, '').trim(),
+  );
+  expect(tabs).toEqual(['a.ts', 'c.ts']);
+
+  const active = container.querySelector('[role="tab"][data-state="active"]');
+  expect((active?.textContent ?? '').startsWith('a.ts')).toBe(true);
+});
+
+it('shows the empty state after the last tab is closed', () => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+
+  act(() => {
+    root!.render(
+      <CodeMode
+        entryTitle="Planning"
+        codeAssetPaths={['src/only.ts']}
+        backendAssetPaths={[]}
+        codeFiles={{ 'src/only.ts': '<pre class="shiki"><code>x</code></pre>' }}
+        promptFiles={{}}
+      />,
+    );
+  });
+
+  const closeBtn = container.querySelector('[role="tab"] [data-tab-close]') as HTMLElement;
+  act(() => { closeBtn.click(); });
+
+  expect(container.querySelectorAll('[role="tab"]')).toHaveLength(0);
+  expect(container.textContent).toContain('Select a file from the tree');
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx nx test cockpit -- src/components/code-mode/code-mode.spec.tsx`
+Expected: FAIL — `[data-tab-close]` not present.
+
+- [ ] **Step 3: Add the close handler and the close button**
+
+In `apps/cockpit/src/components/code-mode/code-mode.tsx`, add the handler near `handleSelect`:
+
+```tsx
+const handleClose = React.useCallback((path: string) => {
+  setOpenPaths((prev) => {
+    const idx = prev.indexOf(path);
+    if (idx < 0) return prev;
+    const next = prev.filter((p) => p !== path);
+    setActivePath((current) => {
+      if (current !== path) return current;
+      if (next.length === 0) return null;
+      // Activate the left neighbor; if the closed tab was leftmost, activate the new leftmost.
+      const neighborIdx = Math.max(0, idx - 1);
+      return next[neighborIdx] ?? next[0];
+    });
+    return next;
+  });
+}, []);
+```
+
+Replace the `TabsTrigger` element inside the `TabsList` map with a version that includes the close button:
+
+```tsx
+<TabsTrigger
+  key={path}
+  value={path}
+  className={
+    isPromptPath(path)
+      ? 'text-[var(--ds-accent)]/70 data-[state=active]:text-[var(--ds-accent)] cockpit-tab-trigger'
+      : 'cockpit-tab-trigger'
+  }
+>
+  <span>{getTabLabel(path)}</span>
+  <span
+    role="button"
+    aria-label={`Close ${getTabLabel(path)}`}
+    data-tab-close
+    onPointerDown={(e) => { e.stopPropagation(); }}
+    onClick={(e) => { e.stopPropagation(); handleClose(path); }}
+    className="cockpit-tab-trigger__close"
+  >×</span>
+</TabsTrigger>
+```
+
+Below the `<Tabs>` in the same `<div className="flex flex-col h-full min-w-0">`, add an empty-state fallback that renders when `activePath === null`:
+
+```tsx
+{activePath === null ? (
+  <div className="flex-1 grid place-items-center text-sm text-[var(--ds-text-muted)] px-4 text-center">
+    <p>Select a file from the tree to begin.</p>
+  </div>
+) : null}
+```
+
+Place this *outside* the `<Tabs>` element but inside the wrapping `<div>` — it shows only when `openPaths` is empty so the Radix `<Tabs>` won't render content for a missing `value`.
+
+- [ ] **Step 4: Add close-button styles**
+
+Append to `apps/cockpit/src/app/cockpit.css`:
+
+```css
+/* Tab close (×) on Code-mode tabs */
+.cockpit-tab-trigger { display: inline-flex; align-items: center; gap: 0.4rem; }
+.cockpit-tab-trigger__close {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 0.95rem; height: 0.95rem; border-radius: 0.2rem;
+  color: var(--ds-text-muted); font-size: 0.85rem; line-height: 1;
+  opacity: 0; cursor: pointer;
+}
+.cockpit-tab-trigger:hover .cockpit-tab-trigger__close,
+.cockpit-tab-trigger[data-state="active"] .cockpit-tab-trigger__close { opacity: 1; }
+.cockpit-tab-trigger__close:hover { background: var(--ds-accent-surface); color: var(--ds-text-primary); }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npx nx test cockpit -- src/components/code-mode/code-mode.spec.tsx`
+Expected: PASS — both new tests and all earlier ones.
+
+- [ ] **Step 6: Run the full suite**
+
+Run: `npx nx test cockpit`
+Expected: PASS.
+
+- [ ] **Step 7: Browser verify**
+
+Reload Code mode. Hover a tab → × appears. Click × on a non-active tab → tab disappears, active unchanged. Click × on the active tab → left neighbor becomes active. Close every tab → empty-state message renders. Click a file in the tree → it opens and becomes active.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/cockpit/src/components/code-mode/code-mode.tsx apps/cockpit/src/components/code-mode/code-mode.spec.tsx apps/cockpit/src/app/cockpit.css
+git commit -m "feat(cockpit): tab close button + last-tab empty state in Code mode"
+```
+
+---
+
+## Task 7: Tree collapse toggle with localStorage persistence
+
+Two chevron buttons collapse/expand the tree. State persists in `localStorage` under `cockpit:codeTree:collapsed`. When collapsed, the tree column hides and the tab strip widens; an expand chevron sits flush at the tab strip's left edge.
+
+**Files:**
+- Modify: `apps/cockpit/src/components/code-mode/code-mode.tsx`
+- Modify: `apps/cockpit/src/app/cockpit.css`
+
+- [ ] **Step 1: Add the collapse state and persistence**
+
+In `apps/cockpit/src/components/code-mode/code-mode.tsx`, add state + hydration just below the existing `openPaths`/`activePath` declarations:
+
+```tsx
+const [treeCollapsed, setTreeCollapsed] = React.useState(false);
+
+React.useEffect(() => {
+  try {
+    if (typeof window !== 'undefined' && window.localStorage.getItem('cockpit:codeTree:collapsed') === '1') {
+      setTreeCollapsed(true);
+    }
+  } catch {
+    /* localStorage unavailable — leave default */
+  }
+}, []);
+
+const toggleTreeCollapsed = React.useCallback(() => {
+  setTreeCollapsed((prev) => {
+    const next = !prev;
+    try {
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem('cockpit:codeTree:collapsed', next ? '1' : '0');
+      }
+    } catch {
+      /* ignore */
+    }
+    return next;
+  });
+}, []);
+```
+
+- [ ] **Step 2: Wire the chevron buttons**
+
+Change the `<aside>` to conditionally hide its content when `treeCollapsed` is true, and add a chevron in its header:
+
+```tsx
+<aside
+  aria-label="File tree"
+  className={`hidden lg:flex lg:flex-col border-r border-[var(--ds-border)] bg-[var(--ds-surface-tinted)]/40 transition-[width] duration-200 ${treeCollapsed ? 'lg:w-0 lg:overflow-hidden lg:border-r-0' : 'lg:w-[220px] lg:overflow-y-auto'}`}
+>
+  <div className="flex items-center justify-between px-2 py-1.5 border-b border-[var(--ds-border)] bg-[var(--ds-surface-tinted)]/70">
+    <span className="font-mono text-[10px] uppercase tracking-wide text-[var(--ds-text-muted)] pl-1">Files</span>
+    <button
+      type="button"
+      aria-label="Collapse file tree"
+      onClick={toggleTreeCollapsed}
+      className="text-[var(--ds-text-muted)] hover:text-[var(--ds-text-primary)] px-1.5 py-0.5 rounded"
+    >‹</button>
+  </div>
+  <FileTree paths={allPaths} activePath={activePath} onSelect={handleSelect} />
+</aside>
+```
+
+Inside the right column (the `<div className="flex flex-col h-full min-w-0">`), add an inline expand chevron that renders only when `treeCollapsed` is true, placed at the left edge above the `<Tabs>`:
+
+```tsx
+{treeCollapsed ? (
+  <button
+    type="button"
+    aria-label="Expand file tree"
+    onClick={toggleTreeCollapsed}
+    className="hidden lg:flex shrink-0 items-center justify-center w-7 self-start mt-1 ml-1 rounded text-[var(--ds-accent)] hover:bg-[var(--ds-accent-surface)]"
+  >›</button>
+) : null}
+```
+
+(Position it as a small persistent affordance at the top-left of the right column; the Radix `Tabs` keeps its full width.)
+
+- [ ] **Step 3: Adjust the grid so the right column expands when collapsed**
+
+Change the outer `<section>` className to:
+
+```tsx
+<section
+  aria-label="Code mode"
+  className={`h-full lg:grid lg:overflow-hidden ${treeCollapsed ? 'lg:grid-cols-[0_1fr]' : 'lg:grid-cols-[220px_1fr]'}`}
+>
+```
+
+(Below `lg:`, the layout falls back to `h-full` only — the responsive grid is the desktop case.)
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `npx nx test cockpit`
+Expected: PASS — no tests assert on the chevron presence; behavior unchanged for existing tests.
+
+- [ ] **Step 5: Browser verify**
+
+At ≥1024px viewport: click the `‹` chevron in the tree header → tree slides closed with a 200ms transition; an expand chevron `›` appears at the top-left of the right column. Click `›` → tree reopens. Reload the page → collapsed state persists.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/cockpit/src/components/code-mode/code-mode.tsx
+git commit -m "feat(cockpit): persistent collapse toggle for Code-mode file tree"
+```
+
+---
+
+## Task 8: Cross-theme + responsive verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full cockpit test suite**
+
+Run: `npx nx test cockpit`
+Expected: PASS (all specs green).
+
+- [ ] **Step 2: Browser pass (both themes, both breakpoints)**
+
+Serve the cockpit and visit `deep-agents/core-capabilities/planning`. For BOTH light and dark (toggle in the cockpit sidebar):
+
+At ≥1024px:
+- Tree visible, grouped under the compact-merged folder rows (`angular/src/app`, etc.).
+- Active file has the accent left border + lighter text.
+- Clicking a tree file activates the matching tab (no duplicate tab).
+- Hover a tab → × appears; click × → tab closes, left neighbor activates.
+- Close all tabs → "Select a file from the tree to begin" empty state.
+- Collapse chevron → tree slides closed; expand chevron in the right column → tree slides open. Refresh → collapse state preserved.
+
+At <1024px (e.g. 768px):
+- Tree hidden, tabs span the full pane.
+- Close X still works.
+- Resize back over 1024px → tree returns (unless explicitly collapsed).
+
+In both themes:
+- Tree colors flip correctly (no hardcoded literals remained).
+- The chat-aligned `#64C3FD` accent is consistent across active tab, active tree row, and language chips.
+
+- [ ] **Step 3: Final commit (if any verification fixups were needed)**
+
+```bash
+git add -A
+git commit -m "chore(cockpit): file-tree verification fixups"
+```
+
+(Skip this commit if no fixups were needed.)
+
+---
+
+## Self-review notes
+
+- **Spec coverage:**
+  - §Layout & breakpoints → Tasks 5 (grid + lg:) and 7 (collapse).
+  - §Tree content & organization → Task 2 (`buildTree` with compact-folders + flat fallback) and Task 4 (rendering).
+  - §Tabs & lifecycle → Task 3 (state migration), Task 5 (tree-open semantics), Task 6 (close + empty state).
+  - §Visual integration → Tasks 4 (tree styles) + 6 (close button) + 7 (chevrons), all token-driven.
+  - §Components & file structure → matches the file map verbatim.
+  - §Out of scope items confirmed: no `content-bundle.ts` changes; no `package.json`/`tsconfig.json` walking; no keyboard shortcuts; no resizable width.
+- **Placeholder scan:** no TBD/TODO; every code step ships the actual code.
+- **Type consistency:** `TreeNode`/`FileNode`/`FolderNode` defined once in Task 2 and consumed by Task 4. `openPaths`/`activePath`/`treeCollapsed` introduced in Task 3 and extended in Tasks 5–7 with the same names.
+- **`localStorage` SSR safety:** all access wrapped in `typeof window !== 'undefined'` + `try/catch` (Task 7).
+- **Tab close interaction:** `data-tab-close` is the stable hook for tests; `onPointerDown` stops propagation to keep Radix from also activating the tab when the user clicks the close button.

--- a/docs/superpowers/specs/2026-06-03-code-mode-file-tree-design.md
+++ b/docs/superpowers/specs/2026-06-03-code-mode-file-tree-design.md
@@ -1,0 +1,130 @@
+# Code Mode File Tree — Design Spec
+
+**Date:** 2026-06-03
+**Status:** Design — pending review
+**Scope:** `apps/cockpit` Code-mode UI only. No changes to `libs/*`, `content-bundle.ts`, or `cockpit-registry`.
+
+## Goal
+
+Give Code mode a VS Code / Zed–style **file tree on the left of the tab strip** at desktop widths, so multi-file capabilities (Angular + Python + prompt) are oriented at a glance, while preserving the current tab interaction for fast file switching. Below the responsive breakpoint the tree auto-hides and Code mode falls back to today's tabs-only layout. The user can also collapse the tree explicitly at any width.
+
+This is purely a layout enrichment of an existing mode — no new data model, no new content bundle, no new dependencies.
+
+## Direction (validated via mockups)
+
+Chosen option: **B — tree opens tabs (VS Code / Zed style)**, refined with:
+
+- **All files from the content bundle pre-opened as tabs on first load.** Matches today's behavior ("everything is visible") and adds open/close semantics only as a *capability*, not a forced workflow. The first `codeAssetPath` is the initial active tab.
+- **No persistence.** Each capability navigation resets to all-tabs-open. Closed-tab state is not stored in `localStorage` or cookies. (Collapse state of the tree itself *is* persisted — see §4.)
+- **Tree on the LEFT of the tabs**, full-height for the Code-mode pane. Tabs and code area both sit right of the tree.
+
+## Layout & breakpoints
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ Tree header                  │ Tab strip                │
+│ (collapse chevron, label)    │ (file tabs, optional × ) │
+├──────────────────────────────┼──────────────────────────┤
+│ file-tree rows               │ Code block (active tab)  │
+│ folders + files              │                          │
+│                              │                          │
+└──────────────────────────────┴──────────────────────────┘
+```
+
+- **`lg:` (≥1024px):** tree visible by default at `width: 220px`, sharing the Code-mode pane's full height. The tree's right border meets the tab-strip's bottom border so the two read as one IDE-like surface.
+- **<`lg:`:** tree auto-hidden. Tab strip + code area take the full pane width — i.e. today's layout. No mobile overlay (the cockpit shell's main sidebar already handles narrow-viewport navigation; adding a second overlay would be noisy).
+- **Explicit collapse toggle:** chevron buttons on the tree header *and* on the tab-strip's left edge (visible only when the tree is expanded vs. collapsed respectively). State stored in `localStorage` under `cockpit:codeTree:collapsed`. The Tailwind `lg:` media query and the explicit toggle compose: a user can collapse at any width, and the tree only auto-shows at `lg:` when not explicitly collapsed.
+- **Transition:** 200ms CSS width transition on the tree, so the collapse/expand isn't a layout jump.
+
+## Tree content & organization
+
+The tree shows only files the content bundle already provides — `codeAssetPaths` + `backendAssetPaths` + `promptFiles`. No new file-system walking; no `package.json`/`tsconfig.json` noise.
+
+Each path is **trimmed of the capability's common prefix** (e.g. `cockpit/deep-agents/planning/`), then organized as folder/file rows grouped under their language root:
+
+```
+▾ angular/src/app
+    planning.component.ts        TS
+    app.config.ts                TS
+  ▾ views
+      plan-checklist.component.ts  TS
+▾ python/src
+    graph.py                     PY
+▾ prompts
+    planning.md                  MD
+```
+
+Rules:
+
+- **Folder rows are click-collapsible.** Default expanded. Collapse state is per-folder in component state (not persisted).
+- **File rows render the existing language chip** (`TS` / `PY` / `MD` / fallback) in `.doc-codeblock__lang` style, right-aligned in the row.
+- **Active file** gets a 2px `--ds-accent` left border, `--ds-text-primary` text, and a subtle accent-surface row background.
+- **Common-prefix trimming** is per-capability: the longest path segment shared by all paths in the bundle. If trimming leaves the tree with only loose leaves (e.g. just `planning.md` and `graph.py`), display them as a flat list under a `files` group header rather than synthesizing folders.
+
+## Tabs & lifecycle
+
+The Code-mode component owns explicit `openPaths` + `activePath` state (replacing today's `Tabs.defaultValue` usage). Radix `Tabs` continues to provide the tab strip itself.
+
+- **Initial state:** on capability load, `openPaths = [...codeAssetPaths, ...backendAssetPaths, ...promptPaths]` (preserving today's order) and `activePath = openPaths[0]`.
+- **Click a tree row:**
+  - If `path` is already in `openPaths` → set `activePath = path` (just activate).
+  - If not → push to `openPaths` and set `activePath = path`.
+- **Tab close (×) button:** appears on hover. Clicking removes the path from `openPaths`. If the closed tab was active, activate its left neighbor; if it was the leftmost, activate the new leftmost.
+- **Closing the last tab:** code area shows an empty state ("Select a file from the tree to begin") with a faint chevron pointing left toward the tree. The tab strip becomes empty (just the collapse chevron).
+- **No keyboard shortcuts** in this iteration. (Cmd/Ctrl+W to close, etc., can land in a follow-up.)
+
+## Visual integration
+
+Tree and tab strip share the cockpit's chat-aligned dark palette and existing tokens. No new colors:
+
+- Tree background: `var(--ds-surface)` with the same right border (`var(--ds-border)`) the sidebar uses.
+- Tree header (where the collapse chevron lives): same height as the tab strip (~34px), `var(--ds-surface-tinted)` background, `border-bottom: 1px solid var(--ds-border)`.
+- File rows: mono font for the filename (`var(--font-mono)`), 12px size, line-height 1.7 — same scale as Docs prose code chips.
+- Lang chip on rows: reuses `.doc-codeblock__lang` styling.
+- Active tree row: `border-left: 2px solid var(--ds-accent)`; row background `var(--ds-accent-surface)`; text `var(--ds-text-primary)`.
+- Hover tree row: text `var(--ds-text-primary)`, no background change (subtle).
+- Folder chevron: a 9px caret in `var(--ds-text-muted)`, rotates 90° when collapsed.
+- Tab strip and code block keep the styles from the merged redesign (`.doc-codeblock`, the `.cockpit-prose--code` 56rem wrapper for the code body, etc.) — *only* the surrounding tree is new.
+
+When the tree is collapsed, an expand chevron sits flush at the left edge of the tab strip in the same color treatment as the active-tab accent, so it reads as a discoverable toggle rather than dead space.
+
+## Components & file structure
+
+| File | Change | Responsibility |
+|------|--------|----------------|
+| `apps/cockpit/src/components/code-mode/file-tree.tsx` | **NEW** | Pure presentational tree. Takes `paths`, `activePath`, emits `onSelect(path)`. Owns folder-collapse state internally. |
+| `apps/cockpit/src/components/code-mode/file-tree.spec.tsx` | **NEW** | Renders the tree from a known path list; click → emits `onSelect` with the right path; folder header click toggles its children's visibility. |
+| `apps/cockpit/src/components/code-mode/code-mode.tsx` | Modify | Adds `openPaths` + `activePath` state, renders the `<FileTree>` inside a responsive `lg:grid-cols-[220px_1fr]` wrapper, threads `onSelect` from tree to state, adds the collapse-chevron buttons, hooks `localStorage` for tree-collapsed. The existing `CodeFileContent` and Radix `Tabs` structure stays. |
+| `apps/cockpit/src/components/code-mode/code-mode.spec.tsx` | Modify | Adds assertions for (a) all-files-pre-opened initial state, (b) closing a tab removes it from the strip and selects the neighbor, (c) tree click activates an existing tab without duplicating, (d) closing the last tab renders the empty state. |
+
+Internal helper to keep `file-tree.tsx` small: a pure `buildTree(paths: string[])` function (also in `file-tree.tsx` or in a `file-tree.utils.ts` sibling if it grows >30 lines) that returns a discriminated `Folder | File` node array used by the renderer. This makes the prefix-trimming and folder-grouping testable in isolation.
+
+## Out of scope
+
+- File-system walking to surface package.json / tsconfig.json / additional adjacent files.
+- Drag-to-reorder tabs.
+- Keyboard shortcuts (Cmd+W close, Cmd+P quick-open, etc.).
+- Cross-capability persistence of which tabs were closed.
+- Resizable tree width (drag-to-resize). Fixed 220px.
+- Mobile / overlay tree on `<lg:` viewports.
+- Changes to `content-bundle.ts`, the registry, or the markdown renderer.
+
+## Risks & notes
+
+- **`localStorage` is client-only**, but Code mode is already a `'use client'` component so this is fine. Read on mount; SSR sees the default (tree expanded at `lg:`).
+- **Initial-render flash:** Code mode is `'use client'`, so on first paint the tree renders in its default (expanded at `lg:`) before the `localStorage` value is read. A one-frame flash is acceptable for a dev-tool surface; no cookie-based SSR hydration is added in this iteration.
+- **Common-prefix trimming** edge case: paths with no common prefix (rare, but possible if a capability mixes paths) render as a flat list under a `files` header — see §3.
+- **No new dependencies.** Tailwind `lg:` plus React state is sufficient; no `react-resizable-panels`, no `allotment`.
+- **Light-mode preserved.** All colors via tokens; verify both themes.
+
+## Verification
+
+Manual:
+- Serve cockpit, visit `deep-agents/core-capabilities/planning`, switch to **Code** mode.
+- At ≥1024px: tree shows; clicking a tree row activates the matching tab; closing a tab removes it; tree row stays in tree; re-click in tree re-activates. Toggle the chevron — tree collapses with a 200ms transition; tab strip widens. Refresh — collapse state restored.
+- At <1024px: tree hidden, current layout intact. Resize: tree appears/disappears smoothly at the breakpoint *unless* the user explicitly collapsed it (in which case it stays collapsed regardless).
+- Toggle the cockpit theme — tree colors flip correctly.
+
+Tests (`vitest` + jsdom, established `createRoot/act` style):
+- `file-tree.spec.tsx`: 4–6 focused tests on tree rendering and onSelect emission.
+- `code-mode.spec.tsx`: extend with the 4 assertions above. Existing assertions (Shiki render, file label, Copy analytics) continue to pass.


### PR DESCRIPTION
## Summary
- Adds a VS Code / Zed-style file tree on the left of the Code-mode tab strip at `lg:` widths (≥1024px); below `lg:` the tree auto-hides and Code mode falls back to today's tabs-only layout.
- All files from the content bundle are pre-opened as tabs; clicking a tree row activates the matching tab if open, or opens a new tab if not.
- Each tab gains a close (×) button (hover or active) with keyboard support (Enter/Space); closing the active tab activates its left neighbor; closing the last tab shows an empty state.
- Tree has a persistent collapse toggle (chevrons in aside header + right column), state persisted in `localStorage` under `cockpit:codeTree:collapsed`; hydration-flash is suppressed via a `mounted` gate so returning users don't see an animated collapse on reload.
- `buildTree(paths)` is a pure utility with VS Code-style "Compact Folders" — single-child folder chains merge into one row (e.g. `angular/src/app`).
- Folds in a tighter prose layer: `.cockpit-prose--wide` and `.cockpit-prose--code` width modifiers, Code-mode `cockpit-prose--code` 56rem wrapper, API mode `py-6` for outer-pane consistency with Docs.

## Spec & plan
- Spec: \`docs/superpowers/specs/2026-06-03-code-mode-file-tree-design.md\`
- Plan: \`docs/superpowers/plans/2026-06-03-code-mode-file-tree.md\`

## Test plan
- [ ] At ≥1024px: tree visible left of tabs; click any tree row activates the matching tab; tree row + active tab stay in sync.
- [ ] Hover any tab → × appears; click × → tab closes, left neighbor activates; close all tabs → "Select a file from the tree to begin" empty state; click a tree row → reopens.
- [ ] Keyboard-only: Tab to the close button on the active tab, press Enter → tab closes.
- [ ] Click the ‹ chevron in the tree header → tree slides closed with a 200ms transition; expand chevron (›) appears in the right column; click → tree slides open. Reload → collapsed state persisted.
- [ ] At <1024px: tree hidden; tabs span full width; close × still works.
- [ ] Toggle the cockpit theme (sidebar toggle) → tree colors flip correctly; embedded RunMode iframe theme handshake unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)