### PR TITLE
feat(cockpit): register ag-ui examples in sidebar + capability modules

### DIFF
--- a/apps/cockpit/src/lib/route-resolution.spec.ts
+++ b/apps/cockpit/src/lib/route-resolution.spec.ts
@@ -47,7 +47,7 @@ describe('buildNavigationTree', () => {
   it('groups manifest entries by product and section', () => {
     const tree = buildNavigationTree(cockpitManifest);
 
-    expect(tree).toHaveLength(4);
+    expect(tree).toHaveLength(5);
     expect(tree[0]).toMatchObject({
       product: 'deep-agents',
     });
@@ -55,9 +55,12 @@ describe('buildNavigationTree', () => {
       product: 'langgraph',
     });
     expect(tree[2]).toMatchObject({
-      product: 'render',
+      product: 'ag-ui',
     });
     expect(tree[3]).toMatchObject({
+      product: 'render',
+    });
+    expect(tree[4]).toMatchObject({
       product: 'chat',
     });
   });

--- a/apps/cockpit/src/lib/route-resolution.ts
+++ b/apps/cockpit/src/lib/route-resolution.ts
@@ -11,6 +11,8 @@ import { langgraphDurableExecutionPythonModule } from '../../../../cockpit/langg
 import { langgraphSubgraphsPythonModule } from '../../../../cockpit/langgraph/subgraphs/python/src/index';
 import { langgraphTimeTravelPythonModule } from '../../../../cockpit/langgraph/time-travel/python/src/index';
 import { langgraphDeploymentRuntimePythonModule } from '../../../../cockpit/langgraph/deployment-runtime/python/src/index';
+import { agUiInterruptsPythonModule } from '../../../../cockpit/ag-ui/interrupts/python/src/index';
+import { agUiStreamingPythonModule } from '../../../../cockpit/ag-ui/streaming/python/src/index';
 import { deepAgentsMemoryPythonModule } from '../../../../cockpit/deep-agents/memory/python/src/index';
 import { deepAgentsPlanningPythonModule } from '../../../../cockpit/deep-agents/planning/python/src/index';
 import { deepAgentsFilesystemPythonModule } from '../../../../cockpit/deep-agents/filesystem/python/src/index';
@@ -81,6 +83,8 @@ const capabilityModules = [
   langgraphSubgraphsPythonModule,
   langgraphTimeTravelPythonModule,
   langgraphDeploymentRuntimePythonModule,
+  agUiInterruptsPythonModule,
+  agUiStreamingPythonModule,
   deepAgentsMemoryPythonModule,
   deepAgentsPlanningPythonModule,
   deepAgentsFilesystemPythonModule,
@@ -169,7 +173,7 @@ export const resolveCockpitEntry = ({
 export const buildNavigationTree = (
   manifest: CockpitManifestEntry[]
 ): NavigationProduct[] => {
-  const products: CockpitManifestEntry['product'][] = ['deep-agents', 'langgraph', 'render', 'chat'];
+  const products: CockpitManifestEntry['product'][] = ['deep-agents', 'langgraph', 'ag-ui', 'render', 'chat'];
   const sections: CockpitManifestEntry['section'][] = [
     'getting-started',
     'core-capabilities',


### PR DESCRIPTION
## Summary

Closes the cockpit-side gap I surfaced while finishing #571: even though PR #567 added \`ag-ui\` to the cockpit-registry manifest and shipped two standalone examples (\`cockpit/ag-ui/interrupts\`, \`cockpit/ag-ui/streaming\`), the cockpit app itself never picked them up. Two hardcoded spots in \`apps/cockpit/src/lib/route-resolution.ts\` needed parallel updates:

- **\`capabilityModules\`** is a static import-and-array list. Without entries for the ag-ui descriptors, \`capabilityModules.find(c => c.manifestIdentity.product === 'ag-ui' ...)\` returned undefined, so \`<RunMode>\` rendered the "No runtime available" fallback even when the route resolved correctly.
- **\`buildNavigationTree\`** hardcoded the products array to the original four (\`['deep-agents', 'langgraph', 'render', 'chat']\`), so ag-ui examples were filtered out of the sidebar entirely. This is why \`cockpit.threadplane.ai/ag-ui/core-capabilities/interrupts/overview/python\` rendered with breadcrumbs but no sidebar entry.

This PR adds both: static imports + array entries for \`agUiInterruptsPythonModule\` / \`agUiStreamingPythonModule\`, and inserts \`'ag-ui'\` between \`'langgraph'\` and \`'render'\` to match the manifest's \`APPROVED_TOPICS\` ordering.

After this lands + cockpit redeploys: the AG-UI section appears in the sidebar; Code, Docs, and API tabs all work (they read from the imported descriptors' asset paths). The Run tab will still say "No runtime available" — that depends on hosting a uvicorn \`ag-ui-langgraph\` runtime somewhere reachable, which is Phase 2 (a real infra brainstorm — LangGraph Cloud can't host FastAPI apps).

Test \`buildNavigationTree > groups manifest entries by product and section\` updated to expect 5 products with \`'ag-ui'\` in position 3.

## Test Plan

- [x] \`nx test cockpit\` green (the updated spec asserts the new tree shape)
- [x] \`nx test cockpit-registry\` green (manifest unchanged; sanity)
- [x] Confirmed only one hardcoded products list exists in \`apps/cockpit/src\` — no other places to update
- [ ] After merge + cockpit redeploy: verify the AG-UI section appears in the sidebar at \`cockpit.threadplane.ai\` and Code/Docs/API tabs render real content

🤖 Generated with [Claude Code](https://claude.com/claude-code)