### PR TITLE
docs(chat): relocate A2UI pages from render to chat product

### DIFF
--- a/apps/website/content/docs/chat/a2ui/catalog.mdx
+++ b/apps/website/content/docs/chat/a2ui/catalog.mdx
@@ -128,7 +128,7 @@ Renders children in a scrollable vertical list (max height 24rem).
 | `spec` | `Spec` | Injected automatically by the render engine |
 
 <Callout type="info" title="Template children">
-For data-driven lists, use the `A2uiChildTemplate` form instead of static `childKeys`. Set `children` to `{"path": "/items", "componentId": "item-template"}` and the surface component will expand the template once per array item. See the [Surface Component](/docs/render/a2ui/surface-component) page for details.
+For data-driven lists, use the `A2uiChildTemplate` form instead of static `childKeys`. Set `children` to `{"path": "/items", "componentId": "item-template"}` and the surface component will expand the template once per array item. See the [Surface Component](/docs/chat/a2ui/surface-component) page for details.
 </Callout>
 
 ## Interactive Components
@@ -459,14 +459,14 @@ Props that use `A2uiFunctionCall` can reference these built-in functions:
   <Card
     title="A2UI Overview"
     icon="book-open"
-    href="/docs/render/a2ui/overview"
+    href="/docs/chat/a2ui/overview"
   >
     How the A2UI protocol works end-to-end.
   </Card>
   <Card
     title="Surface Component"
     icon="layers"
-    href="/docs/render/a2ui/surface-component"
+    href="/docs/chat/a2ui/surface-component"
   >
     Render surfaces and understand dynamic value resolution.
   </Card>

--- a/apps/website/content/docs/chat/a2ui/overview.mdx
+++ b/apps/website/content/docs/chat/a2ui/overview.mdx
@@ -290,21 +290,21 @@ Do not assume the progressive chat renderer and the render-spec compatibility pa
   <Card
     title="Surface Component"
     icon="layers"
-    href="/docs/render/a2ui/surface-component"
+    href="/docs/chat/a2ui/surface-component"
   >
     Render a surface outside the full ChatComponent composition.
   </Card>
   <Card
     title="Surface Store"
     icon="database"
-    href="/docs/render/a2ui/surface-store"
+    href="/docs/chat/a2ui/surface-store"
   >
     Understand how messages update surfaces and data models.
   </Card>
   <Card
     title="Component Catalog"
     icon="grid"
-    href="/docs/render/a2ui/catalog"
+    href="/docs/chat/a2ui/catalog"
   >
     See the built-in catalog components and their props.
   </Card>

--- a/apps/website/content/docs/chat/a2ui/surface-component.mdx
+++ b/apps/website/content/docs/chat/a2ui/surface-component.mdx
@@ -114,14 +114,14 @@ Returns `null` when the surface has no `root` component. Otherwise returns a com
   <Card
     title="Surface Store"
     icon="database"
-    href="/docs/render/a2ui/surface-store"
+    href="/docs/chat/a2ui/surface-store"
   >
     Manage surfaces and apply A2UI messages reactively.
   </Card>
   <Card
     title="Component Catalog"
     icon="grid"
-    href="/docs/render/a2ui/catalog"
+    href="/docs/chat/a2ui/catalog"
   >
     All 18 built-in components and their props.
   </Card>

--- a/apps/website/content/docs/chat/a2ui/surface-store.mdx
+++ b/apps/website/content/docs/chat/a2ui/surface-store.mdx
@@ -138,14 +138,14 @@ The `components` map is keyed by component ID. The `dataModel` is a plain object
   <Card
     title="Surface Component"
     icon="layers"
-    href="/docs/render/a2ui/surface-component"
+    href="/docs/chat/a2ui/surface-component"
   >
     Render a surface using A2uiSurfaceComponent.
   </Card>
   <Card
     title="Component Catalog"
     icon="grid"
-    href="/docs/render/a2ui/catalog"
+    href="/docs/chat/a2ui/catalog"
   >
     All 18 built-in components and their props.
   </Card>

--- a/apps/website/content/docs/chat/components/chat.mdx
+++ b/apps/website/content/docs/chat/components/chat.mdx
@@ -174,7 +174,7 @@ views = a2uiBasicCatalog();
 
 The catalog currently maps 18 component types: Text, Image, Icon, Divider, Row, Column, Card, List, Button, TextField, CheckBox, MultipleChoice, DateTimeInput, Slider, Tabs, Modal, Video, and AudioPlayer.
 
-A2UI surfaces support two-way data binding, button actions, template expansion over collections, and validation. See the [A2UI guide](/docs/render/a2ui/overview) for details.
+A2UI surfaces support two-way data binding, button actions, template expansion over collections, and validation. See the [A2UI guide](/docs/chat/a2ui/overview) for details.
 
 ## Auto-Scroll Behavior
 

--- a/apps/website/content/docs/chat/guides/generative-ui.mdx
+++ b/apps/website/content/docs/chat/guides/generative-ui.mdx
@@ -133,7 +133,7 @@ The store enables two-way data binding between generative UI components and your
 
 ## A2UI Protocol
 
-For agents that emit A2UI JSONL payloads, `ChatComponent` auto-detects content prefixed with `---a2ui_JSON---`. Pass `a2uiBasicCatalog()` to `[views]` when you want those surfaces rendered with the built-in components. See the [A2UI guide](/docs/render/a2ui/overview) for details.
+For agents that emit A2UI JSONL payloads, `ChatComponent` auto-detects content prefixed with `---a2ui_JSON---`. Pass `a2uiBasicCatalog()` to `[views]` when you want those surfaces rendered with the built-in components. See the [A2UI guide](/docs/chat/a2ui/overview) for details.
 
 ## What's Next
 
