### PR TITLE
docs(langgraph): fix api reference accuracy (threadId, AgentConfig, generics)

### DIFF
--- a/apps/website/content/docs/langgraph/api/inject-agent.mdx
+++ b/apps/website/content/docs/langgraph/api/inject-agent.mdx
@@ -4,7 +4,11 @@
 
 Call it in an Angular injection context, usually as a component field initializer. The returned object exposes Angular Signals for UI state and async methods for user actions.
 
-Configuration is supplied globally via `provideAgent({...})` — `injectAgent()` itself takes no arguments.
+Configuration is supplied globally via `provideAgent({...})` — `injectAgent()` itself takes no arguments. For typed state, supply its generics:
+
+```ts
+injectAgent<T, ResolvedBag>(): LangGraphAgent<T, ResolvedBag>
+```
 
 ```ts
 import { injectAgent } from '@threadplane/langgraph';

--- a/apps/website/content/docs/langgraph/api/mock-stream-transport.mdx
+++ b/apps/website/content/docs/langgraph/api/mock-stream-transport.mdx
@@ -80,7 +80,7 @@ describe('ChatComponent', () => {
 
 | Method | Description |
 |--------|-------------|
-| `constructor(script?)` | Optionally seeds scripted event batches for manual stepping. |
+| `constructor(script?: StreamEvent[][])` | Optionally seeds scripted event batches for manual stepping (defaults to `[]`). |
 | `nextBatch()` | Returns the next scripted event batch. |
 | `emit(events)` | Pushes one or more `StreamEvent` objects into the active stream. |
 | `emitError(err)` | Causes the active stream to reject with `err`. |

--- a/apps/website/content/docs/langgraph/api/provide-agent.mdx
+++ b/apps/website/content/docs/langgraph/api/provide-agent.mdx
@@ -31,9 +31,15 @@ bootstrapApplication(AppComponent, {
 |--------|------|-------------|
 | `apiUrl` | `string` | LangGraph Platform API base URL. |
 | `assistantId` | `string` | LangGraph assistant id to bind to. |
-| `threadId` | `() => string \| undefined` | Optional thread id provider, used to resume a persisted thread. |
-| `onThreadId` | `(id: string) => void` | Optional callback fired when a new thread id is assigned. |
+| `threadId` | `Signal<string \| null> \| string \| null` | Thread ID to connect to. Pass a Signal for reactive thread switching. |
+| `onThreadId` | `(id: string) => void` | Called when a new thread is auto-created by the transport. |
+| `initialValues` | `Partial<T>` | Initial state values before the first stream response arrives. |
+| `throttle` | `number \| false` | Throttle signal updates in milliseconds. `false` to disable. (default 16) |
+| `toMessage` | `(msg: unknown) => BaseMessage` | Custom message deserializer for non-standard message formats. |
 | `transport` | `AgentTransport` | Optional transport instance. Defaults to `FetchStreamTransport` when omitted. |
+| `telemetry` | `AgentRuntimeTelemetrySink \| false` | Optional app-owned telemetry sink. No telemetry is emitted unless this is provided. |
+| `filterSubagentMessages` | `boolean` | When true, subagent messages are filtered from the main messages signal. |
+| `subagentToolNames` | `string[]` | Tool names that indicate a subagent invocation. |
 
 ## Singleton model
 

--- a/apps/website/content/docs/langgraph/guides/persistence.mdx
+++ b/apps/website/content/docs/langgraph/guides/persistence.mdx
@@ -291,6 +291,10 @@ export class ThreadListComponent {
 </Tab>
 </Tabs>
 
+<Callout type="info" title="LANGGRAPH_CLIENT">
+`LANGGRAPH_CLIENT` is the DI token that holds the shared LangGraph SDK `Client` used by the threads adapter (`LangGraphThreadsAdapter`). The adapter injects it optionally and, when no client is provided, constructs one via `createLangGraphClient(apiUrl)`. Provide your own client through this token to share a single SDK instance — or to inject an explicit client in tests.
+</Callout>
+
 ## Reactive Thread Switching
 
 When you pass a Signal as `threadId` to `provideAgent({...})`, `injectAgent()` reacts to every change. Set the signal and the conversation switches automatically — no imperative calls needed.


### PR DESCRIPTION
## Summary

PR 2 of 2 from the langgraph docs technical review (findings: `docs/superpowers/specs/2026-06-06-langgraph-docs-review-findings.md`). Fixes the api reference (getting-started had no findings).

- **P0:** `provide-agent.mdx` documented `threadId` as `() => string | undefined`; corrected to `Signal<string | null> | string | null` (agent.provider.ts:30).
- **P2:** the `AgentConfig` table documented only 5 of 11 keys — added `initialValues`, `throttle` (default 16ms), `toMessage`, `telemetry`, `filterSubagentMessages`, `subagentToolNames` with exact source types.
- **P2:** `inject-agent.mdx` now shows the `<T, ResolvedBag>` generics for typed state.
- **P2:** `mock-stream-transport.mdx` constructor documents `script?: StreamEvent[][]` (defaults to `[]`).
- **P2:** documented `LANGGRAPH_CLIENT` (the DI token for the shared LangGraph SDK client) in the persistence guide, next to the threads adapter.

This completes the langgraph docs technical review (with PR #601). Guides + agent-contract were clean.

## Test Plan
- [x] Each fix re-verified against its cited source line by an independent reviewer (PASS).
- [x] All edited api/guide routes return HTTP 200; api-docs.json not hand-edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)