### PR TITLE
docs(ag-ui): fix event-mapping multi-signal effects + FakeAgent/architecture gaps

### DIFF
--- a/apps/website/content/docs/ag-ui/concepts/architecture.mdx
+++ b/apps/website/content/docs/ag-ui/concepts/architecture.mdx
@@ -87,6 +87,7 @@ Every AG-UI event is passed through the reducer. The reducer updates Angular sig
 - `status`, `isLoading`, and `error` for run lifecycle.
 - `toolCalls` for tool call starts, arguments, results, and completion.
 - `state` for AG-UI state snapshots and JSON Patch deltas.
+- `interrupt` cleared on `RUN_STARTED` and set by the `CUSTOM` `on_interrupt` event.
 - `events$` for custom events.
 
 When the user submits input, the adapter builds a user message, appends it locally, adds it to the AG-UI source with `source.addMessage()`, then calls `source.runAgent()`.

--- a/apps/website/content/docs/ag-ui/getting-started/installation.mdx
+++ b/apps/website/content/docs/ag-ui/getting-started/installation.mdx
@@ -81,6 +81,7 @@ export const appConfig: ApplicationConfig = {
   providers: [
     provideFakeAgent({
       tokens: ['Hello', ' from', ' a', ' fake', ' agent.'],
+      reasoningTokens: ['Thinking', ' it', ' over...'],
       delayMs: 60,
     }),
   ],
@@ -88,6 +89,14 @@ export const appConfig: ApplicationConfig = {
 ```
 
 `FakeAgent` extends `AbstractAgent` and emits a canned `RUN_STARTED -> TEXT_MESSAGE_START -> TEXT_MESSAGE_CONTENT x N -> TEXT_MESSAGE_END -> RUN_FINISHED` sequence. It's a drop-in replacement for `provideAgent({ url })` while you're prototyping.
+
+`provideFakeAgent` accepts:
+
+| Option | Type | Description |
+|---|---|---|
+| `tokens` | `string[]` | Optional. Tokens streamed back as the assistant reply. |
+| `reasoningTokens` | `string[]` | Optional. Reasoning chunks emitted before the text reply (defaults to `[]`). |
+| `delayMs` | `number` | Optional. Milliseconds between successive token emissions (defaults to `60`). |
 
 ## Custom transport
 

--- a/apps/website/content/docs/ag-ui/reference/event-mapping.mdx
+++ b/apps/website/content/docs/ag-ui/reference/event-mapping.mdx
@@ -8,7 +8,7 @@ This page is the compatibility map. If your backend emits these events with the 
 
 | AG-UI event | Agent field | Behavior |
 | --- | --- | --- |
-| `RUN_STARTED` | `status`, `isLoading`, `error` | Sets `status` to `running`, `isLoading` to `true`, and clears `error`. |
+| `RUN_STARTED` | `status`, `isLoading`, `error`, `interrupt` | Sets `status` to `running`, `isLoading` to `true`, clears `error`, and clears any pending `interrupt`. |
 | `RUN_FINISHED` | `status`, `isLoading` | Sets `status` to `idle` and `isLoading` to `false`. |
 | `RUN_ERROR` | `status`, `isLoading`, `error` | Sets `status` to `error`, stops loading, and stores the event message when present. |
 | `TEXT_MESSAGE_START` | `messages` | Creates or reuses an assistant message slot. |
@@ -25,7 +25,8 @@ This page is the compatibility map. If your backend emits these events with the 
 | `STATE_SNAPSHOT` | `state`, `messages` | Replaces state and merges citations from `state.citations`. |
 | `STATE_DELTA` | `state`, `messages` | Applies JSON Patch to state and merges citations from `state.citations`. |
 | `MESSAGES_SNAPSHOT` | `messages` | Replaces the full message list. |
-| `CUSTOM` | `events$` | Emits a runtime-neutral custom event. |
+| `CUSTOM` (name: `on_interrupt`) | `interrupt` | Sets the `interrupt` signal to `{ id, value, resumable: true }`. The value is JSON-parsed when it arrives as a string. |
+| `CUSTOM` (other names) | `events$` | Emits a runtime-neutral custom event. |
 | unknown event | none | Ignored. Future protocol events do not crash the adapter. |
 
 ## Run lifecycle

--- a/apps/website/content/docs/ag-ui/reference/event-mapping.mdx
+++ b/apps/website/content/docs/ag-ui/reference/event-mapping.mdx
@@ -18,13 +18,13 @@ This page is the compatibility map. If your backend emits these events with the 
 | `REASONING_MESSAGE_CONTENT` | `messages` | Appends `delta` to `message.reasoning`. |
 | `REASONING_MESSAGE_CHUNK` | `messages` | Treated the same as `REASONING_MESSAGE_CONTENT`. |
 | `REASONING_MESSAGE_END` | `messages` | Adds `reasoningDurationMs` when timing is available. |
-| `TOOL_CALL_START` | `toolCalls` | Adds a running tool call. |
+| `TOOL_CALL_START` | `toolCalls`, `messages` | Adds a running tool call; also links the call to its parent assistant message (via `parentMessageId`), creating a message slot if needed. |
 | `TOOL_CALL_ARGS` | `toolCalls` | Parses `delta` as JSON and replaces args on the matching tool call. |
 | `TOOL_CALL_RESULT` | `toolCalls` | Stores the tool result on the matching tool call. |
 | `TOOL_CALL_END` | `toolCalls` | Marks the matching tool call complete. |
 | `STATE_SNAPSHOT` | `state`, `messages` | Replaces state and merges citations from `state.citations`. |
 | `STATE_DELTA` | `state`, `messages` | Applies JSON Patch to state and merges citations from `state.citations`. |
-| `MESSAGES_SNAPSHOT` | `messages` | Replaces the full message list. |
+| `MESSAGES_SNAPSHOT` | `messages`, `toolCalls` | Replaces the message list and merges snapshot-embedded tool calls into `toolCalls` (by id). |
 | `CUSTOM` (name: `on_interrupt`) | `interrupt` | Sets the `interrupt` signal to `{ id, value, resumable: true }`. The value is JSON-parsed when it arrives as a string. |
 | `CUSTOM` (other names) | `events$` | Emits a runtime-neutral custom event. |
 | unknown event | none | Ignored. Future protocol events do not crash the adapter. |


### PR DESCRIPTION
## Summary

Fixes from the ag-ui docs technical review (findings: `docs/superpowers/specs/2026-06-06-ag-ui-docs-review-findings.md`). The ag-ui docs were in excellent shape — all 5 guides clean, no P0s. Findings clustered in the **event-mapping reference**, whose "Agent field" column under-reported the AG-UI event reducer's multi-signal effects.

- **P1:** `CUSTOM` row — documented the special `on_interrupt` case (sets the `interrupt` signal, resumable; other CUSTOM events emit via `events$`).
- **P2:** `RUN_STARTED` also clears `interrupt`; `TOOL_CALL_START` also updates `messages` (via `parentMessageId`); `MESSAGES_SNAPSHOT` also merges `toolCalls` (by id); `architecture.mdx` signals list now includes `interrupt`; `installation.mdx` FakeAgent options now include `reasoningTokens`.

All verified against `libs/ag-ui/src/lib/reducer.ts` (313-line current version) and `fake-agent.ts`.

> Note: the fix branch was initially cut from a stale local `main` whose `reducer.ts` predated the `parentMessageId`/snapshot-toolCalls handling; rebased onto current `origin/main` before applying #4/#5, then re-verified end-to-end.

## Test Plan
- [x] Every fix re-verified against its cited source line by an independent reviewer (PASS; all 6, no over-reach, no `type="note"`).
- [x] All 3 edited ag-ui routes return HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)