### PR TITLE
test(smoke): regression guard for examples langgraph proxy hardening

### DIFF
--- a/apps/cockpit/e2e/production-smoke.spec.ts
+++ b/apps/cockpit/e2e/production-smoke.spec.ts
@@ -207,3 +207,37 @@ test.describe('ag-ui Railway runtime', () => {
     expect(res?.status()).toBeLessThan(400);
   });
 });
+
+/**
+ * Regression guard for the examples LangGraph proxy hardening
+ * (scripts/examples-middleware.ts → createProxyHandler). These assert the
+ * origin allowlist and body-size cap stay live after future redeploys.
+ *
+ * Both checks are rejected by the proxy BEFORE the rate-limit gate and before
+ * any forward to LangGraph Cloud, so they burn no LLM tokens and consume no
+ * rate-limit budget. The rate-limit (429) path is deliberately NOT asserted
+ * here — it is stateful/time-windowed and would race with real traffic.
+ */
+test.describe('examples langgraph proxy hardening', () => {
+  const streamPath = () =>
+    `${EXAMPLES_URL}/api/threads/00000000-0000-0000-0000-000000000000/runs/stream`;
+  const runBody = { assistant_id: 'streaming', input: { messages: [] } };
+
+  test('rejects a forbidden Origin with 403', async ({ request }) => {
+    const res = await request.post(streamPath(), {
+      headers: { Origin: 'https://evil.example.com', 'content-type': 'application/json' },
+      data: runBody,
+    });
+    expect(res.status()).toBe(403);
+    expect(await res.json()).toMatchObject({ error: 'origin_not_allowed' });
+  });
+
+  test('rejects an oversized body with 413', async ({ request }) => {
+    const res = await request.post(streamPath(), {
+      headers: { Origin: EXAMPLES_URL, 'content-type': 'application/json' },
+      data: { assistant_id: 'streaming', input: { blob: 'A'.repeat(70_000) } },
+    });
+    expect(res.status()).toBe(413);
+    expect(await res.json()).toMatchObject({ error: 'payload_too_large' });
+  });
+});


### PR DESCRIPTION
## Summary

Adds two deterministic production-smoke assertions guarding the examples LangGraph proxy hardening shipped in #593, so a future edit to `scripts/examples-middleware.ts` that drops the origin check or body cap is caught post-deploy.

- `rejects a forbidden Origin with 403` — POST to the stream endpoint with `Origin: https://evil.example.com` → `403 origin_not_allowed`.
- `rejects an oversized body with 413` — allowed Origin, >64 KB body → `413 payload_too_large`.

Both reject **before** the rate-limit gate and before any forward to LangGraph Cloud, so they burn no LLM tokens and consume no rate-limit budget. The 429 path is intentionally not asserted (stateful / time-windowed; would race with real traffic).

Verified green against `examples.threadplane.ai` (2 passed, 2.2s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)