### PR TITLE
fix(website): make Card hover lift render border/shadow (+ accent ring)

### DIFF
--- a/apps/website/src/app/docs/page.tsx
+++ b/apps/website/src/app/docs/page.tsx
@@ -285,13 +285,7 @@ const helperLinkStyle = {
   fontWeight: 600,
 } as const;
 
-const accentCardStyle = {
-  height: '100%',
-  background: tokens.colors.accentSurface,
-  border: `1px solid ${tokens.colors.accentBorder}`,
-} as const;
-
-const plainCardStyle = {
+const fillHeightStyle = {
   height: '100%',
 } as const;
 
@@ -352,7 +346,7 @@ export default function DocsLandingPage() {
           <div style={gridStyle}>
             {BACKENDS.map((b) => (
               <Link key={b.href} href={b.href} style={{ textDecoration: 'none' }}>
-                <Card padding="lg" hoverable accent style={accentCardStyle}>
+                <Card padding="lg" hoverable accent style={fillHeightStyle}>
                   <div style={cardHeaderStyle}>
                     <LogoChip src={b.logoSrc} />
                     <div>
@@ -387,7 +381,7 @@ export default function DocsLandingPage() {
           <div style={gridStyle}>
             {GENERATIVE_UI.map((g) => (
               <Link key={g.href} href={g.href} style={{ textDecoration: 'none' }}>
-                <Card padding="lg" hoverable accent style={accentCardStyle}>
+                <Card padding="lg" hoverable accent style={fillHeightStyle}>
                   <div style={cardHeaderStyle}>
                     <LogoChip src={g.logoSrc} />
                     <div>
@@ -416,7 +410,7 @@ export default function DocsLandingPage() {
           <div style={dividerStyle} />
           <StepLabel id="chat-heading" step={3}>Chat UI</StepLabel>
           <Link href="/docs/chat/getting-started/introduction" style={{ textDecoration: 'none' }}>
-            <Card padding="lg" hoverable style={plainCardStyle}>
+            <Card padding="lg" hoverable style={fillHeightStyle}>
               <div style={cardHeaderStyle}>
                 <GlyphChip size={30}><ChatGlyph /></GlyphChip>
                 <div>
@@ -444,7 +438,7 @@ export default function DocsLandingPage() {
               const Glyph = GLYPHS[s.glyph];
               return (
                 <Link key={s.href} href={s.href} style={{ textDecoration: 'none' }}>
-                  <Card padding="lg" hoverable style={plainCardStyle}>
+                  <Card padding="lg" hoverable style={fillHeightStyle}>
                     <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
                       <GlyphChip size={26}><Glyph /></GlyphChip>
                       <div>

--- a/apps/website/src/app/docs/page.tsx
+++ b/apps/website/src/app/docs/page.tsx
@@ -305,11 +305,6 @@ const dividerStyle = {
 export default function DocsLandingPage() {
   return (
     <>
-      <style>{`
-        [data-ui="docs-card"] { transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease; }
-        [data-ui="docs-card"]:hover { border-color: ${tokens.colors.accentBorderHover}; box-shadow: ${tokens.shadows.md}; transform: translateY(-1px); }
-        @media (prefers-reduced-motion: reduce) { [data-ui="docs-card"]:hover { transform: none; } }
-      `}</style>
 
       {/* Hero */}
       <Section surface="canvas" ariaLabelledBy="docs-heading">
@@ -357,7 +352,7 @@ export default function DocsLandingPage() {
           <div style={gridStyle}>
             {BACKENDS.map((b) => (
               <Link key={b.href} href={b.href} style={{ textDecoration: 'none' }}>
-                <Card padding="lg" data-ui="docs-card" style={accentCardStyle}>
+                <Card padding="lg" hoverable accent style={accentCardStyle}>
                   <div style={cardHeaderStyle}>
                     <LogoChip src={b.logoSrc} />
                     <div>
@@ -392,7 +387,7 @@ export default function DocsLandingPage() {
           <div style={gridStyle}>
             {GENERATIVE_UI.map((g) => (
               <Link key={g.href} href={g.href} style={{ textDecoration: 'none' }}>
-                <Card padding="lg" data-ui="docs-card" style={accentCardStyle}>
+                <Card padding="lg" hoverable accent style={accentCardStyle}>
                   <div style={cardHeaderStyle}>
                     <LogoChip src={g.logoSrc} />
                     <div>
@@ -421,7 +416,7 @@ export default function DocsLandingPage() {
           <div style={dividerStyle} />
           <StepLabel id="chat-heading" step={3}>Chat UI</StepLabel>
           <Link href="/docs/chat/getting-started/introduction" style={{ textDecoration: 'none' }}>
-            <Card padding="lg" data-ui="docs-card" style={plainCardStyle}>
+            <Card padding="lg" hoverable style={plainCardStyle}>
               <div style={cardHeaderStyle}>
                 <GlyphChip size={30}><ChatGlyph /></GlyphChip>
                 <div>
@@ -449,7 +444,7 @@ export default function DocsLandingPage() {
               const Glyph = GLYPHS[s.glyph];
               return (
                 <Link key={s.href} href={s.href} style={{ textDecoration: 'none' }}>
-                  <Card padding="lg" data-ui="docs-card" style={plainCardStyle}>
+                  <Card padding="lg" hoverable style={plainCardStyle}>
                     <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
                       <GlyphChip size={26}><Glyph /></GlyphChip>
                       <div>

--- a/apps/website/src/app/global.css
+++ b/apps/website/src/app/global.css
@@ -194,9 +194,15 @@ html {
 [data-ui="card"][data-hoverable] {
   cursor: pointer;
 }
-[data-ui="card"][data-hoverable]:hover {
-  box-shadow: var(--shadow-md);
-  border-color: var(--color-border-strong);
+/* !important so the hover lift wins over Card's inline border/box-shadow. */
+[data-ui="card"][data-hoverable]:not([data-accent]):hover {
+  box-shadow: var(--shadow-md) !important;
+  border-color: var(--color-border-strong) !important;
+  transform: translateY(-1px);
+}
+/* Accent cards keep their accent border and gain an accent ring on hover. */
+[data-ui="card"][data-hoverable][data-accent]:hover {
+  box-shadow: 0 0 0 3px var(--color-accent-glow), var(--shadow-md) !important;
   transform: translateY(-1px);
 }
 @media (prefers-reduced-motion: reduce) {

--- a/apps/website/src/app/global.css
+++ b/apps/website/src/app/global.css
@@ -188,21 +188,42 @@ html {
 .docs-prose td { padding: 0.5rem 0.75rem; border-bottom: 1px solid rgba(0, 64, 144, 0.08); color: #555770; }
 .docs-prose td code { font-size: 0.8em; }
 
-/* UI primitive — Card hover.
- * Hoverable cards are virtually always links; pointer is the right default.
+/* UI primitive — Card.
+ * Resting background / border / shadow live here (not inline on the element)
+ * so the :hover rules below can override border-color and box-shadow. Inline
+ * styles beat any stylesheet :hover rule, which previously left the lift
+ * rendering only the transform. See components/ui/Card.tsx. */
+[data-ui="card"] {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-sm);
+  transition: box-shadow 160ms ease, border-color 160ms ease, transform 160ms ease;
+}
+[data-ui="card"][data-surface="tinted"] {
+  background: var(--color-surface-tinted);
+}
+[data-ui="card"][data-surface="dim"] {
+  background: var(--color-surface-dim);
+}
+/* Accent-filled cards (e.g. docs backend / generative-UI cards). */
+[data-ui="card"][data-accent] {
+  background: var(--color-accent-surface);
+  border-color: var(--color-accent-border);
+}
+
+/* Hoverable cards are virtually always links; pointer is the right default.
  * If a non-link gets `data-hoverable`, override inline. */
 [data-ui="card"][data-hoverable] {
   cursor: pointer;
 }
-/* !important so the hover lift wins over Card's inline border/box-shadow. */
 [data-ui="card"][data-hoverable]:not([data-accent]):hover {
-  box-shadow: var(--shadow-md) !important;
-  border-color: var(--color-border-strong) !important;
+  box-shadow: var(--shadow-md);
+  border-color: var(--color-border-strong);
   transform: translateY(-1px);
 }
 /* Accent cards keep their accent border and gain an accent ring on hover. */
 [data-ui="card"][data-hoverable][data-accent]:hover {
-  box-shadow: 0 0 0 3px var(--color-accent-glow), var(--shadow-md) !important;
+  box-shadow: 0 0 0 3px var(--color-accent-glow), var(--shadow-md);
   transform: translateY(-1px);
 }
 @media (prefers-reduced-motion: reduce) {

--- a/apps/website/src/components/docs/DocsPrevNext.tsx
+++ b/apps/website/src/components/docs/DocsPrevNext.tsx
@@ -55,14 +55,9 @@ export function DocsPrevNext({ library, section, slug }: Props) {
         marginBottom: 16,
       }}
     >
-      <style>{`
-        [data-ui="docs-card"] { transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease; }
-        [data-ui="docs-card"]:hover { border-color: ${tokens.colors.accentBorderHover}; box-shadow: ${tokens.shadows.md}; transform: translateY(-1px); }
-        @media (prefers-reduced-motion: reduce) { [data-ui="docs-card"]:hover { transform: none; } }
-      `}</style>
       {prev ? (
         <Link href={prev.href} style={{ textDecoration: 'none' }}>
-          <Card padding="md" data-ui="docs-card" style={{ height: '100%' }}>
+          <Card padding="md" hoverable style={{ height: '100%' }}>
             <Eyebrow style={{ marginBottom: 8 }}>← Previous</Eyebrow>
             <div
               style={{
@@ -81,7 +76,7 @@ export function DocsPrevNext({ library, section, slug }: Props) {
       )}
       {next ? (
         <Link href={next.href} style={{ textDecoration: 'none' }}>
-          <Card padding="md" data-ui="docs-card" style={{ height: '100%', textAlign: 'right' }}>
+          <Card padding="md" hoverable style={{ height: '100%', textAlign: 'right' }}>
             <Eyebrow style={{ marginBottom: 8 }}>Next →</Eyebrow>
             <div
               style={{

--- a/apps/website/src/components/ui/Card.tsx
+++ b/apps/website/src/components/ui/Card.tsx
@@ -9,6 +9,9 @@ interface CardProps extends HTMLAttributes<HTMLDivElement> {
   children: ReactNode;
   /** If true, applies a subtle hover lift via CSS. */
   hoverable?: boolean;
+  /** If true (with hoverable), the hover lift uses an accent ring instead of
+   * the neutral border treatment — for accent-bordered cards. */
+  accent?: boolean;
   /** Internal padding tier. */
   padding?: Padding;
   /** Override the surface color. */
@@ -29,6 +32,7 @@ const PADDING: Record<Padding, string> = {
 export function Card({
   children,
   hoverable = false,
+  accent = false,
   padding = 'md',
   surface = 'white',
   className,
@@ -39,6 +43,7 @@ export function Card({
     <div
       data-ui="card"
       data-hoverable={hoverable || undefined}
+      data-accent={accent || undefined}
       className={cn(className)}
       style={{
         background: SURFACE[surface],

--- a/apps/website/src/components/ui/Card.tsx
+++ b/apps/website/src/components/ui/Card.tsx
@@ -7,22 +7,18 @@ type Padding = 'md' | 'lg';
 
 interface CardProps extends HTMLAttributes<HTMLDivElement> {
   children: ReactNode;
-  /** If true, applies a subtle hover lift via CSS. */
+  /** If true, applies a subtle hover lift (border + shadow + translate) via CSS. */
   hoverable?: boolean;
-  /** If true (with hoverable), the hover lift uses an accent ring instead of
-   * the neutral border treatment — for accent-bordered cards. */
+  /**
+   * If true, renders an accent-tinted surface + border, and — when hoverable —
+   * the hover lift uses an accent ring instead of the neutral border treatment.
+   */
   accent?: boolean;
   /** Internal padding tier. */
   padding?: Padding;
   /** Override the surface color. */
   surface?: Surface;
 }
-
-const SURFACE: Record<Surface, string> = {
-  white: tokens.surfaces.surface,
-  tinted: tokens.surfaces.surfaceTinted,
-  dim: tokens.surfaces.surfaceDim,
-};
 
 const PADDING: Record<Padding, string> = {
   md: '20px',
@@ -39,19 +35,21 @@ export function Card({
   style,
   ...rest
 }: CardProps) {
+  // Resting background / border / shadow live in the `[data-ui="card"]`
+  // stylesheet (apps/website/src/app/global.css) — never inline — so the
+  // :hover rules can actually override border-color and box-shadow. Inline
+  // styles beat any stylesheet :hover rule, which previously left the lift
+  // rendering only the transform.
   return (
     <div
       data-ui="card"
       data-hoverable={hoverable || undefined}
       data-accent={accent || undefined}
+      data-surface={surface !== 'white' ? surface : undefined}
       className={cn(className)}
       style={{
-        background: SURFACE[surface],
-        border: `1px solid ${tokens.surfaces.border}`,
         borderRadius: tokens.radius.lg,
-        boxShadow: tokens.shadows.sm,
         padding: PADDING[padding],
-        transition: 'box-shadow 160ms ease, border-color 160ms ease, transform 160ms ease',
         ...style,
       }}
       {...rest}


### PR DESCRIPTION
## Summary
Card's resting `border`/`box-shadow` were set as **inline styles**, which beat any stylesheet `:hover` rule — so every hoverable card (solutions, dev/primitives, docs prev/next, and the docs fork cards) only got the `translateY` lift, never the shadow/border change. The docs cards papered over this with ad-hoc `data-ui="docs-card"` scoped `<style>` blocks that hit the same inline-specificity wall.

**Root-cause fix (no `!important`):**
- Move Card's resting `background`/`border`/`box-shadow`/`transition` **out of inline** and into the `[data-ui="card"]` stylesheet. With nothing inline, the `:hover` rules win on specificity alone — no `!important` anywhere, and future states (focus, active) work for free.
- Drive surface via `data-surface` and the accent fill via `[data-ui="card"][data-accent]`.
- Add an `accent` prop to `Card`: accent cards render the accent-tinted surface + border and gain an **accent ring** (`0 0 0 3px accent-glow`) + shadow on hover; plain cards get the neutral `border-strong` + `shadow-md` lift.
- Replace the broken `data-ui="docs-card"` scoped `<style>` blocks on the docs landing and `DocsPrevNext` with the shared `hoverable`/`accent` mechanism, and delete the duplicated styles.

Follow-up to the docs polish work (#568/#573).

## Test Plan
- [x] `e2e/docs.spec.ts` — 8/8
- [x] `eslint` on changed files — clean
- [x] Real Playwright `hover()`: accent cards show the ring (`rgba(0,64,144,0.2) 0 0 0 3px` + `shadow-md`, accent border preserved, `translateY(-1px)`); plain cards get `border-strong` + `shadow-md`; resting states unchanged
- [x] SSR: card elements carry `data-accent`/`data-hoverable`/`data-surface` with inline style trimmed to `border-radius`/`padding` only (no border/shadow/bg) — nothing blocks hover
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
