### PR TITLE
docs(chat): technical review spec, plan + findings report

### DIFF
--- a/docs/superpowers/plans/2026-06-06-chat-docs-technical-review.md
+++ b/docs/superpowers/plans/2026-06-06-chat-docs-technical-review.md
@@ -1,0 +1,240 @@
+# Chat Docs Technical Review Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Audit the 33 chat documentation pages against library source, produce one severity-ranked findings report, then ship the accuracy fixes as 3 batched PRs — every snippet, import/package, component selector, `@Input`/`@Output`, signature, behavioral claim, and link matching the implementation.
+
+**Architecture:** Two gated phases. Phase 1 fans out six read-only section auditors (component pages split 7+7) plus a completeness sweep; the controller re-verifies borderline findings and consolidates one report. Phase 2 fixes the report's findings as 3 batched PRs (components / guides+concepts / api+getting-started), each finding re-verified against its cited source line. The 4 `chat/a2ui/*` pages (reviewed in #590) and generated `changelog.mdx` are excluded.
+
+**Tech Stack:** MDX docs (Next.js App Router), Angular library `libs/chat` (+ cross-lib `libs/render`, `libs/langgraph`, `libs/ag-ui`, `libs/a2ui`), `docs-config.ts` for link/nav resolution, `git diff` + source citation as the accuracy gate, dev-server/curl for render checks.
+
+**Reference spec:** `docs/superpowers/specs/2026-06-06-chat-docs-technical-review-design.md`
+
+---
+
+## Ground-truth source map (used by every audit task)
+
+| Audit | Pages (relative to `apps/website/content/docs/chat/`) | Ground-truth source |
+|---|---|---|
+| getting-started | `getting-started/{introduction,quickstart,installation}.mdx` (skip changelog) | `libs/chat/src/public-api.ts`, `lib/agent/*` (Agent contract), `provideChat` |
+| guides | `guides/{layout-modes,theming,markdown,generative-ui,custom-catalogs,streaming,configuration,writing-an-adapter,lifecycle}.mdx` | `libs/chat/src` + cross-lib: `libs/render` (generative-ui), `libs/langgraph` & `libs/ag-ui` (writing-an-adapter), `libs/a2ui` (streaming) |
+| concepts | `concepts/{primitives-vs-compositions,message-model}.mdx` | `libs/chat/src/lib/primitives/*`, `lib/compositions/*`, message types |
+| components A | `components/{chat,chat-popup,chat-sidebar,chat-message-list,chat-trace,chat-input,chat-reasoning}.mdx` | each component class under `libs/chat/src/lib/primitives/*` or `lib/compositions/*` |
+| components B | `components/{chat-interrupt-panel,chat-tool-calls,chat-tool-call-template,chat-tool-call-card,chat-subagent-card,chat-debug,chat-select}.mdx` | same |
+| api | `api/{provide-chat,chat-config,mock-agent,content-classifier,parse-tree-store}.mdx` | `libs/chat/src/public-api.ts` + each named module + `apps/website/content/docs/chat/api/api-docs.json` |
+
+`libs/chat/src/public-api.ts` is authoritative (136 exports). Component classes live under `libs/chat/src/lib/primitives/<name>/<name>.component.ts` or `libs/chat/src/lib/compositions/<name>/<name>.component.ts`.
+
+## Findings severity taxonomy + row schema (used by report + fix gating)
+
+- **P0 — wrong:** breaks copy-paste (wrong import/package, nonexistent API, wrong selector/signature/type).
+- **P1 — misleading:** runs but teaches a wrong model.
+- **P2 — gap:** undocumented export, missing input/output/option, thin coverage.
+- **P3 — polish:** stale wording, inconsistent naming, dead link.
+
+Finding row (every finding MUST use this):
+`page:line · dimension · severity · what's-wrong · source-evidence(libs/…:line) · proposed-fix`
+Dimensions: `accuracy` | `conceptual` | `links` | `completeness`.
+
+---
+
+# PHASE 1 — AUDIT (read-only, parallel)
+
+> Phase 1 produces NO docs edits. The controller dispatches Tasks 1–6 concurrently (disjoint reads), runs Task 7, re-verifies borderline findings, then writes the report in Task 8.
+
+## Tasks 1–6: Section audit subagents
+
+Each task dispatches ONE read-only audit subagent. The prompt template is identical except for **section name**, **page list**, and **ground-truth source** (from the map above). Use `subagent_type: Explore`.
+
+**Shared subagent prompt template:**
+
+```
+You are a READ-ONLY technical-docs auditor. DO NOT edit, write, or commit any file. You only read and return findings.
+
+Repo root: /Users/blove/repos/angular-agent-framework. Branch: claude/chat-docs-technical-review.
+
+## Your section: <SECTION>
+## Pages to audit (read each in full):
+<ABSOLUTE PAGE PATHS>
+## Ground-truth source (read what you need to verify claims):
+<SOURCE PATHS>
+
+## Method
+For every code fence, inline `code`, prose claim, and internal link in your pages, verify it against the ground-truth source. Open the source files and confirm: import paths/packages, exported symbol names, component selectors, @Input/@Output (Angular signal input()/output()) names and types, function/class signatures, generic params, option/property keys, types, and documented behavior. For COMPONENT pages specifically: confirm the component's selector string and every documented input/output name + type against the component class (signal inputs declared as `readonly x = input<T>()` / `input.required<T>()`, outputs as `output<T>()`). For internal links (href="/docs/..."), confirm the target exists in apps/website/src/lib/docs-config.ts (it builds hrefs from product/section/slug — check the entry exists; do not grep literal href strings).
+
+## The four dimensions
+1. accuracy — import/package, symbol, selector, signature, option key, type matches source EXACTLY. Wrong package or nonexistent symbol = P0.
+2. conceptual — behavior claims match implementation; runs-but-wrong-model = P1.
+3. links — internal links resolve via docs-config.ts; examples internally coherent (imports cover symbols used; required providers present) and runnable.
+4. completeness — flag any obviously missing input/output/option/behavior a reader needs.
+
+## Severity
+P0 wrong (breaks copy-paste) | P1 misleading | P2 gap | P3 polish.
+
+## Return format — a markdown table, columns EXACTLY:
+| page:line | dimension | severity | what's wrong | source evidence | proposed fix |
+- page:line = relative path + line, e.g. chat/components/chat-input.mdx:42
+- source evidence = libs/…:line you verified against
+- proposed fix = the concrete corrected text/snippet (specific enough to apply)
+If a page is clean: | <page> | — | clean | no issues found | <source checked> | none |
+Every finding MUST cite a real source line. If a documented symbol can't be found in source, that's a P0 ("documented symbol not found in source"). End with a short "Systemic notes" paragraph for any cross-page pattern.
+
+Your entire final message IS the audit result (table + systemic notes). Return only that.
+```
+
+- [ ] **Task 1 — getting-started.** Pages: `getting-started/{introduction,quickstart,installation}.mdx` (absolute paths under `apps/website/content/docs/chat/`). Source: `libs/chat/src/public-api.ts`, `libs/chat/src/lib/agent/*`, `provideChat`. Dispatch; save the returned table verbatim for Task 8.
+
+- [ ] **Task 2 — guides.** Pages: the 9 guide files. Source: `libs/chat/src` + cross-lib (`libs/render` for generative-ui; `libs/langgraph`, `libs/ag-ui` for writing-an-adapter + Agent contract; `libs/a2ui` for streaming). For cross-lib refs, verify the symbol/package against the OWNING lib (but do not audit those libs' own docs). Dispatch; save table.
+
+- [ ] **Task 3 — concepts.** Pages: `concepts/{primitives-vs-compositions,message-model}.mdx`. Source: `libs/chat/src/lib/primitives/*`, `lib/compositions/*`, message types. Dispatch; save table.
+
+- [ ] **Task 4 — components A (7).** Pages: `components/{chat,chat-popup,chat-sidebar,chat-message-list,chat-trace,chat-input,chat-reasoning}.mdx`. Source: each page's component class (locate under `libs/chat/src/lib/primitives/*` or `lib/compositions/*`). Emphasize selector + input/output exactness. Dispatch; save table.
+
+- [ ] **Task 5 — components B (7).** Pages: `components/{chat-interrupt-panel,chat-tool-calls,chat-tool-call-template,chat-tool-call-card,chat-subagent-card,chat-debug,chat-select}.mdx`. Source: each page's component class / directive. Note: `chat-tool-call-template` documents `ChatToolCallTemplateDirective`; `chat-tool-calls` documents `ChatToolCallsComponent`. Dispatch; save table.
+
+- [ ] **Task 6 — api (5).** Pages: `api/{provide-chat,chat-config,mock-agent,content-classifier,parse-tree-store}.mdx`. Source: `libs/chat/src/public-api.ts` + each named module + `apps/website/content/docs/chat/api/api-docs.json`. Verify each documented signature/option against BOTH source and api-docs.json; flag drift (note which is right per `libs/chat/src`). Dispatch; save table.
+
+## Task 7: Completeness sweep (exports-vs-docs)
+
+**Files:** none (analysis). Run inline or as one subagent.
+
+- [ ] **Step 1: List chat public exports**
+
+```bash
+cd /Users/blove/repos/angular-agent-framework
+grep -E "^export" libs/chat/src/public-api.ts | wc -l
+grep -E "^export \{" libs/chat/src/public-api.ts | grep -oE "Component[A-Za-z]*|[A-Za-z]+Component|provide[A-Za-z]+|create[A-Za-z]+|mock[A-Za-z]+" | sort -u
+```
+
+- [ ] **Step 2: Cross-check documented components/APIs against exports**
+
+For every component the docs document (the 14 component pages) and every api page symbol, confirm the symbol is exported from `libs/chat/src/public-api.ts`. Any documented symbol NOT exported (and not a known internal) is a **P0** (documented-but-nonexistent). Conversely, list notable exported Components/`provide*`/`create*` symbols that have NO doc page — record as **P2** gaps (do not attempt to document every one of 136 exports; flag the material ones, e.g. an exported composition/component or public factory with zero coverage).
+
+```bash
+cd /Users/blove/repos/angular-agent-framework
+# documented component class names appear in the component pages; spot the exported set:
+grep -oE "Chat[A-Za-z]+Component|chatToolCallTemplate|ChatToolCallTemplateDirective" libs/chat/src/public-api.ts | sort -u
+```
+
+- [ ] **Step 3: Record findings** in the row schema for Task 8.
+
+## Task 8: Consolidate the findings report
+
+**Files:** Create `docs/superpowers/specs/2026-06-06-chat-docs-review-findings.md`
+
+- [ ] **Step 1: Re-verify borderline findings.** Before consolidating, the controller spot-checks a sample of cited source lines and re-verifies any finding that looks surprising or contradicts another (as in the render review, which caught two auditor false alarms). Drop or correct unverified findings.
+
+- [ ] **Step 2: Assemble the report**
+
+Structure:
+```markdown
+# Chat Docs Technical Review — Findings
+
+**Date:** 2026-06-06
+**Pages audited:** 33  **Source verified against:** libs/chat (+ render/langgraph/ag-ui/a2ui cross-refs)
+
+## Summary
+- P0: <n>  P1: <n>  P2: <n>  P3: <n>
+- Systemic issues: <bullets>
+
+## Findings by severity
+### P0 — wrong
+<merged rows from all sections, sorted by page>
+### P1 — misleading
+### P2 — gap
+### P3 — polish
+
+## Structural / won't-fix-here
+- <api-docs.json regeneration if a finding is doc↔generated drift — note the fix is `npm run generate-api-docs`, scoped separately if needed>
+- <any libs/* source bug noticed — flagged for separate follow-up, NOT fixed here>
+
+## Fix plan (3 PRs)
+- PR-1 components: <component findings>
+- PR-2 guides + concepts: <findings>
+- PR-3 api + getting-started: <findings>
+P-level cutoff: default P0+P1+P2, P3 where it's a one-line change. Structural + source-bug items listed, not actioned.
+```
+Merge the section tables verbatim into the severity buckets; keep every source citation.
+
+- [ ] **Step 3: Commit the report**
+
+```bash
+cd /Users/blove/repos/angular-agent-framework
+git add docs/superpowers/specs/2026-06-06-chat-docs-review-findings.md
+git commit -m "docs(chat): technical review findings report"
+```
+
+- [ ] **Step 4: CHECKPOINT — surface the report to the user.** Present summary counts + systemic issues + the 3-PR fix plan. Confirm the P-level cutoff and that structural/source items stay flagged-only, before starting Phase 2.
+
+---
+
+# PHASE 2 — FIX (subagent-driven, 3 batched PRs)
+
+> Each PR is its own branch off the latest `origin/main`. Within a PR, fix grouped by section; each group's edits gated by re-verification against the cited source line + an independent accuracy review before commit. Use the Task 8 report as the source of truth for what to change.
+
+**Shared fix-gate (run after each section's edits, before commit):**
+
+```bash
+cd /Users/blove/repos/angular-agent-framework
+# $FILES = edited .mdx paths for this section
+git --no-pager diff $FILES   # eyeball: each change matches a report finding's proposed fix; no unrelated heading/link/component churn
+```
+Then an independent accuracy-reviewer subagent confirms each edit matches its cited source line and no finding was missed/over-applied; loop until clean.
+
+## Task 9: PR-1 — components (14 pages)
+
+**Branch:** `claude/fix-chat-docs-components` off `origin/main`.
+**Files:** the component pages with findings (per report).
+
+- [ ] **Step 1:** Create the branch off latest `origin/main`.
+- [ ] **Step 2:** Dispatch implementer subagent(s) with the report's component findings (full rows, grouped — e.g. components A then B). Instruction: apply each proposed fix EXACTLY; re-read the cited component-class line (selector / `input()` / `output()`) before each edit; do NOT touch anything not in a finding.
+- [ ] **Step 3:** Shared fix-gate on edited files.
+- [ ] **Step 4:** Independent accuracy reviewer subagent; loop until clean.
+- [ ] **Step 5:** Render check — the edited component routes return 200 (serve website on :3000; curl each `/docs/chat/components/<slug>`).
+- [ ] **Step 6:** Commit (`docs(chat): fix component reference technical accuracy`), push, open PR, enable auto-merge (squash).
+
+## Task 10: PR-2 — guides + concepts (11 pages)
+
+**Branch:** `claude/fix-chat-docs-guides-concepts` off `origin/main` (create after PR-1 is up; rebase/update-branch if main moves).
+**Files:** the guide + concept pages with findings (per report).
+
+- [ ] **Step 1:** Create the branch off latest `origin/main`.
+- [ ] **Step 2:** Dispatch implementer with the guides+concepts findings; apply proposed fixes exactly; re-verify each against `libs/chat/src` (and the owning lib for cross-lib refs) cited lines.
+- [ ] **Step 3:** Shared fix-gate.
+- [ ] **Step 4:** Independent accuracy reviewer; loop until clean.
+- [ ] **Step 5:** Render check — edited guide/concept routes return 200.
+- [ ] **Step 6:** Commit (`docs(chat): fix guides + concepts technical accuracy`), push, open PR, enable auto-merge.
+
+## Task 11: PR-3 — api + getting-started (8 pages)
+
+**Branch:** `claude/fix-chat-docs-api-gs` off `origin/main`.
+**Files:** the api + getting-started pages with findings (per report).
+
+- [ ] **Step 1:** Create the branch off latest `origin/main`.
+- [ ] **Step 2:** Dispatch implementer with the api+getting-started findings; verify each signature/option against `libs/chat/src/public-api.ts` + named modules. If a finding is "doc drifted from generated api-docs.json", fix the doc prose to match source; if the generated JSON itself is stale, note whether `npm run generate-api-docs` is the fix (run ONLY if the report says the generator output is wrong, and scope the commit to the chat api-docs.json).
+- [ ] **Step 3:** Shared fix-gate.
+- [ ] **Step 4:** Independent accuracy reviewer; loop until clean.
+- [ ] **Step 5:** Render check — edited api/getting-started routes return 200.
+- [ ] **Step 6:** Commit (`docs(chat): fix api + getting-started technical accuracy`), push, open PR, enable auto-merge.
+
+## Task 12: Final verification + follow-ups
+
+**Files:** none (verification) + update the findings report.
+
+- [ ] **Step 1: All 33 reviewed chat routes return 200** (serve website on :3000; curl each reviewed page under getting-started/guides/concepts/components/api).
+- [ ] **Step 2:** Mark each fixed finding ✅ in `2026-06-06-chat-docs-review-findings.md`; leave structural/source items open. Commit on whichever fix branch is last, or a tiny follow-up branch.
+- [ ] **Step 3: Spawn follow-ups** for any real `libs/*` source bug or generator drift the report flagged (do not fix here).
+- [ ] **Step 4:** Confirm all 3 PRs merged (monitor; `gh pr update-branch` any that go BEHIND); sync local main; delete merged branches.
+
+---
+
+## Manual verification (before each merge)
+- [ ] Every fix traces to a report finding with a source citation; no edit lacks a finding.
+- [ ] The PR's chat routes render; internal links resolve; no documented chat API attributed to the wrong package.
+- [ ] Findings report committed; structural + source items listed, not actioned.
+
+## Self-Review (completed during planning)
+
+- **Spec coverage:** 33 pages across 5 reviewed sections audited (Tasks 1–6, components split 7+7) ✓; four dimensions in every audit prompt, with component selector/input/output emphasis ✓; completeness sweep (Task 7) ✓; controller re-verification of borderline findings (Task 8 Step 1) ✓; one severity-ranked report at the spec'd path (Task 8) ✓; triage checkpoint (Task 8 Step 4) ✓; 3 batched fix PRs grouped by section with source-cited reviews + render checks (Tasks 9–11) ✓; final verification + follow-ups (Task 12) ✓; exclusions (a2ui, changelog) honored; out-of-scope (other libs' docs, source changes, restructuring) honored.
+- **Placeholder scan:** No TBD/TODO. Phase 2 fix snippets are intentionally report-driven (the audit produces the exact corrected text — inherent to a review whose fixes aren't known until discovery); the gates (source re-verification, fix-gate diff, reviewer loop, render 200) make each edit checkable. Commands have expected output.
+- **Consistency:** the ground-truth map, severity taxonomy, and row schema are defined once and referenced by every task; the component pages list in Tasks 4+5 (7+7=14) matches the spec; the 3-PR grouping in Tasks 9–11 matches the report's fix-plan section and the spec's Phase 2; `claude/chat-docs-technical-review` is the audit/report branch, with separate fix branches per PR off `origin/main`.

--- a/docs/superpowers/specs/2026-06-06-chat-docs-review-findings.md
+++ b/docs/superpowers/specs/2026-06-06-chat-docs-review-findings.md
@@ -5,6 +5,17 @@
 **Source verified against:** `libs/chat` (+ cross-refs `libs/render`, `libs/langgraph`, `libs/a2ui`), generated `api-docs.json`
 **Method:** 6 parallel read-only auditors + completeness sweep; controller re-verified every high-impact finding against source (dropped 1 auditor false alarm).
 
+## Resolution status — ✅ ALL FINDINGS FIXED (3 PRs merged)
+
+Cutoff: P0+P1+P2 + cheap P3. Each fix re-verified against its cited source by an independent reviewer (all PASS, no over-reach).
+- ✅ **PR #594 — components:** systemic `agent()`→`injectAgent()`/`provideAgent()` across the component pages + folded-in `chat/a2ui/overview.mdx`; chat.mdx inputs/outputs; chat-input slots/inputs/outputs; chat-tool-calls, chat-select, chat-trace, popup/sidebar two-way, message-list reword.
+- ✅ **PR #595 — guides + concepts:** `agent()` migration (generative-ui, layout-modes ×3, markdown comment); streaming `'undetermined'`→`'pending'`; writing-an-adapter `regenerate`; custom-catalogs `loading` optional; message-model `toolCallIds` + `Citation` shape.
+- ✅ **PR #596 — api + getting-started:** `agent()` migration (quickstart, provide-chat); introduction base-Agent `history()` correction; content-classifier `'undetermined'`→`'pending'` + `a2uiSurfaceStates`; mock-agent `opts` + `events$`. (#4 parse-tree-store param and #22 provideChat return type were verified already-correct — no change.)
+
+**Verification:** no `agent()` factory or `'undetermined'` remains in chat docs; all edited routes returned HTTP 200.
+
+**Spawned as a separate follow-up (not in these PRs):** the `api-docs.json` default-valued-param `optional` flag (generator nuance — `mockAgent(opts = {})` marked `optional: false`).
+
 ## Summary
 
 - **P0: 4 (one systemic, ~13 files)** · **P1: 7** · **P2: 8** · **P3: 3**

--- a/docs/superpowers/specs/2026-06-06-chat-docs-review-findings.md
+++ b/docs/superpowers/specs/2026-06-06-chat-docs-review-findings.md
@@ -1,0 +1,85 @@
+# Chat Docs Technical Review — Findings
+
+**Date:** 2026-06-06
+**Pages audited:** 33 (getting-started ×3, guides ×9, concepts ×2, components ×14, api ×5)
+**Source verified against:** `libs/chat` (+ cross-refs `libs/render`, `libs/langgraph`, `libs/a2ui`), generated `api-docs.json`
+**Method:** 6 parallel read-only auditors + completeness sweep; controller re-verified every high-impact finding against source (dropped 1 auditor false alarm).
+
+## Summary
+
+- **P0: 4 (one systemic, ~13 files)** · **P1: 7** · **P2: 8** · **P3: 3**
+- **Headline systemic issue:** the chat docs pervasively import a **nonexistent** `agent` from `@threadplane/langgraph` and call `agent({ assistantId, threadId })`. `@threadplane/langgraph` exports only `provideAgent` and `injectAgent`; the canonical pattern (per langgraph's own installation page) is `provideAgent({...})` at the app root + **`injectAgent()` with no arguments** in the component. This appears in **~13 reviewed pages** and also in the *excluded* `chat/a2ui/overview.mdx` (the render review's a2ui audit missed it).
+- Other systemic notes: `ContentType` value `'undetermined'` (doesn't exist; real value `'pending'`) in two pages; the `chat.mdx` and `chat-input.mdx` component pages under-document real inputs/outputs.
+- **Dropped (verified non-issue):** the "missing theming guide" link — `theming` IS in `docs-config.ts:158`; the link resolves.
+
+---
+
+## Findings by severity
+
+### P0 — wrong (breaks copy-paste)
+
+| # | page:line | dim | what's wrong | source evidence | fix |
+|---|---|---|---|---|---|
+| 1 | **SYSTEMIC** — `getting-started/quickstart.mdx:41,52`; `guides/generative-ui.mdx:27,48`; `guides/layout-modes.mdx:22,37,59,76,105,123`; `components/chat-debug.mdx:17,39`; `components/chat-interrupt-panel.mdx:125,148`; `components/chat-subagent-card.mdx:80,112`; `components/chat-sidebar.mdx:23,41,113`; `components/chat-message-list.mdx:142`; `components/chat-input.mdx:139,164`; `components/chat-trace.mdx:93,119`; `components/chat-popup.mdx:23,37,90`; `api/provide-chat.mdx:140` | accuracy | `import { agent } from '@threadplane/langgraph'` + `agent({ assistantId, threadId })` — `agent` is **not exported**; and config doesn't go in the inject call | `libs/langgraph/src/public-api.ts:3,7` (only `provideAgent`, `injectAgent`); `lib/inject-agent.ts:16` (`injectAgent()` takes no args); canonical pattern in `docs/langgraph/getting-started/installation.mdx:105-109` | Replace with `import { injectAgent } from '@threadplane/langgraph'` and `injectAgent()` (no args); move `assistantId`/`threadId` config to `provideAgent({...})` in the app config or component `providers` (show it where the snippet implies app setup). Apply consistently. **Also fix the excluded `chat/a2ui/overview.mdx:258,266`** (same bug). |
+| 2 | `guides/streaming.mdx:60,69` | accuracy | `ContentType` documented value `'undetermined'` doesn't exist | `libs/chat/src/lib/streaming/content-classifier.ts:11` → `'pending' \| 'markdown' \| 'json-render' \| 'a2ui' \| 'mixed'` | Replace `'undetermined'` → `'pending'` (both lines) |
+| 3 | `api/content-classifier.mdx:56` | accuracy | same `'undetermined'` in the ContentType enum | `content-classifier.ts:11` | Replace `'undetermined'` → `'pending'` |
+| 4 | `api/parse-tree-store.mdx:15` | accuracy | `createParseTreeStore()` shown with no params; it requires `parser: PartialJsonParser` | `libs/chat/src/lib/streaming/parse-tree-store.ts:20` | Signature → `createParseTreeStore(parser: PartialJsonParser): ParseTreeStore`; show acquiring a `PartialJsonParser` |
+
+### P1 — misleading (runs/reads but wrong model)
+
+| # | page:line | dim | what's wrong | source evidence | fix |
+|---|---|---|---|---|---|
+| 5 | `getting-started/introduction.mdx:61` | conceptual | claims base `Agent` exposes `history()`; that's on the optional `AgentWithHistory` | `libs/chat/src/lib/agent/agent.ts` (base contract has no `history`) | Drop `history()` from the base-contract list; note some adapters add `AgentWithHistory` with `history()` |
+| 6 | `guides/writing-an-adapter.mdx:26-38` | completeness | Agent contract table omits the **required** `regenerate` method | `agent.ts:47` (`regenerate: (assistantMessageIndex: number) => Promise<void>`) | Add `regenerate` row; add it to the EchoAgent example (or the example fails the contract) |
+| 7 | `guides/custom-catalogs.mdx:90` | accuracy | example types `loading` as required `input<boolean>(false)`; the contract field is optional | `libs/render/src/lib/render.types.ts:11` (`loading?: boolean`) | `input<boolean>()` (no default); optionally show `bindings` too |
+| 8 | `concepts/message-model.mdx:9-20` | accuracy | `Message` interface omits `toolCallIds?: string[]` | `libs/chat/src/lib/agent/message.ts:44` | Add `toolCallIds?: string[]` with a one-line comment |
+| 9 | `components/chat-message-list.mdx:19,159` | conceptual | says the component "reads `injectAgent().messages()`"; it takes the agent as a required input | `chat-message-list.component.ts:54` (`readonly agent = input.required<Agent>()`) | Reword to "receives an `agent` input and reads `agent.messages()`"; align the example with the `[agent]` pattern |
+| 10 | `api/mock-agent.mdx:15` | accuracy | parameter named `options`; source is `opts` | `libs/chat/src/lib/testing/mock-agent.ts:65` (`mockAgent(opts: MockAgentOptions = {})`) | Rename to `opts` |
+| 11 | `components/chat-popup.mdx:54`, `components/chat-sidebar.mdx:71`, `components/chat.mdx` (`selectedModel`) | accuracy | two-way `model()` inputs documented as plain inputs | `chat-popup.component.ts:101`, `chat-sidebar.component.ts:142`, `chat.component.ts:319` (all `model(...)`) | Mark these as two-way (e.g. "boolean (two-way)") so `[(open)]` / `[(selectedModel)]` is discoverable |
+
+### P2 — gap
+
+| # | page:line | dim | what's wrong | source evidence | fix |
+|---|---|---|---|---|---|
+| 12 | `components/chat.mdx:75-91` | completeness | omits inputs `welcomeDisabled`, `modelOptions`, `showModelPicker`, `selectedModel`, `modelPickerPlaceholder`, `genuiToolNames` and outputs `renderEvent`, `regenerate`, `rate`, `messageCopy` | `chat.component.ts:295-348` | Add the missing input/output rows with source types/defaults |
+| 13 | `components/chat-input.mdx:23-134` | completeness | omits `showStopButton` input, `stopped` output, and content-projection slots (`[chatInputBanner]`, `[chatInputAttachments]`, `[chatInputLeading]`, `[chatInputTrailing]`, `[chatInputFooter]`) | `chat-input.component.ts:41-102` | Add the missing input/output + a Slots table |
+| 14 | `components/chat-reasoning.mdx:21-29` | completeness | omits `label` input | `chat-reasoning.component.ts:68` | Add `label: string \| undefined` (default `undefined`) row |
+| 15 | `components/chat-tool-calls.mdx:13-20` | completeness | omits `excludeToolNames` input | `chat-tool-calls.component.ts:101` (`input<readonly string[]>([])`) | Add `excludeToolNames` row |
+| 16 | `components/chat-select.mdx` | completeness | no explicit `valueChange` output (auto-created by `model()`) | `chat-select.component.ts:84` (`value = model<string>('')`) | Add an Outputs note documenting `valueChange` |
+| 17 | `api/content-classifier.mdx:23-50` | completeness | `ContentClassifier` omits `a2uiSurfaceStates` signal | `content-classifier.ts:22` (`a2uiSurfaceStates: Signal<Map<string, A2uiSurfaceState>>`) | Document the property |
+| 18 | `api/mock-agent.mdx` | completeness | `MockAgentOptions` table omits `events$?: Observable<AgentEvent>` | `mock-agent.ts:62` | Add `events$` row |
+| 19 | `concepts/message-model.mdx` | completeness | `Citation` shape undocumented though citations are discussed | `libs/chat/src/lib/agent/citation.ts` | Add a short Citation-shape note |
+
+### P3 — polish
+
+| # | page:line | dim | what's wrong | source evidence | fix |
+|---|---|---|---|---|---|
+| 20 | `components/chat-trace.mdx:31,47-53` | polish | refers to the state union inline instead of the exported `TraceState`; slots not marked optional | `chat-trace.component.ts:7,40` (`TraceState` exported) | Cite `TraceState`; mark slots optional |
+| 21 | `components/chat-reasoning.mdx:3-4` | conceptual | doesn't say `<chat>` auto-renders this when `Message.reasoning` is set | `chat.component.ts` (auto-renders chat-reasoning) | One-line clarification |
+| 22 | `api/provide-chat.mdx:21` | polish | signature omits the return type | `libs/chat/src/lib/provide-chat.ts:36` (returns `EnvironmentProviders`) | Show `: EnvironmentProviders` in the signature |
+
+---
+
+## Structural / won't-fix-here
+
+- **`api-docs.json` default-param drift:** `mockAgent`'s `opts` (which has a default `= {}`) is marked `optional: false` in the generated JSON. The generator doesn't treat default-valued params as optional. This is a generator nuance not covered by the earlier generator fix (#591) — flag for a separate follow-up; do not hand-edit the JSON.
+- No `libs/*` source bugs identified in this review.
+
+## Verified NON-issues (no change)
+
+- **`introduction.mdx:108` theming link:** `theming` is registered in `docs-config.ts:158`; `/docs/chat/guides/theming` resolves. (One auditor mis-flagged.)
+- **`ChatConfig` `__licenseEnvHint` / `__licensePublicKey`:** `@internal` test-only props; correctly omitted from the public reference.
+
+---
+
+## Fix plan (3 PRs)
+
+Default cutoff: **fix P0 + P1 + P2; fix P3 where it's a one-liner** (#20–22). Structural item flagged only.
+
+- **PR-1 — components** (Task 9): #1 (component-page occurrences), #9, #11 (popup/sidebar/chat), #12, #13, #14, #15, #16, #20, #21.
+- **PR-2 — guides + concepts** (Task 10): #1 (guides occurrences), #2, #5*, #6, #7, #8, #19. (*#5 is on getting-started — see PR-3; listed once.)
+- **PR-3 — api + getting-started** (Task 11): #1 (gs + provide-chat occurrences), #3, #4, #5, #10, #11 (selectedModel if in api), #17, #18, #22.
+
+**Decision needed at checkpoint:** the systemic `agent()` P0 (#1) also affects the *excluded* `chat/a2ui/overview.mdx`. Recommend folding that one-file fix into PR-1 (the exclusion was based on a review that missed this), rather than leaving a known-broken snippet.
+
+> Note: finding #1 spans all three batches (each PR fixes the `agent()`→`injectAgent()`/`provideAgent()` pattern in its own files). The correct replacement keeps `assistantId`/`threadId` but moves them into `provideAgent({...})` (app config or component `providers`), with `injectAgent()` taking no args.

--- a/docs/superpowers/specs/2026-06-06-chat-docs-technical-review-design.md
+++ b/docs/superpowers/specs/2026-06-06-chat-docs-technical-review-design.md
@@ -1,0 +1,141 @@
+# Chat Docs Technical Review — Design
+
+**Date:** 2026-06-06
+**Status:** Draft for review
+**Scope:** A full technical-accuracy review of the chat documentation (33 pages), cross-referenced against library source, producing one severity-ranked findings report and shipping fixes as batched PRs. Reuses the methodology proven on the render docs review (#590).
+
+## Goal
+
+Make the chat docs technically correct: every code snippet, import/package, component
+selector, `@Input`/`@Output` name and type, function signature, behavioral claim, and
+internal link matches the implementation. Catch documented-but-nonexistent APIs and
+exported-but-undocumented ones. Discovery is separated from fixing so findings are
+triaged before any edit lands.
+
+This is a **docs accuracy** review. It does not change `libs/*` source and does not
+restructure the docs; it corrects what the docs say so they match what the code does.
+
+## Surface under review (33 pages)
+
+`apps/website/content/docs/chat/` — ~5,600 lines across 6 sections; **2 sections excluded**.
+
+- **getting-started** (3): `introduction.mdx`, `quickstart.mdx`, `installation.mdx` (skip `changelog.mdx` — generated/list).
+- **guides** (9): `layout-modes`, `theming`, `markdown`, `generative-ui`, `custom-catalogs`, `streaming`, `configuration`, `writing-an-adapter`, `lifecycle`.
+- **concepts** (2): `primitives-vs-compositions`, `message-model`.
+- **components** (14): `chat`, `chat-popup`, `chat-sidebar`, `chat-message-list`, `chat-trace`, `chat-input`, `chat-reasoning`, `chat-interrupt-panel`, `chat-tool-calls`, `chat-tool-call-template`, `chat-tool-call-card`, `chat-subagent-card`, `chat-debug`, `chat-select`.
+- **api** (5): `provide-chat`, `chat-config`, `mock-agent`, `content-classifier`, `parse-tree-store`.
+
+**Excluded:** the 4 `chat/a2ui/*` pages (just reviewed + corrected in render review #590) and `getting-started/changelog.mdx` (generated).
+
+## Ground-truth sources
+
+`libs/chat/src` is authoritative (136 public exports in `libs/chat/src/public-api.ts`).
+Components live under `libs/chat/src/lib/primitives/*` and `libs/chat/src/lib/compositions/*`.
+Cross-lib references appear in some guides and must be verified against the owning lib:
+
+| Section | Pages | Ground-truth source |
+|---|---|---|
+| getting-started | 3 | `libs/chat/src` — `public-api.ts`, `provide-chat`, the Agent contract under `lib/agent` |
+| guides | 9 | `libs/chat/src` + cross-lib: `libs/render` (generative-ui), `libs/langgraph` & `libs/ag-ui` (writing-an-adapter, the Agent contract), `libs/a2ui` (streaming protocol refs) |
+| concepts | 2 | `libs/chat/src` — `lib/primitives/*`, `lib/compositions/*`, message types |
+| components A | 7 | the specific component class for each page in `lib/primitives/*` or `lib/compositions/*` |
+| components B | 7 | same |
+| api | 5 | `libs/chat/src/public-api.ts` + `provide-chat`, `chat-config`, `mock-agent`, `content-classifier`, `parse-tree-store` modules + generated `apps/website/content/docs/chat/api/api-docs.json` |
+
+Component-page → source mapping is established per page during the audit (each page names a
+component; the auditor locates its class file under `primitives/` or `compositions/`).
+
+## Methodology — two gated phases
+
+### Phase 1 — Audit (read-only, parallel)
+
+Six section audit subagents run concurrently (disjoint reads, no conflict). The 14
+component pages are split across **two** auditors (7 + 7) — the heaviest, highest-API-surface
+section. Each subagent is read-only and returns findings as rows:
+`page:line · dimension · severity · what's-wrong · source-evidence(libs/…:line) · proposed-fix`.
+
+Then a **completeness sweep**: diff `libs/chat/src/public-api.ts` exports against what the
+docs document (exported-but-undocumented and documented-but-nonexistent), scoped to the
+components + api the chat docs claim to cover (the chat surface is large; the sweep flags
+notable gaps, not every internal symbol).
+
+The controller consolidates all findings into one severity-ranked report, flags
+systemic/cross-page issues, and **pauses at a triage checkpoint** before Phase 2.
+
+### Phase 2 — Fix (subagent-driven, batched PRs)
+
+After triage, fixes ship as **3 PRs** to keep each reviewable:
+
+- **PR-1 — components** (the 14 component pages).
+- **PR-2 — guides + concepts** (11 pages).
+- **PR-3 — api + getting-started** (8 pages).
+
+Within each PR, fixes are grouped by section; each group's implementer re-verifies every
+changed snippet against the cited source line, re-checks internal links against
+`docs-config.ts`, and an independent accuracy reviewer confirms each fix matches source and
+introduces no new error before the group is committed. Each PR ends with a render-200 check
+on its pages.
+
+## The four audit dimensions
+
+1. **Code-snippet accuracy** — import path/package, exported symbol name, component
+   **selector**, `@Input`/`@Output` (signal `input()`/`output()`) names and types,
+   function signatures, generics, option keys, and types match source exactly.
+   Wrong package or nonexistent symbol = P0.
+2. **Conceptual correctness** — prose claims about component behavior, the message model,
+   primitives vs compositions, streaming/classification, and the adapter/Agent contract
+   match the implementation. Runs-but-wrong-model = P1.
+3. **Links + runnability** — internal links resolve via `docs-config.ts`; each example is
+   internally coherent (imports cover every symbol used; required providers present) and
+   would compile/run as written.
+4. **Completeness/gaps** — exported-but-undocumented APIs, documented-but-nonexistent
+   APIs, missing inputs/outputs/options, thin coverage.
+
+## Findings report format
+
+One report: `docs/superpowers/specs/2026-06-06-chat-docs-review-findings.md`.
+
+Severity taxonomy (same as render):
+- **P0 — wrong:** breaks copy-paste (wrong import/package, nonexistent API, wrong
+  selector/signature/type).
+- **P1 — misleading:** runs but teaches a wrong mental model.
+- **P2 — gap:** undocumented export, missing input/output/option, thin coverage.
+- **P3 — polish:** stale wording, inconsistent naming, dead link.
+
+Each row: `file:line · dimension · severity · what's-wrong · source-evidence(libs/…:line) ·
+proposed-fix`. The report ends with a "Structural / won't-fix-here" section (e.g.
+`api-docs.json` regeneration if needed, any `libs/*` source bug) listed but not actioned,
+and a "Fix plan" grouping findings into the 3 PRs with a P-level cutoff.
+
+## Testing & verification
+
+- **Phase 1:** every finding carries a concrete source citation; the controller spot-checks
+  a sample of citations + re-verifies any borderline finding before trusting it (as in the
+  render review, which caught two auditor false alarms this way).
+- **Phase 2 per PR:** each changed snippet re-verified against its cited source line;
+  internal links re-checked against `docs-config.ts`; edited pages return HTTP 200; an
+  independent accuracy reviewer signs off per section group.
+- **Final per PR:** the PR's chat routes return 200; no documented chat API attributed to
+  the wrong package.
+
+## Out of scope
+
+- The 4 `chat/a2ui/*` pages (reviewed in #590) and `getting-started/changelog.mdx`.
+- Voice/prose-register edits (already shipped) — except where a P0/P1 fix rewrites a sentence.
+- `libs/*` **source** changes — real code bugs get flagged for separate follow-ups, not fixed here.
+- Net-new pages/examples beyond filling documented gaps the report identifies.
+- Other libraries' docs; relocating/restructuring chat pages.
+
+## Self-review notes
+
+- **Placeholder scan:** none — every section names concrete files/sources; the per-page
+  component→class mapping is resolved during the audit (each page names its component).
+- **Internal consistency:** the 6-auditor split (components ×2) in the methodology matches
+  the ground-truth table; the 3-PR batching matches the Phase 2 description and the report's
+  fix-plan section; excluded sets (a2ui, changelog) are stated identically in scope and
+  out-of-scope.
+- **Scope:** one product's docs; large but coherent — one audit/report, batched fixes with a
+  triage gate between. Decomposition (components ×2 auditors, 3 fix PRs) handles the size.
+- **Ambiguity:** "audit + fix in PR(s)" = one findings report committed, then corrections
+  shipped as 3 batched PRs; cross-lib references verified against the owning lib but those
+  libs' own pages stay out of scope.


### PR DESCRIPTION
## Summary

Lands the planning artifacts for the chat docs technical review (the fixes shipped in #594, #595, #596):
- the design spec, implementation plan, and the severity-ranked findings report (22 findings: 4 P0, 7 P1, 8 P2, 3 P3 — all resolved).

The headline was a systemic P0: chat docs imported a nonexistent `agent` from `@threadplane/langgraph` across ~14 pages; corrected to the public `provideAgent()` + `injectAgent()` pattern.

## Test Plan
- [x] Docs-only (superpowers planning artifacts); no app/code changes.
- [x] Findings report marked resolved with the 3 merged PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)