### PR TITLE
docs(a2ui): quickstart + 3 guides + v1 alignment

### DIFF
--- a/apps/website/content/docs/a2ui/getting-started/quickstart.mdx
+++ b/apps/website/content/docs/a2ui/getting-started/quickstart.mdx
@@ -1,0 +1,95 @@
+# Quick Start
+
+Parse an A2UI stream, build its data model, and resolve a dynamic value — end to end, in a few minutes.
+
+`@threadplane/a2ui` is the protocol layer. It parses the JSONL message stream, gives you typed envelopes, and resolves dynamic values against a data model. It does not render anything. Rendering is `@threadplane/chat`'s [`<a2ui-surface>`](/docs/chat/getting-started/introduction). This library is what sits underneath it.
+
+## Goals
+
+By the end of this page you'll be able to:
+
+- Install `@threadplane/a2ui`.
+- Parse a newline-delimited A2UI stream into typed messages.
+- Build a plain data-model object with `setByPointer`.
+- Resolve a dynamic value with `resolveDynamic`.
+
+## Install
+
+```bash
+npm install @threadplane/a2ui
+```
+
+The package has no peer dependencies.
+
+## Parse a stream
+
+Let's start with a real stream. An agent emits A2UI as newline-delimited JSON — one envelope per line. Here's a booking form, in emission order: data first, then the component tree, then the signal to render.
+
+```text
+---a2ui_JSON---
+{"dataModelUpdate":{"surfaceId":"booking","contents":[{"key":"origin","valueString":"LAX"},{"key":"dest","valueString":"JFK"},{"key":"passengers","valueNumber":1}]}}
+{"surfaceUpdate":{"surfaceId":"booking","components":[{"id":"root","component":{"Column":{"children":{"explicitList":["title","origin","submit"]}}}},{"id":"title","component":{"Text":{"text":"Book a flight","usageHint":"h2"}}},{"id":"origin","component":{"MultipleChoice":{"label":"Origin","options":[{"label":"LAX","value":"LAX"},{"label":"JFK","value":"JFK"}],"selections":{"path":"/origin"},"maxAllowedSelections":1}}},{"id":"submit_label","component":{"Text":{"text":"Search flights"}}},{"id":"submit","component":{"Button":{"child":"submit_label","primary":true,"action":{"name":"bookingSubmit","context":[{"key":"origin","value":{"path":"/origin"}},{"key":"dest","value":{"path":"/dest"}}]}}}}]}}
+{"beginRendering":{"surfaceId":"booking","root":"root"}}
+```
+
+Feed each chunk to a parser. `push` returns the `A2uiMessage[]` it could complete from everything buffered so far.
+
+```ts
+import { createA2uiMessageParser } from '@threadplane/a2ui';
+
+const parser = createA2uiMessageParser();
+
+const messages = parser.push(
+  '{"beginRendering":{"surfaceId":"s1","root":"root"}}\n',
+);
+// messages -> 1 message: { beginRendering: { surfaceId: 's1', root: 'root' } }
+```
+
+The parser is line-oriented. A line is only parsed once a newline arrives, so partial JSON buffers until it's complete:
+
+```ts
+parser.push('{"beginRendering":');           // -> []  (incomplete, buffered)
+parser.push('{"surfaceId":"s1","root":"root"}}\n'); // -> 1 message
+```
+
+That buffering is deliberate. Agent output streams in fragments, and a half-finished line shouldn't throw mid-render.
+
+## Build the data model
+
+A `dataModelUpdate` carries `contents` — an array of typed entries, each with a `key` and one of `valueString` / `valueNumber` / `valueBoolean` / `valueMap`. The parser hands you those entries verbatim. Turning them into a plain object the resolver can read is your code.
+
+For the booking stream that's three entries: `origin`, `dest`, `passengers`. `setByPointer` builds the object immutably — each call returns a new object, the input is untouched.
+
+```ts
+import { setByPointer } from '@threadplane/a2ui';
+
+let model: Record<string, unknown> = {};
+model = setByPointer(model, '/origin', 'LAX');
+model = setByPointer(model, '/dest', 'JFK');
+model = setByPointer(model, '/passengers', 1);
+// model -> { origin: 'LAX', dest: 'JFK', passengers: 1 }
+```
+
+To be clear: assembling the model from `contents` (reading `valueString` vs `valueNumber`, honoring the entry's optional `path`, recursing into `valueMap`) is the caller's job. This library gives you the pointer helpers; it doesn't ship a `contents` -> object reducer. The [data model guide](/docs/a2ui/guides/data-model) covers the helpers in depth.
+
+## Resolve a value
+
+A component's props can be literals or path references. `resolveDynamic` collapses both against the model.
+
+```ts
+import { resolveDynamic } from '@threadplane/a2ui';
+
+resolveDynamic({ path: '/origin' }, model);       // "LAX"
+resolveDynamic({ literalString: 'Search flights' }, model); // "Search flights"
+resolveDynamic({ path: '/missing' }, model);      // undefined
+```
+
+A literal wrapper unwraps to its value. A `{ path }` reads from the model by JSON-Pointer. A missing path resolves to `undefined` rather than throwing — same conservative posture as the parser.
+
+## Conclusion
+
+That's the full loop: stream in, model built, value resolved. From here, the three guides go deeper:
+
+- [The A2UI message protocol](/docs/a2ui/guides/message-protocol) — surfaces, components, dynamic values, and the four envelopes.
+- [Working with the data model](/docs/a2ui/guides/data-model) — the pointer helpers, immutability, and scopes.
+- [Validating and adapting an A2UI stream](/docs/a2ui/guides/adapters-and-validation) — guards, test payloads, and custom renderers.

--- a/apps/website/content/docs/a2ui/guides/adapters-and-validation.mdx
+++ b/apps/website/content/docs/a2ui/guides/adapters-and-validation.mdx
@@ -1,0 +1,107 @@
+# Validating and adapting an A2UI stream
+
+Take a streaming agent response, turn it into typed A2UI messages, narrow the dynamic values, and feed a renderer — with the right amount of validation for your trust level.
+
+`@threadplane/a2ui` is the protocol layer beneath any A2UI integration. This guide shows how to consume a stream, guard the values, build test payloads, and back a custom renderer.
+
+## Consume a streaming response
+
+The parser is fed-by-chunk and line-oriented. Hand each chunk of the response to `push`; it returns the `A2uiMessage[]` it could complete from everything buffered so far.
+
+```ts
+import { createA2uiMessageParser } from '@threadplane/a2ui';
+
+const parser = createA2uiMessageParser();
+
+for await (const chunk of streamChunks) {
+  for (const message of parser.push(chunk)) {
+    applyToSurfaceStore(message);
+  }
+}
+```
+
+The posture (straight from `parser.ts`) is conservative fallback:
+
+- Malformed lines are skipped silently — partial JSONL is normal mid-stream.
+- Lines whose object has no known envelope key are ignored.
+- Incomplete JSON buffers until a newline arrives.
+
+That last point in practice:
+
+```ts
+parser.push('{"beginRendering":');                    // -> []  (buffers)
+parser.push('{"surfaceId":"s1","root":"root"}}\n');   // -> 1 message
+```
+
+A line is only attempted once its trailing newline lands, so a split-mid-value chunk never throws.
+
+## Validate and narrow values
+
+When you walk a component's props, you need to tell a literal from a path reference. The package exports four guards:
+
+```ts
+import {
+  isPathRef,
+  isLiteralString,
+  isLiteralNumber,
+  isLiteralBoolean,
+} from '@threadplane/a2ui';
+
+isPathRef({ path: '/x' });               // true
+isLiteralString({ literalString: 'x' }); // true
+```
+
+<Callout type="warning" title="There is no isLiteralArray">
+The package exports `isPathRef`, `isLiteralString`, `isLiteralNumber`, and `isLiteralBoolean` — and no array guard. `resolveDynamic` unwraps `literalArray` internally, but there's no exported predicate for it. If you need to detect a `literalArray` shape yourself, check for the `literalArray` key directly.
+</Callout>
+
+For most rendering you don't branch on guards at all — `resolveDynamic` already handles literals, paths, arrays, and passthrough in one call. Reach for the guards when you need to *narrow a type* or make a decision before resolving.
+
+## Build payloads for tests
+
+The cleanest way to test an adapter is to drive the real parser with assembled lines, then assert the envelope kinds. This mirrors the parser's own multi-message test.
+
+```ts
+import { createA2uiMessageParser } from '@threadplane/a2ui';
+
+const parser = createA2uiMessageParser();
+
+const chunk = [
+  JSON.stringify({ surfaceUpdate: { surfaceId: 's1', components: [] } }),
+  JSON.stringify({ dataModelUpdate: { surfaceId: 's1', contents: [] } }),
+  JSON.stringify({ beginRendering: { surfaceId: 's1', root: 'root' } }),
+].join('\n') + '\n';
+
+const messages = parser.push(chunk);
+
+messages.map(m => Object.keys(m)[0]);
+// ['surfaceUpdate', 'dataModelUpdate', 'beginRendering']
+```
+
+Each `A2uiMessage` is a single-key envelope object, so `Object.keys(m)[0]` is the envelope kind — handy for assertions.
+
+## Build a custom renderer
+
+To render a surface, resolve each component's props against the surface's data model and emit your own UI. The resolver does the literal/path collapsing:
+
+```ts
+import { resolveDynamic } from '@threadplane/a2ui';
+
+function renderText(props: { text: unknown }, model: Record<string, unknown>) {
+  const text = resolveDynamic(props.text, model); // literal or path -> string
+  return makeTextNode(text);
+}
+```
+
+The full mechanics — component resolution, event dispatch, action emission, surface store — are exactly what Threadplane's own Angular renderer, `@threadplane/chat`'s [`<a2ui-surface>`](/docs/chat/getting-started/introduction), already implements. If you're on Angular, use it rather than re-deriving it. A custom renderer makes sense when you're on another platform or have rendering needs the component doesn't cover.
+
+## A tradeoff: the parser swallows parse errors
+
+For me, the parser's silent-skip behavior is the right default — it's what lets a half-streamed line not blow up a live render, and it's why feeding raw agent output Just Works. The cost is honest: the parser is not a validator. It will quietly drop a malformed line and ignore an unknown envelope, so a structurally-wrong payload simply produces fewer messages, not an error you can catch.
+
+So the rule of thumb: if you need strictness, validate the parsed `A2uiMessage[]` *after* `push` returns — assert the envelope kinds and shapes you expect, rather than counting on the parser to reject bad input. The parser optimizes for streaming resilience; strict validation is your boundary's job.
+
+## Next
+
+- [Quick Start](/docs/a2ui/getting-started/quickstart) — the parse / build / resolve loop end to end.
+- [The A2UI message protocol](/docs/a2ui/guides/message-protocol) — surfaces, components, envelopes, and actions.

--- a/apps/website/content/docs/a2ui/guides/data-model.mdx
+++ b/apps/website/content/docs/a2ui/guides/data-model.mdx
@@ -1,0 +1,112 @@
+# Working with the data model
+
+A surface's data lives in a plain object, and you read and write it through three pointer helpers plus a resolver. This guide covers all four.
+
+The data model is just a `Record<string, unknown>`. A2UI components reference into it by JSON-Pointer-style path; `@threadplane/a2ui` gives you the helpers to read, write, and resolve against it.
+
+## The pointer helpers
+
+`getByPointer`, `setByPointer`, and `deleteByPointer` all take a model and a pointer string (`/user/name`, `/items/1`).
+
+`getByPointer` walks the path and returns the value, or `undefined` if any segment is missing:
+
+```ts
+import { getByPointer } from '@threadplane/a2ui';
+
+getByPointer({ items: ['a', 'b', 'c'] }, '/items/1'); // "b"
+```
+
+`setByPointer` writes immutably. It returns a clone with the change applied; the original is untouched.
+
+```ts
+import { setByPointer } from '@threadplane/a2ui';
+
+const original = { user: { name: 'Alice', age: 30 } };
+const next = setByPointer(original, '/user/name', 'Bob');
+
+next.user.name;     // "Bob"
+original.user.name; // "Alice" — unchanged
+```
+
+It also creates intermediate objects along the way, so you don't have to pre-build nesting:
+
+```ts
+setByPointer({}, '/a/b/c', 42); // { a: { b: { c: 42 } } }
+```
+
+`deleteByPointer` removes a key, again immutably:
+
+```ts
+import { deleteByPointer } from '@threadplane/a2ui';
+
+deleteByPointer({ a: 1, b: 2 }, '/a'); // { b: 2 }
+```
+
+If the parent of the target doesn't exist, `deleteByPointer` returns the original model unchanged rather than fabricating a path to delete from.
+
+<Callout type="warning" title="No RFC-6901 escaping">
+These helpers use JSON-Pointer-style syntax but do **not** implement RFC 6901's `~0` / `~1` unescaping. A path is split on `/` and the segments are used as literal keys. So keys that themselves contain `/` or `~` aren't addressable — there's no escape sequence to reach them.
+</Callout>
+
+## Resolving dynamic values
+
+`resolveDynamic` collapses a component's prop to a concrete value against the model. The order is fixed:
+
+1. `null` / `undefined` pass through as-is.
+2. Arrays are mapped recursively — each element resolved in turn.
+3. Literal wrappers unwrap first: `literalString`, `literalNumber`, `literalBoolean`, `literalArray`.
+4. A `{ path }` reference reads from the model.
+5. Anything else — a plain string, number, or unrecognized object — passes through unchanged.
+
+```ts
+import { resolveDynamic } from '@threadplane/a2ui';
+
+const model = { name: 'Brian', count: 7, active: true, tags: ['a', 'b'] };
+
+resolveDynamic({ literalString: 'hello' }, model); // "hello"
+resolveDynamic({ path: '/name' }, model);          // "Brian"
+resolveDynamic({ path: '/tags/0' }, model);        // "a"
+resolveDynamic({ path: '/missing' }, model);       // undefined
+```
+
+A missing path resolves to `undefined`, never an error. That keeps a half-streamed surface renderable while data is still arriving.
+
+## Scopes and template children
+
+How do you resolve a relative path, like inside a repeated template row?
+
+`resolveDynamic` takes an optional third argument, an `A2uiScope`:
+
+```ts
+export interface A2uiScope {
+  basePath: string;
+  item: unknown;
+}
+```
+
+Path resolution depends on the leading slash:
+
+- An **absolute** path (`/name`) always resolves from the model root, scope or not.
+- A **relative** path (`name`) resolves against `scope.basePath` when a scope is given.
+
+```ts
+resolveDynamic({ path: 'name' }, model, { basePath: '', item: undefined }); // "Brian"
+```
+
+With `basePath: ''`, the relative path `name` resolves to `/name`. That's the lever the `template` / `dataBinding` pattern pulls. When a container repeats a template over the array at, say, `/items`, it resolves each instance's props with a per-item scope:
+
+```ts
+items.forEach((_, i) => {
+  const scope = { basePath: `/items/${i}`, item: items[i] };
+  // a child prop of { path: 'label' } now resolves to /items/{i}/label
+  resolveDynamic({ path: 'label' }, model, scope);
+});
+```
+
+<Callout type="warning" title="scope.item is informational">
+`A2uiScope` carries an `item` field, but the resolver only reads `basePath` to rewrite relative paths. `item` is typed for callers that want the bound element on hand, yet `resolveDynamic` itself never touches it. Don't expect setting `item` to change resolution.
+</Callout>
+
+## Next
+
+- [Validating and adapting an A2UI stream](/docs/a2ui/guides/adapters-and-validation) — guards, test payloads, and wiring a custom renderer.

--- a/apps/website/content/docs/a2ui/guides/message-protocol.mdx
+++ b/apps/website/content/docs/a2ui/guides/message-protocol.mdx
@@ -1,0 +1,126 @@
+# The A2UI message protocol
+
+A2UI is a declarative, streamed wire format: the agent describes a UI, sends it as newline-delimited JSON, and the client renders it and ships actions back.
+
+This page walks the shapes. Everything here is what `@threadplane/a2ui` types and parses; rendering belongs to `@threadplane/chat`'s [`<a2ui-surface>`](/docs/chat/getting-started/introduction).
+
+## What's a surface?
+
+A surface is one self-contained unit of UI. It owns its own component set and its own data model, and it's addressed by a `surfaceId`.
+
+Every envelope carries that `surfaceId`. A `dataModelUpdate` for `"booking"` only touches the `booking` surface's data; a `surfaceUpdate` for `"booking"` only defines its components. One stream can drive several surfaces in parallel, kept separate by id.
+
+## How are components described?
+
+As an **id-keyed adjacency list**. A `surfaceUpdate` carries a flat `components` array. Each entry has an `id` and a single `component` definition. Parent-child links are by id reference, not by nesting.
+
+```json
+{"surfaceUpdate":{"surfaceId":"booking","components":[{"id":"root","component":{"Column":{"children":{"explicitList":["title","origin","submit"]}}}},{"id":"title","component":{"Text":{"text":"Book a flight","usageHint":"h2"}}}]}}
+```
+
+The `component` value is a **keyed union**: a single-key object where the key names the component type and the value holds its props — `{ "<Name>": { props } }`. `{ "Text": { ... } }` is a Text, `{ "Column": { ... } }` is a Column. There's no separate `type` field; the key *is* the type.
+
+Containers reference their children with `A2uiChildren`, which has two forms:
+
+- `explicitList` — a fixed array of child ids, in order.
+
+  ```json
+  {"children":{"explicitList":["title","origin","submit"]}}
+  ```
+
+- `template` — one component repeated per item in a bound array.
+
+  ```json
+  {"children":{"template":{"componentId":"rowTemplate","dataBinding":"/items"}}}
+  ```
+
+  The container instantiates `componentId` once per element of the array at `dataBinding`. Each instance resolves its dynamic values against that element. The [data model guide](/docs/a2ui/guides/data-model) covers how that per-item resolution works.
+
+## What's a dynamic value?
+
+A prop that's either a literal baked into the message or a reference into the data model.
+
+In v1 the canonical form for a literal is a wrapper object, matched to the prop's type:
+
+- `{ literalString: "..." }`
+- `{ literalNumber: 7 }`
+- `{ literalBoolean: true }`
+- `{ literalArray: ["a", "b"] }`
+
+A reference is `{ path: "/origin" }` — a JSON-Pointer into the surface's data model.
+
+```json
+{"Text":{"text":{"literalString":"Book a flight"}}}
+{"Text":{"text":{"path":"/headline"}}}
+```
+
+A raw string in a value slot (`"text": "Book a flight"`) is tolerated — `resolveDynamic` passes plain values through unchanged — but the wrapper is the canonical shape. Prefer the wrapper when you author messages; rely on passthrough only when consuming.
+
+<Callout type="info">
+There's no `isLiteralArray` guard exported from this package. The resolver unwraps `literalArray` internally, and you get `isLiteralString`, `isLiteralNumber`, `isLiteralBoolean`, and `isPathRef` as exported guards — but not one for arrays. See [Validating and adapting](/docs/a2ui/guides/adapters-and-validation).
+</Callout>
+
+## What are the four envelopes?
+
+The stream is a sequence of single-key envelope objects. The parser recognizes exactly four keys; anything else is ignored.
+
+### `surfaceUpdate`
+
+Defines (or replaces) the components for a surface.
+
+```json
+{"surfaceUpdate":{"surfaceId":"booking","components":[{"id":"submit_label","component":{"Text":{"text":"Search flights"}}},{"id":"submit","component":{"Button":{"child":"submit_label","primary":true,"action":{"name":"bookingSubmit","context":[{"key":"origin","value":{"path":"/origin"}},{"key":"dest","value":{"path":"/dest"}}]}}}}]}}
+```
+
+### `dataModelUpdate`
+
+Sets data for a surface. `contents` is an array of typed entries — each has a `key` and one of `valueString`, `valueNumber`, `valueBoolean`, or `valueMap` (a nested array of entries). An optional top-level `path` scopes where the entries land.
+
+```json
+{"dataModelUpdate":{"surfaceId":"booking","contents":[{"key":"origin","valueString":"LAX"},{"key":"dest","valueString":"JFK"},{"key":"passengers","valueNumber":1}]}}
+```
+
+### `beginRendering`
+
+Names the `root` component id for the surface — the entry point the renderer mounts. It may also carry `styles` (`font`, `primaryColor`).
+
+```json
+{"beginRendering":{"surfaceId":"booking","root":"root"}}
+```
+
+### `deleteSurface`
+
+Tears a surface down by id.
+
+```json
+{"deleteSurface":{"surfaceId":"booking"}}
+```
+
+In the booking stream the order is `dataModelUpdate` -> `surfaceUpdate` -> `beginRendering`: data ready, tree defined, then render.
+
+## How do actions go back?
+
+A user interacts — clicks the Button — and the client sends an `A2uiActionMessage` back to the agent. The version is `v1`.
+
+```json
+{"version":"v1","action":{"name":"bookingSubmit","surfaceId":"booking","sourceComponentId":"submit","timestamp":"2026-06-05T12:34:56.789Z","context":{"origin":{"literalString":"LAX"},"dest":{"literalString":"JFK"}},"label":"Search flights"}}
+```
+
+Two details worth pinning down, because the inbound and outbound shapes differ:
+
+- **Context flips from list to map.** The inbound Button's `action.context` is a *list* of `{ key, value }` entries, where each `value` is still a dynamic value (often a `{ path }`). The outbound message's `action.context` is a *map* keyed by those keys, with each value already a wrapped literal — the path references resolved against the current model and re-wrapped (here `{ path: '/origin' }` became `{ literalString: 'LAX' }`).
+- **`label` is derived.** It comes from the source component's authored text — for a Button-with-Text-child, the child Text's literal string ("Search flights"). It's optional; the transcript renderer uses it to label the user bubble, and backends may ignore it.
+
+The client's current data model is only attached as `metadata.a2uiClientDataModel` when the surface opts in. It's omitted otherwise.
+
+## Relationship to Google's A2UI
+
+Threadplane implements Google's open [A2UI protocol](https://a2ui.org) ([source](https://github.com/google/A2UI)) — the same declarative, catalog-based model: surfaces, a per-surface data model, dynamic values (literals vs paths), and outbound actions.
+
+Threadplane's implementation version is `v1` — the value you'll see in `A2uiActionMessage` and `A2uiClientDataModel`. That's *our* version tag. It does not claim numbering parity with any particular Google release. Treat `v1` as the Threadplane wire contract, and the linked spec as the conceptual reference.
+
+## Next
+
+- [Working with the data model](/docs/a2ui/guides/data-model) — pointers, immutability, and template scopes.
+- [Validating and adapting an A2UI stream](/docs/a2ui/guides/adapters-and-validation) — guards and test payloads.
+- Rendering these surfaces in Angular: [`<a2ui-surface>`](/docs/chat/getting-started/introduction) in `@threadplane/chat`.

--- a/apps/website/content/docs/a2ui/reference/schema.mdx
+++ b/apps/website/content/docs/a2ui/reference/schema.mdx
@@ -186,13 +186,14 @@ When a rendered surface sends an action back to the agent, the typed outbound sh
 
 ```ts
 interface A2uiActionMessage {
-  version: 'v0.9';
+  version: 'v1';
   action: {
     name: string;
     surfaceId: string;
     sourceComponentId: string;
     timestamp: string;
     context: Record<string, unknown>;
+    label?: string;
   };
   metadata?: {
     a2uiClientDataModel: A2uiClientDataModel;
@@ -200,4 +201,4 @@ interface A2uiActionMessage {
 }
 ```
 
-The outbound action version is currently typed as `v0.9` in source.
+The outbound action version is `v1`. The optional `label` is a human-readable label derived from the source component's text (for example, a Button's child Text), used to describe the action in transcripts; backends may ignore it.

