### PR TITLE
feat(website): docs LLM markdown export (raw-markdown route + PageActions)

### DIFF
--- a/apps/website/e2e/docs.spec.ts
+++ b/apps/website/e2e/docs.spec.ts
@@ -64,6 +64,8 @@ test.describe('Docs slug page', () => {
     await expect(page.getByText(/LangGraph\s+·\s+Getting Started/i).first()).toBeVisible();
     // Prev/Next: introduction is the first page, so a "Next →" card is present
     await expect(page.getByText('Next →').first()).toBeVisible();
+    // Per-page LLM actions trigger
+    await expect(page.locator('main button[aria-label="Page actions"]').first()).toBeVisible();
   });
 
   test('breadcrumb shows the library + page title', async ({ page }) => {

--- a/apps/website/src/app/api/markdown/[library]/[section]/[slug]/route.spec.ts
+++ b/apps/website/src/app/api/markdown/[library]/[section]/[slug]/route.spec.ts
@@ -1,0 +1,28 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { GET } from './route';
+
+function ctx(params: { library: string; section: string; slug: string }) {
+  return { params: Promise.resolve(params) };
+}
+
+describe('GET /api/markdown/[library]/[section]/[slug]', () => {
+  it('returns the raw mdx for a known page as text/markdown', async () => {
+    const res = await GET(
+      new Request('http://localhost/api/markdown/langgraph/getting-started/introduction'),
+      ctx({ library: 'langgraph', section: 'getting-started', slug: 'introduction' }),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/markdown');
+    const body = await res.text();
+    expect(body).toContain('# Introduction');
+  });
+
+  it('404s for an unknown page', async () => {
+    const res = await GET(
+      new Request('http://localhost/api/markdown/langgraph/getting-started/does-not-exist'),
+      ctx({ library: 'langgraph', section: 'getting-started', slug: 'does-not-exist' }),
+    );
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/website/src/app/api/markdown/[library]/[section]/[slug]/route.ts
+++ b/apps/website/src/app/api/markdown/[library]/[section]/[slug]/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+import { getDocBySlug, getAllDocSlugs } from '../../../../../../lib/docs';
+
+export function generateStaticParams() {
+  return getAllDocSlugs();
+}
+
+interface RouteContext {
+  params: Promise<{ library: string; section: string; slug: string }>;
+}
+
+export async function GET(_req: Request, context: RouteContext): Promise<Response> {
+  const { library, section, slug } = await context.params;
+  const doc = getDocBySlug(library, section, slug);
+
+  if (!doc) {
+    return new NextResponse('Not found', {
+      status: 404,
+      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    });
+  }
+
+  return new NextResponse(doc.content, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'Cache-Control': 'public, max-age=60, must-revalidate',
+    },
+  });
+}

--- a/apps/website/src/app/docs/[library]/[section]/[slug]/page.tsx
+++ b/apps/website/src/app/docs/[library]/[section]/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { MdxRenderer } from '../../../../../components/docs/MdxRenderer';
 import { DocsSearch } from '../../../../../components/docs/DocsSearch';
 import { DocsBreadcrumb } from '../../../../../components/docs/DocsBreadcrumb';
 import { DocsPageHeader } from '../../../../../components/docs/DocsPageHeader';
+import { PageActions } from '../../../../../components/docs/PageActions';
 import { DocsPrevNext } from '../../../../../components/docs/DocsPrevNext';
 import { getDocBySlug, getAllDocSlugs, getDocMetadata } from '../../../../../lib/docs';
 import { ApiDocRenderer, type ApiDocEntry } from '../../../../../components/docs/ApiDocRenderer';
@@ -74,7 +75,11 @@ export default async function DocsPage({ params }: DocsRouteProps) {
         <div className="flex-1 min-w-0">
           <div className="px-6 md:px-12 pt-6">
             <DocsBreadcrumb library={library as LibraryId} section={section} slug={slug} title={doc.title} />
-            <DocsPageHeader library={library as LibraryId} section={section} />
+            <DocsPageHeader
+              library={library as LibraryId}
+              section={section}
+              actions={<PageActions library={library} section={section} slug={slug} />}
+            />
           </div>
           <article className="flex-1 py-8 px-4 sm:px-6 md:px-12 md:max-w-3xl overflow-x-hidden">
             <MdxRenderer

--- a/apps/website/src/components/docs/PageActions.spec.tsx
+++ b/apps/website/src/components/docs/PageActions.spec.tsx
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+// @vitest-environment jsdom
+import React from 'react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const trackMock = vi.hoisted(() => vi.fn());
+const writeTextMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const fetchMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../../lib/analytics/client', () => ({ track: trackMock }));
+
+beforeEach(() => {
+  trackMock.mockClear();
+  writeTextMock.mockClear();
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue({ ok: true, text: () => Promise.resolve('# Streaming\n\nbody') });
+  Object.assign(navigator, { clipboard: { writeText: writeTextMock } });
+  Object.assign(globalThis, { fetch: fetchMock });
+});
+
+async function open() {
+  const { PageActions } = await import('./PageActions');
+  render(<PageActions library="langgraph" section="guides" slug="streaming" />);
+  fireEvent.click(screen.getByRole('button', { name: /page actions/i }));
+}
+
+describe('PageActions', () => {
+  it('copies the raw markdown from the route and fires analytics', async () => {
+    await open();
+    fireEvent.click(screen.getByRole('menuitem', { name: /copy page as markdown/i }));
+    await waitFor(() => expect(writeTextMock).toHaveBeenCalledWith('# Streaming\n\nbody'));
+    expect(fetchMock).toHaveBeenCalledWith('/api/markdown/langgraph/guides/streaming');
+    expect(trackMock).toHaveBeenCalledWith(
+      'docs:copy_code_click',
+      expect.objectContaining({ surface: 'docs', cta_id: 'copy_page_markdown' }),
+    );
+  });
+
+  it('links to ChatGPT with the page URL and to GitHub edit', async () => {
+    await open();
+    const chatgpt = screen.getByRole('menuitem', { name: /open in chatgpt/i }) as HTMLAnchorElement;
+    expect(chatgpt.getAttribute('href')).toContain('https://chatgpt.com/?hints=search&q=');
+    expect(chatgpt.getAttribute('href')).toContain(encodeURIComponent('https://threadplane.ai/docs/langgraph/guides/streaming'));
+    const github = screen.getByRole('menuitem', { name: /edit on github/i }) as HTMLAnchorElement;
+    expect(github.getAttribute('href')).toBe('https://github.com/cacheplane/angular-agent-framework/edit/main/apps/website/content/docs/langgraph/guides/streaming.mdx');
+  });
+});

--- a/apps/website/src/components/docs/PageActions.tsx
+++ b/apps/website/src/components/docs/PageActions.tsx
@@ -1,0 +1,148 @@
+'use client';
+import { useEffect, useRef, useState } from 'react';
+import { tokens } from '@threadplane/design-tokens';
+import { analyticsEvents } from '../../lib/analytics/events';
+import { track } from '../../lib/analytics/client';
+
+// NOTE: SITE_ORIGIN is duplicated from lib/site-metadata rather than imported,
+// because site-metadata transitively pulls in lib/blog (Node `fs`), which a
+// 'use client' component cannot bundle. Keep in sync with site-metadata.ts.
+const SITE_ORIGIN = 'https://threadplane.ai';
+
+const GITHUB_EDIT_BASE =
+  'https://github.com/cacheplane/angular-agent-framework/edit/main/apps/website/content/docs';
+
+interface Props {
+  library: string;
+  section: string;
+  slug: string;
+}
+
+export function PageActions({ library, section, slug }: Props) {
+  const [open, setOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', onDown);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDown);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  const path = `${library}/${section}/${slug}`;
+  const pageUrl = `${SITE_ORIGIN}/docs/${path}`;
+  const chatgptUrl = `https://chatgpt.com/?hints=search&q=${encodeURIComponent(
+    `Read this Threadplane docs page and help me apply it to my project: ${pageUrl}`,
+  )}`;
+  const githubUrl = `${GITHUB_EDIT_BASE}/${path}.mdx`;
+
+  const copyMarkdown = async () => {
+    try {
+      const res = await fetch(`/api/markdown/${path}`);
+      if (!res.ok) throw new Error(String(res.status));
+      const text = await res.text();
+      await navigator.clipboard.writeText(text);
+      track(analyticsEvents.docsCopyCodeClick, { surface: 'docs', cta_id: 'copy_page_markdown' });
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // network/clipboard failure — silently ignore
+    }
+    setOpen(false);
+  };
+
+  const itemStyle: React.CSSProperties = {
+    display: 'block',
+    width: '100%',
+    textAlign: 'left',
+    padding: '8px 12px',
+    fontFamily: tokens.typography.fontSans,
+    fontSize: 13,
+    color: tokens.colors.textPrimary,
+    background: 'transparent',
+    border: 'none',
+    textDecoration: 'none',
+    cursor: 'pointer',
+    whiteSpace: 'nowrap',
+  };
+
+  return (
+    <div ref={ref} style={{ position: 'relative' }}>
+      <button
+        type="button"
+        aria-label="Page actions"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((o) => !o)}
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: 32,
+          height: 32,
+          padding: 0,
+          border: `1px solid ${tokens.surfaces.border}`,
+          borderRadius: tokens.radius.md,
+          background: tokens.surfaces.surface,
+          color: tokens.colors.textSecondary,
+          cursor: 'pointer',
+          fontSize: 18,
+          lineHeight: 1,
+        }}
+      >
+        <span aria-hidden="true">⋯</span>
+      </button>
+      {open ? (
+        <div
+          role="menu"
+          style={{
+            position: 'absolute',
+            top: 'calc(100% + 6px)',
+            right: 0,
+            minWidth: 200,
+            background: tokens.surfaces.surface,
+            border: `1px solid ${tokens.surfaces.border}`,
+            borderRadius: tokens.radius.md,
+            boxShadow: tokens.shadows.md,
+            padding: 4,
+            zIndex: 20,
+          }}
+        >
+          <button type="button" role="menuitem" onClick={copyMarkdown} style={itemStyle}>
+            {copied ? 'Copied' : 'Copy page as Markdown'}
+          </button>
+          <a
+            role="menuitem"
+            href={chatgptUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() => setOpen(false)}
+            style={itemStyle}
+          >
+            Open in ChatGPT
+          </a>
+          <a
+            role="menuitem"
+            href={githubUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() => setOpen(false)}
+            style={itemStyle}
+          >
+            Edit on GitHub
+          </a>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/docs/superpowers/plans/2026-06-04-docs-llm-export.md
+++ b/docs/superpowers/plans/2026-06-04-docs-llm-export.md
@@ -1,0 +1,452 @@
+# Docs LLM Markdown Export Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Mintlify-style per-page LLM export — a raw-markdown route and a `PageActions` dropdown (Copy page as Markdown, Open in ChatGPT, Edit on GitHub) that mounts into the docs page-header actions slot reserved by Spec 1.
+
+**Architecture:** A new Next.js route handler serves each doc's raw `.mdx` verbatim as `text/markdown` (reusing the existing `getDocBySlug` for lookup + validation). A new `'use client'` `PageActions` dropdown calls that route for copy and links out to ChatGPT/GitHub; it's passed into the existing `DocsPageHeader` `actions` prop. No new dependencies or analytics events.
+
+**Tech Stack:** Next.js (App Router route handlers), React client component, TypeScript, `@threadplane/design-tokens`, Vitest + Testing Library, Playwright.
+
+**Reference spec:** `docs/superpowers/specs/2026-06-04-docs-llm-export-design.md`
+
+---
+
+## File Structure
+
+- **Create:** `apps/website/src/app/api/markdown/[library]/[section]/[slug]/route.ts` — GET returns raw `.mdx` as `text/markdown` (404 for unknown slugs); `generateStaticParams` from `getAllDocSlugs()`.
+- **Create:** `apps/website/src/app/api/markdown/[library]/[section]/[slug]/route.spec.ts` — route test (node env).
+- **Create:** `apps/website/src/components/docs/PageActions.tsx` — client dropdown.
+- **Create:** `apps/website/src/components/docs/PageActions.spec.tsx` — component test (jsdom).
+- **Modify:** `apps/website/src/app/docs/[library]/[section]/[slug]/page.tsx` — pass `<PageActions>` as the header `actions`.
+- **Modify:** `apps/website/e2e/docs.spec.ts` — assert the actions trigger renders.
+
+---
+
+## Task 1: Raw-markdown route (TDD)
+
+**Files:**
+- Create: `apps/website/src/app/api/markdown/[library]/[section]/[slug]/route.spec.ts`
+- Create: `apps/website/src/app/api/markdown/[library]/[section]/[slug]/route.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/website/src/app/api/markdown/[library]/[section]/[slug]/route.spec.ts`:
+
+```ts
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { GET } from './route';
+
+function ctx(params: { library: string; section: string; slug: string }) {
+  return { params: Promise.resolve(params) };
+}
+
+describe('GET /api/markdown/[library]/[section]/[slug]', () => {
+  it('returns the raw mdx for a known page as text/markdown', async () => {
+    const res = await GET(
+      new Request('http://localhost/api/markdown/langgraph/getting-started/introduction'),
+      ctx({ library: 'langgraph', section: 'getting-started', slug: 'introduction' }),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/markdown');
+    const body = await res.text();
+    expect(body).toContain('# Introduction');
+  });
+
+  it('404s for an unknown page', async () => {
+    const res = await GET(
+      new Request('http://localhost/api/markdown/langgraph/getting-started/does-not-exist'),
+      ctx({ library: 'langgraph', section: 'getting-started', slug: 'does-not-exist' }),
+    );
+    expect(res.status).toBe(404);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+```bash
+cd apps/website && npx vitest run "src/app/api/markdown/[library]/[section]/[slug]/route.spec.ts"
+```
+Expected: FAIL — cannot resolve `./route`.
+
+- [ ] **Step 3: Write the route handler**
+
+Create `apps/website/src/app/api/markdown/[library]/[section]/[slug]/route.ts`:
+
+```ts
+import { NextResponse } from 'next/server';
+import { getDocBySlug, getAllDocSlugs } from '../../../../../../lib/docs';
+
+export function generateStaticParams() {
+  return getAllDocSlugs();
+}
+
+interface RouteContext {
+  params: Promise<{ library: string; section: string; slug: string }>;
+}
+
+export async function GET(_req: Request, context: RouteContext): Promise<Response> {
+  const { library, section, slug } = await context.params;
+  const doc = getDocBySlug(library, section, slug);
+
+  if (!doc) {
+    return new NextResponse('Not found', {
+      status: 404,
+      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    });
+  }
+
+  return new NextResponse(doc.content, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'Cache-Control': 'public, max-age=60, must-revalidate',
+    },
+  });
+}
+```
+
+**Import-path note:** the relative path from this route file to `apps/website/src/lib/docs.ts` is six levels up to `src` (`../../../../../../lib/docs`). If `tsc`/the test reports the import can't be resolved, count the directory depth and adjust the number of `../` segments — do not change the design.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run:
+```bash
+cd apps/website && npx vitest run "src/app/api/markdown/[library]/[section]/[slug]/route.spec.ts"
+```
+Expected: PASS (2 passed). The test reads real files via `getDocBySlug` (cwd = `apps/website`).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+cd /Users/blove/repos/angular-agent-framework
+npx eslint "apps/website/src/app/api/markdown/[library]/[section]/[slug]/route.ts" "apps/website/src/app/api/markdown/[library]/[section]/[slug]/route.spec.ts"
+git add "apps/website/src/app/api/markdown"
+git commit -m "feat(website): raw-markdown route for docs pages"
+```
+Expected: eslint exit 0. (Do NOT run `nx lint website`.) If `next-env.d.ts`/`tsconfig.tsbuildinfo` show modified, do not stage them.
+
+---
+
+## Task 2: PageActions dropdown (TDD)
+
+**Files:**
+- Create: `apps/website/src/components/docs/PageActions.spec.tsx`
+- Create: `apps/website/src/components/docs/PageActions.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/website/src/components/docs/PageActions.spec.tsx`:
+
+```tsx
+// SPDX-License-Identifier: MIT
+// @vitest-environment jsdom
+import React from 'react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const trackMock = vi.hoisted(() => vi.fn());
+const writeTextMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const fetchMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../../lib/analytics/client', () => ({ track: trackMock }));
+
+beforeEach(() => {
+  trackMock.mockClear();
+  writeTextMock.mockClear();
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue({ ok: true, text: () => Promise.resolve('# Streaming\n\nbody') });
+  Object.assign(navigator, { clipboard: { writeText: writeTextMock } });
+  Object.assign(globalThis, { fetch: fetchMock });
+});
+
+async function open() {
+  const { PageActions } = await import('./PageActions');
+  render(<PageActions library="langgraph" section="guides" slug="streaming" />);
+  fireEvent.click(screen.getByRole('button', { name: /page actions/i }));
+}
+
+describe('PageActions', () => {
+  it('copies the raw markdown from the route and fires analytics', async () => {
+    await open();
+    fireEvent.click(screen.getByRole('menuitem', { name: /copy page as markdown/i }));
+    await waitFor(() => expect(writeTextMock).toHaveBeenCalledWith('# Streaming\n\nbody'));
+    expect(fetchMock).toHaveBeenCalledWith('/api/markdown/langgraph/guides/streaming');
+    expect(trackMock).toHaveBeenCalledWith(
+      'docs:copy_code_click',
+      expect.objectContaining({ surface: 'docs', cta_id: 'copy_page_markdown' }),
+    );
+  });
+
+  it('links to ChatGPT with the page URL and to GitHub edit', async () => {
+    await open();
+    const chatgpt = screen.getByRole('menuitem', { name: /open in chatgpt/i }) as HTMLAnchorElement;
+    expect(chatgpt.getAttribute('href')).toContain('https://chatgpt.com/?hints=search&q=');
+    expect(chatgpt.getAttribute('href')).toContain(encodeURIComponent('https://threadplane.ai/docs/langgraph/guides/streaming'));
+    const github = screen.getByRole('menuitem', { name: /edit on github/i }) as HTMLAnchorElement;
+    expect(github.getAttribute('href')).toBe('https://github.com/cacheplane/angular-agent-framework/edit/main/apps/website/content/docs/langgraph/guides/streaming.mdx');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+```bash
+cd apps/website && npx vitest run src/components/docs/PageActions.spec.tsx
+```
+Expected: FAIL — cannot resolve `./PageActions`.
+
+- [ ] **Step 3: Write the component**
+
+Create `apps/website/src/components/docs/PageActions.tsx`:
+
+```tsx
+'use client';
+import { useEffect, useRef, useState } from 'react';
+import { tokens } from '@threadplane/design-tokens';
+import { analyticsEvents } from '../../lib/analytics/events';
+import { track } from '../../lib/analytics/client';
+import { SITE_ORIGIN } from '../../lib/site-metadata';
+
+const GITHUB_EDIT_BASE =
+  'https://github.com/cacheplane/angular-agent-framework/edit/main/apps/website/content/docs';
+
+interface Props {
+  library: string;
+  section: string;
+  slug: string;
+}
+
+export function PageActions({ library, section, slug }: Props) {
+  const [open, setOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', onDown);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDown);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  const path = `${library}/${section}/${slug}`;
+  const pageUrl = `${SITE_ORIGIN}/docs/${path}`;
+  const chatgptUrl = `https://chatgpt.com/?hints=search&q=${encodeURIComponent(
+    `Read this Threadplane docs page and help me apply it to my project: ${pageUrl}`,
+  )}`;
+  const githubUrl = `${GITHUB_EDIT_BASE}/${path}.mdx`;
+
+  const copyMarkdown = async () => {
+    try {
+      const res = await fetch(`/api/markdown/${path}`);
+      if (!res.ok) throw new Error(String(res.status));
+      const text = await res.text();
+      await navigator.clipboard.writeText(text);
+      track(analyticsEvents.docsCopyCodeClick, { surface: 'docs', cta_id: 'copy_page_markdown' });
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // network/clipboard failure — silently ignore
+    }
+    setOpen(false);
+  };
+
+  const itemStyle: React.CSSProperties = {
+    display: 'block',
+    width: '100%',
+    textAlign: 'left',
+    padding: '8px 12px',
+    fontFamily: tokens.typography.fontSans,
+    fontSize: 13,
+    color: tokens.colors.textPrimary,
+    background: 'transparent',
+    border: 'none',
+    textDecoration: 'none',
+    cursor: 'pointer',
+    whiteSpace: 'nowrap',
+  };
+
+  return (
+    <div ref={ref} style={{ position: 'relative' }}>
+      <button
+        type="button"
+        aria-label="Page actions"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((o) => !o)}
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: 32,
+          height: 32,
+          padding: 0,
+          border: `1px solid ${tokens.surfaces.border}`,
+          borderRadius: tokens.radius.md,
+          background: tokens.surfaces.surface,
+          color: tokens.colors.textSecondary,
+          cursor: 'pointer',
+          fontSize: 18,
+          lineHeight: 1,
+        }}
+      >
+        <span aria-hidden="true">⋯</span>
+      </button>
+      {open ? (
+        <div
+          role="menu"
+          style={{
+            position: 'absolute',
+            top: 'calc(100% + 6px)',
+            right: 0,
+            minWidth: 200,
+            background: tokens.surfaces.surface,
+            border: `1px solid ${tokens.surfaces.border}`,
+            borderRadius: tokens.radius.md,
+            boxShadow: tokens.shadows.md,
+            padding: 4,
+            zIndex: 20,
+          }}
+        >
+          <button type="button" role="menuitem" onClick={copyMarkdown} style={itemStyle}>
+            {copied ? 'Copied' : 'Copy page as Markdown'}
+          </button>
+          <a
+            role="menuitem"
+            href={chatgptUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() => setOpen(false)}
+            style={itemStyle}
+          >
+            Open in ChatGPT
+          </a>
+          <a
+            role="menuitem"
+            href={githubUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() => setOpen(false)}
+            style={itemStyle}
+          >
+            Edit on GitHub
+          </a>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run:
+```bash
+cd apps/website && npx vitest run src/components/docs/PageActions.spec.tsx
+```
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+cd /Users/blove/repos/angular-agent-framework
+npx eslint apps/website/src/components/docs/PageActions.tsx apps/website/src/components/docs/PageActions.spec.tsx
+git add apps/website/src/components/docs/PageActions.tsx apps/website/src/components/docs/PageActions.spec.tsx
+git commit -m "feat(website): PageActions dropdown (copy markdown, ChatGPT, GitHub)"
+```
+Expected: eslint exit 0.
+
+---
+
+## Task 3: Mount in the route + e2e + verify
+
+**Files:**
+- Modify: `apps/website/src/app/docs/[library]/[section]/[slug]/page.tsx`
+- Modify: `apps/website/e2e/docs.spec.ts`
+
+- [ ] **Step 1: Pass PageActions into the header slot**
+
+In `apps/website/src/app/docs/[library]/[section]/[slug]/page.tsx`, add the import after the existing `DocsPageHeader` import:
+```tsx
+import { PageActions } from '../../../../../components/docs/PageActions';
+```
+
+Then replace:
+```tsx
+            <DocsPageHeader library={library as LibraryId} section={section} />
+```
+with:
+```tsx
+            <DocsPageHeader
+              library={library as LibraryId}
+              section={section}
+              actions={<PageActions library={library} section={section} slug={slug} />}
+            />
+```
+
+- [ ] **Step 2: Add the e2e assertion**
+
+In `apps/website/e2e/docs.spec.ts`, in the `Docs slug page` block, extend the `'renders the branded chrome ...'` test by adding this line before its closing `});`:
+```ts
+    // Per-page LLM actions trigger
+    await expect(page.locator('main button[aria-label="Page actions"]').first()).toBeVisible();
+```
+
+- [ ] **Step 3: Lint + typecheck**
+
+```bash
+cd /Users/blove/repos/angular-agent-framework
+npx eslint "apps/website/src/app/docs/[library]/[section]/[slug]/page.tsx"
+npx tsc --noEmit -p apps/website/tsconfig.json 2>&1 | grep -E "PageActions|api/markdown|\[slug\]/page.tsx" || echo "no new type errors in changed files"
+```
+Expected: eslint exit 0; `no new type errors in changed files`.
+
+- [ ] **Step 4: Run the full docs e2e**
+
+```bash
+cd apps/website && npx playwright test e2e/docs.spec.ts
+```
+Expected: PASS (all blocks). The actions trigger now renders in the page header.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/blove/repos/angular-agent-framework
+git add "apps/website/src/app/docs/[library]/[section]/[slug]/page.tsx" apps/website/e2e/docs.spec.ts
+git commit -m "feat(website): mount PageActions in the docs page header"
+```
+
+---
+
+## Manual verification (browser)
+
+After e2e passes, open `/docs/langgraph/guides/streaming` on the dev server and confirm:
+
+- [ ] A kebab (⋯) button sits at the right of the `LANGGRAPH · GUIDES` page header.
+- [ ] Clicking it opens a menu with "Copy page as Markdown", "Open in ChatGPT", "Edit on GitHub"; clicking outside or pressing Escape closes it.
+- [ ] "Copy page as Markdown" copies (the menu item briefly shows "Copied"); pasting yields the raw MDX.
+- [ ] Visiting `/api/markdown/langgraph/guides/streaming` directly shows the raw `.mdx` as plain text.
+- [ ] "Open in ChatGPT" / "Edit on GitHub" open the expected URLs in a new tab.
+- [ ] No console errors.
+
+---
+
+## Self-Review (completed during planning)
+
+- **Spec coverage:** Raw-markdown route serving verbatim `.mdx` via `getDocBySlug`, 404 for unknown, `generateStaticParams` ✓ (Task 1). `PageActions` client dropdown with the three dawn items, copy-from-route + `docs:copy_code_click`/`cta_id: copy_page_markdown`, ChatGPT page-URL link, GitHub edit link, outside-click/Escape close ✓ (Task 2). Mounted via the existing `actions` slot ✓ (Task 3). Tests: route test, component test, e2e trigger assertion ✓. No `llms.txt` change, no Claude, no View-as-Markdown ✓.
+- **Placeholder scan:** No TBD/TODO; every code step is complete; commands have expected output.
+- **Type consistency:** `PageActions` props `{ library, section, slug }` (all `string`) match the call site in the route page. Route `GET(_req, { params: Promise<{library,section,slug}> })` matches the test's `ctx()`. `getDocBySlug`/`getAllDocSlugs` are existing `lib/docs` exports. Analytics event `docsCopyCodeClick` + `cta_id: 'copy_page_markdown'` consistent between component and test. The `/api/markdown/${path}` URL in the component matches the route folder structure and the test's `fetch` assertion.
+```

--- a/docs/superpowers/specs/2026-06-04-docs-llm-export-design.md
+++ b/docs/superpowers/specs/2026-06-04-docs-llm-export-design.md
@@ -1,0 +1,111 @@
+# Docs LLM Markdown Export — Design
+
+**Date:** 2026-06-04
+**Status:** Draft for review
+**Scope:** Add Mintlify-style per-page LLM export to the docs — a raw-markdown route plus a `PageActions` dropdown that mounts in the page-header actions slot reserved by the docs-chrome polish (Spec 1). Mirrors the pattern built in `~/repos/dawn`.
+
+## Goal
+
+Let readers (and their LLMs) pull a doc page as raw markdown and jump into
+ChatGPT or GitHub from any doc page. This is the **second of two** docs specs;
+Spec 1 (docs chrome) reserved the `actions` slot in `DocsPageHeader` that this
+control fills.
+
+The repo already ships `/llms.txt`, `/llms-full.txt`, and a `content/prompts/`
+dir — those are unchanged. This spec adds only the **per-page** experience.
+
+## Decisions (locked during brainstorming)
+
+- **Mirror dawn exactly.** Menu items: Copy page as Markdown, Open in ChatGPT,
+  Edit on GitHub. No "Open in Claude", no "View as Markdown" link.
+- **Serve raw MDX verbatim** (JSX components and all), like dawn — no MDX→md
+  conversion.
+- **ChatGPT link passes the page URL** (relies on ChatGPT fetching it), not the
+  embedded markdown body.
+
+## 1. Raw-markdown route
+
+- **Create:** `apps/website/src/app/api/markdown/[library]/[section]/[slug]/route.ts`.
+- `GET` handler: `await params` → call the existing
+  `getDocBySlug(library, section, slug)` (from `apps/website/src/lib/docs.ts`).
+  - If it returns a doc, respond `200` with the doc's `.content` (raw `.mdx`
+    string, verbatim) and headers `Content-Type: text/markdown; charset=utf-8`
+    and `Cache-Control: public, max-age=60, must-revalidate`.
+  - If it returns `null` (unknown library/section/slug), respond `404` with a
+    short plain-text body. (Reusing `getDocBySlug` gives slug validation for
+    free — only real doc pages resolve, so no path-traversal handling is
+    needed.)
+- `export function generateStaticParams()` → map `getAllDocSlugs()` to
+  `{ library, section, slug }` so the routes are statically generated, matching
+  the doc page route.
+
+URL example: `/api/markdown/langgraph/guides/streaming` →
+`content/docs/langgraph/guides/streaming.mdx` verbatim.
+
+## 2. `PageActions` dropdown component
+
+- **Create:** `apps/website/src/components/docs/PageActions.tsx` (`'use client'`).
+- Props: `{ library: string; section: string; slug: string }`.
+- A kebab (⋯) trigger button (icon, `aria-haspopup="menu"`, `aria-expanded`)
+  that toggles a popover `role="menu"`. Closes on outside-click (a `mousedown`
+  listener like the sidebar's `LibraryDropdown`) and on `Escape`.
+- Three items:
+  1. **Copy page as Markdown** — `fetch('/api/markdown/<library>/<section>/<slug>')`,
+     `await res.text()`, `navigator.clipboard.writeText(text)`; show a brief
+     "Copied" state (2s). Fires
+     `track(analyticsEvents.docsCopyCodeClick, { surface: 'docs', cta_id: 'copy_page_markdown' })`
+     (reuses the existing event). On fetch/clipboard failure, fail silently
+     (try/catch), matching `CopyButton`.
+  2. **Open in ChatGPT** — `window.open(url, '_blank', 'noopener,noreferrer')`
+     where `url = 'https://chatgpt.com/?hints=search&q=' + encodeURIComponent(prompt)`
+     and `prompt = 'Read this Threadplane docs page and help me apply it to my
+     project: ' + pageUrl`, `pageUrl = 'https://threadplane.ai/docs/<library>/<section>/<slug>'`.
+     (`https://threadplane.ai` is `SITE_ORIGIN` from `src/lib/site-metadata.ts`.)
+  3. **Edit on GitHub** — opens
+     `https://github.com/cacheplane/angular-agent-framework/edit/main/apps/website/content/docs/<library>/<section>/<slug>.mdx`
+     in a new tab (`noopener,noreferrer`).
+- Styling: tokens-based, consistent with the existing docs components
+  (`LibraryDropdown` popover treatment — surface bg, border, `shadows.md`,
+  `radius`).
+
+## 3. Mount in the reserved slot
+
+- **Modify:** `apps/website/src/app/docs/[library]/[section]/[slug]/page.tsx` —
+  pass the control into the header's reserved slot:
+  ```tsx
+  <DocsPageHeader
+    library={library as LibraryId}
+    section={section}
+    actions={<PageActions library={library} section={section} slug={slug} />}
+  />
+  ```
+- No other change to `DocsPageHeader` (the `actions` prop already exists).
+
+## Components & implementation
+
+- **Create:** the route + `PageActions.tsx`.
+- **Modify:** the doc route page to pass `actions`.
+- **Reuse:** `getDocBySlug`/`getAllDocSlugs` (`lib/docs.ts`), `SITE_ORIGIN`
+  (`lib/site-metadata.ts`), `track`/`analyticsEvents` (existing), design tokens.
+  No new dependencies, no new analytics event, no `llms.txt` changes.
+
+## Testing
+
+- **Route test** `apps/website/src/app/api/markdown/[library]/[section]/[slug]/route.spec.ts`
+  (vitest, node env): a known slug (e.g. langgraph/getting-started/introduction)
+  → `200`, `Content-Type` includes `text/markdown`, body contains the doc's
+  first heading; an unknown slug → `404`. (Follows the existing API route-test
+  pattern, e.g. `api/leads/route.spec.ts`.)
+- **Component test** `PageActions.spec.tsx` (vitest, jsdom): clicking "Copy page
+  as Markdown" fetches `/api/markdown/<lib>/<sec>/<slug>` and writes the response
+  to the clipboard and fires `docs:copy_code_click` with `cta_id: 'copy_page_markdown'`;
+  the ChatGPT and GitHub items have the exact expected hrefs/URLs. Mock `fetch`,
+  `navigator.clipboard.writeText`, `window.open`, and `track`.
+- **e2e** (`docs.spec.ts`, slug-page block): the page header renders the
+  PageActions trigger (assert by its `aria-label`, e.g. "Page actions").
+
+## Out of scope
+
+- "Open in Claude", "View as Markdown" link, per-page prompts.
+- Changes to `/llms.txt` or `/llms-full.txt`.
+- Any visual change to `DocsPageHeader` beyond filling its existing slot.


### PR DESCRIPTION
## Summary
Per-page LLM export for the docs, mirroring the dawn pattern (second of two docs specs; **stacked on #573** — the page-header actions slot it fills lands there):
- **Raw-markdown route** `GET /api/markdown/<library>/<section>/<slug>` → the page's `.mdx` verbatim as `text/markdown` (reuses `getDocBySlug` for lookup + validation; 404 for unknown; `generateStaticParams` from `getAllDocSlugs`).
- **`PageActions`** kebab dropdown — Copy page as Markdown (fetches the route → clipboard, fires `docs:copy_code_click`/`cta_id: copy_page_markdown`), Open in ChatGPT (`chatgpt.com/?hints=search&q=…` with the page URL), Edit on GitHub. Outside-click / Escape close.
- Mounted into the page header's reserved `actions` slot.

Note: `SITE_ORIGIN` is inlined in the client component (with a keep-in-sync comment) because `lib/site-metadata` transitively imports `lib/blog` (Node `fs`) and can't be bundled client-side — a follow-up chip tracks splitting it into a client-safe leaf module.

Spec: `docs/superpowers/specs/2026-06-04-docs-llm-export-design.md`
Plan: `docs/superpowers/plans/2026-06-04-docs-llm-export.md`

## Test Plan
- [x] route test — 2/2 (200 + text/markdown for known slug; 404 unknown)
- [x] `PageActions.spec.tsx` — 2/2 (copy flow + analytics; ChatGPT/GitHub hrefs)
- [x] `e2e/docs.spec.ts` — 8/8 (actions trigger renders)
- [x] Manual: `/api/markdown/langgraph/guides/streaming` returns raw `.mdx` as `text/markdown`; kebab renders in the header
- [ ] Rebase onto main after #573 merges; CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)