### PR TITLE
fix(ag-ui-proxy): name function in route dest so Vercel actually invokes it

### DIFF
--- a/scripts/ag-ui-proxy.ts
+++ b/scripts/ag-ui-proxy.ts
@@ -15,8 +15,11 @@
  * `.vercel/output/functions/ag-ui-proxy/[[...path]].func/index.js`
  * (NOT under functions/api/ — the route table's catch-all `^/api/(.*)` for
  * the langgraph proxy would otherwise re-match the rewrite via check:true
- * and shadow this function). Reachable via the route rewrite
- *   /ag-ui/<topic>/agent*  →  /ag-ui-proxy/<topic>*
+ * and shadow this function). Invoked by the route
+ *   { src: '^/ag-ui/([^/]+)/agent(/.*)?$', dest: '/ag-ui-proxy/[[...path]]' }
+ * The dest names the catch-all function, which Vercel invokes while
+ * PRESERVING the original request URL in req.url — so this function parses
+ * the public `/ag-ui/<topic>/agent` path, not the `/ag-ui-proxy/...` dest.
  *
  * AG-UI uses streaming responses (Server-Sent Events / chunked), so the
  * upstream body is piped chunk-by-chunk rather than buffered.
@@ -88,16 +91,22 @@ function getOrigin(headers: VercelRequest['headers']): string | undefined {
 }
 
 /**
- * Parse `/ag-ui-proxy/<topic>[/<rest>]` into { topic, rest } so the
- * upstream URL can be built as `<railway>/agent/<topic><rest>`.
+ * Parse the original public URL `/ag-ui/<topic>/agent[/<rest>]` into
+ * { topic, rest } so the upstream URL can be built as
+ * `<railway>/agent/<topic><rest>`.
+ *
+ * The route dest `/ag-ui-proxy/[[...path]]` invokes this function while
+ * Vercel PRESERVES the original request URL in req.url (same mechanism the
+ * langgraph proxy relies on), so what we parse here is the public path the
+ * browser requested, not the rewritten `/ag-ui-proxy/...` path.
  */
 function parseProxyPath(url: string): { topic: string; rest: string } | null {
   const u = new URL(url, 'http://placeholder');
   const segments = u.pathname.split('/').filter(Boolean);
-  // Expected: ['ag-ui-proxy', '<topic>', ...rest]
-  if (segments[0] !== 'ag-ui-proxy' || !segments[1]) return null;
+  // Expected: ['ag-ui', '<topic>', 'agent', ...rest]
+  if (segments[0] !== 'ag-ui' || !segments[1] || segments[2] !== 'agent') return null;
   const topic = segments[1];
-  const rest = segments.slice(2).join('/');
+  const rest = segments.slice(3).join('/');
   const restPath = rest ? `/${rest}` : '';
   return { topic, rest: restPath };
 }
@@ -147,7 +156,12 @@ module.exports = async function handler(req: VercelRequest, res: VercelResponse)
   // fail-open on rate-limit so a misconfigured Vercel project doesn't
   // brick the runtime. Origin allowlist + internal token still apply.
 
-  const upstreamUrl = `${RAILWAY_BASE_URL}/agent/${parsed.topic}${parsed.rest}`;
+  // Preserve any query string from the original request on the upstream call.
+  const query = (() => {
+    const qIndex = (req.url ?? '').indexOf('?');
+    return qIndex >= 0 ? (req.url as string).slice(qIndex) : '';
+  })();
+  const upstreamUrl = `${RAILWAY_BASE_URL}/agent/${parsed.topic}${parsed.rest}${query}`;
   const upstreamHeaders: Record<string, string> = {
     'x-internal-token': internalToken,
   };

--- a/scripts/assemble-examples.ts
+++ b/scripts/assemble-examples.ts
@@ -140,12 +140,15 @@ writeFileSync(resolve(agUiFuncDir, '.vc-config.json'), JSON.stringify({
 writeFileSync(resolve(outputDir, 'config.json'), JSON.stringify({
   version: 3,
   routes: [
-    // ag-ui proxy: /ag-ui/<topic>/agent[/rest] → /ag-ui-proxy/<topic>[/rest]
-    // Must precede the filesystem handle so static index.html lookups for
-    // /ag-ui/<topic>/ still resolve while POSTs to /agent are proxied.
-    // Deliberately NOT under /api/ — that would re-match the langgraph
-    // proxy rule below via check: true re-evaluation.
-    { src: '^/ag-ui/([^/]+)/agent(/.*)?$', dest: '/ag-ui-proxy/$1$2', check: true },
+    // ag-ui proxy: /ag-ui/<topic>/agent[/rest] → ag-ui-proxy function.
+    // Mirrors the langgraph rule exactly: dest names the catch-all function
+    // (`[[...path]]`), which invokes it while PRESERVING the original request
+    // URL in req.url. The function (scripts/ag-ui-proxy.ts) parses the topic
+    // out of `/ag-ui/<topic>/agent`. A function is only reachable when a route
+    // dest names it like this — the filesystem handle does NOT auto-serve
+    // catch-all functions. Must precede the filesystem handle so static
+    // index.html lookups for /ag-ui/<topic>/ still resolve.
+    { src: '^/ag-ui/([^/]+)/agent(/.*)?$', dest: '/ag-ui-proxy/[[...path]]', check: true },
     { src: '^/api/(.*)', dest: '/api/[[...path]]', check: true },
     { handle: 'filesystem' },
     { src: '^/(langgraph|deep-agents|render|chat|ag-ui)/([^/]+)/(.+\\..+)$', dest: '/$1/$2/$3' },


### PR DESCRIPTION
## Problem

After #587 moved the proxy out of `/api/`, production smoke showed a **direct** request to `/ag-ui-proxy/streaming` returning Vercel's own `NOT_FOUND` — the function was unreachable, not just the route.

Root cause: a Vercel Build Output API function is only invoked when a route's `dest` names its catch-all placeholder (`[[...path]]`). The `{ handle: 'filesystem' }` phase does **not** auto-serve catch-all functions. The previous `dest: '/ag-ui-proxy/$1$2'` produced a literal path (`/ag-ui-proxy/streaming`) that matched no static file and no function → 404.

The langgraph proxy works because its route names the function: `{ src: '^/api/(.*)', dest: '/api/[[...path]]' }`.

## Fix

Mirror the langgraph rule exactly:

```js
{ src: '^/ag-ui/([^/]+)/agent(/.*)?$', dest: '/ag-ui-proxy/[[...path]]', check: true }
```

Vercel invokes the `ag-ui-proxy` catch-all function and **preserves the original request URL** in `req.url` (same mechanism langgraph relies on). So `parseProxyPath` now parses the public `/ag-ui/<topic>/agent[/rest]` path instead of the rewritten `/ag-ui-proxy/...`. Also preserves query strings on the upstream Railway call.

Verified locally: esbuild bundles clean; parse logic unit-checked (`/ag-ui/streaming/agent` → topic=streaming; `/ag-ui/interrupts/agent/foo/bar` → topic=interrupts, rest=/foo/bar).

## Test plan (post-merge, against examples.threadplane.ai)

- [ ] `POST /ag-ui/streaming/agent` with allowed Origin → streaming AG-UI SSE (RUN_STARTED … RUN_FINISHED)
- [ ] same with wrong Origin → 403 `{"error":"origin_not_allowed"}`
- [ ] spam >10 req/min with allowed Origin → 429
- [ ] `GET /ag-ui/streaming/` → 200 (SPA unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)