### PR TITLE
fix(website): api-docs generator — rest params, function types, interface methods

### DIFF
--- a/apps/website/content/docs/a2ui/api/api-docs.json
+++ b/apps/website/content/docs/a2ui/api/api-docs.json
@@ -455,12 +455,20 @@
     "name": "A2uiMessageParser",
     "kind": "interface",
     "description": "",
-    "properties": [
+    "properties": [],
+    "methods": [
       {
         "name": "push",
-        "type": "unknown",
+        "signature": "push(chunk: string): A2uiMessage[]",
         "description": "",
-        "optional": false
+        "params": [
+          {
+            "name": "chunk",
+            "type": "string",
+            "description": "",
+            "optional": false
+          }
+        ]
       }
     ],
     "examples": []

--- a/apps/website/content/docs/ag-ui/api/api-docs.json
+++ b/apps/website/content/docs/ag-ui/api/api-docs.json
@@ -59,13 +59,13 @@
     "methods": [
       {
         "name": "abortRun",
-        "signature": "abortRun()",
+        "signature": "abortRun(): void",
         "description": "",
         "params": []
       },
       {
         "name": "addMessage",
-        "signature": "addMessage(message: object | object | object | object | object | object | object)",
+        "signature": "addMessage(message: object | object | object | object | object | object | object): void",
         "description": "",
         "params": [
           {
@@ -78,7 +78,7 @@
       },
       {
         "name": "addMessages",
-        "signature": "addMessages(messages: object | object | object | object | object | object | object[])",
+        "signature": "addMessages(messages: object | object | object | object | object | object | object[]): void",
         "description": "",
         "params": [
           {
@@ -91,7 +91,7 @@
       },
       {
         "name": "apply",
-        "signature": "apply(input: object, events$: Observable<objectOutputType<object, ZodTypeAny, \"passthrough\">>, subscribers: AgentSubscriber[])",
+        "signature": "apply(input: object, events$: Observable<objectOutputType<object, ZodTypeAny, \"passthrough\">>, subscribers: AgentSubscriber[]): Observable<AgentStateMutation>",
         "description": "",
         "params": [
           {
@@ -116,13 +116,13 @@
       },
       {
         "name": "clone",
-        "signature": "clone()",
+        "signature": "clone(): any",
         "description": "",
         "params": []
       },
       {
         "name": "connect",
-        "signature": "connect(input: object)",
+        "signature": "connect(input: object): Observable<objectOutputType<object, ZodTypeAny, \"passthrough\">>",
         "description": "",
         "params": [
           {
@@ -135,7 +135,7 @@
       },
       {
         "name": "connectAgent",
-        "signature": "connectAgent(parameters: Partial<Pick<object, \"runId\" | \"tools\" | \"context\" | \"forwardedProps\">>, subscriber: AgentSubscriber)",
+        "signature": "connectAgent(parameters: Partial<Pick<object, \"runId\" | \"tools\" | \"context\" | \"forwardedProps\">>, subscriber: AgentSubscriber): Promise<RunAgentResult>",
         "description": "",
         "params": [
           {
@@ -154,19 +154,19 @@
       },
       {
         "name": "detachActiveRun",
-        "signature": "detachActiveRun()",
+        "signature": "detachActiveRun(): Promise<void>",
         "description": "",
         "params": []
       },
       {
         "name": "getCapabilities",
-        "signature": "getCapabilities()",
+        "signature": "getCapabilities(): Promise<object>",
         "description": "Returns the agent's current capabilities.\nOptional — subclasses implement this to advertise what they support.",
         "params": []
       },
       {
         "name": "legacy_to_be_removed_runAgentBridged",
-        "signature": "legacy_to_be_removed_runAgentBridged(config: Partial<Pick<object, \"runId\" | \"tools\" | \"context\" | \"forwardedProps\">>)",
+        "signature": "legacy_to_be_removed_runAgentBridged(config: Partial<Pick<object, \"runId\" | \"tools\" | \"context\" | \"forwardedProps\">>): Observable<object | object | object | object | object | object | object | object | object | object>",
         "description": "",
         "params": [
           {
@@ -179,7 +179,7 @@
       },
       {
         "name": "onError",
-        "signature": "onError(input: object, error: Error, subscribers: AgentSubscriber[])",
+        "signature": "onError(input: object, error: Error, subscribers: AgentSubscriber[]): Observable<AgentStateMutation>",
         "description": "",
         "params": [
           {
@@ -204,7 +204,7 @@
       },
       {
         "name": "onFinalize",
-        "signature": "onFinalize(input: object, subscribers: AgentSubscriber[])",
+        "signature": "onFinalize(input: object, subscribers: AgentSubscriber[]): Promise<void>",
         "description": "",
         "params": [
           {
@@ -223,7 +223,7 @@
       },
       {
         "name": "onInitialize",
-        "signature": "onInitialize(input: object, subscribers: AgentSubscriber[])",
+        "signature": "onInitialize(input: object, subscribers: AgentSubscriber[]): Promise<void>",
         "description": "",
         "params": [
           {
@@ -242,7 +242,7 @@
       },
       {
         "name": "prepareRunAgentInput",
-        "signature": "prepareRunAgentInput(parameters: Partial<Pick<object, \"runId\" | \"tools\" | \"context\" | \"forwardedProps\">>)",
+        "signature": "prepareRunAgentInput(parameters: Partial<Pick<object, \"runId\" | \"tools\" | \"context\" | \"forwardedProps\">>): object",
         "description": "",
         "params": [
           {
@@ -255,7 +255,7 @@
       },
       {
         "name": "processApplyEvents",
-        "signature": "processApplyEvents(input: object, events$: Observable<AgentStateMutation>, subscribers: AgentSubscriber[])",
+        "signature": "processApplyEvents(input: object, events$: Observable<AgentStateMutation>, subscribers: AgentSubscriber[]): Observable<AgentStateMutation>",
         "description": "",
         "params": [
           {
@@ -280,7 +280,7 @@
       },
       {
         "name": "run",
-        "signature": "run(input: object)",
+        "signature": "run(input: object): Observable<objectOutputType<object, ZodTypeAny, \"passthrough\">>",
         "description": "",
         "params": [
           {
@@ -293,7 +293,7 @@
       },
       {
         "name": "runAgent",
-        "signature": "runAgent(parameters: Partial<Pick<object, \"runId\" | \"tools\" | \"context\" | \"forwardedProps\">>, subscriber: AgentSubscriber)",
+        "signature": "runAgent(parameters: Partial<Pick<object, \"runId\" | \"tools\" | \"context\" | \"forwardedProps\">>, subscriber: AgentSubscriber): Promise<RunAgentResult>",
         "description": "",
         "params": [
           {
@@ -312,7 +312,7 @@
       },
       {
         "name": "setMessages",
-        "signature": "setMessages(messages: object | object | object | object | object | object | object[])",
+        "signature": "setMessages(messages: object | object | object | object | object | object | object[]): void",
         "description": "",
         "params": [
           {
@@ -325,7 +325,7 @@
       },
       {
         "name": "setState",
-        "signature": "setState(state: any)",
+        "signature": "setState(state: any): void",
         "description": "",
         "params": [
           {
@@ -338,7 +338,7 @@
       },
       {
         "name": "subscribe",
-        "signature": "subscribe(subscriber: AgentSubscriber)",
+        "signature": "subscribe(subscriber: AgentSubscriber): object",
         "description": "",
         "params": [
           {
@@ -351,11 +351,11 @@
       },
       {
         "name": "use",
-        "signature": "use(middlewares: Middleware<> | MiddlewareFunction[])",
+        "signature": "use(...middlewares: Middleware<> | MiddlewareFunction[]): this",
         "description": "",
         "params": [
           {
-            "name": "middlewares",
+            "name": "...middlewares",
             "type": "Middleware<> | MiddlewareFunction[]",
             "description": "",
             "optional": false
@@ -457,11 +457,11 @@
     "name": "provideAgent",
     "kind": "function",
     "description": "Provides an Agent instance wired through HttpAgent and toAgent.\nConstructs an HttpAgent from config and wraps it in the runtime-neutral\nAgent contract via toAgent(). Returns a provider array suitable for\nbootstrapApplication or TestBed.configureTestingModule().\n\n**Static vs factory config.** Pass a plain `AgentConfig` object when the\nconfig is known up front. Pass a `() => AgentConfig` factory when the config\ndepends on runtime/DI state — the factory runs inside an Angular injection\ncontext, so it may call `inject()` to read services or route params.",
-    "signature": "provideAgent(configOrFactory: AgentConfig | object): Provider[]",
+    "signature": "provideAgent(configOrFactory: AgentConfig | () => AgentConfig): Provider[]",
     "params": [
       {
         "name": "configOrFactory",
-        "type": "AgentConfig | object",
+        "type": "AgentConfig | () => AgentConfig",
         "description": "",
         "optional": false
       }

--- a/apps/website/content/docs/chat/api/api-docs.json
+++ b/apps/website/content/docs/chat/api/api-docs.json
@@ -38,7 +38,7 @@
       },
       {
         "name": "emit",
-        "type": "InputSignal<object>",
+        "type": "InputSignal<(event: string) => void>",
         "description": "",
         "optional": false
       },
@@ -90,7 +90,7 @@
       },
       {
         "name": "emit",
-        "type": "InputSignal<object>",
+        "type": "InputSignal<(event: string) => void>",
         "description": "",
         "optional": false
       },
@@ -116,7 +116,7 @@
     "methods": [
       {
         "name": "handleClick",
-        "signature": "handleClick()",
+        "signature": "handleClick(): void",
         "description": "",
         "params": []
       }
@@ -143,7 +143,7 @@
       },
       {
         "name": "emit",
-        "type": "InputSignal<object>",
+        "type": "InputSignal<(event: string) => void>",
         "description": "",
         "optional": false
       },
@@ -201,7 +201,7 @@
       },
       {
         "name": "emit",
-        "type": "InputSignal<object>",
+        "type": "InputSignal<(event: string) => void>",
         "description": "",
         "optional": false
       },
@@ -233,7 +233,7 @@
     "methods": [
       {
         "name": "onChange",
-        "signature": "onChange(event: Event)",
+        "signature": "onChange(event: Event): void",
         "description": "",
         "params": [
           {
@@ -285,7 +285,7 @@
       },
       {
         "name": "emit",
-        "type": "InputSignal<object>",
+        "type": "InputSignal<(event: string) => void>",
         "description": "",
         "optional": false
       },
@@ -349,7 +349,7 @@
       },
       {
         "name": "emit",
-        "type": "InputSignal<object>",
+        "type": "InputSignal<(event: string) => void>",
         "description": "",
         "optional": false
       },
@@ -399,7 +399,7 @@
     "methods": [
       {
         "name": "onChange",
-        "signature": "onChange(event: Event)",
+        "signature": "onChange(event: Event): void",
         "description": "",
         "params": [
           {
@@ -445,7 +445,7 @@
       },
       {
         "name": "emit",
-        "type": "InputSignal<object>",
+        "type": "InputSignal<(event: string) => void>",
         "description": "",
         "optional": false
       },
@@ -497,7 +497,7 @@
       },
       {
         "name": "emit",
-        "type": "InputSignal<object>",
+        "type": "InputSignal<(event: string) => void>",
         "description": "",
         "optional": false
       },
@@ -561,7 +561,7 @@
       },
       {
         "name": "emit",
-        "type": "InputSignal<object>",
+        "type": "InputSignal<(event: string) => void>",
         "description": "",
         "optional": false
       },
@@ -611,19 +611,19 @@
     "methods": [
       {
         "name": "explicitHeight",
-        "signature": "explicitHeight()",
+        "signature": "explicitHeight(): string | null",
         "description": "",
         "params": []
       },
       {
         "name": "explicitWidth",
-        "signature": "explicitWidth()",
+        "signature": "explicitWidth(): string | null",
         "description": "",
         "params": []
       },
       {
         "name": "hintStyle",
-        "signature": "hintStyle()",
+        "signature": "hintStyle(): object | null",
         "description": "",
         "params": []
       }
@@ -668,7 +668,7 @@
       },
       {
         "name": "emit",
-        "type": "InputSignal<object>",
+        "type": "InputSignal<(event: string) => void>",
         "description": "",
         "optional": false
       },
@@ -720,7 +720,7 @@
       },
       {
         "name": "emit",
-        "type": "InputSignal<object>",
+        "type": "InputSignal<(event: string) => void>",
         "description": "",
         "optional": false
       },
@@ -784,7 +784,7 @@
       },
       {
         "name": "emit",
-        "type": "InputSignal<object>",
+        "type": "InputSignal<(event: string) => void>",
         "description": "",
         "optional": false
       },
@@ -840,7 +840,7 @@
     "methods": [
       {
         "name": "isSelected",
-        "signature": "isSelected(value: string)",
+        "signature": "isSelected(value: string): boolean",
         "description": "",
         "params": [
           {
@@ -853,7 +853,7 @@
       },
       {
         "name": "onCheckChange",
-        "signature": "onCheckChange(value: string, event: Event)",
+        "signature": "onCheckChange(value: string, event: Event): void",
         "description": "",
         "params": [
           {
@@ -872,7 +872,7 @@
       },
       {
         "name": "onSelectChange",
-        "signature": "onSelectChange(event: Event)",
+        "signature": "onSelectChange(event: Event): void",
         "description": "",
         "params": [
           {
@@ -924,7 +924,7 @@
       },
       {
         "name": "emit",
-        "type": "InputSignal<object>",
+        "type": "InputSignal<(event: string) => void>",
         "description": "",
         "optional": false
       },
@@ -994,7 +994,7 @@
       },
       {
         "name": "emit",
-        "type": "InputSignal<object>",
+        "type": "InputSignal<(event: string) => void>",
         "description": "",
         "optional": false
       },
@@ -1044,7 +1044,7 @@
     "methods": [
       {
         "name": "onInput",
-        "signature": "onInput(event: Event)",
+        "signature": "onInput(event: Event): void",
         "description": "",
         "params": [
           {
@@ -1090,7 +1090,7 @@
       },
       {
         "name": "handlers",
-        "type": "InputSignal<Record<string, object>>",
+        "type": "InputSignal<Record<string, (params: Record<string, unknown>) => unknown>>",
         "description": "",
         "optional": false
       },
@@ -1146,7 +1146,7 @@
     "methods": [
       {
         "name": "onRenderEvent",
-        "signature": "onRenderEvent(event: RenderEvent)",
+        "signature": "onRenderEvent(event: RenderEvent): void",
         "description": "",
         "params": [
           {
@@ -1192,7 +1192,7 @@
       },
       {
         "name": "emit",
-        "type": "InputSignal<object>",
+        "type": "InputSignal<(event: string) => void>",
         "description": "",
         "optional": false
       },
@@ -1218,7 +1218,7 @@
     "methods": [
       {
         "name": "selectTab",
-        "signature": "selectTab(index: number)",
+        "signature": "selectTab(index: number): void",
         "description": "",
         "params": [
           {
@@ -1252,7 +1252,7 @@
       },
       {
         "name": "emit",
-        "type": "InputSignal<object>",
+        "type": "InputSignal<(event: string) => void>",
         "description": "",
         "optional": false
       },
@@ -1284,7 +1284,7 @@
     "methods": [
       {
         "name": "cssClass",
-        "signature": "cssClass()",
+        "signature": "cssClass(): string",
         "description": "",
         "params": []
       }
@@ -1323,7 +1323,7 @@
       },
       {
         "name": "emit",
-        "type": "InputSignal<object>",
+        "type": "InputSignal<(event: string) => void>",
         "description": "",
         "optional": false
       },
@@ -1385,7 +1385,7 @@
     "methods": [
       {
         "name": "onInput",
-        "signature": "onInput(event: Event)",
+        "signature": "onInput(event: Event): void",
         "description": "",
         "params": [
           {
@@ -1431,7 +1431,7 @@
       },
       {
         "name": "emit",
-        "type": "InputSignal<object>",
+        "type": "InputSignal<(event: string) => void>",
         "description": "",
         "optional": false
       },
@@ -1509,7 +1509,7 @@
     "methods": [
       {
         "name": "emit",
-        "signature": "emit(action: ChatApprovalAction)",
+        "signature": "emit(action: ChatApprovalAction): void",
         "description": "",
         "params": [
           {
@@ -1522,7 +1522,7 @@
       },
       {
         "name": "onCancelEvent",
-        "signature": "onCancelEvent(ev: Event)",
+        "signature": "onCancelEvent(ev: Event): void",
         "description": "",
         "params": [
           {
@@ -1535,7 +1535,7 @@
       },
       {
         "name": "onDialogClose",
-        "signature": "onDialogClose()",
+        "signature": "onDialogClose(): void",
         "description": "",
         "params": []
       }
@@ -1640,7 +1640,7 @@
       },
       {
         "name": "handlers",
-        "type": "InputSignal<Record<string, object>>",
+        "type": "InputSignal<Record<string, (params: Record<string, unknown>) => unknown>>",
         "description": "",
         "optional": false
       },
@@ -1652,7 +1652,7 @@
       },
       {
         "name": "messageContent",
-        "type": "object",
+        "type": "(message: BaseMessage<>) => string",
         "description": "",
         "optional": false
       },
@@ -1762,7 +1762,7 @@
     "methods": [
       {
         "name": "classifyMessage",
-        "signature": "classifyMessage(content: string, message: object)",
+        "signature": "classifyMessage(content: string, message: object): ContentClassifier",
         "description": "",
         "params": [
           {
@@ -1781,19 +1781,19 @@
       },
       {
         "name": "clearClassifiers",
-        "signature": "clearClassifiers()",
+        "signature": "clearClassifiers(): void",
         "description": "",
         "params": []
       },
       {
         "name": "clearThread",
-        "signature": "clearThread()",
+        "signature": "clearThread(): void",
         "description": "Clears local view state (classifiers, surface store, lifecycle counters)\nfor a new thread.\n\nResets messageCount to 0 and inputSubmittedAt to null. componentReady and\nfirstMessageSent are NOT reset (sticky for the chat instance lifetime).",
         "params": []
       },
       {
         "name": "humanContent",
-        "signature": "humanContent(message: unknown)",
+        "signature": "humanContent(message: unknown): string",
         "description": "Renderable content for a human-role message bubble. Most human\nmessages are typed prompts and pass through `messageContent`\nunchanged. A2UI action messages (e.g. form submits, button clicks\non a rendered surface) flow through the same submit channel and\nland in the message stream as a HumanMessage whose content is a\nJSON-serialized `A2uiActionMessage`. Showing the raw JSON as if\nthe user typed it leaks the protocol; per the A2UI spec\nthose events resemble tool calls more than user utterances.\n\n`a2uiActionLabel` returns a short human-readable label for\nrecognized action shapes (\"Search flights\", \"Selected flight UA123\",\netc.) — or null for any non-action content, in which case we fall\nback to the original text.",
         "params": [
           {
@@ -1806,7 +1806,7 @@
       },
       {
         "name": "isGenuiTurn",
-        "signature": "isGenuiTurn(message: unknown, _prevMsg: unknown, index: number)",
+        "signature": "isGenuiTurn(message: unknown, _prevMsg: unknown, index: number): boolean",
         "description": "True when this assistant message is part of a GenUI render turn.\nWalks backward through messages from `index` until it finds either\nan assistant message with `tool_calls` referencing a GenUI tool\n(→ this turn produces a surface) or a human message (→ the\npreceding turn ended; this assistant message stands on its own).\n\nAlso checks the message itself for:\n  - `extra.tool_calls[].name` matching a GenUI tool (post-streaming\n    state of the tool-call AI message), OR\n  - `extra.content[].type === 'function_call' && .name` matching\n    (live during the OpenAI Responses-API streaming chunks before\n    `tool_calls` populates).\n\nThe walk-back approach is robust to LangGraph's in-place\nreplacement of the ToolMessage (which strips the `name` field),\nunlike a single prev-message check.",
         "params": [
           {
@@ -1831,7 +1831,7 @@
       },
       {
         "name": "isReasoningStreaming",
-        "signature": "isReasoningStreaming(message: Message, index: number)",
+        "signature": "isReasoningStreaming(message: Message, index: number): boolean",
         "description": "True while a message's reasoning is mid-stream — i.e. it's the latest\nmessage, the agent is loading, the message has reasoning content, and\nno response text has arrived yet. Once the response text begins, the\nreasoning pill collapses (per its internal logic).",
         "params": [
           {
@@ -1850,7 +1850,7 @@
       },
       {
         "name": "onA2uiAction",
-        "signature": "onA2uiAction(message: A2uiActionMessage)",
+        "signature": "onA2uiAction(message: A2uiActionMessage): void",
         "description": "",
         "params": [
           {
@@ -1863,7 +1863,7 @@
       },
       {
         "name": "onA2uiEvent",
-        "signature": "onA2uiEvent(event: RenderEvent, messageIndex: number, surfaceId: string)",
+        "signature": "onA2uiEvent(event: RenderEvent, messageIndex: number, surfaceId: string): void",
         "description": "",
         "params": [
           {
@@ -1888,7 +1888,7 @@
       },
       {
         "name": "onCopy",
-        "signature": "onCopy(message: unknown, content: string)",
+        "signature": "onCopy(message: unknown, content: string): void",
         "description": "",
         "params": [
           {
@@ -1907,7 +1907,7 @@
       },
       {
         "name": "onRate",
-        "signature": "onRate(message: unknown, value: \"up\" | \"down\")",
+        "signature": "onRate(message: unknown, value: \"up\" | \"down\"): void",
         "description": "",
         "params": [
           {
@@ -1926,7 +1926,7 @@
       },
       {
         "name": "onRegenerate",
-        "signature": "onRegenerate(messageIndex: number)",
+        "signature": "onRegenerate(messageIndex: number): void",
         "description": "Regenerate the assistant response at the given message index.",
         "params": [
           {
@@ -1939,19 +1939,19 @@
       },
       {
         "name": "onScroll",
-        "signature": "onScroll()",
+        "signature": "onScroll(): void",
         "description": "",
         "params": []
       },
       {
         "name": "onScrollBubbleClick",
-        "signature": "onScrollBubbleClick()",
+        "signature": "onScrollBubbleClick(): void",
         "description": "",
         "params": []
       },
       {
         "name": "onSpecEvent",
-        "signature": "onSpecEvent(event: RenderEvent, messageIndex: number)",
+        "signature": "onSpecEvent(event: RenderEvent, messageIndex: number): void",
         "description": "",
         "params": [
           {
@@ -1970,13 +1970,13 @@
       },
       {
         "name": "onUserSubmitted",
-        "signature": "onUserSubmitted()",
+        "signature": "onUserSubmitted(): void",
         "description": "",
         "params": []
       },
       {
         "name": "prevMessage",
-        "signature": "prevMessage(index: number)",
+        "signature": "prevMessage(index: number): unknown",
         "description": "Look up the previous message in the agent's messages list.\nReturns undefined for the first message.",
         "params": [
           {
@@ -1989,7 +1989,7 @@
       },
       {
         "name": "prevRole",
-        "signature": "prevRole(index: number)",
+        "signature": "prevRole(index: number): ChatMessageRole | undefined",
         "description": "",
         "params": [
           {
@@ -2002,7 +2002,7 @@
       },
       {
         "name": "submitMessage",
-        "signature": "submitMessage(text: string)",
+        "signature": "submitMessage(text: string): void",
         "description": "Programmatic submit. Calls `agent.submit({ message: text })` and updates\nthe CHAT_LIFECYCLE signals. Trimmed-empty text is a no-op.",
         "params": [
           {
@@ -2086,7 +2086,7 @@
     "methods": [
       {
         "name": "onDialogKeydown",
-        "signature": "onDialogKeydown(e: KeyboardEvent)",
+        "signature": "onDialogKeydown(e: KeyboardEvent): void",
         "description": "",
         "params": [
           {
@@ -2136,7 +2136,7 @@
       },
       {
         "name": "handlers",
-        "type": "InputSignal<Record<string, object> | undefined>",
+        "type": "InputSignal<Record<string, (params: Record<string, unknown>) => unknown> | undefined>",
         "description": "",
         "optional": false
       },
@@ -2241,13 +2241,13 @@
     "methods": [
       {
         "name": "activeRowId",
-        "signature": "activeRowId()",
+        "signature": "activeRowId(): string | null",
         "description": "",
         "params": []
       },
       {
         "name": "onInput",
-        "signature": "onInput(e: Event)",
+        "signature": "onInput(e: Event): void",
         "description": "",
         "params": [
           {
@@ -2260,7 +2260,7 @@
       },
       {
         "name": "onInputKeydown",
-        "signature": "onInputKeydown(e: KeyboardEvent)",
+        "signature": "onInputKeydown(e: KeyboardEvent): void",
         "description": "",
         "params": [
           {
@@ -2273,7 +2273,7 @@
       },
       {
         "name": "onRowClick",
-        "signature": "onRowClick(id: string)",
+        "signature": "onRowClick(id: string): void",
         "description": "",
         "params": [
           {
@@ -2286,7 +2286,7 @@
       },
       {
         "name": "rowId",
-        "signature": "rowId(index: number)",
+        "signature": "rowId(index: number): string",
         "description": "",
         "params": [
           {
@@ -2382,13 +2382,13 @@
     "methods": [
       {
         "name": "focusTextarea",
-        "signature": "focusTextarea()",
+        "signature": "focusTextarea(): void",
         "description": "",
         "params": []
       },
       {
         "name": "onKeydown",
-        "signature": "onKeydown(event: KeyboardEvent)",
+        "signature": "onKeydown(event: KeyboardEvent): void",
         "description": "",
         "params": [
           {
@@ -2401,13 +2401,13 @@
       },
       {
         "name": "onStop",
-        "signature": "onStop()",
+        "signature": "onStop(): void",
         "description": "Abort the current streaming response (if the adapter supports it).",
         "params": []
       },
       {
         "name": "onSubmit",
-        "signature": "onSubmit()",
+        "signature": "onSubmit(): void",
         "description": "",
         "params": []
       }
@@ -2442,7 +2442,7 @@
     "methods": [
       {
         "name": "defaultText",
-        "signature": "defaultText(i: AgentInterrupt)",
+        "signature": "defaultText(i: AgentInterrupt): string",
         "description": "",
         "params": [
           {
@@ -2558,13 +2558,13 @@
     "methods": [
       {
         "name": "onCopy",
-        "signature": "onCopy()",
+        "signature": "onCopy(): Promise<void>",
         "description": "",
         "params": []
       },
       {
         "name": "onRate",
-        "signature": "onRate(value: \"up\" | \"down\")",
+        "signature": "onRate(value: \"up\" | \"down\"): void",
         "description": "",
         "params": [
           {
@@ -2650,7 +2650,7 @@
       },
       {
         "name": "getMessageType",
-        "type": "object",
+        "type": "(message: Message) => MessageTemplateType",
         "description": "",
         "optional": false
       },
@@ -2670,7 +2670,7 @@
     "methods": [
       {
         "name": "findTemplate",
-        "signature": "findTemplate(type: MessageTemplateType)",
+        "signature": "findTemplate(type: MessageTemplateType): MessageTemplateDirective<> | undefined",
         "description": "",
         "params": [
           {
@@ -2736,7 +2736,7 @@
     "methods": [
       {
         "name": "onItemClick",
-        "signature": "onItemClick(item: OverflowMenuItem)",
+        "signature": "onItemClick(item: OverflowMenuItem): void",
         "description": "",
         "params": [
           {
@@ -2749,7 +2749,7 @@
       },
       {
         "name": "onMenuKeydown",
-        "signature": "onMenuKeydown(e: KeyboardEvent)",
+        "signature": "onMenuKeydown(e: KeyboardEvent): void",
         "description": "",
         "params": [
           {
@@ -2821,19 +2821,19 @@
     "methods": [
       {
         "name": "closeWindow",
-        "signature": "closeWindow()",
+        "signature": "closeWindow(): void",
         "description": "",
         "params": []
       },
       {
         "name": "openWindow",
-        "signature": "openWindow()",
+        "signature": "openWindow(): void",
         "description": "",
         "params": []
       },
       {
         "name": "toggle",
-        "signature": "toggle()",
+        "signature": "toggle(): void",
         "description": "",
         "params": []
       }
@@ -2940,25 +2940,25 @@
     "methods": [
       {
         "name": "cancelCreate",
-        "signature": "cancelCreate()",
+        "signature": "cancelCreate(): void",
         "description": "",
         "params": []
       },
       {
         "name": "cancelRename",
-        "signature": "cancelRename()",
+        "signature": "cancelRename(): void",
         "description": "",
         "params": []
       },
       {
         "name": "commitCreate",
-        "signature": "commitCreate()",
+        "signature": "commitCreate(): Promise<void>",
         "description": "",
         "params": []
       },
       {
         "name": "commitRename",
-        "signature": "commitRename(projectId: string)",
+        "signature": "commitRename(projectId: string): Promise<void>",
         "description": "",
         "params": [
           {
@@ -2971,7 +2971,7 @@
       },
       {
         "name": "onCreateInput",
-        "signature": "onCreateInput(e: Event)",
+        "signature": "onCreateInput(e: Event): void",
         "description": "",
         "params": [
           {
@@ -2984,7 +2984,7 @@
       },
       {
         "name": "onEditInput",
-        "signature": "onEditInput(e: Event)",
+        "signature": "onEditInput(e: Event): void",
         "description": "",
         "params": [
           {
@@ -2997,7 +2997,7 @@
       },
       {
         "name": "onMenuAction",
-        "signature": "onMenuAction(id: string)",
+        "signature": "onMenuAction(id: string): void",
         "description": "",
         "params": [
           {
@@ -3010,13 +3010,13 @@
       },
       {
         "name": "onNewProjectClicked",
-        "signature": "onNewProjectClicked()",
+        "signature": "onNewProjectClicked(): void",
         "description": "",
         "params": []
       },
       {
         "name": "openMenu",
-        "signature": "openMenu(projectId: string, anchor: HTMLElement)",
+        "signature": "openMenu(projectId: string, anchor: HTMLElement): void",
         "description": "",
         "params": [
           {
@@ -3035,13 +3035,13 @@
       },
       {
         "name": "performDelete",
-        "signature": "performDelete()",
+        "signature": "performDelete(): Promise<void>",
         "description": "",
         "params": []
       },
       {
         "name": "selectProject",
-        "signature": "selectProject(projectId: string)",
+        "signature": "selectProject(projectId: string): void",
         "description": "",
         "params": [
           {
@@ -3054,7 +3054,7 @@
       },
       {
         "name": "showKebab",
-        "signature": "showKebab()",
+        "signature": "showKebab(): boolean",
         "description": "",
         "params": []
       }
@@ -3125,7 +3125,7 @@
     "methods": [
       {
         "name": "toggle",
-        "signature": "toggle()",
+        "signature": "toggle(): void",
         "description": "",
         "params": []
       }
@@ -3212,7 +3212,7 @@
     "methods": [
       {
         "name": "onMenuKeydown",
-        "signature": "onMenuKeydown(e: KeyboardEvent)",
+        "signature": "onMenuKeydown(e: KeyboardEvent): void",
         "description": "",
         "params": [
           {
@@ -3225,7 +3225,7 @@
       },
       {
         "name": "onTriggerKeydown",
-        "signature": "onTriggerKeydown(e: KeyboardEvent)",
+        "signature": "onTriggerKeydown(e: KeyboardEvent): void",
         "description": "",
         "params": [
           {
@@ -3238,7 +3238,7 @@
       },
       {
         "name": "selectOption",
-        "signature": "selectOption(opt: ChatSelectOption)",
+        "signature": "selectOption(opt: ChatSelectOption): void",
         "description": "",
         "params": [
           {
@@ -3251,7 +3251,7 @@
       },
       {
         "name": "toggle",
-        "signature": "toggle()",
+        "signature": "toggle(): void",
         "description": "",
         "params": []
       }
@@ -3316,19 +3316,19 @@
     "methods": [
       {
         "name": "closeWindow",
-        "signature": "closeWindow()",
+        "signature": "closeWindow(): void",
         "description": "",
         "params": []
       },
       {
         "name": "openWindow",
-        "signature": "openWindow()",
+        "signature": "openWindow(): void",
         "description": "",
         "params": []
       },
       {
         "name": "toggle",
-        "signature": "toggle()",
+        "signature": "toggle(): void",
         "description": "",
         "params": []
       }
@@ -3471,19 +3471,19 @@
     "methods": [
       {
         "name": "onCollapseToggle",
-        "signature": "onCollapseToggle()",
+        "signature": "onCollapseToggle(): void",
         "description": "",
         "params": []
       },
       {
         "name": "onEscape",
-        "signature": "onEscape()",
+        "signature": "onEscape(): void",
         "description": "",
         "params": []
       },
       {
         "name": "openDebug",
-        "signature": "openDebug(event: MouseEvent)",
+        "signature": "openDebug(event: MouseEvent): void",
         "description": "",
         "params": [
           {
@@ -3773,13 +3773,13 @@
     "methods": [
       {
         "name": "cancelRename",
-        "signature": "cancelRename()",
+        "signature": "cancelRename(): void",
         "description": "",
         "params": []
       },
       {
         "name": "commitRename",
-        "signature": "commitRename(threadId: string)",
+        "signature": "commitRename(threadId: string): Promise<void>",
         "description": "",
         "params": [
           {
@@ -3792,7 +3792,7 @@
       },
       {
         "name": "dropPositionFor",
-        "signature": "dropPositionFor(threadId: string)",
+        "signature": "dropPositionFor(threadId: string): \"before\" | \"after\" | null",
         "description": "",
         "params": [
           {
@@ -3805,7 +3805,7 @@
       },
       {
         "name": "initialOf",
-        "signature": "initialOf(title: string)",
+        "signature": "initialOf(title: string): string",
         "description": "First grapheme of a title rendered as an uppercase initial for the\n collapsed sidenav. Falls back to \"?\" for empty/whitespace titles.",
         "params": [
           {
@@ -3818,13 +3818,13 @@
       },
       {
         "name": "onDragEnd",
-        "signature": "onDragEnd()",
+        "signature": "onDragEnd(): void",
         "description": "",
         "params": []
       },
       {
         "name": "onDragLeave",
-        "signature": "onDragLeave(_e: DragEvent, threadId: string)",
+        "signature": "onDragLeave(_e: DragEvent, threadId: string): void",
         "description": "",
         "params": [
           {
@@ -3843,7 +3843,7 @@
       },
       {
         "name": "onDragOver",
-        "signature": "onDragOver(e: DragEvent, threadId: string)",
+        "signature": "onDragOver(e: DragEvent, threadId: string): void",
         "description": "",
         "params": [
           {
@@ -3862,7 +3862,7 @@
       },
       {
         "name": "onDragStart",
-        "signature": "onDragStart(e: DragEvent, threadId: string)",
+        "signature": "onDragStart(e: DragEvent, threadId: string): void",
         "description": "",
         "params": [
           {
@@ -3881,7 +3881,7 @@
       },
       {
         "name": "onDrop",
-        "signature": "onDrop(e: DragEvent, targetThreadId: string)",
+        "signature": "onDrop(e: DragEvent, targetThreadId: string): void",
         "description": "",
         "params": [
           {
@@ -3900,7 +3900,7 @@
       },
       {
         "name": "onEditInput",
-        "signature": "onEditInput(e: Event)",
+        "signature": "onEditInput(e: Event): void",
         "description": "",
         "params": [
           {
@@ -3913,7 +3913,7 @@
       },
       {
         "name": "onMenuAction",
-        "signature": "onMenuAction(id: string)",
+        "signature": "onMenuAction(id: string): void",
         "description": "",
         "params": [
           {
@@ -3926,7 +3926,7 @@
       },
       {
         "name": "onMoveMenuAction",
-        "signature": "onMoveMenuAction(itemId: string)",
+        "signature": "onMoveMenuAction(itemId: string): void",
         "description": "",
         "params": [
           {
@@ -3939,7 +3939,7 @@
       },
       {
         "name": "onRowContextMenu",
-        "signature": "onRowContextMenu(threadId: string, event: MouseEvent)",
+        "signature": "onRowContextMenu(threadId: string, event: MouseEvent): void",
         "description": "Right-click on a row opens the same overflow menu anchored at the\n cursor. Always prevents the native context menu — including when the\n adapter exposes no row actions (in which case we open nothing rather\n than confusing the user with the OS menu on what looks like a custom\n list).",
         "params": [
           {
@@ -3958,7 +3958,7 @@
       },
       {
         "name": "openMenu",
-        "signature": "openMenu(threadId: string, anchor: HTMLElement)",
+        "signature": "openMenu(threadId: string, anchor: HTMLElement): void",
         "description": "",
         "params": [
           {
@@ -3977,7 +3977,7 @@
       },
       {
         "name": "performArchive",
-        "signature": "performArchive(threadId: string)",
+        "signature": "performArchive(threadId: string): Promise<void>",
         "description": "",
         "params": [
           {
@@ -3990,13 +3990,13 @@
       },
       {
         "name": "performDelete",
-        "signature": "performDelete()",
+        "signature": "performDelete(): Promise<void>",
         "description": "",
         "params": []
       },
       {
         "name": "performMoveDown",
-        "signature": "performMoveDown(threadId: string)",
+        "signature": "performMoveDown(threadId: string): Promise<void>",
         "description": "",
         "params": [
           {
@@ -4009,7 +4009,7 @@
       },
       {
         "name": "performMoveToProject",
-        "signature": "performMoveToProject(threadId: string, projectId: string | null)",
+        "signature": "performMoveToProject(threadId: string, projectId: string | null): Promise<void>",
         "description": "",
         "params": [
           {
@@ -4028,7 +4028,7 @@
       },
       {
         "name": "performMoveUp",
-        "signature": "performMoveUp(threadId: string)",
+        "signature": "performMoveUp(threadId: string): Promise<void>",
         "description": "",
         "params": [
           {
@@ -4041,7 +4041,7 @@
       },
       {
         "name": "performPin",
-        "signature": "performPin(threadId: string)",
+        "signature": "performPin(threadId: string): Promise<void>",
         "description": "",
         "params": [
           {
@@ -4054,7 +4054,7 @@
       },
       {
         "name": "performReorderPinned",
-        "signature": "performReorderPinned(threadId: string, beforeId: string | null)",
+        "signature": "performReorderPinned(threadId: string, beforeId: string | null): Promise<void>",
         "description": "",
         "params": [
           {
@@ -4073,7 +4073,7 @@
       },
       {
         "name": "performUnarchive",
-        "signature": "performUnarchive(threadId: string)",
+        "signature": "performUnarchive(threadId: string): Promise<void>",
         "description": "",
         "params": [
           {
@@ -4086,7 +4086,7 @@
       },
       {
         "name": "performUnpin",
-        "signature": "performUnpin(threadId: string)",
+        "signature": "performUnpin(threadId: string): Promise<void>",
         "description": "",
         "params": [
           {
@@ -4099,7 +4099,7 @@
       },
       {
         "name": "relativeTime",
-        "signature": "relativeTime(epochMs: number)",
+        "signature": "relativeTime(epochMs: number): string",
         "description": "",
         "params": [
           {
@@ -4112,7 +4112,7 @@
       },
       {
         "name": "selectThread",
-        "signature": "selectThread(threadId: string)",
+        "signature": "selectThread(threadId: string): void",
         "description": "",
         "params": [
           {
@@ -4125,13 +4125,13 @@
       },
       {
         "name": "showKebab",
-        "signature": "showKebab()",
+        "signature": "showKebab(): boolean",
         "description": "",
         "params": []
       },
       {
         "name": "threadLabel",
-        "signature": "threadLabel(thread: Thread)",
+        "signature": "threadLabel(thread: Thread): string",
         "description": "",
         "params": [
           {
@@ -4179,7 +4179,7 @@
     "methods": [
       {
         "name": "selectCheckpoint",
-        "signature": "selectCheckpoint(cp: AgentCheckpoint)",
+        "signature": "selectCheckpoint(cp: AgentCheckpoint): void",
         "description": "",
         "params": [
           {
@@ -4233,7 +4233,7 @@
     "methods": [
       {
         "name": "fork",
-        "signature": "fork(cp: AgentCheckpoint, index: number)",
+        "signature": "fork(cp: AgentCheckpoint, index: number): void",
         "description": "",
         "params": [
           {
@@ -4252,7 +4252,7 @@
       },
       {
         "name": "replay",
-        "signature": "replay(cp: AgentCheckpoint)",
+        "signature": "replay(cp: AgentCheckpoint): void",
         "description": "",
         "params": [
           {
@@ -4312,7 +4312,7 @@
     "methods": [
       {
         "name": "formatJson",
-        "signature": "formatJson(value: unknown)",
+        "signature": "formatJson(value: unknown): string",
         "description": "",
         "params": [
           {
@@ -4364,7 +4364,7 @@
       },
       {
         "name": "groupSummary",
-        "type": "InputSignal<object | undefined>",
+        "type": "InputSignal<(name: string, count: number) => string | undefined>",
         "description": "",
         "optional": false
       },
@@ -4390,7 +4390,7 @@
     "methods": [
       {
         "name": "summarize",
-        "signature": "summarize(name: string, count: number)",
+        "signature": "summarize(name: string, count: number): string",
         "description": "",
         "params": [
           {
@@ -4409,7 +4409,7 @@
       },
       {
         "name": "toggleGroup",
-        "signature": "toggleGroup(index: number)",
+        "signature": "toggleGroup(index: number): void",
         "description": "",
         "params": [
           {
@@ -4422,7 +4422,7 @@
       },
       {
         "name": "toToolCallInfo",
-        "signature": "toToolCallInfo(tc: ToolCall)",
+        "signature": "toToolCallInfo(tc: ToolCall): ToolCallInfo",
         "description": "",
         "params": [
           {
@@ -4492,7 +4492,7 @@
     "methods": [
       {
         "name": "toggle",
-        "signature": "toggle()",
+        "signature": "toggle(): void",
         "description": "",
         "params": []
       }
@@ -4589,7 +4589,7 @@
     "methods": [
       {
         "name": "lookup",
-        "signature": "lookup(refId: string)",
+        "signature": "lookup(refId: string): Signal<ResolvedCitation | null>",
         "description": "",
         "params": [
           {
@@ -4657,7 +4657,7 @@
     "methods": [
       {
         "name": "resolve",
-        "signature": "resolve(child: MarkdownNode)",
+        "signature": "resolve(child: MarkdownNode): Type<unknown> | null",
         "description": "",
         "params": [
           {
@@ -5134,36 +5134,79 @@
         "type": "Signal<Map<string, A2uiSurfaceState>>",
         "description": "Chat-side projections with per-component readiness.",
         "optional": false
-      },
+      }
+    ],
+    "methods": [
       {
         "name": "apply",
-        "type": "unknown",
+        "signature": "apply(message: A2uiMessage): void",
         "description": "",
-        "optional": false
+        "params": [
+          {
+            "name": "message",
+            "type": "A2uiMessage",
+            "description": "",
+            "optional": false
+          }
+        ]
       },
       {
         "name": "applyPartialArgs",
-        "type": "unknown",
-        "description": "",
-        "optional": false
+        "signature": "applyPartialArgs(toolCallId: string, envelopes: readonly A2uiMessage[]): void",
+        "description": "Live-stream entry point. Iterates envelopes and feeds each through\n`apply()`. Records the tool_call_id so the wrapped-content classifier\ncan short-circuit duplicate dispatch when the final AIMessage arrives.",
+        "params": [
+          {
+            "name": "toolCallId",
+            "type": "string",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "envelopes",
+            "type": "readonly A2uiMessage[]",
+            "description": "",
+            "optional": false
+          }
+        ]
       },
       {
         "name": "isPartialLive",
-        "type": "unknown",
-        "description": "",
-        "optional": false
+        "signature": "isPartialLive(toolCallId: string): boolean",
+        "description": "True if a tool_call_id has produced live envelopes via applyPartialArgs.",
+        "params": [
+          {
+            "name": "toolCallId",
+            "type": "string",
+            "description": "",
+            "optional": false
+          }
+        ]
       },
       {
         "name": "surface",
-        "type": "unknown",
+        "signature": "surface(surfaceId: string): Signal<any>",
         "description": "",
-        "optional": false
+        "params": [
+          {
+            "name": "surfaceId",
+            "type": "string",
+            "description": "",
+            "optional": false
+          }
+        ]
       },
       {
         "name": "surfaceState",
-        "type": "unknown",
+        "signature": "surfaceState(surfaceId: string): Signal<A2uiSurfaceState | undefined>",
         "description": "",
-        "optional": false
+        "params": [
+          {
+            "name": "surfaceId",
+            "type": "string",
+            "description": "",
+            "optional": false
+          }
+        ]
       }
     ],
     "examples": []
@@ -5205,7 +5248,7 @@
       },
       {
         "name": "regenerate",
-        "type": "object",
+        "type": "(assistantMessageIndex: number) => Promise<void>",
         "description": "Discards the assistant message at the given index AND all messages after\nit, then re-runs the agent against the trimmed conversation tail. The\npreceding user message (at index - 1) is preserved and re-submitted as\nthe agent's input. No new user message is added to the history.\n\nThrows if the message at `index` is not 'assistant' role, or if the\nagent is currently loading another response.",
         "optional": false
       },
@@ -5223,7 +5266,7 @@
       },
       {
         "name": "stop",
-        "type": "object",
+        "type": "() => Promise<void>",
         "description": "",
         "optional": false
       },
@@ -5235,7 +5278,7 @@
       },
       {
         "name": "submit",
-        "type": "object",
+        "type": "(input: AgentSubmitInput, opts: AgentSubmitOptions) => Promise<void>",
         "description": "",
         "optional": false
       },
@@ -5505,7 +5548,7 @@
       },
       {
         "name": "regenerate",
-        "type": "object",
+        "type": "(assistantMessageIndex: number) => Promise<void>",
         "description": "Discards the assistant message at the given index AND all messages after\nit, then re-runs the agent against the trimmed conversation tail. The\npreceding user message (at index - 1) is preserved and re-submitted as\nthe agent's input. No new user message is added to the history.\n\nThrows if the message at `index` is not 'assistant' role, or if the\nagent is currently loading another response.",
         "optional": false
       },
@@ -5523,7 +5566,7 @@
       },
       {
         "name": "stop",
-        "type": "object",
+        "type": "() => Promise<void>",
         "description": "",
         "optional": false
       },
@@ -5535,7 +5578,7 @@
       },
       {
         "name": "submit",
-        "type": "object",
+        "type": "(input: AgentSubmitInput, opts: AgentSubmitOptions) => Promise<void>",
         "description": "",
         "optional": false
       },
@@ -5792,18 +5835,27 @@
         "type": "Signal<ContentType>",
         "description": "",
         "optional": false
-      },
+      }
+    ],
+    "methods": [
       {
         "name": "dispose",
-        "type": "unknown",
+        "signature": "dispose(): void",
         "description": "",
-        "optional": false
+        "params": []
       },
       {
         "name": "update",
-        "type": "unknown",
+        "signature": "update(content: string): void",
         "description": "",
-        "optional": false
+        "params": [
+          {
+            "name": "content",
+            "type": "string",
+            "description": "",
+            "optional": false
+          }
+        ]
       }
     ],
     "examples": []
@@ -5963,7 +6015,7 @@
       },
       {
         "name": "regenerate",
-        "type": "object",
+        "type": "(assistantMessageIndex: number) => Promise<void>",
         "description": "Discards the assistant message at the given index AND all messages after\nit, then re-runs the agent against the trimmed conversation tail. The\npreceding user message (at index - 1) is preserved and re-submitted as\nthe agent's input. No new user message is added to the history.\n\nThrows if the message at `index` is not 'assistant' role, or if the\nagent is currently loading another response.",
         "optional": false
       },
@@ -5981,7 +6033,7 @@
       },
       {
         "name": "stop",
-        "type": "object",
+        "type": "() => Promise<void>",
         "description": "",
         "optional": false
       },
@@ -5999,7 +6051,7 @@
       },
       {
         "name": "submit",
-        "type": "object",
+        "type": "(input: AgentSubmitInput, opts: AgentSubmitOptions) => Promise<void>",
         "description": "",
         "optional": false
       },
@@ -6134,12 +6186,21 @@
         "type": "Signal<Spec | null>",
         "description": "",
         "optional": false
-      },
+      }
+    ],
+    "methods": [
       {
         "name": "push",
-        "type": "unknown",
+        "signature": "push(chunk: string): void",
         "description": "",
-        "optional": false
+        "params": [
+          {
+            "name": "chunk",
+            "type": "string",
+            "description": "",
+            "optional": false
+          }
+        ]
       }
     ],
     "examples": []
@@ -6148,18 +6209,39 @@
     "name": "PartialArgsBridge",
     "kind": "interface",
     "description": "",
-    "properties": [
+    "properties": [],
+    "methods": [
       {
         "name": "isPoisoned",
-        "type": "unknown",
-        "description": "",
-        "optional": false
+        "signature": "isPoisoned(toolCallId: string): boolean",
+        "description": "True if a tool_call_id has been poisoned by malformed input.",
+        "params": [
+          {
+            "name": "toolCallId",
+            "type": "string",
+            "description": "",
+            "optional": false
+          }
+        ]
       },
       {
         "name": "push",
-        "type": "unknown",
-        "description": "",
-        "optional": false
+        "signature": "push(toolCallId: string, argsSoFar: string): void",
+        "description": "Replace the cumulative argument-string buffer for `toolCallId` with\n`argsSoFar` and re-extract any newly-complete envelopes. The args\nstring is expected to grow monotonically.",
+        "params": [
+          {
+            "name": "toolCallId",
+            "type": "string",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "argsSoFar",
+            "type": "string",
+            "description": "",
+            "optional": false
+          }
+        ]
       }
     ],
     "examples": []
@@ -6168,24 +6250,52 @@
     "name": "ProjectActionAdapter",
     "kind": "interface",
     "description": "Consumer-provided adapter for project lifecycle actions. The framework calls\nthese methods after user confirmation (delete) or commit (create/rename) and\nmanages optimistic UI + rollback on rejection.",
-    "properties": [
+    "properties": [],
+    "methods": [
       {
         "name": "create",
-        "type": "unknown",
-        "description": "",
-        "optional": true
+        "signature": "create(name: string): Promise<object>",
+        "description": "Create a new project. Returns the new project id; consumer is expected\n to also refresh its projects signal.",
+        "params": [
+          {
+            "name": "name",
+            "type": "string",
+            "description": "",
+            "optional": false
+          }
+        ]
       },
       {
         "name": "delete",
-        "type": "unknown",
-        "description": "",
-        "optional": true
+        "signature": "delete(projectId: string): Promise<void>",
+        "description": "Permanently delete the project. The framework calls this AFTER user\n confirms via the confirm dialog.",
+        "params": [
+          {
+            "name": "projectId",
+            "type": "string",
+            "description": "",
+            "optional": false
+          }
+        ]
       },
       {
         "name": "rename",
-        "type": "unknown",
+        "signature": "rename(projectId: string, newName: string): Promise<void>",
         "description": "",
-        "optional": true
+        "params": [
+          {
+            "name": "projectId",
+            "type": "string",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "newName",
+            "type": "string",
+            "description": "",
+            "optional": false
+          }
+        ]
       }
     ],
     "examples": []
@@ -6252,54 +6362,129 @@
     "name": "ThreadActionAdapter",
     "kind": "interface",
     "description": "Per-thread row-action adapter. Consumer-provided. The framework calls\nthese methods after user confirmation (delete) or commit (rename) and\nmanages optimistic UI + rollback on rejection.\n\nConsumers MUST refresh their `threads` signal on success — the framework\nclears optimistic overrides in a `finally` block, so a successful adapter\ncall that leaves the input list unchanged would re-render the row.",
-    "properties": [
+    "properties": [],
+    "methods": [
       {
         "name": "archive",
-        "type": "unknown",
-        "description": "",
-        "optional": true
+        "signature": "archive(threadId: string): Promise<void>",
+        "description": "Archive a thread (reversible). No confirmation dialog — framework calls\n this immediately on click.",
+        "params": [
+          {
+            "name": "threadId",
+            "type": "string",
+            "description": "",
+            "optional": false
+          }
+        ]
       },
       {
         "name": "delete",
-        "type": "unknown",
+        "signature": "delete(threadId: string): Promise<void>",
         "description": "",
-        "optional": true
+        "params": [
+          {
+            "name": "threadId",
+            "type": "string",
+            "description": "",
+            "optional": false
+          }
+        ]
       },
       {
         "name": "moveToProject",
-        "type": "unknown",
-        "description": "",
-        "optional": true
+        "signature": "moveToProject(threadId: string, projectId: string | null): Promise<void>",
+        "description": "Move thread to a project (or pass null to remove from any project).\n Optimistically hides the row from the current project's visible list;\n consumer is expected to refresh the threads input.",
+        "params": [
+          {
+            "name": "threadId",
+            "type": "string",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "projectId",
+            "type": "string | null",
+            "description": "",
+            "optional": false
+          }
+        ]
       },
       {
         "name": "pin",
-        "type": "unknown",
-        "description": "",
-        "optional": true
+        "signature": "pin(threadId: string): Promise<void>",
+        "description": "Mark the thread as pinned.",
+        "params": [
+          {
+            "name": "threadId",
+            "type": "string",
+            "description": "",
+            "optional": false
+          }
+        ]
       },
       {
         "name": "rename",
-        "type": "unknown",
+        "signature": "rename(threadId: string, newTitle: string): Promise<void>",
         "description": "",
-        "optional": true
+        "params": [
+          {
+            "name": "threadId",
+            "type": "string",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "newTitle",
+            "type": "string",
+            "description": "",
+            "optional": false
+          }
+        ]
       },
       {
         "name": "reorderPinned",
-        "type": "unknown",
-        "description": "",
-        "optional": true
+        "signature": "reorderPinned(threadId: string, beforeId: string | null): Promise<void>",
+        "description": "Reorder a pinned thread. `beforeId` is the id of the pinned thread it\n should be placed before, or null to move to the end of the pinned list.\n Framework optimistically reorders the visible list and awaits this\n method; rejection rolls back.",
+        "params": [
+          {
+            "name": "threadId",
+            "type": "string",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "beforeId",
+            "type": "string | null",
+            "description": "",
+            "optional": false
+          }
+        ]
       },
       {
         "name": "unarchive",
-        "type": "unknown",
-        "description": "",
-        "optional": true
+        "signature": "unarchive(threadId: string): Promise<void>",
+        "description": "Restore an archived thread to the active list.",
+        "params": [
+          {
+            "name": "threadId",
+            "type": "string",
+            "description": "",
+            "optional": false
+          }
+        ]
       },
       {
         "name": "unpin",
-        "type": "unknown",
-        "description": "",
-        "optional": true
+        "signature": "unpin(threadId: string): Promise<void>",
+        "description": "Unpin a previously pinned thread.",
+        "params": [
+          {
+            "name": "threadId",
+            "type": "string",
+            "description": "",
+            "optional": false
+          }
+        ]
       }
     ],
     "examples": []
@@ -6451,7 +6636,7 @@
     "name": "AgentRuntimeTelemetrySink",
     "kind": "type",
     "description": "",
-    "signature": "object",
+    "signature": "(payload: AgentRuntimeTelemetryPayload) => void | Promise<void>",
     "examples": []
   },
   {
@@ -6669,11 +6854,11 @@
     "name": "emitBinding",
     "kind": "function",
     "description": "Emits a data model binding event if the prop has a binding path.",
-    "signature": "emitBinding(emit: object, bindings: Record<string, string> | undefined, prop: string, value: unknown): void",
+    "signature": "emitBinding(emit: (event: string) => void, bindings: Record<string, string> | undefined, prop: string, value: unknown): void",
     "params": [
       {
         "name": "emit",
-        "type": "object",
+        "type": "(event: string) => void",
         "description": "",
         "optional": false
       },
@@ -7098,7 +7283,7 @@
     "name": "withoutViews",
     "kind": "function",
     "description": "Removes views from a registry by name.",
-    "signature": "withoutViews(base: ViewRegistry, names: string[]): ViewRegistry",
+    "signature": "withoutViews(base: ViewRegistry, ...names: string[]): ViewRegistry",
     "params": [
       {
         "name": "base",
@@ -7107,7 +7292,7 @@
         "optional": false
       },
       {
-        "name": "names",
+        "name": "...names",
         "type": "string[]",
         "description": "",
         "optional": false
@@ -7213,7 +7398,7 @@
     "name": "runAgentConformance",
     "kind": "function",
     "description": "Runs a suite of contract conformance assertions against a factory that\nproduces a fresh Agent. Adapter packages should call this in their\nown test suites to verify the contract is satisfied.",
-    "signature": "runAgentConformance(label: string, factory: object): void",
+    "signature": "runAgentConformance(label: string, factory: () => Agent): void",
     "params": [
       {
         "name": "label",
@@ -7223,7 +7408,7 @@
       },
       {
         "name": "factory",
-        "type": "object",
+        "type": "() => Agent",
         "description": "",
         "optional": false
       }
@@ -7238,7 +7423,7 @@
     "name": "runAgentWithHistoryConformance",
     "kind": "function",
     "description": "Conformance suite for AgentWithHistory implementations.\n\nRuns the base Agent conformance suite, then verifies the history\nsignal is present and returns an array of AgentCheckpoint-shaped entries.",
-    "signature": "runAgentWithHistoryConformance(label: string, factory: object): void",
+    "signature": "runAgentWithHistoryConformance(label: string, factory: (seed: object) => AgentWithHistory): void",
     "params": [
       {
         "name": "label",
@@ -7248,7 +7433,7 @@
       },
       {
         "name": "factory",
-        "type": "object",
+        "type": "(seed: object) => AgentWithHistory",
         "description": "",
         "optional": false
       }

--- a/apps/website/content/docs/langgraph/api/api-docs.json
+++ b/apps/website/content/docs/langgraph/api/api-docs.json
@@ -16,7 +16,7 @@
     "methods": [
       {
         "name": "register",
-        "signature": "register(lifecycle: AgentLifecycle)",
+        "signature": "register(lifecycle: AgentLifecycle): void",
         "description": "",
         "params": [
           {
@@ -46,7 +46,7 @@
     "methods": [
       {
         "name": "cancelRun",
-        "signature": "cancelRun(_threadId: string, _runId: string, _signal: AbortSignal)",
+        "signature": "cancelRun(_threadId: string, _runId: string, _signal: AbortSignal): Promise<void>",
         "description": "Optional: cancel a server-side run.",
         "params": [
           {
@@ -71,7 +71,7 @@
       },
       {
         "name": "createQueuedRun",
-        "signature": "createQueuedRun(_assistantId: string, threadId: string, payload: unknown, _signal: AbortSignal, options: LangGraphSubmitOptions)",
+        "signature": "createQueuedRun(_assistantId: string, threadId: string, payload: unknown, _signal: AbortSignal, options: LangGraphSubmitOptions): Promise<AgentQueueEntry<unknown>>",
         "description": "Optional: create a server-side queued run without joining it immediately.",
         "params": [
           {
@@ -108,7 +108,7 @@
       },
       {
         "name": "getHistory",
-        "signature": "getHistory(_threadId: string, _signal: AbortSignal)",
+        "signature": "getHistory(_threadId: string, _signal: AbortSignal): Promise<ThreadState<DefaultValues>[]>",
         "description": "Optional: load persisted checkpoint history for a thread.",
         "params": [
           {
@@ -127,13 +127,13 @@
       },
       {
         "name": "joinStream",
-        "signature": "joinStream()",
+        "signature": "joinStream(): AsyncIterable<StreamEvent>",
         "description": "Optional: join an already-started run without creating a new one.",
         "params": []
       },
       {
         "name": "stream",
-        "signature": "stream(_assistantId: string, _threadId: string | null, _payload: unknown, signal: AbortSignal, _options: LangGraphSubmitOptions)",
+        "signature": "stream(_assistantId: string, _threadId: string | null, _payload: unknown, signal: AbortSignal, _options: LangGraphSubmitOptions): AsyncIterable<StreamEvent>",
         "description": "Open a streaming connection to an agent and yield events.",
         "params": [
           {
@@ -183,7 +183,7 @@
       },
       {
         "name": "onThreadId",
-        "type": "object",
+        "type": "(id: string) => void",
         "description": "Optional callback invoked when a new thread is created",
         "optional": true
       }
@@ -195,7 +195,7 @@
     "methods": [
       {
         "name": "cancelRun",
-        "signature": "cancelRun(threadId: string, runId: string, signal: AbortSignal)",
+        "signature": "cancelRun(threadId: string, runId: string, signal: AbortSignal): Promise<void>",
         "description": "Cancel a server-side run.",
         "params": [
           {
@@ -220,7 +220,7 @@
       },
       {
         "name": "createQueuedRun",
-        "signature": "createQueuedRun(assistantId: string, threadId: string, payload: unknown, signal: AbortSignal, options: LangGraphSubmitOptions)",
+        "signature": "createQueuedRun(assistantId: string, threadId: string, payload: unknown, signal: AbortSignal, options: LangGraphSubmitOptions): Promise<AgentQueueEntry<unknown>>",
         "description": "Create a pending server-side run using LangGraph's enqueue strategy.",
         "params": [
           {
@@ -257,7 +257,7 @@
       },
       {
         "name": "getHistory",
-        "signature": "getHistory(threadId: string, signal: AbortSignal)",
+        "signature": "getHistory(threadId: string, signal: AbortSignal): Promise<ThreadState<DefaultValues>[]>",
         "description": "Load persisted checkpoint history for a thread.",
         "params": [
           {
@@ -276,7 +276,7 @@
       },
       {
         "name": "joinStream",
-        "signature": "joinStream(threadId: string, runId: string, lastEventId: string | undefined, signal: AbortSignal)",
+        "signature": "joinStream(threadId: string, runId: string, lastEventId: string | undefined, signal: AbortSignal): AsyncIterable<StreamEvent>",
         "description": "Join an already-started run without creating a new thread.",
         "params": [
           {
@@ -307,7 +307,7 @@
       },
       {
         "name": "stream",
-        "signature": "stream(assistantId: string, threadId: string | null, payload: unknown, signal: AbortSignal, options: LangGraphSubmitOptions)",
+        "signature": "stream(assistantId: string, threadId: string | null, payload: unknown, signal: AbortSignal, options: LangGraphSubmitOptions): AsyncIterable<StreamEvent>",
         "description": "Open a streaming connection, creating a thread if needed.",
         "params": [
           {
@@ -344,7 +344,7 @@
       },
       {
         "name": "updateState",
-        "signature": "updateState(threadId: string, values: Record<string, unknown>, _signal: AbortSignal, options: object)",
+        "signature": "updateState(threadId: string, values: Record<string, unknown>, _signal: AbortSignal, options: object): Promise<void>",
         "description": "Update server-side thread state, e.g. to remove messages for regenerate rollback.",
         "params": [
           {
@@ -400,7 +400,7 @@
     "methods": [
       {
         "name": "archive",
-        "signature": "archive(threadId: string)",
+        "signature": "archive(threadId: string): Promise<void>",
         "description": "",
         "params": [
           {
@@ -413,7 +413,7 @@
       },
       {
         "name": "create",
-        "signature": "create(metadata: Record<string, unknown>)",
+        "signature": "create(metadata: Record<string, unknown>): Promise<string | null>",
         "description": "",
         "params": [
           {
@@ -426,7 +426,7 @@
       },
       {
         "name": "delete",
-        "signature": "delete(threadId: string)",
+        "signature": "delete(threadId: string): Promise<void>",
         "description": "",
         "params": [
           {
@@ -439,7 +439,7 @@
       },
       {
         "name": "getThread",
-        "signature": "getThread(threadId: string)",
+        "signature": "getThread(threadId: string): Promise<Thread | null>",
         "description": "Fetch a single thread by id. Returns `null` when the server\n returns 404 (thread doesn't exist) so callers can distinguish\n \"missing\" from \"couldn't reach the server\" — genuine network\n errors rethrow. Used by URL-based thread routing to validate a\n pasted/shared thread id before activating it.",
         "params": [
           {
@@ -452,7 +452,7 @@
       },
       {
         "name": "moveToProject",
-        "signature": "moveToProject(threadId: string, projectId: string | null)",
+        "signature": "moveToProject(threadId: string, projectId: string | null): Promise<void>",
         "description": "",
         "params": [
           {
@@ -471,7 +471,7 @@
       },
       {
         "name": "pin",
-        "signature": "pin(threadId: string)",
+        "signature": "pin(threadId: string): Promise<void>",
         "description": "",
         "params": [
           {
@@ -484,13 +484,13 @@
       },
       {
         "name": "refresh",
-        "signature": "refresh()",
+        "signature": "refresh(): Promise<void>",
         "description": "Fetch the latest thread list from the server. Failures are\n logged via `console.error` (not swallowed silently — silent\n catches have masked prod issues in the past).\n\n Invocation and resolution are logged at `console.debug` so prod\n inspection can distinguish \"never called\" from \"called but\n resolved empty\" from \"called and threw.\" This was prompted by a\n demo.threadplane.ai cold-load bug where the sidenav stayed empty\n with no visible signal. Tighten the log volume if it becomes\n noisy.",
         "params": []
       },
       {
         "name": "rename",
-        "signature": "rename(threadId: string, newTitle: string)",
+        "signature": "rename(threadId: string, newTitle: string): Promise<void>",
         "description": "",
         "params": [
           {
@@ -509,7 +509,7 @@
       },
       {
         "name": "reorderPinned",
-        "signature": "reorderPinned(threadId: string, beforeId: string | null)",
+        "signature": "reorderPinned(threadId: string, beforeId: string | null): Promise<void>",
         "description": "Re-stamp `metadata.pinnedOrder = 0,1,2,...` for the pinned slice\n to reflect the new ordering.",
         "params": [
           {
@@ -528,7 +528,7 @@
       },
       {
         "name": "unarchive",
-        "signature": "unarchive(threadId: string)",
+        "signature": "unarchive(threadId: string): Promise<void>",
         "description": "",
         "params": [
           {
@@ -541,7 +541,7 @@
       },
       {
         "name": "unpin",
-        "signature": "unpin(threadId: string)",
+        "signature": "unpin(threadId: string): Promise<void>",
         "description": "",
         "params": [
           {
@@ -610,7 +610,7 @@
     "methods": [
       {
         "name": "cancelRun",
-        "signature": "cancelRun(threadId: string, runId: string, signal: AbortSignal)",
+        "signature": "cancelRun(threadId: string, runId: string, signal: AbortSignal): Promise<void>",
         "description": "Optional: cancel a server-side run.",
         "params": [
           {
@@ -635,13 +635,13 @@
       },
       {
         "name": "close",
-        "signature": "close()",
+        "signature": "close(): void",
         "description": "Close the stream. Remaining queued events are drained before completion.",
         "params": []
       },
       {
         "name": "createQueuedRun",
-        "signature": "createQueuedRun(_assistantId: string, threadId: string, payload: unknown, signal: AbortSignal, options: LangGraphSubmitOptions)",
+        "signature": "createQueuedRun(_assistantId: string, threadId: string, payload: unknown, signal: AbortSignal, options: LangGraphSubmitOptions): Promise<AgentQueueEntry<unknown>>",
         "description": "Optional: create a server-side queued run without joining it immediately.",
         "params": [
           {
@@ -678,7 +678,7 @@
       },
       {
         "name": "emit",
-        "signature": "emit(events: StreamEvent[])",
+        "signature": "emit(events: StreamEvent[]): void",
         "description": "Manually emit events into the stream.",
         "params": [
           {
@@ -691,7 +691,7 @@
       },
       {
         "name": "emitError",
-        "signature": "emitError(err: Error)",
+        "signature": "emitError(err: Error): void",
         "description": "Inject an error into the stream.",
         "params": [
           {
@@ -704,7 +704,7 @@
       },
       {
         "name": "getHistory",
-        "signature": "getHistory(threadId: string, signal: AbortSignal)",
+        "signature": "getHistory(threadId: string, signal: AbortSignal): Promise<ThreadState<DefaultValues>[]>",
         "description": "Optional: load persisted checkpoint history for a thread.",
         "params": [
           {
@@ -723,13 +723,13 @@
       },
       {
         "name": "isStreaming",
-        "signature": "isStreaming()",
+        "signature": "isStreaming(): boolean",
         "description": "Returns true if a stream is currently active.",
         "params": []
       },
       {
         "name": "joinStream",
-        "signature": "joinStream(threadId: string, runId: string, lastEventId: string | undefined, signal: AbortSignal)",
+        "signature": "joinStream(threadId: string, runId: string, lastEventId: string | undefined, signal: AbortSignal): AsyncIterable<StreamEvent>",
         "description": "Optional: join an already-started run without creating a new one.",
         "params": [
           {
@@ -760,13 +760,13 @@
       },
       {
         "name": "nextBatch",
-        "signature": "nextBatch()",
+        "signature": "nextBatch(): StreamEvent[]",
         "description": "Advance to the next scripted batch. Pass the returned events to `emit()`.",
         "params": []
       },
       {
         "name": "stream",
-        "signature": "stream(_assistantId: string, _threadId: string | null, _payload: unknown, signal: AbortSignal, options: LangGraphSubmitOptions)",
+        "signature": "stream(_assistantId: string, _threadId: string | null, _payload: unknown, signal: AbortSignal, options: LangGraphSubmitOptions): AsyncIterable<StreamEvent>",
         "description": "Open a streaming connection to an agent and yield events.",
         "params": [
           {
@@ -900,7 +900,7 @@
       },
       {
         "name": "onThreadId",
-        "type": "object",
+        "type": "(id: string) => void",
         "description": "Called when a new thread is auto-created by the transport.",
         "optional": true
       },
@@ -930,7 +930,7 @@
       },
       {
         "name": "toMessage",
-        "type": "object",
+        "type": "(msg: unknown) => BaseMessage<>",
         "description": "Custom message deserializer for non-standard message formats.",
         "optional": true
       },
@@ -1030,7 +1030,7 @@
       },
       {
         "name": "onThreadId",
-        "type": "object",
+        "type": "(id: string) => void",
         "description": "Called when a new thread is auto-created by the transport.",
         "optional": true
       },
@@ -1060,7 +1060,7 @@
       },
       {
         "name": "toMessage",
-        "type": "object",
+        "type": "(msg: unknown) => BaseMessage<>",
         "description": "Custom message deserializer for non-standard message formats.",
         "optional": true
       },
@@ -1080,13 +1080,13 @@
     "properties": [
       {
         "name": "cancel",
-        "type": "object",
+        "type": "(id: string) => Promise<boolean>",
         "description": "Cancel a specific pending run by server run ID.",
         "optional": false
       },
       {
         "name": "clear",
-        "type": "object",
+        "type": "() => Promise<void>",
         "description": "Cancel all pending runs and clear the queue.",
         "optional": false
       },
@@ -1147,42 +1147,187 @@
     "name": "AgentTransport",
     "kind": "interface",
     "description": "Transport interface for connecting to a LangGraph agent.",
-    "properties": [
+    "properties": [],
+    "methods": [
       {
         "name": "cancelRun",
-        "type": "unknown",
-        "description": "",
-        "optional": true
+        "signature": "cancelRun(threadId: string, runId: string, signal: AbortSignal): Promise<void>",
+        "description": "Optional: cancel a server-side run.",
+        "params": [
+          {
+            "name": "threadId",
+            "type": "string",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "runId",
+            "type": "string",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "signal",
+            "type": "AbortSignal",
+            "description": "",
+            "optional": false
+          }
+        ]
       },
       {
         "name": "createQueuedRun",
-        "type": "unknown",
-        "description": "",
-        "optional": true
+        "signature": "createQueuedRun(assistantId: string, threadId: string, payload: unknown, signal: AbortSignal, options: LangGraphSubmitOptions): Promise<AgentQueueEntry<unknown>>",
+        "description": "Optional: create a server-side queued run without joining it immediately.",
+        "params": [
+          {
+            "name": "assistantId",
+            "type": "string",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "threadId",
+            "type": "string",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "payload",
+            "type": "unknown",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "signal",
+            "type": "AbortSignal",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "options",
+            "type": "LangGraphSubmitOptions",
+            "description": "",
+            "optional": true
+          }
+        ]
       },
       {
         "name": "getHistory",
-        "type": "unknown",
-        "description": "",
-        "optional": true
+        "signature": "getHistory(threadId: string, signal: AbortSignal): Promise<ThreadState<DefaultValues>[]>",
+        "description": "Optional: load persisted checkpoint history for a thread.",
+        "params": [
+          {
+            "name": "threadId",
+            "type": "string",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "signal",
+            "type": "AbortSignal",
+            "description": "",
+            "optional": false
+          }
+        ]
       },
       {
         "name": "joinStream",
-        "type": "unknown",
-        "description": "",
-        "optional": true
+        "signature": "joinStream(threadId: string, runId: string, lastEventId: string | undefined, signal: AbortSignal): AsyncIterable<StreamEvent>",
+        "description": "Optional: join an already-started run without creating a new one.",
+        "params": [
+          {
+            "name": "threadId",
+            "type": "string",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "runId",
+            "type": "string",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "lastEventId",
+            "type": "string | undefined",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "signal",
+            "type": "AbortSignal",
+            "description": "",
+            "optional": false
+          }
+        ]
       },
       {
         "name": "stream",
-        "type": "unknown",
-        "description": "",
-        "optional": false
+        "signature": "stream(assistantId: string, threadId: string | null, payload: unknown, signal: AbortSignal, options: LangGraphSubmitOptions): AsyncIterable<StreamEvent>",
+        "description": "Open a streaming connection to an agent and yield events.",
+        "params": [
+          {
+            "name": "assistantId",
+            "type": "string",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "threadId",
+            "type": "string | null",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "payload",
+            "type": "unknown",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "signal",
+            "type": "AbortSignal",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "options",
+            "type": "LangGraphSubmitOptions",
+            "description": "",
+            "optional": true
+          }
+        ]
       },
       {
         "name": "updateState",
-        "type": "unknown",
-        "description": "",
-        "optional": true
+        "signature": "updateState(threadId: string, values: Record<string, unknown>, signal: AbortSignal, options: object): Promise<void>",
+        "description": "Optional: update server-side thread state (e.g. to emit RemoveMessage\nentries for regenerate rollback). Forwards to the LangGraph\n`threads.updateState` API.\n\n`options.asNode` corresponds to LangGraph's `as_node` parameter — the\nserver treats the update as if that node had just produced the values,\nwhich determines what the next pull resumes. `regenerate()` passes\n`asNode: '__start__'` so the next `submit(null)` resumes at the entry\nnode and re-runs `generate` against the rolled-back state.",
+        "params": [
+          {
+            "name": "threadId",
+            "type": "string",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "values",
+            "type": "Record<string, unknown>",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "signal",
+            "type": "AbortSignal",
+            "description": "",
+            "optional": false
+          },
+          {
+            "name": "options",
+            "type": "object",
+            "description": "",
+            "optional": true
+          }
+        ]
       }
     ],
     "examples": []
@@ -1288,31 +1433,31 @@
       },
       {
         "name": "getMessagesMetadata",
-        "type": "object",
+        "type": "(msg: BaseMessage<>, idx: number) => MessageMetadata<Record<string, unknown>> | undefined",
         "description": "Get metadata for a specific message by index.",
         "optional": false
       },
       {
         "name": "getSubagent",
-        "type": "object",
+        "type": "(toolCallId: string) => SubagentStreamRef | undefined",
         "description": "Get a subagent stream by the tool call ID that spawned it.",
         "optional": false
       },
       {
         "name": "getSubagentsByMessage",
-        "type": "object",
+        "type": "(msg: AIMessage<>) => SubagentStreamRef[]",
         "description": "Get subagent streams spawned by the tool calls on a specific AI message.",
         "optional": false
       },
       {
         "name": "getSubagentsByType",
-        "type": "object",
+        "type": "(type: string) => SubagentStreamRef[]",
         "description": "Get subagent streams by their configured subagent type/name.",
         "optional": false
       },
       {
         "name": "getToolCalls",
-        "type": "object",
+        "type": "(msg: AIMessage<>) => ToolCallWithResult<>[]",
         "description": "Get tool call results associated with an AI message (LangGraph types).",
         "optional": false
       },
@@ -1348,7 +1493,7 @@
       },
       {
         "name": "joinStream",
-        "type": "object",
+        "type": "(runId: string, lastEventId: string) => Promise<void>",
         "description": "Join an already-running stream by run ID.",
         "optional": false
       },
@@ -1402,19 +1547,19 @@
       },
       {
         "name": "regenerate",
-        "type": "object",
+        "type": "(assistantMessageIndex: number) => Promise<void>",
         "description": "Discards the assistant message at the given index AND all messages after\nit, then re-runs the agent against the trimmed conversation tail. The\npreceding user message (at index - 1) is preserved and re-submitted as\nthe agent's input. No new user message is added to the history.\n\nThrows if the message at `index` is not 'assistant' role, or if the\nagent is currently loading another response.",
         "optional": false
       },
       {
         "name": "reload",
-        "type": "object",
+        "type": "() => void",
         "description": "Re-submit the last input to restart the stream.",
         "optional": false
       },
       {
         "name": "setBranch",
-        "type": "object",
+        "type": "(branch: string) => void",
         "description": "Set the active branch for time-travel navigation.",
         "optional": false
       },
@@ -1432,7 +1577,7 @@
       },
       {
         "name": "stop",
-        "type": "object",
+        "type": "() => Promise<void>",
         "description": "",
         "optional": false
       },
@@ -1444,13 +1589,13 @@
       },
       {
         "name": "submit",
-        "type": "object",
+        "type": "(input: AgentSubmitInput | null | undefined, opts: AgentSubmitOptions & LangGraphSubmitOptions) => Promise<void>",
         "description": "Submit input, resume commands, checkpoint forks, or other LangGraph run options.",
         "optional": false
       },
       {
         "name": "switchThread",
-        "type": "object",
+        "type": "(threadId: string | null) => void",
         "description": "Switch to a different thread, resetting derived state.",
         "optional": false
       },
@@ -1578,7 +1723,7 @@
       },
       {
         "name": "onRunCreated",
-        "type": "object",
+        "type": "(params: object) => void",
         "description": "",
         "optional": true
       },
@@ -1690,31 +1835,31 @@
       },
       {
         "name": "getMessagesMetadata",
-        "type": "object",
+        "type": "(msg: BaseMessage<>, idx: number) => MessageMetadata<Record<string, unknown>> | undefined",
         "description": "Get metadata for a specific message by index.",
         "optional": false
       },
       {
         "name": "getSubagent",
-        "type": "object",
+        "type": "(toolCallId: string) => SubagentStreamRef | undefined",
         "description": "Get a subagent stream by the tool call ID that spawned it.",
         "optional": false
       },
       {
         "name": "getSubagentsByMessage",
-        "type": "object",
+        "type": "(msg: AIMessage<>) => SubagentStreamRef[]",
         "description": "Get subagent streams spawned by the tool calls on a specific AI message.",
         "optional": false
       },
       {
         "name": "getSubagentsByType",
-        "type": "object",
+        "type": "(type: string) => SubagentStreamRef[]",
         "description": "Get subagent streams by their configured subagent type/name.",
         "optional": false
       },
       {
         "name": "getToolCalls",
-        "type": "object",
+        "type": "(msg: AIMessage<>) => ToolCallWithResult<>[]",
         "description": "Get tool call results associated with an AI message (LangGraph types).",
         "optional": false
       },
@@ -1750,7 +1895,7 @@
       },
       {
         "name": "joinStream",
-        "type": "object",
+        "type": "(runId: string, lastEventId: string) => Promise<void>",
         "description": "Join an already-running stream by run ID.",
         "optional": false
       },
@@ -1804,19 +1949,19 @@
       },
       {
         "name": "regenerate",
-        "type": "object",
+        "type": "(assistantMessageIndex: number) => Promise<void>",
         "description": "Discards the assistant message at the given index AND all messages after\nit, then re-runs the agent against the trimmed conversation tail. The\npreceding user message (at index - 1) is preserved and re-submitted as\nthe agent's input. No new user message is added to the history.\n\nThrows if the message at `index` is not 'assistant' role, or if the\nagent is currently loading another response.",
         "optional": false
       },
       {
         "name": "reload",
-        "type": "object",
+        "type": "() => void",
         "description": "Re-submit the last input to restart the stream.",
         "optional": false
       },
       {
         "name": "setBranch",
-        "type": "object",
+        "type": "(branch: string) => void",
         "description": "Set the active branch for time-travel navigation.",
         "optional": false
       },
@@ -1834,7 +1979,7 @@
       },
       {
         "name": "stop",
-        "type": "object",
+        "type": "() => Promise<void>",
         "description": "",
         "optional": false
       },
@@ -1852,7 +1997,7 @@
       },
       {
         "name": "submit",
-        "type": "object",
+        "type": "(input: AgentSubmitInput | null | undefined, opts: AgentSubmitOptions & LangGraphSubmitOptions) => Promise<void>",
         "description": "Submit input, resume commands, checkpoint forks, or other LangGraph run options.",
         "optional": false
       },
@@ -1864,7 +2009,7 @@
       },
       {
         "name": "switchThread",
-        "type": "object",
+        "type": "(threadId: string | null) => void",
         "description": "Switch to a different thread, resetting derived state.",
         "optional": false
       },
@@ -2038,13 +2183,13 @@
       },
       {
         "name": "onError",
-        "type": "object",
+        "type": "(error: unknown, run: RunCallbackMeta | undefined) => void",
         "description": "Callback that is called when an error occurs during this specific submit call.\nUnlike the hook-level `onError`, this allows handling errors on a per-submit basis,\ne.g. to show a retry button or a specific error message to the user.",
         "optional": true
       },
       {
         "name": "optimisticValues",
-        "type": "Partial<StateType> | object",
+        "type": "Partial<StateType> | (prev: StateType) => Partial<StateType>",
         "description": "",
         "optional": true
       },
@@ -2234,11 +2379,11 @@
     "name": "provideAgent",
     "kind": "function",
     "description": "Wire the LangGraph adapter into Angular's dependency injection.\n\nRegisters a singleton `LangGraphAgent` constructed from `config`. Retrieve it\nin any component with `injectAgent()`. Provide this at the application root\n(`app.config.ts`) for an app-wide agent.\n\nTo use a different agent in a component subtree, re-provide\n`provideAgent({...})` in that component's `providers: []` array —\nAngular's hierarchical DI scopes the singleton accordingly.\n\n**Static vs factory config.** Pass a plain `AgentConfig` object when the\nconfig is known up front. Pass a `() => AgentConfig` factory when the config\ndepends on runtime/DI state — the factory runs inside an Angular injection\ncontext, so it may call `inject()` to read services, route params, or\ncomponent-scoped signals:\n\n```ts\nproviders: [\n  provideAgent(() => {\n    const route = inject(ActivatedRoute);\n    return { assistantId: 'chat', threadId: toSignal(route.paramMap) };\n  }),\n];\n```",
-    "signature": "provideAgent(configOrFactory: AgentConfig<T, BagTemplate> | object): Provider[]",
+    "signature": "provideAgent(configOrFactory: AgentConfig<T, BagTemplate> | () => AgentConfig<T>): Provider[]",
     "params": [
       {
         "name": "configOrFactory",
-        "type": "AgentConfig<T, BagTemplate> | object",
+        "type": "AgentConfig<T, BagTemplate> | () => AgentConfig<T>",
         "description": "",
         "optional": false
       }
@@ -2272,7 +2417,7 @@
     "name": "refreshOnRunEnd",
     "kind": "function",
     "description": "Call `fn` whenever the agent's status transitions out of `'running'`\n(i.e. when a run completes — success, error, or interrupt). Useful\nfor refreshing thread lists, telemetry, or any other state that\nlags the agent.\n\nMust be called within an injection context (constructor or\n`runInInjectionContext`) — uses Angular's `effect` under the hood.",
-    "signature": "refreshOnRunEnd(agent: LangGraphAgent<>, fn: object): void",
+    "signature": "refreshOnRunEnd(agent: LangGraphAgent<>, fn: () => void | Promise<void>): void",
     "params": [
       {
         "name": "agent",
@@ -2282,7 +2427,7 @@
       },
       {
         "name": "fn",
-        "type": "object",
+        "type": "() => void | Promise<void>",
         "description": "",
         "optional": false
       }
@@ -2299,7 +2444,7 @@
     "name": "refreshOnTransition",
     "kind": "function",
     "description": "Call `fn` whenever any of the watched signals transitions from a\ntruthy \"active\" value to a non-active value. Generic version of\nrefreshOnRunEnd for callers tracking custom state machines.\n\nMust be called within an injection context.",
-    "signature": "refreshOnTransition(watch: Signal<T>, isActive: object, fn: object): void",
+    "signature": "refreshOnTransition(watch: Signal<T>, isActive: (v: T) => boolean, fn: () => void | Promise<void>): void",
     "params": [
       {
         "name": "watch",
@@ -2309,13 +2454,13 @@
       },
       {
         "name": "isActive",
-        "type": "object",
+        "type": "(v: T) => boolean",
         "description": "",
         "optional": false
       },
       {
         "name": "fn",
-        "type": "object",
+        "type": "() => void | Promise<void>",
         "description": "",
         "optional": false
       }

--- a/apps/website/content/docs/licensing/api/api-docs.json
+++ b/apps/website/content/docs/licensing/api/api-docs.json
@@ -12,7 +12,7 @@
       },
       {
         "name": "warn",
-        "type": "object",
+        "type": "(message: string) => void",
         "description": "Injected warn channel; defaults to `console.warn`.",
         "optional": true
       }
@@ -140,7 +140,7 @@
       },
       {
         "name": "warn",
-        "type": "object",
+        "type": "(message: string) => void",
         "description": "Injected warn channel, defaults to console.warn.",
         "optional": true
       }

--- a/apps/website/content/docs/render/api/api-docs.json
+++ b/apps/website/content/docs/render/api/api-docs.json
@@ -97,7 +97,7 @@
     "methods": [
       {
         "name": "ngOnInit",
-        "signature": "ngOnInit()",
+        "signature": "ngOnInit(): void",
         "description": "A callback method that is invoked immediately after the\ndefault change detector has checked the directive's\ndata-bound properties for the first time,\nand before any of the view or content children have been checked.\nIt is invoked only once when the directive is instantiated.",
         "params": []
       }
@@ -132,7 +132,7 @@
       },
       {
         "name": "handlers",
-        "type": "InputSignal<Record<string, object> | undefined>",
+        "type": "InputSignal<Record<string, (params: Record<string, unknown>) => unknown> | undefined>",
         "description": "",
         "optional": false
       },
@@ -164,7 +164,7 @@
     "methods": [
       {
         "name": "ngOnInit",
-        "signature": "ngOnInit()",
+        "signature": "ngOnInit(): void",
         "description": "A callback method that is invoked immediately after the\ndefault change detector has checked the directive's\ndata-bound properties for the first time,\nand before any of the view or content children have been checked.\nIt is invoked only once when the directive is instantiated.",
         "params": []
       }
@@ -189,7 +189,7 @@
       },
       {
         "name": "emit",
-        "type": "object",
+        "type": "(event: string) => void",
         "description": "Emit a named event",
         "optional": false
       },
@@ -212,24 +212,39 @@
     "name": "AngularRegistry",
     "kind": "interface",
     "description": "",
-    "properties": [
+    "properties": [],
+    "methods": [
       {
         "name": "get",
-        "type": "unknown",
+        "signature": "get(name: string): AngularComponentRenderer | undefined",
         "description": "",
-        "optional": false
+        "params": [
+          {
+            "name": "name",
+            "type": "string",
+            "description": "",
+            "optional": false
+          }
+        ]
       },
       {
         "name": "getFallback",
-        "type": "unknown",
-        "description": "",
-        "optional": false
+        "signature": "getFallback(name: string): AngularComponentRenderer | undefined",
+        "description": "Returns the configured fallback for a registered name, OR the\nlib's default fallback if the entry omits one, OR undefined if\nthe name is not registered.",
+        "params": [
+          {
+            "name": "name",
+            "type": "string",
+            "description": "",
+            "optional": false
+          }
+        ]
       },
       {
         "name": "names",
-        "type": "unknown",
+        "signature": "names(): string[]",
         "description": "",
-        "optional": false
+        "params": []
       }
     ],
     "examples": []
@@ -247,7 +262,7 @@
       },
       {
         "name": "handlers",
-        "type": "Record<string, object>",
+        "type": "Record<string, (params: Record<string, unknown>) => unknown>",
         "description": "",
         "optional": true
       },
@@ -273,7 +288,7 @@
     "properties": [
       {
         "name": "emitEvent",
-        "type": "object",
+        "type": "(event: RenderEvent) => void",
         "description": "",
         "optional": true
       },
@@ -285,7 +300,7 @@
       },
       {
         "name": "handlers",
-        "type": "Record<string, object>",
+        "type": "Record<string, (params: Record<string, unknown>) => unknown>",
         "description": "",
         "optional": true
       },
@@ -660,7 +675,7 @@
     "name": "withoutViews",
     "kind": "function",
     "description": "Removes views from a registry by name.",
-    "signature": "withoutViews(base: ViewRegistry, names: string[]): ViewRegistry",
+    "signature": "withoutViews(base: ViewRegistry, ...names: string[]): ViewRegistry",
     "params": [
       {
         "name": "base",
@@ -669,7 +684,7 @@
         "optional": false
       },
       {
-        "name": "names",
+        "name": "...names",
         "type": "string[]",
         "description": "",
         "optional": false

--- a/apps/website/scripts/generate-api-docs.ts
+++ b/apps/website/scripts/generate-api-docs.ts
@@ -41,13 +41,33 @@ function extractExamples(comment: any): string[] {
     .map((t: any) => t.content.map((c: any) => c.text ?? '').join('').trim());
 }
 
+/** Renders a single parameter for a signature string, preserving rest (`...`) syntax. */
+function paramToSigString(p: any): string {
+  return `${p.flags?.isRest ? '...' : ''}${p.name}: ${extractType(p.type)}`;
+}
+
+/** Builds a `(a: A, ...rest: B[]): R` signature body from a TypeDoc signature reflection. */
+function signatureToString(name: string, sig: any): string {
+  const params = (sig?.parameters ?? []).map(paramToSigString).join(', ');
+  const ret = sig?.type ? `: ${extractType(sig.type)}` : '';
+  return `${name}(${params})${ret}`;
+}
+
 function extractType(typeObj: any): string {
   if (!typeObj) return 'unknown';
   if (typeObj.type === 'intrinsic') return typeObj.name;
   if (typeObj.type === 'reference') return typeObj.name + (typeObj.typeArguments ? `<${typeObj.typeArguments.map(extractType).join(', ')}>` : '');
   if (typeObj.type === 'union') return typeObj.types.map(extractType).join(' | ');
   if (typeObj.type === 'literal') return JSON.stringify(typeObj.value);
-  if (typeObj.type === 'reflection') return 'object';
+  if (typeObj.type === 'reflection') {
+    // Function-typed property/value: render its call signature, e.g. `(event: RenderEvent) => void`.
+    const sig = typeObj.declaration?.signatures?.[0];
+    if (sig) {
+      const params = (sig.parameters ?? []).map(paramToSigString).join(', ');
+      return `(${params}) => ${extractType(sig.type)}`;
+    }
+    return 'object';
+  }
   if (typeObj.type === 'array') return `${extractType(typeObj.elementType)}[]`;
   return typeObj.toString?.() ?? 'unknown';
 }
@@ -55,7 +75,7 @@ function extractType(typeObj: any): string {
 function extractParams(sig: any): ApiParam[] {
   if (!sig?.parameters) return [];
   return sig.parameters.map((p: any) => ({
-    name: p.name,
+    name: `${p.flags?.isRest ? '...' : ''}${p.name}`,
     type: extractType(p.type),
     description: extractDescription(p.comment),
     optional: p.flags?.isOptional ?? false,
@@ -73,7 +93,7 @@ function reflectionToEntry(ref: any): ApiDocEntry | null {
       name: ref.name,
       kind: 'function',
       description: desc || extractDescription(sig?.comment),
-      signature: sig ? `${ref.name}(${(sig.parameters ?? []).map((p: any) => `${p.name}: ${extractType(p.type)}`).join(', ')}): ${extractType(sig.type)}` : ref.name,
+      signature: sig ? signatureToString(ref.name, sig) : ref.name,
       params: extractParams(sig),
       returns: sig?.type ? { type: extractType(sig.type), description: '' } : undefined,
       examples: examples.length ? examples : extractExamples(sig?.comment),
@@ -88,7 +108,7 @@ function reflectionToEntry(ref: any): ApiDocEntry | null {
       .filter((c: any) => c.kind === ReflectionKind.Method)
       .map((c: any) => {
         const sig = c.signatures?.[0];
-        return { name: c.name, signature: `${c.name}(${(sig?.parameters ?? []).map((p: any) => `${p.name}: ${extractType(p.type)}`).join(', ')})`, description: extractDescription(c.comment) || extractDescription(sig?.comment), params: extractParams(sig) };
+        return { name: c.name, signature: signatureToString(c.name, sig), description: extractDescription(c.comment) || extractDescription(sig?.comment), params: extractParams(sig) };
       });
     const ctorSig = (ref.children ?? []).find((c: any) => c.kind === ReflectionKind.Constructor)?.signatures?.[0];
     return {
@@ -103,13 +123,27 @@ function reflectionToEntry(ref: any): ApiDocEntry | null {
   }
 
   if (kind === ReflectionKind.Interface) {
-    const props = (ref.children ?? []).map((c: any) => ({
-      name: c.name,
-      type: extractType(c.type),
-      description: extractDescription(c.comment),
-      optional: c.flags?.isOptional,
-    }));
-    return { name: ref.name, kind: 'interface', description: desc, properties: props, examples };
+    const children = ref.children ?? [];
+    const props = children
+      .filter((c: any) => c.kind !== ReflectionKind.Method)
+      .map((c: any) => ({
+        name: c.name,
+        type: extractType(c.type),
+        description: extractDescription(c.comment),
+        optional: c.flags?.isOptional,
+      }));
+    const methods = children
+      .filter((c: any) => c.kind === ReflectionKind.Method)
+      .map((c: any) => {
+        const sig = c.signatures?.[0];
+        return {
+          name: c.name,
+          signature: signatureToString(c.name, sig),
+          description: extractDescription(c.comment) || extractDescription(sig?.comment),
+          params: extractParams(sig),
+        };
+      });
+    return { name: ref.name, kind: 'interface', description: desc, properties: props, methods: methods.length ? methods : undefined, examples };
   }
 
   if (kind === ReflectionKind.TypeAlias) {


### PR DESCRIPTION
## Summary

The TypeDoc-based API-docs generator (`apps/website/scripts/generate-api-docs.ts`) degraded type fidelity in the generated `api-docs.json` (which is rendered by `ApiDocRenderer` on every `*/api/*` page and included in `llms-full.txt`):

- **Rest parameters lost `...`** — `withoutViews(base, names: string[])` instead of `...names: string[]`.
- **Function-typed properties collapsed to `object`** — e.g. `RenderContext.emitEvent` and every `InputSignal<(event) => void>`.
- **Interface methods collapsed to `unknown`-typed properties** — e.g. `AngularRegistry.get/getFallback/names` lost their signatures entirely.

### Fix
- `extractType`: render a reflection's call signature as `(a: A) => R` instead of `object`.
- New `paramToSigString` / `signatureToString` helpers prefix rest params with `...` and append return types; used by the function, class-method, and interface-method builders.
- Interfaces now split children into `properties` vs `methods`, emitting real method signatures into the `methods[]` array (already supported by `ApiDocRenderer`).
- Regenerated **all** libs' `api-docs.json` — the generator improvement applies repo-wide.

Discovered during the render docs technical review (the report flagged this as a generator bug, not a prose fix).

### Why all libs changed
The same extraction bug affected every library. Every diff is a **strict accuracy improvement** (`unknown`→real signature, `object`→function type, added return types, `...` rest); no regressions. The two new `payload: unknown` params are accurate to source (`payload: unknown`).

## Test Plan
- [x] `eslint` clean on the generator.
- [x] `npm run generate-api-docs` succeeds for all 7 libs.
- [x] Render/chat/langgraph `*/api/*` pages render HTTP 200 with the regenerated JSON.
- [x] Render targets verified: `withoutViews(base: ViewRegistry, ...names: string[])`, AngularRegistry methods with full signatures, `emitEvent: (event: RenderEvent) => void`.
- [x] `docs.spec.ts` api-docs assertion (exists + non-empty) still holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)