### PR TITLE
fix(ag-ui-proxy): move out of /api/ namespace so route doesn't shadow into langgraph proxy

### DIFF
--- a/scripts/ag-ui-proxy.ts
+++ b/scripts/ag-ui-proxy.ts
@@ -12,9 +12,11 @@
  *      middleware before any /agent/<topic> handler runs.
  *
  * Bundled by scripts/assemble-examples.ts into
- * `.vercel/output/functions/api/ag-ui-proxy/[[...path]].func/index.js`
- * and reachable via the route rewrite
- *   /ag-ui/<topic>/agent*  →  /api/ag-ui-proxy/<topic>*
+ * `.vercel/output/functions/ag-ui-proxy/[[...path]].func/index.js`
+ * (NOT under functions/api/ — the route table's catch-all `^/api/(.*)` for
+ * the langgraph proxy would otherwise re-match the rewrite via check:true
+ * and shadow this function). Reachable via the route rewrite
+ *   /ag-ui/<topic>/agent*  →  /ag-ui-proxy/<topic>*
  *
  * AG-UI uses streaming responses (Server-Sent Events / chunked), so the
  * upstream body is piped chunk-by-chunk rather than buffered.
@@ -86,16 +88,16 @@ function getOrigin(headers: VercelRequest['headers']): string | undefined {
 }
 
 /**
- * Parse `/api/ag-ui-proxy/<topic>[/<rest>]` into { topic, rest } so the
+ * Parse `/ag-ui-proxy/<topic>[/<rest>]` into { topic, rest } so the
  * upstream URL can be built as `<railway>/agent/<topic><rest>`.
  */
 function parseProxyPath(url: string): { topic: string; rest: string } | null {
   const u = new URL(url, 'http://placeholder');
   const segments = u.pathname.split('/').filter(Boolean);
-  // Expected: ['api', 'ag-ui-proxy', '<topic>', ...rest]
-  if (segments[0] !== 'api' || segments[1] !== 'ag-ui-proxy' || !segments[2]) return null;
-  const topic = segments[2];
-  const rest = segments.slice(3).join('/');
+  // Expected: ['ag-ui-proxy', '<topic>', ...rest]
+  if (segments[0] !== 'ag-ui-proxy' || !segments[1]) return null;
+  const topic = segments[1];
+  const rest = segments.slice(2).join('/');
   const restPath = rest ? `/${rest}` : '';
   return { topic, rest: restPath };
 }

--- a/scripts/assemble-examples.ts
+++ b/scripts/assemble-examples.ts
@@ -95,7 +95,10 @@ for (const cap of capabilities) {
 const outputDir = resolve(deployDir, '.vercel/output');
 const staticDir = resolve(outputDir, 'static');
 const funcDir = resolve(outputDir, 'functions/api/[[...path]].func');
-const agUiFuncDir = resolve(outputDir, 'functions/api/ag-ui-proxy/[[...path]].func');
+// NOTE: deliberately NOT under functions/api/ — that would re-trigger the
+// langgraph proxy rule on the rewrite (check: true causes re-evaluation,
+// and ^/api/(.*) would catch /api/ag-ui-proxy/* and shadow the function).
+const agUiFuncDir = resolve(outputDir, 'functions/ag-ui-proxy/[[...path]].func');
 
 // Copy static files to the output directory
 mkdirSync(staticDir, { recursive: true });
@@ -137,10 +140,12 @@ writeFileSync(resolve(agUiFuncDir, '.vc-config.json'), JSON.stringify({
 writeFileSync(resolve(outputDir, 'config.json'), JSON.stringify({
   version: 3,
   routes: [
-    // ag-ui proxy: /ag-ui/<topic>/agent[/rest] → /api/ag-ui-proxy/<topic>[/rest]
+    // ag-ui proxy: /ag-ui/<topic>/agent[/rest] → /ag-ui-proxy/<topic>[/rest]
     // Must precede the filesystem handle so static index.html lookups for
     // /ag-ui/<topic>/ still resolve while POSTs to /agent are proxied.
-    { src: '^/ag-ui/([^/]+)/agent(/.*)?$', dest: '/api/ag-ui-proxy/$1$2', check: true },
+    // Deliberately NOT under /api/ — that would re-match the langgraph
+    // proxy rule below via check: true re-evaluation.
+    { src: '^/ag-ui/([^/]+)/agent(/.*)?$', dest: '/ag-ui-proxy/$1$2', check: true },
     { src: '^/api/(.*)', dest: '/api/[[...path]]', check: true },
     { handle: 'filesystem' },
     { src: '^/(langgraph|deep-agents|render|chat|ag-ui)/([^/]+)/(.+\\..+)$', dest: '/$1/$2/$3' },


### PR DESCRIPTION
## Problem

Production smoke against examples.threadplane.ai showed POST `/ag-ui/streaming/agent` with an evil Origin returning `{"detail":"Not Found"}` (FastAPI body) with `x-api-key` in `access-control-allow-headers` — meaning the request hit the langgraph proxy at LangGraph Cloud, not the ag-ui-proxy.

Root cause: route table in `scripts/assemble-examples.ts`:

```
{ src: '^/ag-ui/([^/]+)/agent(/.*)?$', dest: '/api/ag-ui-proxy/$1$2', check: true },
{ src: '^/api/(.*)',                   dest: '/api/[[...path]]',    check: true },
```

With `check: true`, after the first rewrite Vercel re-evaluates routes. `/api/ag-ui-proxy/streaming` matches rule 2, which rewrites again to the langgraph catch-all function — shadowing our function.

## Fix

Move the ag-ui proxy out of `/api/`:
- Function path: `functions/ag-ui-proxy/[[...path]].func` (was `functions/api/ag-ui-proxy/...`)
- Route dest: `/ag-ui-proxy/$1$2` (was `/api/ag-ui-proxy/$1$2`)
- `parseProxyPath` in `ag-ui-proxy.ts` updated to expect `['ag-ui-proxy', '<topic>', ...]` instead of `['api', 'ag-ui-proxy', '<topic>', ...]`

After the rewrite, the path `/ag-ui-proxy/<topic>` no longer matches the langgraph rule, falls through to the filesystem handle, finds the function, served.

## Test plan

- [ ] CI green
- [ ] Post-merge: examples.threadplane.ai/ag-ui/streaming/agent with wrong Origin returns 403 `{"error":"origin_not_allowed"}`
- [ ] Post-merge: same path with allowed Origin returns streaming AG-UI events

🤖 Generated with [Claude Code](https://claude.com/claude-code)