@@ -152,7 +152,7 @@ For agents that emit A2UI JSONL payloads, `ChatComponent` auto-detects content p
   >
     Full reference for the JSON spec format, prop expressions, and element types.
   </Card>
-  <Card title="A2UI Protocol" icon="layers" href="/docs/render/a2ui/overview">
+  <Card title="A2UI Protocol" icon="layers" href="/docs/chat/a2ui/overview">
     Render A2UI surfaces with the built-in 18-component catalog.
   </Card>
 </CardGroup>

--- a/apps/website/content/docs/chat/guides/streaming.mdx
+++ b/apps/website/content/docs/chat/guides/streaming.mdx
@@ -110,7 +110,7 @@ A2UI content uses a different detection trigger than JSON-render specs. Instead 
 
 Once detected, the classifier switches to A2UI mode and parses the remaining content as JSONL — one JSON object per line — rather than a single JSON object. Each line represents an A2UI message that builds up surfaces with components and data models.
 
-The resulting surfaces are available via `classifier.a2uiSurfaces()`, which returns a `Map<string, A2uiSurface>` keyed by surface ID. See the [A2UI guide](/docs/render/a2ui/overview) for full details on the A2UI protocol and surface structure.
+The resulting surfaces are available via `classifier.a2uiSurfaces()`, which returns a `Map<string, A2uiSurface>` keyed by surface ID. See the [A2UI guide](/docs/chat/a2ui/overview) for full details on the A2UI protocol and surface structure.
 
 ## Error Handling
 

--- a/apps/website/e2e/website.spec.ts
+++ b/apps/website/e2e/website.spec.ts
@@ -214,7 +214,7 @@ test('sitemap.xml includes configured docs pages', async ({ request }) => {
   const body = await response.text();
   expect(body).toContain('https://threadplane.ai/docs');
   expect(body).toContain('https://threadplane.ai/docs/langgraph/getting-started/introduction');
-  expect(body).toContain('https://threadplane.ai/docs/render/a2ui/overview');
+  expect(body).toContain('https://threadplane.ai/docs/chat/a2ui/overview');
 });
 
 test('docs pages render canonical and social metadata', async ({ page }) => {
@@ -254,7 +254,7 @@ test('representative docs pages do not create page-level horizontal overflow', a
     '/docs/langgraph/getting-started/introduction',
     '/docs/langgraph/api/inject-agent',
     '/docs/chat/components/chat-tool-calls',
-    '/docs/render/a2ui/overview',
+    '/docs/chat/a2ui/overview',
     '/docs/telemetry/guides/browser',
   ];
   const widths = [320, 375, 768, 1280];

--- a/apps/website/src/lib/docs-config.ts
+++ b/apps/website/src/lib/docs-config.ts
@@ -120,17 +120,6 @@ export const docsConfig: DocsLibrary[] = [
         ],
       },
       {
-        title: 'A2UI',
-        id: 'a2ui',
-        color: 'red',
-        pages: [
-          { title: 'Overview', slug: 'overview', section: 'a2ui' },
-          { title: 'A2uiSurfaceComponent', slug: 'surface-component', section: 'a2ui' },
-          { title: 'createA2uiSurfaceStore()', slug: 'surface-store', section: 'a2ui' },
-          { title: 'Component Catalog', slug: 'catalog', section: 'a2ui' },
-        ],
-      },
-      {
         title: 'API Reference',
         id: 'api',
         color: 'blue',
@@ -204,6 +193,17 @@ export const docsConfig: DocsLibrary[] = [
           { title: 'ChatSubagentCard', slug: 'chat-subagent-card', section: 'components' },
           { title: 'ChatDebug', slug: 'chat-debug', section: 'components' },
           { title: 'ChatSelect', slug: 'chat-select', section: 'components' },
+        ],
+      },
+      {
+        title: 'A2UI',
+        id: 'a2ui',
+        color: 'red',
+        pages: [
+          { title: 'Overview', slug: 'overview', section: 'a2ui' },
+          { title: 'A2uiSurfaceComponent', slug: 'surface-component', section: 'a2ui' },
+          { title: 'createA2uiSurfaceStore()', slug: 'surface-store', section: 'a2ui' },
+          { title: 'Component Catalog', slug: 'catalog', section: 'a2ui' },
         ],
       },
       {


### PR DESCRIPTION
## Summary

The four A2UI surface pages (Overview, `A2uiSurfaceComponent`, `createA2uiSurfaceStore()`, Component Catalog) document **`@threadplane/chat`** runtime APIs, yet lived under the render docs. Every inbound link to them came from chat docs, and the chat product already has A2UI-adjacent guides. This moves them to a new **A2UI** section under the chat product.

- `git mv` the 4 pages `/docs/render/a2ui/*` → `/docs/chat/a2ui/*` (tracked as renames; content is the post-#590 corrected version).
- `docs-config.ts`: removed the A2UI section from the render product; added it to chat (before API Reference).
- Repointed all internal links: 3 chat pages (chat.mdx, streaming.mdx, generative-ui.mdx) + cross-links among the moved pages.
- Updated the e2e sitemap assertion and the overflow-route list to the new path.

**No redirects** (per decision) — old `/docs/render/a2ui/*` URLs now 404.

Follow-up to the render docs technical review.

## Test Plan
- [x] New `/docs/chat/a2ui/*` routes return 200 (all 4).
- [x] Old `/docs/render/a2ui/*` routes return 404 (expected).
- [x] Chat pages linking to A2UI render 200; sitemap + llms-full.txt reference the new path; no tracked source references the old path.
- [x] `eslint` clean on docs-config.ts.
- [x] e2e (`website.spec.ts`) sitemap + overflow checks updated to the new URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)