### PR TITLE
docs(chat): fix guides + concepts technical accuracy

### DIFF
--- a/apps/website/content/docs/chat/concepts/message-model.mdx
+++ b/apps/website/content/docs/chat/concepts/message-model.mdx
@@ -17,6 +17,9 @@ interface Message {
   reasoningDurationMs?: number;
   extra?: Record<string, unknown>;
   citations?: Citation[];
+  // IDs of tool calls emitted BY this assistant message (distinct from the
+  // singular `toolCallId` above, which is the call a `tool` message answers).
+  toolCallIds?: string[];
 }
 ```
 
@@ -124,6 +127,19 @@ Messages can carry provider-agnostic citations:
 
 ```ts
 message.citations;
+```
+
+Each entry has the following shape:
+
+```ts
+interface Citation {
+  id: string;       // stable id matched against [^id] markers in content
+  index: number;    // 1-based display order, stable per-message
+  title?: string;
+  url?: string;
+  snippet?: string;
+  extra?: Record<string, unknown>; // provider-specific extras
+}
 ```
 
 `@threadplane/langgraph` exports `extractCitations()` for advanced adapters that need to normalize nonstandard citation payloads. Chat markdown views can render citation markers against the message citation list.

--- a/apps/website/content/docs/chat/guides/custom-catalogs.mdx
+++ b/apps/website/content/docs/chat/guides/custom-catalogs.mdx
@@ -87,7 +87,7 @@ export class MyChartComponent {
   readonly childKeys = input<string[]>([]);
   readonly spec = input.required<Spec>();
   readonly emit = input<(event: string) => void>(() => {});
-  readonly loading = input<boolean>(false);
+  readonly loading = input<boolean>();
 }
 ```
 

--- a/apps/website/content/docs/chat/guides/generative-ui.mdx
+++ b/apps/website/content/docs/chat/guides/generative-ui.mdx
@@ -24,7 +24,7 @@ Pass a `ViewRegistry` via the `[views]` input on `ChatComponent`:
 
 ```typescript
 import { Component, signal } from '@angular/core';
-import { agent } from '@threadplane/langgraph';
+import { injectAgent, provideAgent } from '@threadplane/langgraph';
 import { ChatComponent, views } from '@threadplane/chat';
 import { WeatherCardComponent } from './weather-card.component';
 import { ChartComponent } from './chart.component';
@@ -38,6 +38,13 @@ const myViews = views({
   selector: 'app-chat',
   standalone: true,
   imports: [ChatComponent],
+  providers: [
+    provideAgent({
+      apiUrl: 'http://localhost:2024',
+      assistantId: 'gen_ui_agent',
+      threadId: signal(null),
+    }),
+  ],
   template: `
     <div style="height: 100vh;">
       <chat [agent]="chatRef" [views]="myViews" />
