### PR TITLE
docs(chat): fix api + getting-started technical accuracy

### DIFF
--- a/apps/website/content/docs/chat/api/content-classifier.mdx
+++ b/apps/website/content/docs/chat/api/content-classifier.mdx
@@ -42,6 +42,9 @@ interface ContentClassifier {
   /** A2UI surfaces parsed from the stream. */
   readonly a2uiSurfaces: Signal<Map<string, A2uiSurface>>;
 
+  /** Per-surface A2UI accumulation state, keyed by surface ID. */
+  readonly a2uiSurfaceStates: Signal<Map<string, A2uiSurfaceState>>;
+
   /** Parse errors encountered (non-fatal). */
   readonly errors: Signal<string[]>;
 
@@ -53,12 +56,12 @@ interface ContentClassifier {
 ## ContentType
 
 ```typescript
-type ContentType = 'undetermined' | 'markdown' | 'json-render' | 'a2ui' | 'mixed';
+type ContentType = 'pending' | 'markdown' | 'json-render' | 'a2ui' | 'mixed';
 ```
 
 | Value | Meaning |
 |-------|---------|
-| `undetermined` | No content received yet |
+| `pending` | No content received yet |
 | `markdown` | Plain text / markdown prose |
 | `json-render` | JSON spec detected (first non-whitespace is `{`) |
 | `a2ui` | A2UI payload detected via `---a2ui_JSON---` prefix, parsed as JSONL messages |

--- a/apps/website/content/docs/chat/api/mock-agent.mdx
+++ b/apps/website/content/docs/chat/api/mock-agent.mdx
@@ -12,7 +12,7 @@ import type { MockAgent } from '@threadplane/chat';
 ## Signature
 
 ```typescript
-function mockAgent(options?: MockAgentOptions): MockAgent
+function mockAgent(opts?: MockAgentOptions): MockAgent
 ```
 
 ### Options
@@ -28,6 +28,7 @@ function mockAgent(options?: MockAgentOptions): MockAgent
 | `withInterrupt` | `boolean` | `false` | Include a writable `interrupt` signal |
 | `withSubagents` | `boolean` | `false` | Include a writable `subagents` signal |
 | `history` | `AgentCheckpoint[]` | `undefined` | Include history and return an `AgentWithHistory`-compatible mock |
+| `events$` | `Observable<AgentEvent>` | `EMPTY` | Event stream the mock exposes via `events$` (defaults to RxJS `EMPTY`) |
 
 ## Basic Test Usage
 

--- a/apps/website/content/docs/chat/api/provide-chat.mdx
+++ b/apps/website/content/docs/chat/api/provide-chat.mdx
@@ -132,16 +132,21 @@ All chat components work without `provideChat()`. They use defaults:
 
 ```typescript
 // This works fine without provideChat()
+import { injectAgent, provideAgent } from '@threadplane/langgraph';
+
 @Component({
   imports: [ChatComponent],
+  providers: [
+    provideAgent({
+      apiUrl: 'http://localhost:2024',
+      assistantId: 'chat',
+      threadId: signal(null),
+    }),
+  ],
   template: `<chat [agent]="chatRef" />`,
 })
 export class SimpleChatComponent {
-  chatRef = agent({
-    apiUrl: 'http://localhost:2024',
-    assistantId: 'chat',
-    threadId: signal(null),
-  });
+  chatRef = injectAgent();
 }
 ```
 

--- a/apps/website/content/docs/chat/getting-started/introduction.mdx
+++ b/apps/website/content/docs/chat/getting-started/introduction.mdx
@@ -58,7 +58,7 @@ Your App
 LangGraph Platform
 ```
 
-- **`@threadplane/langgraph`** provides `provideAgent()` and `injectAgent()` returning a `LangGraphAgent`, which satisfies the `Agent` contract consumed by `@threadplane/chat`. It exposes reactive Signals for `messages()`, `isLoading()`, `error()`, `interrupt()`, `toolCalls()`, `history()`, and more.
+- **`@threadplane/langgraph`** provides `provideAgent()` and `injectAgent()` returning a `LangGraphAgent`, which satisfies the `Agent` contract consumed by `@threadplane/chat`. The base `Agent` contract exposes reactive Signals for `messages()`, `status()`, `isLoading()`, `error()`, `toolCalls()`, and `state()`, plus optional `interrupt()` and `subagents()`. Adapters can layer on more: LangGraph implements `AgentWithHistory`, adding `history()` for checkpoint time-travel.
 
 - **`@threadplane/render`** provides `RenderSpecComponent` and view registries for rendering JSON UI specs as Angular components. The `ChatComponent` auto-detects JSON specs in AI messages and renders them through `@threadplane/render` - pass a view registry via the `[views]` input. The same `[views]` input enables A2UI rendering with `a2uiBasicCatalog()`, which currently maps 18 component types.
 

--- a/apps/website/content/docs/chat/getting-started/quickstart.mdx
+++ b/apps/website/content/docs/chat/getting-started/quickstart.mdx
@@ -38,7 +38,7 @@ export const appConfig: ApplicationConfig = {
 ```ts
 // chat-page.component.ts
 import { Component, ChangeDetectionStrategy, signal } from '@angular/core';
-import { agent } from '@threadplane/langgraph';
+import { injectAgent, provideAgent } from '@threadplane/langgraph';
 import { ChatComponent } from '@threadplane/chat';
 
 @Component({
@@ -46,13 +46,16 @@ import { ChatComponent } from '@threadplane/chat';
   standalone: true,
   imports: [ChatComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [
+    provideAgent({
+      assistantId: 'chat',
+      threadId: signal(null),
+    }),
+  ],
   template: `<div style="height: 100vh"><chat [agent]="chatAgent" /></div>`,
 })
 export class ChatPageComponent {
-  protected readonly chatAgent = agent({
-    assistantId: 'chat',
-    threadId: signal(null),
-  });
+  protected readonly chatAgent = injectAgent();
 }
 ```
 


### PR DESCRIPTION
## Summary

PR 3 of 3 from the chat docs technical review (findings: `docs/superpowers/specs/2026-06-06-chat-docs-review-findings.md`). Fixes the api reference + getting-started pages.

- **Systemic `agent()` P0:** `agent({...})` → `provideAgent({...})` + `injectAgent()` in quickstart and provide-chat examples.
- **introduction.mdx (P1):** corrected the base `Agent` signal list — `history()` is on the optional `AgentWithHistory` (LangGraph), not the base contract.
- **content-classifier.mdx (P0/P2):** `ContentType '​undetermined'` → `'pending'`; documented the missing `a2uiSurfaceStates` signal.
- **mock-agent.mdx (P1/P2):** parameter is `opts` (not `options`); documented the missing `events$` option.
- Verified already-correct (no change): `createParseTreeStore(parser)` signature and `provideChat(): EnvironmentProviders` return type.

This completes the chat docs technical review (PRs #594, #595, this).

## Test Plan
- [x] Every fix re-verified against its cited source line by an independent reviewer (PASS; #4/#22 confirmed already-correct, not skipped).
- [x] No residual `import { agent }` / `agent({`; no `'undetermined'`.
- [x] All 6 edited chat routes return HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)