--- a/apps/website/content/docs/render/a2ui/catalog.mdx
+++ b/apps/website/content/docs/render/a2ui/catalog.mdx
@@ -159,7 +159,7 @@ Renders a button that dispatches an action when clicked.
 **Action types:**
 
 ```json
-// Emit a named event with resolved context (sent back to the agent as v0.9 action)
+// Emit a named event with resolved context (sent back to the agent as v1 action)
 {"action": {"event": {"name": "submit", "context": {"email": {"path": "/email"}, "formId": "contact"}}}}
 
 // Execute a local function (e.g., open a URL) — agent never sees this

--- a/apps/website/content/docs/render/a2ui/overview.mdx
+++ b/apps/website/content/docs/render/a2ui/overview.mdx
@@ -193,7 +193,7 @@ In the render-spec compatibility path, `surfaceToSpec()` turns this into a rende
 
 ```json
 {
-  "version": "v0.9",
+  "version": "v1",
   "action": {
     "name": "formSubmit",
     "surfaceId": "contact",

--- a/apps/website/content/docs/render/concepts/json-render-vs-a2ui.mdx
+++ b/apps/website/content/docs/render/concepts/json-render-vs-a2ui.mdx
@@ -15,7 +15,7 @@ This matters because the tradeoff is not "which renderer is better." The tradeof
   renders a Spec using an Angular registry, state store, functions, and handlers
 
 @threadplane/a2ui
-  defines A2UI v0.9 message and component types
+  defines A2UI v1 message and component types
 
 @threadplane/chat
   detects assistant content, manages streaming state, and mounts render or A2UI surfaces
@@ -166,7 +166,7 @@ A2UI actions produce `A2uiActionMessage` objects:
 
 ```ts
 interface A2uiActionMessage {
-  version: 'v0.9';
+  version: 'v1';
   action: {
     name: string;
     surfaceId: string;

--- a/apps/website/e2e/docs.spec.ts
+++ b/apps/website/e2e/docs.spec.ts
@@ -95,6 +95,22 @@ test.describe('Docs slug page', () => {
   });
 });
 
+test.describe('a2ui docs', () => {
+  test('quickstart renders with sidebar + article', async ({ page }) => {
+    await page.goto('/docs/a2ui/getting-started/quickstart');
+    await expect(page.locator('aside').first()).toBeVisible();
+    await expect(page.locator('article').first()).toBeVisible();
+    await expect(page.locator('article h1').first()).toContainText('Quick Start');
+  });
+
+  test('sidebar lists the new guides', async ({ page }) => {
+    await page.goto('/docs/a2ui/getting-started/quickstart');
+    await expect(page.locator('aside').getByText('Message Protocol').first()).toBeVisible();
+    await expect(page.locator('aside').getByText('Data Model').first()).toBeVisible();
+    await expect(page.locator('aside').getByText('Validating & Adapting').first()).toBeVisible();
+  });
+});
+
 test.describe('Docs search', () => {
   test('Cmd+K opens the search modal', async ({ page, browserName }) => {
     await page.goto('/docs/langgraph/getting-started/introduction');

--- a/apps/website/src/lib/docs-config.ts
+++ b/apps/website/src/lib/docs-config.ts
@@ -276,6 +276,17 @@ export const docsConfig: DocsLibrary[] = [
         color: 'blue',
         pages: [
           { title: 'Introduction', slug: 'introduction', section: 'getting-started' },
+          { title: 'Quick Start', slug: 'quickstart', section: 'getting-started' },
+        ],
+      },
+      {
+        title: 'Guides',
+        id: 'guides',
+        color: 'blue',
+        pages: [
+          { title: 'Message Protocol', slug: 'message-protocol', section: 'guides' },
+          { title: 'Data Model', slug: 'data-model', section: 'guides' },
+          { title: 'Validating & Adapting', slug: 'adapters-and-validation', section: 'guides' },
         ],
       },
       {

--- a/docs/superpowers/plans/2026-06-05-a2ui-docs-content.md
+++ b/docs/superpowers/plans/2026-06-05-a2ui-docs-content.md
@@ -1,0 +1,402 @@
+# a2ui Docs Fill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Quickstart and three guides to `@threadplane/a2ui` docs (plus a schema accuracy fix and a v0.9→v1 sweep), in Brian's technical-register voice, grounded entirely in the real API and the real cockpit booking-form example.
+
+**Architecture:** New MDX content pages under `apps/website/content/docs/a2ui/`, wired into the a2ui section of `docs-config.ts` (drives nav, routing, prev/next, search, llms-full). a2ui MDX pages have **no frontmatter** — the page title is the leading `# H1`. No new components.
+
+**Tech Stack:** Next.js MDX docs, TypeScript (`docs-config.ts`), Playwright (e2e), `@threadplane/a2ui` (the documented library).
+
+**Reference spec:** `docs/superpowers/specs/2026-06-05-a2ui-docs-content-design.md`
+
+**ACCURACY IS THE TOP PRIORITY.** Every code snippet and API claim must match `libs/a2ui/src` (entry `libs/a2ui/src/index.ts`; impl in `lib/parser.ts`, `lib/resolve.ts`, `lib/pointer.ts`, `lib/guards.ts`, `lib/types.ts`). Do not invent exports, message shapes, or behavior. When unsure, read the source. The maintainer reviews every page for accuracy + voice before merge.
+
+---
+
+## Grounding reference (use these verbatim — they are real)
+
+**Real A2UI stream** (booking form; emission order dataModelUpdate → surfaceUpdate → beginRendering; source `cockpit/chat/a2ui/python/src/graph.py`). Abbreviated form to use in pages:
+
+```text
+---a2ui_JSON---
+{"dataModelUpdate":{"surfaceId":"booking","contents":[{"key":"origin","valueString":"LAX"},{"key":"dest","valueString":"JFK"},{"key":"passengers","valueNumber":1}]}}
+{"surfaceUpdate":{"surfaceId":"booking","components":[{"id":"root","component":{"Column":{"children":{"explicitList":["title","origin","submit"]}}}},{"id":"title","component":{"Text":{"text":"Book a flight","usageHint":"h2"}}},{"id":"origin","component":{"MultipleChoice":{"label":"Origin","options":[{"label":"LAX","value":"LAX"},{"label":"JFK","value":"JFK"}],"selections":{"path":"/origin"},"maxAllowedSelections":1}}},{"id":"submit_label","component":{"Text":{"text":"Search flights"}}},{"id":"submit","component":{"Button":{"child":"submit_label","primary":true,"action":{"name":"bookingSubmit","context":[{"key":"origin","value":{"path":"/origin"}},{"key":"dest","value":{"path":"/dest"}}]}}}}]}}
+{"beginRendering":{"surfaceId":"booking","root":"root"}}
+```
+
+**Real outbound action** (`A2uiActionMessage`, `version: 'v1'`; from `graph.py` docstring + `build-action-message.ts`):
+
+```json
+{
+  "version": "v1",
+  "action": {
+    "name": "bookingSubmit",
+    "surfaceId": "booking",
+    "sourceComponentId": "submit",
+    "timestamp": "2026-06-05T12:34:56.789Z",
+    "context": { "origin": {"literalString": "LAX"}, "dest": {"literalString": "JFK"} },
+    "label": "Search flights"
+  }
+}
+```
+
+**Test-derived snippets** (verbatim from `libs/a2ui/src/lib/*.spec.ts`):
+
+```ts
+// parser — basic + partial stream
+const parser = createA2uiMessageParser();
+const msgs = parser.push('{"beginRendering":{"surfaceId":"s1","root":"root"}}\n'); // -> 1 message
+// partial: push without trailing newline buffers
+parser.push('{"beginRendering":');      // -> []
+parser.push('{"surfaceId":"s1","root":"root"}}\n'); // -> 1 message
+
+// resolveDynamic
+const model = { name: 'Brian', count: 7, active: true, tags: ['a', 'b'] };
+resolveDynamic({ literalString: 'hello' }, model);  // "hello"
+resolveDynamic({ path: '/name' }, model);           // "Brian"
+resolveDynamic({ path: '/missing' }, model);        // undefined
+resolveDynamic({ path: '/tags/0' }, model);         // "a"
+resolveDynamic({ path: 'name' }, model, { basePath: '', item: undefined }); // "Brian"
+
+// pointer helpers (immutable)
+const original = { user: { name: 'Alice', age: 30 } };
+const next = setByPointer(original, '/user/name', 'Bob');
+next.user.name;      // "Bob"
+original.user.name;  // "Alice" (unchanged)
+setByPointer({}, '/a/b/c', 42);            // creates intermediates
+getByPointer({ items: ['a','b','c'] }, '/items/1'); // "b"
+deleteByPointer({ a: 1, b: 2 }, '/a');     // { b: 2 }
+
+// guards
+isPathRef({ path: '/x' });          // true
+isLiteralString({ literalString: 'x' }); // true
+```
+
+**Exact public exports** (`libs/a2ui/src/index.ts`): types from `./lib/types`; `getByPointer, setByPointer, deleteByPointer`; `createA2uiMessageParser` (+ type `A2uiMessageParser`); `resolveDynamic` (+ type `A2uiScope`); guards `isLiteralString, isLiteralNumber, isLiteralBoolean, isPathRef`. **There is no exported `isLiteralArray`.** Package: `@threadplane/a2ui` v0.0.49.
+
+**Voice rules (every page):** title restated as a one-line lede; contractions; one thought per line; tutorial pages get `## Goals` + `## Conclusion` + "Let's" transitions; concept pages use H2-as-question; opinions flagged + paired with a tradeoff. **No emojis, no anecdotes, no hype.** Cross-link rendering to `@threadplane/chat` `<a2ui-surface>` where relevant (this lib is the protocol/parse/resolve layer).
+
+---
+
+## Task 1: Wire the new pages into docs-config
+
+**Files:**
+- Modify: `apps/website/src/lib/docs-config.ts` (the `a2ui` library object, ~lines 267-289)
+
+- [ ] **Step 1: Add Quick Start + a Guides section**
+
+Replace the `a2ui` library's `sections` array (Getting Started has only Introduction; there's a Reference section) so it becomes:
+
+```ts
+    sections: [
+      {
+        title: 'Getting Started',
+        id: 'getting-started',
+        color: 'blue',
+        pages: [
+          { title: 'Introduction', slug: 'introduction', section: 'getting-started' },
+          { title: 'Quick Start', slug: 'quickstart', section: 'getting-started' },
+        ],
+      },
+      {
+        title: 'Guides',
+        id: 'guides',
+        color: 'blue',
+        pages: [
+          { title: 'Message Protocol', slug: 'message-protocol', section: 'guides' },
+          { title: 'Data Model', slug: 'data-model', section: 'guides' },
+          { title: 'Validating & Adapting', slug: 'adapters-and-validation', section: 'guides' },
+        ],
+      },
+      {
+        title: 'Reference',
+        id: 'reference',
+        color: 'blue',
+        pages: [
+          { title: 'Schema', slug: 'schema', section: 'reference' },
+          { title: 'Parser, Resolver, and Guards', slug: 'parser-resolver-guards', section: 'reference' },
+        ],
+      },
+    ],
+```
+
+- [ ] **Step 2: Typecheck + lint**
+
+```bash
+cd /Users/blove/repos/angular-agent-framework
+npx eslint apps/website/src/lib/docs-config.ts
+npx tsc --noEmit -p apps/website/tsconfig.json 2>&1 | grep -E "docs-config" || echo "no new type errors in docs-config"
+```
+Expected: eslint exit 0; "no new type errors in docs-config".
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/website/src/lib/docs-config.ts
+git commit -m "docs(a2ui): add Quick Start + Guides nav entries"
+```
+
+(The five new slugs now resolve in routing/sidebar/prev-next/search; the next tasks add the MDX bodies. Until then those routes 404 on missing files — that's expected mid-plan.)
+
+---
+
+## Task 2: Quickstart page
+
+**Files:**
+- Create: `apps/website/content/docs/a2ui/getting-started/quickstart.mdx`
+
+- [ ] **Step 1: Write the page**
+
+Create the file. No frontmatter; first line is `# Quick Start`. Structure (author the connecting prose in-voice; the code blocks below are mandatory and verbatim-grounded):
+
+1. **Lede (one sentence):** "Parse an A2UI stream and read its resolved values with `@threadplane/a2ui`."
+2. One-paragraph scope note: this library is the protocol/parse/resolve layer; rendering A2UI in Angular is `@threadplane/chat`'s `<a2ui-surface>` (link `/docs/chat/getting-started/introduction`).
+3. `## Goals` — bullets: install; parse a JSONL stream; apply a data-model update with `setByPointer`; resolve a dynamic value with `resolveDynamic`.
+4. `## Install` — ```bash\nnpm install @threadplane/a2ui\n``` (note: no peer dependencies).
+5. `## Parse a stream` — "Let's" transition. Use the **real booking-form stream** (the abbreviated `---a2ui_JSON---` block from the grounding reference) and show:
+   ```ts
+   import { createA2uiMessageParser } from '@threadplane/a2ui';
+
+   const parser = createA2uiMessageParser();
+   const messages = parser.push(streamChunk); // A2uiMessage[]
+   ```
+   Explain: `push` returns the complete envelopes found so far; partial JSON without a trailing newline stays buffered (show the partial-stream snippet from grounding).
+6. `## Build the data model` — apply the `dataModelUpdate` contents into a plain object with `setByPointer` (show converting `{ key, valueString }` entries to `{ origin: 'LAX' }` and `setByPointer(model, '/origin', 'LAX')`). Keep it honest: the library gives you the pointer helpers; assembling the model from `contents` is your code.
+7. `## Resolve a value` — `resolveDynamic({ path: '/origin' }, model)` → `"LAX"`; `resolveDynamic({ literalString: 'Book a flight' }, model)` → `"Book a flight"`. Use the resolve snippet from grounding.
+8. `## Conclusion` — one paragraph; link onward: Message Protocol (`/docs/a2ui/guides/message-protocol`), Data Model (`/docs/a2ui/guides/data-model`), Validating & Adapting (`/docs/a2ui/guides/adapters-and-validation`).
+
+Accuracy constraints: only the real exports; `version: 'v1'`; do not show `isLiteralArray`; do not claim the library renders or mutates state for you.
+
+- [ ] **Step 2: Verify it renders**
+
+```bash
+cd /Users/blove/repos/angular-agent-framework
+lsof -ti tcp:3000 >/dev/null 2>&1 || (export PATH=/Users/blove/.nvm/versions/node/v22.14.0/bin:$PATH && npx nx serve website --port 3000 > /tmp/wd-a2ui.log 2>&1 &)
+sleep 25
+curl -s -o /dev/null -w "quickstart HTTP %{http_code}\n" http://localhost:3000/docs/a2ui/getting-started/quickstart
+```
+Expected: HTTP 200.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/website/content/docs/a2ui/getting-started/quickstart.mdx
+git commit -m "docs(a2ui): add quickstart guide"
+```
+
+---
+
+## Task 3: Guide — The A2UI message protocol
+
+**Files:**
+- Create: `apps/website/content/docs/a2ui/guides/message-protocol.mdx`
+
+- [ ] **Step 1: Write the page**
+
+First line `# The A2UI message protocol`. Concept register, H2-as-question. Sections (prose in-voice; facts below are mandatory and exact):
+
+1. Lede: one sentence ("The A2UI wire format is four JSON-lines envelopes that build and update a surface.").
+2. `## What's a surface?` — an independent UI region with its own component set and its own data model; every envelope targets one via `surfaceId`.
+3. `## How are components shaped?` — an **id-keyed adjacency list**, not a nested tree. The keyed-union shape `{ "<Name>": { ...props } }` (e.g. `{ "Text": { "text": "Book a flight" } }`). Children: `{ explicitList: string[] }` or `{ template: { componentId, dataBinding } }`. Use real components from the booking stream (Column, Text, MultipleChoice, Button).
+4. `## What are dynamic values?` — literal wrappers (`literalString`, `literalNumber`, `literalBoolean`, `literalArray`) vs path refs (`{ path: '/origin' }`). Note the booking stream's `"text":"Book a flight"` raw-string shorthand is also accepted, but the canonical form is the wrapper.
+5. `## The four envelopes` — one short subsection each, each with a real JSON example sliced from the booking stream:
+   - `surfaceUpdate` — components for a surface (buffered until rendering begins).
+   - `dataModelUpdate` — typed `contents` entries (`valueString`/`valueNumber`/`valueBoolean`/`valueMap`), optional JSON-pointer `path`.
+   - `beginRendering` — names the `root` id; optional `styles` (`font`, `primaryColor`).
+   - `deleteSurface` — tears a surface down.
+6. `## Sending actions back` — the `A2uiActionMessage` (**`version: 'v1'`**). Use the real outbound action JSON from grounding. Note: inbound Button `action.context` is a **list** of `{ key, value }`; the outbound message's `context` is a **map** of wrapped literals — that asymmetry is real (from `build-action-message.ts`). Note `label` is derived from the button's text, and `metadata.a2uiClientDataModel` is attached only when the surface opts in.
+7. `## Relationship to Google's A2UI` — accurate, short: Threadplane implements Google's open **A2UI** protocol (declarative, catalog-based; surfaces, per-surface data model, dynamic values, outbound actions). Threadplane's implementation version is **v1**. Link `https://a2ui.org` and `https://github.com/google/A2UI`. Do **not** claim numbering parity with Google's v0.8/v0.9.
+8. Close: forward link to Data Model + Validating & Adapting; rendering link to `@threadplane/chat`.
+
+- [ ] **Step 2: Verify it renders**
+
+```bash
+curl -s -o /dev/null -w "message-protocol HTTP %{http_code}\n" http://localhost:3000/docs/a2ui/guides/message-protocol
+```
+Expected: HTTP 200.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/website/content/docs/a2ui/guides/message-protocol.mdx
+git commit -m "docs(a2ui): add message protocol guide"
+```
+
+---
+
+## Task 4: Guide — Working with the data model
+
+**Files:**
+- Create: `apps/website/content/docs/a2ui/guides/data-model.mdx`
+
+- [ ] **Step 1: Write the page**
+
+First line `# Working with the data model`. Task register. Sections (use the pointer/resolve snippets from grounding verbatim):
+
+1. Lede: one sentence ("The data model is plain JSON; `@threadplane/a2ui` gives you pointer helpers and a resolver to read and update it.").
+2. `## Reading and writing with pointers` — `getByPointer` / `setByPointer` / `deleteByPointer`. Cover, with the grounding snippets:
+   - JSON-Pointer-style paths (`/user/name`, `/items/1`).
+   - **Immutability**: `set`/`delete` return a structurally-shared clone; the original is untouched (show the `original.user.name === 'Alice'` example).
+   - `set` creates intermediate objects for missing segments.
+   - `delete` on a missing parent returns the original model unchanged.
+   - **Caveat** (flag with a `Callout type="warning"`): no RFC-6901 `~0`/`~1` unescaping — keys with `/` or `~` aren't supported.
+3. `## Resolving dynamic values` — `resolveDynamic(value, model, scope?)`: literals unwrapped first, then `{ path }`; arrays mapped recursively; plain values passed through; missing paths → `undefined`. Use the resolve snippet.
+4. `## Scopes and template children` — `A2uiScope` (`{ basePath, item }`). Relative paths resolve against `basePath`; absolute (`/…`) from the root. Show the `template`/`dataBinding` per-item pattern conceptually (each item resolved with `basePath: \`${arrayPath}/${i}\``). Flag honestly: `scope.item` is part of the type but the resolver only reads `basePath`.
+5. Close: forward link to Validating & Adapting.
+
+- [ ] **Step 2: Verify it renders**
+
+```bash
+curl -s -o /dev/null -w "data-model HTTP %{http_code}\n" http://localhost:3000/docs/a2ui/guides/data-model
+```
+Expected: HTTP 200.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/website/content/docs/a2ui/guides/data-model.mdx
+git commit -m "docs(a2ui): add data model guide"
+```
+
+---
+
+## Task 5: Guide — Validating and adapting an A2UI stream
+
+**Files:**
+- Create: `apps/website/content/docs/a2ui/guides/adapters-and-validation.mdx`
+
+- [ ] **Step 1: Write the page**
+
+First line `# Validating and adapting an A2UI stream`. Task register. Sections:
+
+1. Lede: one sentence ("Use `@threadplane/a2ui` to consume, validate, and test A2UI payloads — or to build your own renderer on top of the protocol.").
+2. `## Consume a streaming response` — feed chunks to `parser.push`; the parser's conservative-fallback posture, quoted accurately from `parser.ts`: malformed lines are skipped, unknown envelope keys are ignored, partial JSON buffers until a newline. Use the partial-stream snippet.
+3. `## Validate and narrow payloads` — the exported guards `isPathRef`, `isLiteralString`, `isLiteralNumber`, `isLiteralBoolean` (show the guard snippet). State plainly there is **no** `isLiteralArray` guard.
+4. `## Build payloads for tests` — assemble a `surfaceUpdate` + `dataModelUpdate` + `beginRendering` sequence against the exported types for a unit test (mirror the parser test: push the three lines, assert envelope kinds). This is how to test an emitter.
+5. `## Build a custom renderer` — resolve props with `resolveDynamic` + the data model; this library is the layer a renderer builds on. Note the Threadplane Angular renderer is `@threadplane/chat`'s `<a2ui-surface>` (link) — point there rather than re-documenting rendering.
+6. `## A tradeoff worth knowing` — flagged opinion: the parser intentionally swallows JSON parse errors (great for mid-stream partials), so if you need strict validation, do it on the parsed `A2uiMessage[]`, not by expecting the parser to throw.
+7. Close: link back to Quickstart + Message Protocol.
+
+- [ ] **Step 2: Verify it renders**
+
+```bash
+curl -s -o /dev/null -w "adapters HTTP %{http_code}\n" http://localhost:3000/docs/a2ui/guides/adapters-and-validation
+```
+Expected: HTTP 200.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/website/content/docs/a2ui/guides/adapters-and-validation.mdx
+git commit -m "docs(a2ui): add validating & adapting guide"
+```
+
+---
+
+## Task 6: Schema accuracy fix + v0.9→v1 sweep
+
+**Files:**
+- Modify: `apps/website/content/docs/a2ui/reference/schema.mdx`
+- Modify: `apps/website/content/docs/render/a2ui/overview.mdx`
+- Modify: `apps/website/content/docs/render/a2ui/catalog.mdx`
+- Modify: `apps/website/content/docs/render/concepts/json-render-vs-a2ui.mdx`
+
+- [ ] **Step 1: Fix schema.mdx version + add the label field**
+
+In `apps/website/content/docs/a2ui/reference/schema.mdx`:
+- Change the `version: 'v0.9';` line (≈ line 189) in the `A2uiActionMessage` code block to `version: 'v1';`.
+- Change the sentence "The outbound action version is currently typed as `v0.9` in source." (≈ line 203) to "The outbound action version is `v1`."
+- In the `A2uiActionMessage.action` shape, add the optional field `label?: string;` (present in `libs/a2ui/src/lib/types.ts`). Place it after `context` with a one-line note that it's an optional human-readable label derived from the source component.
+
+- [ ] **Step 2: Sweep the remaining v0.9 references**
+
+For each of `render/a2ui/overview.mdx`, `render/a2ui/catalog.mdx`, `render/concepts/json-render-vs-a2ui.mdx`: read each `v0.9` occurrence in context. If it refers to the Threadplane action-message/version, change it to `v1`. If it is explicitly citing Google's upstream protocol version, leave it accurate to Google (do not blanket-replace). Run to find them:
+```bash
+grep -rn "v0.9\|v0_9" apps/website/content/docs/render
+```
+Make the contextual edits accordingly.
+
+- [ ] **Step 3: Verify no stray Threadplane-version v0.9 remains + pages render**
+
+```bash
+cd /Users/blove/repos/angular-agent-framework
+grep -rn "version.*v0.9\|v0.9.*in source" apps/website/content/docs/a2ui apps/website/content/docs/render || echo "no stale Threadplane-version v0.9 refs"
+curl -s -o /dev/null -w "schema HTTP %{http_code}\n" http://localhost:3000/docs/a2ui/reference/schema
+```
+Expected: no stale refs; schema HTTP 200.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/website/content/docs/a2ui/reference/schema.mdx apps/website/content/docs/render/a2ui/overview.mdx apps/website/content/docs/render/a2ui/catalog.mdx apps/website/content/docs/render/concepts/json-render-vs-a2ui.mdx
+git commit -m "docs(a2ui): align action message version on v1"
+```
+
+---
+
+## Task 7: e2e + full verification
+
+**Files:**
+- Modify: `apps/website/e2e/docs.spec.ts`
+
+- [ ] **Step 1: Add an a2ui-docs e2e test**
+
+In `apps/website/e2e/docs.spec.ts`, add a new describe block:
+
+```ts
+test.describe('a2ui docs', () => {
+  test('quickstart renders with sidebar + article', async ({ page }) => {
+    await page.goto('/docs/a2ui/getting-started/quickstart');
+    await expect(page.locator('aside').first()).toBeVisible();
+    await expect(page.locator('article').first()).toBeVisible();
+    await expect(page.locator('article h1').first()).toContainText('Quick Start');
+  });
+
+  test('sidebar lists the new guides', async ({ page }) => {
+    await page.goto('/docs/a2ui/getting-started/quickstart');
+    await expect(page.locator('aside').getByText('Message Protocol').first()).toBeVisible();
+    await expect(page.locator('aside').getByText('Data Model').first()).toBeVisible();
+    await expect(page.locator('aside').getByText('Validating & Adapting').first()).toBeVisible();
+  });
+});
+```
+
+- [ ] **Step 2: Run the docs e2e**
+
+```bash
+cd apps/website && npx playwright test e2e/docs.spec.ts
+```
+Expected: PASS (all blocks, including the new a2ui block).
+
+- [ ] **Step 3: Verify all five new/changed routes serve**
+
+```bash
+for r in getting-started/quickstart guides/message-protocol guides/data-model guides/adapters-and-validation reference/schema; do
+  curl -s -o /dev/null -w "$r %{http_code}\n" "http://localhost:3000/docs/a2ui/$r"
+done
+```
+Expected: all `200`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/blove/repos/angular-agent-framework
+git add apps/website/e2e/docs.spec.ts
+git commit -m "test(website): assert a2ui quickstart + guides render"
+```
+
+---
+
+## Manual / maintainer verification (required before merge)
+
+- [ ] Open each new page on the dev server and read it for **technical accuracy** against `libs/a2ui/src` — every export named, every snippet, every message shape. This is the gate; wrong docs are worse than thin docs.
+- [ ] Read each page for **voice**: title-as-lede, contractions, one-thought-per-line, `## Goals`/`## Conclusion` on the quickstart, H2-as-question on the protocol guide, opinions flagged with a tradeoff, and **no** emojis/anecdotes/hype.
+- [ ] Confirm `version: 'v1'` everywhere and the Google-A2UI relationship note doesn't over-claim numbering parity.
+- [ ] ⌘K search: typing "quickstart" / "data model" surfaces the new pages.
+
+## Self-Review (completed during planning)
+
+- **Spec coverage:** Quickstart ✓ (Task 2). Message Protocol guide ✓ (Task 3). Data Model guide ✓ (Task 4). Validating & Adapting guide ✓ (Task 5). Schema v0.9→v1 + label fix ✓ (Task 6 Step 1). Docs-wide v0.9→v1 sweep ✓ (Task 6 Step 2). docs-config wiring ✓ (Task 1). e2e ✓ (Task 7). Voice rules + v1 framing + accuracy gate carried into every content task. Out-of-scope items (licensing/telemetry, voice pass, cockpit code refs) left out.
+- **Placeholder scan:** No TBD/TODO; content tasks carry verbatim grounded snippets + exact outlines + the real examples; mechanical steps have exact commands/expected output. (Prose is authored in-voice by the implementer from the provided outline + snippets — that's the nature of content work — then gated by the accuracy review.)
+- **Consistency:** Slugs (`quickstart`, `message-protocol`, `data-model`, `adapters-and-validation`) match between Task 1's docs-config entries, each page's file path, the curl checks, and the e2e titles ("Message Protocol", "Data Model", "Validating & Adapting"). `version: 'v1'` consistent across Tasks 2/3/6. Exports named match `libs/a2ui/src/index.ts`; the "no `isLiteralArray`" caveat is consistent across the protocol and adapters guides.

--- a/docs/superpowers/specs/2026-06-05-a2ui-docs-content-design.md
+++ b/docs/superpowers/specs/2026-06-05-a2ui-docs-content-design.md
@@ -1,0 +1,195 @@
+# a2ui Docs Fill — Design
+
+**Date:** 2026-06-05
+**Status:** Draft for review
+**Scope:** Fill out `@threadplane/a2ui` documentation — a Quickstart, three guides, and an accuracy fix to the schema reference — written in Brian's voice (highly-technical register), grounded in the real exported API and the real cockpit booking-form example. First of three "thin-library" content efforts (licensing, telemetry follow later).
+
+## Goal
+
+`@threadplane/a2ui` (the A2UI protocol/types library) ships only 3 docs pages
+(intro + 2 reference pages), no quickstart, no task guides. This spec adds a
+Quickstart and three guides so a developer can actually use the library — parse
+a stream, work with the data model, and build/validate A2UI payloads — and fixes
+a stale version reference.
+
+Every page is **grounded in real code**: the exported API (`libs/a2ui/src`),
+the library's own tests, and the real A2UI stream emitted by the cockpit
+booking-form example (`cockpit/chat/a2ui/`). **No invented API, no invented
+message shapes.**
+
+## Voice
+
+Apply Brian's structural + sentence-level patterns from `docs/gtm/voice.md`, in
+the **highly-technical register**:
+
+- Opening: title restated as a one-line lede. No "Introduction" header.
+- Contractions ("it's", "let's", "don't"). One thought per line; short paragraphs.
+- Tutorial pages (Quickstart): a `## Goals` block near the top, "Let's"
+  transitions, an explicit `## Conclusion`.
+- Concept/guide pages: H2-as-question where it fits ("## What's a surface?"),
+  answered immediately.
+- Opinions flagged ("For me", "In my experience") and paired with a tradeoff.
+
+**Excluded** (technical register): no emojis, no anecdotes, no folksy asides, no
+hype ("blazing", "game-changing"). Substance over warmth. This matches the
+standing note that 2026 technical content uses the trimmed register.
+
+## The version decision (applies to every page)
+
+Google's A2UI protocol uses **v0.8** (envelope names `beginRendering`,
+`surfaceUpdate`, `dataModelUpdate`, `deleteSurface` — which this library uses)
+and **v0.9** (which renamed three of them). `@threadplane/a2ui` is versioned
+independently and is documented as **v1** — the outbound `A2uiActionMessage` sets
+`version: 'v1'` in source (`libs/a2ui/src/lib/types.ts`).
+
+Per the maintainer's decision, **align everything on `v1`**:
+
+- All new pages present the Threadplane A2UI wire format and action message as
+  **v1**.
+- Each page that frames the protocol notes, accurately, that Threadplane
+  implements Google's open **A2UI** protocol (declarative, catalog-based:
+  surfaces, a per-surface data model, dynamic values, outbound actions) and links
+  the upstream references — **without** claiming numbering parity with Google's
+  v0.8/v0.9. Threadplane's implementation version is v1.
+- Authoritative upstream links: `https://a2ui.org` and
+  `https://github.com/google/A2UI`.
+
+## Pages
+
+### 1. Quickstart — `getting-started/quickstart` (new)
+
+Tutorial register. Goal: from zero to parsing a real A2UI stream and reading a
+resolved value.
+
+- Lede: one sentence ("Parse an A2UI stream and read its resolved values with
+  `@threadplane/a2ui`.").
+- `## Goals`: install; parse a JSONL stream with `createA2uiMessageParser()`;
+  apply `dataModelUpdate` into a plain object with `setByPointer`; read a
+  component's dynamic prop with `resolveDynamic`.
+- Steps use the **real booking-form stream** (abbreviated): the three envelopes
+  in emission order (`dataModelUpdate` → `surfaceUpdate` → `beginRendering`),
+  from `cockpit/chat/a2ui/` (`graph.py` `_wrap_envelopes`). Show
+  `parser.push(text)` returning `A2uiMessage[]`, and the partial-stream behavior
+  (text without a trailing `\n` buffers).
+- Show `resolveDynamic({ path: '/origin' }, model)` → value, and a literal
+  (`{ literalString: 'Book a flight' }`) → value. Snippets adapted from
+  `libs/a2ui/src/lib/{parser,resolve,pointer}.spec.ts`.
+- `## Conclusion`: one paragraph; link onward to the three guides.
+- Note: rendering A2UI surfaces in Angular lives in `@threadplane/chat`
+  (`<a2ui-surface>`) — link there; this library is the protocol/parse/resolve
+  layer.
+
+### 2. Guide — "The A2UI message protocol" — `guides/message-protocol` (new Guides section)
+
+Concept register (H2-as-question). What the four envelopes are and how they fit.
+
+- Surfaces (independent regions, each with its own component set + data model).
+- Components as an **id-keyed adjacency list** (not a nested tree); the
+  `{ "<Name>": { ...props } }` keyed-union shape; children via
+  `explicitList` vs `template`/`dataBinding`.
+- The per-surface **data model** and **dynamic values**: literal wrappers
+  (`literalString`/`literalNumber`/`literalBoolean`/`literalArray`) vs path refs
+  (`{ path: '/origin' }`).
+- The four envelopes with a real example each (from the booking-form stream):
+  `surfaceUpdate`, `dataModelUpdate` (typed `contents` entries:
+  `valueString`/`valueNumber`/`valueBoolean`/`valueMap`), `beginRendering`
+  (names the `root`), `deleteSurface`.
+- Outbound **actions**: the `A2uiActionMessage` (**`version: 'v1'`**, `action`
+  with `name`/`surfaceId`/`sourceComponentId`/`timestamp`/`context`/`label?`,
+  optional `metadata.a2uiClientDataModel`). Use the real booking submit example.
+- A short, accurate "Relationship to Google's A2UI" subsection with the version
+  note + upstream links.
+
+### 3. Guide — "Working with the data model" — `guides/data-model` (new)
+
+Task register. The pointer helpers + resolution.
+
+- `getByPointer` / `setByPointer` / `deleteByPointer`: JSON-Pointer-style paths,
+  **immutability** (`set`/`delete` return a structurally-shared clone; original
+  untouched), intermediate creation on `set`, delete-returns-original-on-missing
+  -parent, and the one caveat: **no RFC-6901 `~0`/`~1` unescaping**.
+- `resolveDynamic(value, model, scope?)`: unwrap order (literals first, then
+  `{ path }`), arrays mapped recursively, plain values passed through, missing
+  paths → `undefined`.
+- `A2uiScope` and **template children**: relative paths resolve against
+  `scope.basePath`; show the `template`/`dataBinding` per-item pattern
+  (`basePath: \`${arrPath}/${i}\``). Note `scope.item` is typed but unused.
+- Snippets verbatim-adapted from `pointer.spec.ts` / `resolve.spec.ts`.
+
+### 4. Guide — "Validating and adapting an A2UI stream" — `guides/adapters-and-validation` (new)
+
+Task register. The library's actual audience (per the intro: "building an
+adapter, validating an agent stream, testing A2UI payloads, integrating a custom
+renderer").
+
+- Consume a streaming agent response: feed chunks to `parser.push`, handle the
+  conservative-fallback posture (malformed lines skipped, unknown envelope keys
+  ignored, partial JSON buffered until newline) — quote the real behavior from
+  `parser.ts`.
+- Validate/type-narrow payloads with the exported guards
+  (`isPathRef`, `isLiteralString`, `isLiteralNumber`, `isLiteralBoolean`).
+- Build/test A2UI payloads against the exported types (e.g. assembling a
+  `surfaceUpdate` + `dataModelUpdate` + `beginRendering` sequence for a test).
+- Integrate a custom renderer: resolve props with `resolveDynamic` + the data
+  model; note that the Threadplane Angular renderer is `@threadplane/chat`'s
+  `<a2ui-surface>` (link), and this library is what an alternative renderer would
+  build on.
+- Honest tradeoff: the parser intentionally swallows parse errors (good for
+  streaming, so validate separately if you need strictness).
+
+### 5. Fix — `reference/schema.mdx` (accuracy)
+
+- Change `A2uiActionMessage.version` from `'v0.9'` → **`'v1'`** (matches source).
+- Add the `action.label?: string` field (present in `types.ts`, missing from the
+  doc).
+
+### 6. Docs-wide v0.9 → v1 alignment (sweep)
+
+Update the stray `v0.9` A2UI references in the website docs to `v1` for
+consistency, where they refer to the Threadplane action-message/version (not to
+an upstream protocol citation):
+
+- `apps/website/content/docs/render/a2ui/overview.mdx`
+- `apps/website/content/docs/render/a2ui/catalog.mdx`
+- `apps/website/content/docs/render/concepts/json-render-vs-a2ui.mdx`
+
+(Leave `chat/api/api-docs.json` — it's generated. Any reference that is explicitly
+citing Google's protocol version stays accurate to Google.)
+
+## Plumbing
+
+- **Modify** `apps/website/src/lib/docs-config.ts`: add to the `a2ui` library a
+  `Quick Start` page under Getting Started, and a new **Guides** section with the
+  three guide pages (slugs: `message-protocol`, `data-model`,
+  `adapters-and-validation`). Order: Getting Started (Introduction, Quick Start)
+  → Guides (Message Protocol, Data Model, Validating & Adapting) → Reference
+  (Schema, Parser/Resolver/Guards).
+- **Create** the four MDX files under `apps/website/content/docs/a2ui/...`.
+- No new components; reuse `Callout`, `Steps`/`Step`, `CodeGroup`, `Card`/
+  `CardGroup` as helpful.
+
+## Testing & verification
+
+- **Build/route:** each new page renders at its `/docs/a2ui/...` route (HTTP 200);
+  the a2ui sidebar shows the new Quick Start + Guides; prev/next links resolve.
+- **e2e:** extend `apps/website/e2e/docs.spec.ts` with a check that
+  `/docs/a2ui/getting-started/quickstart` renders (breadcrumb + article + sidebar)
+  and that the a2ui nav lists the new guide titles.
+- **llms-full / search:** new pages are picked up automatically (they enumerate
+  from `docs-config`); no extra work, but verify the quickstart appears in the
+  ⌘K title search.
+- **Accuracy gate (required):** every code snippet and API claim is checked
+  against `libs/a2ui/src` before commit. After drafting, **the maintainer reviews
+  the MDX for technical accuracy and voice** before merge. Wrong docs are worse
+  than thin docs.
+
+## Out of scope
+
+- licensing and telemetry docs (separate efforts).
+- The broader "voice pass over existing docs" (next phase).
+- Rendering docs (`@threadplane/chat` `<a2ui-surface>`, the catalog) and fixing
+  the stale `render/a2ui/surface-store.mdx` / `surface-component.mdx` /
+  `catalog.mdx` content beyond the v0.9→v1 token sweep — flagged as a follow-up.
+- Code/prompt/demo `v0.9` references (`cockpit/chat/a2ui/python/...`,
+  `types.ts` has none to change) — flagged as a separate follow-up so the
+  maintainer can verify the cockpit example + prompts.


### PR DESCRIPTION
## Summary
Fills out `@threadplane/a2ui` documentation, in Brian's technical-register voice, grounded entirely in the real API + the cockpit booking-form example (nothing invented):
- **Quickstart** — parse a stream → build the data model → resolve a value, end to end.
- **Guide: The A2UI message protocol** — surfaces, id-keyed components, dynamic values, the four envelopes, outbound actions; accurate "relationship to Google's A2UI" note + links.
- **Guide: Working with the data model** — pointer helpers (immutability, no RFC-6901 unescaping), `resolveDynamic`, scopes & template children.
- **Guide: Validating & adapting a stream** — parser fallback posture, guards, building test payloads, custom renderers.
- **Accuracy fix:** `reference/schema` `version: 'v0.9'` → `'v1'`, add `action.label?`; swept 4 stale `v0.9` refs across the docs → `v1`.
- Nav wired in `docs-config.ts`.

Both gates passed: a dedicated **accuracy review** verified every snippet/claim against `libs/a2ui/src` (zero issues); a **voice review** confirmed register conformance.

Spec: `docs/superpowers/specs/2026-06-05-a2ui-docs-content-design.md`
Plan: `docs/superpowers/plans/2026-06-05-a2ui-docs-content.md`

Follow-ups (separate): licensing + telemetry docs; the broader voice pass over existing docs; cockpit example/prompt `v0.9` references.

## Test Plan
- [x] `e2e/docs.spec.ts` — 10/10 (a2ui quickstart + sidebar guides)
- [x] All five a2ui routes return 200
- [x] Accuracy review (snippets vs source) + voice review — both pass
- [ ] CI green
- [ ] Maintainer reads the rendered pages for final accuracy/voice sign-off

🤖 Generated with [Claude Code](https://claude.com/claude-code)