@@ -45,11 +52,7 @@ const myViews = views({
   `,
 })
 export class ChatPageComponent {
-  chatRef = agent({
-    apiUrl: 'http://localhost:2024',
-    assistantId: 'gen_ui_agent',
-    threadId: signal(null),
-  });
+  chatRef = injectAgent();
 
   myViews = myViews;
 }

--- a/apps/website/content/docs/chat/guides/layout-modes.mdx
+++ b/apps/website/content/docs/chat/guides/layout-modes.mdx
@@ -19,7 +19,7 @@ The embedded composition fills its parent container using `height: 100%` and a f
 
 ```typescript
 import { Component, ChangeDetectionStrategy, signal } from '@angular/core';
-import { agent } from '@threadplane/langgraph';
+import { injectAgent, provideAgent } from '@threadplane/langgraph';
 import { ChatComponent } from '@threadplane/chat';
 
 @Component({
@@ -27,6 +27,12 @@ import { ChatComponent } from '@threadplane/chat';
   standalone: true,
   imports: [ChatComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [
+    provideAgent({
+      assistantId: 'chat',
+      threadId: signal(null),
+    }),
+  ],
   template: `
     <div style="height: 100vh;">
       <chat [agent]="chatAgent" />
@@ -34,10 +40,7 @@ import { ChatComponent } from '@threadplane/chat';
   `,
 })
 export class ChatPageComponent {
-  protected readonly chatAgent = agent({
-    assistantId: 'chat',
-    threadId: signal(null),
-  });
+  protected readonly chatAgent = injectAgent();
 }
 ```
 
@@ -56,7 +59,7 @@ The popup composition renders a circular launcher button fixed to the bottom-rig
 
 ```typescript
 import { Component, ChangeDetectionStrategy, signal } from '@angular/core';
-import { agent } from '@threadplane/langgraph';
+import { injectAgent, provideAgent } from '@threadplane/langgraph';
 import { ChatPopupComponent } from '@threadplane/chat';
 
 @Component({
@@ -64,6 +67,12 @@ import { ChatPopupComponent } from '@threadplane/chat';
   standalone: true,
   imports: [ChatPopupComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [
+    provideAgent({
+      assistantId: 'support_agent',
+      threadId: signal(null),
+    }),
+  ],
   template: `
     <!-- your existing app content -->
     <router-outlet />
@@ -73,10 +82,7 @@ import { ChatPopupComponent } from '@threadplane/chat';
   `,
 })
 export class AppComponent {
-  protected readonly chatAgent = agent({
-    assistantId: 'support_agent',
-    threadId: signal(null),
-  });
+  protected readonly chatAgent = injectAgent();
 }
 ```
 
@@ -102,7 +108,7 @@ The sidebar composition renders a slide-in panel anchored to the right edge. It 
 
 ```typescript
 import { Component, ChangeDetectionStrategy, signal } from '@angular/core';
-import { agent } from '@threadplane/langgraph';
+import { injectAgent, provideAgent } from '@threadplane/langgraph';
 import { ChatSidebarComponent } from '@threadplane/chat';
 
 @Component({
@@ -110,6 +116,12 @@ import { ChatSidebarComponent } from '@threadplane/chat';
   standalone: true,
   imports: [ChatSidebarComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [
+    provideAgent({
+      assistantId: 'copilot_agent',
+      threadId: signal(null),
+    }),
+  ],
   template: `
     <chat-sidebar [agent]="chatAgent" [pushContent]="true">
       <!-- app content is projected here and shifts when sidebar opens -->
@@ -120,10 +132,7 @@ import { ChatSidebarComponent } from '@threadplane/chat';
   `,
 })
 export class AppShellComponent {
-  protected readonly chatAgent = agent({
-    assistantId: 'copilot_agent',
-    threadId: signal(null),
-  });
+  protected readonly chatAgent = injectAgent();
 }
 ```
 

--- a/apps/website/content/docs/chat/guides/markdown.mdx
+++ b/apps/website/content/docs/chat/guides/markdown.mdx
@@ -115,7 +115,7 @@ import {
 export class ChatViewComponent {
   private sanitizer = inject(DomSanitizer);
 
-  // chatRef = agent(...)
+  // chatRef = injectAgent(); // with provideAgent({...}) in the component's providers
 
   renderMd(content: string | unknown) {
     if (typeof content !== 'string') return '';

--- a/apps/website/content/docs/chat/guides/streaming.mdx
+++ b/apps/website/content/docs/chat/guides/streaming.mdx
@@ -57,7 +57,7 @@ classifier.dispose();
 
 | Signal | Type | Description |
 |--------|------|-------------|
-| `type` | `Signal<ContentType>` | `'undetermined'`, `'markdown'`, `'json-render'`, `'a2ui'`, or `'mixed'` |
+| `type` | `Signal<ContentType>` | `'pending'`, `'markdown'`, `'json-render'`, `'a2ui'`, or `'mixed'` |
 | `markdown` | `Signal<string>` | Accumulated markdown prose (empty for pure JSON) |
 | `spec` | `Signal<Spec \| null>` | Materialized JSON-render spec with structural sharing |
 | `elementStates` | `Signal<Map<string, ElementAccumulationState>>` | Per-element tracking of which properties have been received |
@@ -66,7 +66,7 @@ classifier.dispose();
 ### ContentType
 
 ```typescript
-type ContentType = 'undetermined' | 'markdown' | 'json-render' | 'a2ui' | 'mixed';
+type ContentType = 'pending' | 'markdown' | 'json-render' | 'a2ui' | 'mixed';
 ```
 
 ## Using ParseTreeStore Directly

--- a/apps/website/content/docs/chat/guides/writing-an-adapter.mdx
+++ b/apps/website/content/docs/chat/guides/writing-an-adapter.mdx
@@ -34,6 +34,7 @@ An `Agent` is a set of Angular **signals** (reactive state) plus an RxJS **obser
 | `events$` | `Observable<AgentEvent>` | Discriminated `state_update` / `custom` events |
 | `submit` | `(input, opts?) => Promise<void>` | Send a message or resume |
 | `stop` | `() => Promise<void>` | Abort the in-flight run |
+| `regenerate` | `(assistantMessageIndex: number) => Promise<void>` | Discard the assistant message at the index and everything after it, then re-run against the trimmed tail |
 | `interrupt?` | `Signal<AgentInterrupt \| undefined>` | (optional) Current pause-for-input |
 | `subagents?` | `Signal<Map<string, Subagent>>` | (optional) Spawned subagents |
 
@@ -108,6 +109,16 @@ export function createEchoAgent(opts: EchoAgentOptions = {}): Agent {
     isLoading.set(false);
   };
 
+  const regenerate = async (assistantMessageIndex: number) => {
+    // Discard the assistant message at the index AND everything after it,
+    // keeping the preceding user message, then re-run against the trimmed tail.
+    const prior = messages()[assistantMessageIndex - 1];
+    messages.update((prev) => prev.slice(0, assistantMessageIndex - 1));
+    if (prior?.role === 'user') {
+      await submit({ message: prior.content });
+    }
+  };
+
   return {
     messages,
     status,
@@ -118,6 +129,7 @@ export function createEchoAgent(opts: EchoAgentOptions = {}): Agent {
     events$: EMPTY satisfies Observable<AgentEvent>,
     submit,
     stop,
+    regenerate,
   };
 }
 


### PR DESCRIPTION
## Summary

PR 2 of 3 from the chat docs technical review (findings: `docs/superpowers/specs/2026-06-06-chat-docs-review-findings.md`). Fixes the guides + concepts pages.

- **Systemic `agent()` P0:** converted `agent({...})` → `provideAgent({...})` + `injectAgent()` in generative-ui, layout-modes (3 examples), and the markdown comment.
- **streaming.mdx (P0):** `ContentType` value `'undetermined'` → `'pending'` (doesn't exist in source).
- **writing-an-adapter.mdx (P1):** added the required `regenerate` method to the Agent contract table and the EchoAgent example (it was missing, so the example didn't satisfy the contract).
- **custom-catalogs.mdx (P1):** `loading` input is optional (`loading?: boolean`), not required-with-default.
- **message-model.mdx (P1/P2):** added `Message.toolCallIds?: string[]` (distinct from singular `toolCallId`); documented the `Citation` shape.

## Test Plan
- [x] Every fix re-verified against its cited source line by an independent reviewer (PASS, no over-reach, no invented fields).
- [x] No residual `import { agent }` / `agent({`; no `'undetermined'`.
- [x] All 7 edited chat routes return HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)