### PR TITLE
refactor(website): client-safe SITE_ORIGIN leaf module

### DIFF
--- a/apps/website/src/components/docs/PageActions.tsx
+++ b/apps/website/src/components/docs/PageActions.tsx
@@ -3,11 +3,7 @@ import { useEffect, useRef, useState } from 'react';
 import { tokens } from '@threadplane/design-tokens';
 import { analyticsEvents } from '../../lib/analytics/events';
 import { track } from '../../lib/analytics/client';
-
-// NOTE: SITE_ORIGIN is duplicated from lib/site-metadata rather than imported,
-// because site-metadata transitively pulls in lib/blog (Node `fs`), which a
-// 'use client' component cannot bundle. Keep in sync with site-metadata.ts.
-const SITE_ORIGIN = 'https://threadplane.ai';
+import { SITE_ORIGIN } from '../../lib/site-origin';
 
 const GITHUB_EDIT_BASE =
   'https://github.com/cacheplane/angular-agent-framework/edit/main/apps/website/content/docs';

--- a/apps/website/src/lib/site-metadata.ts
+++ b/apps/website/src/lib/site-metadata.ts
@@ -3,7 +3,7 @@ import { getAllSolutionSlugs } from './solutions-data';
 import { docsConfig } from './docs-config';
 import { getAllPosts } from './blog';
 
-export const SITE_ORIGIN = 'https://threadplane.ai';
+export { SITE_ORIGIN } from './site-origin';
 export const SITE_NAME = 'Threadplane';
 export const DEFAULT_SOCIAL_IMAGE = '/opengraph-image';
 export {

--- a/apps/website/src/lib/site-metadata.ts
+++ b/apps/website/src/lib/site-metadata.ts
@@ -2,8 +2,9 @@ import type { Metadata } from 'next';
 import { getAllSolutionSlugs } from './solutions-data';
 import { docsConfig } from './docs-config';
 import { getAllPosts } from './blog';
+import { SITE_ORIGIN } from './site-origin';
 
-export { SITE_ORIGIN } from './site-origin';
+export { SITE_ORIGIN };
 export const SITE_NAME = 'Threadplane';
 export const DEFAULT_SOCIAL_IMAGE = '/opengraph-image';
 export {

--- a/apps/website/src/lib/site-origin.ts
+++ b/apps/website/src/lib/site-origin.ts
@@ -1,0 +1,4 @@
+// Leaf module: the canonical site origin with NO Node-only (`fs`) imports, so it
+// is safe to import from `'use client'` components. `site-metadata.ts` re-exports
+// it; client code should import from here directly.
+export const SITE_ORIGIN = 'https://threadplane.ai';


### PR DESCRIPTION
## Summary
Fix the root cause behind the `PageActions` inline workaround: `lib/site-metadata.ts` transitively imports `lib/blog.ts` (`import fs from 'fs'`), so it can't be imported from any `'use client'` component (breaks the client bundle with "Module not found: Can't resolve 'fs'").

- Add leaf module `apps/website/src/lib/site-origin.ts` exporting just `SITE_ORIGIN` (no `fs`-tainted imports).
- `site-metadata.ts` now re-exports `SITE_ORIGIN` from it (server importers like `layout.tsx` and `blog/rss.xml/route.ts` are unaffected).
- `PageActions.tsx` imports from the leaf module and drops the inline duplicate + keep-in-sync comment.

## Test Plan
- [x] `PageActions.spec.tsx` — 2/2
- [x] `e2e/docs.spec.ts` — 8/8
- [x] `eslint` on changed files — clean
- [x] `/docs/langgraph/guides/streaming` returns HTTP 200 (client bundle compiles, no `fs` error)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)