### PR TITLE
docs(ag-ui): technical review spec, plan + findings report

### DIFF
--- a/docs/superpowers/plans/2026-06-06-ag-ui-docs-technical-review.md
+++ b/docs/superpowers/plans/2026-06-06-ag-ui-docs-technical-review.md
@@ -1,0 +1,194 @@
+# AG-UI Docs Technical Review Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Audit the 10 ag-ui documentation pages against library source, produce one severity-ranked findings report, then ship the accuracy fixes (1 PR; split only if large) — every snippet, import/package, API/signature, behavioral claim, and link matching the implementation, with the event-mapping reference as the priority target.
+
+**Architecture:** Two gated phases. Phase 1 fans out three read-only section auditors plus a completeness sweep; the controller re-verifies borderline findings and consolidates one report. Phase 2 fixes the report's findings in a single PR (split if large), each finding re-verified against its cited source line. The `event-mapping.mdx` reference maps AG-UI protocol events to neutral `Agent` signals and must match `to-agent.ts`.
+
+**Tech Stack:** MDX docs (Next.js App Router), Angular library `libs/ag-ui` (+ cross-source `libs/chat` Agent contract, AG-UI protocol event types), `docs-config.ts` for link/nav resolution, `git diff` + source citation as the accuracy gate, dev-server/curl for render checks.
+
+**Reference spec:** `docs/superpowers/specs/2026-06-06-ag-ui-docs-technical-review-design.md`
+
+---
+
+## Ground-truth source map (used by every audit task)
+
+| Audit | Pages (relative to `apps/website/content/docs/ag-ui/`) | Ground-truth source |
+|---|---|---|
+| getting-started | `getting-started/{introduction,quickstart,installation}.mdx` | `libs/ag-ui/src/public-api.ts`, `lib/provide-agent.ts` (`provideAgent`/`injectAgent`/`AgentConfig`), `lib/to-agent.ts` |
+| guides | `guides/{testing,fake-agent,citations,troubleshooting,interrupts}.mdx` | `libs/ag-ui/src` — `lib/testing/fake-agent.ts` (`FakeAgent`), `lib/testing/provide-fake-agent.ts`, `lib/bridge-citations-state.ts`, `lib/to-agent.ts` + `libs/chat/src/lib/agent/*` (Agent contract) |
+| concepts + reference | `concepts/architecture.mdx`, `reference/event-mapping.mdx` | `libs/ag-ui/src/lib/to-agent.ts` (AG-UI-event → neutral-`Agent` translation) + the AG-UI protocol event types it consumes |
+
+`libs/ag-ui/src/public-api.ts` is authoritative. Exports (8): `toAgent`, `ToAgentOptions`, `provideAgent`, `injectAgent`, `AgentConfig`, `FakeAgent`, `provideFakeAgent`, `bridgeCitationsState`.
+
+## Findings severity taxonomy + row schema
+
+- **P0 — wrong:** breaks copy-paste (wrong import/package, nonexistent API, wrong signature/type).
+- **P1 — misleading:** runs but teaches a wrong model.
+- **P2 — gap:** undocumented export, missing option, thin coverage.
+- **P3 — polish:** stale wording, inconsistent naming, dead link.
+
+Finding row: `page:line · dimension · severity · what's-wrong · source-evidence(libs/…:line) · proposed-fix`.
+Dimensions: `accuracy` | `conceptual` | `links` | `completeness`.
+
+---
+
+# PHASE 1 — AUDIT (read-only, parallel)
+
+> Phase 1 produces NO docs edits. The controller dispatches Tasks 1–3 concurrently (disjoint reads), runs Task 4, re-verifies borderline findings, then writes the report in Task 5.
+
+## Tasks 1–3: Section audit subagents
+
+Each task dispatches ONE read-only audit subagent (use `subagent_type: Explore`). The prompt template is identical except for **section name**, **page list**, and **ground-truth source**.
+
+**Shared subagent prompt template:**
+
+```
+You are a READ-ONLY technical-docs auditor. DO NOT edit, write, or commit any file. You only read and return findings.
+
+Repo root: /Users/blove/repos/angular-agent-framework. Branch: claude/ag-ui-docs-technical-review.
+
+## Your section: <SECTION>
+## Pages to audit (read each in full):
+<ABSOLUTE PAGE PATHS>
+## Ground-truth source (read what you need to verify claims):
+<SOURCE PATHS>
+
+## Method
+For every code fence, inline `code`, prose claim, and internal link in your pages, verify it against the ground-truth source. Open the source files and confirm: import paths/packages, exported symbol names, function/class signatures, option/property keys (AgentConfig, ToAgentOptions, FakeAgent config), types, and documented BEHAVIOR. For the event-mapping reference especially: confirm every AG-UI-event → Agent-signal row matches how `to-agent.ts` actually translates events; flag wrong/missing/renamed events. For internal links (href="/docs/..."), confirm the target exists in apps/website/src/lib/docs-config.ts (built from product/section/slug — check the entry exists; do not grep literal href strings).
+
+## The four dimensions
+1. accuracy — import/package, symbol, signature, option key, type matches source EXACTLY. Wrong package or nonexistent symbol = P0.
+2. conceptual — behavior claims match implementation; runs-but-wrong-model = P1.
+3. links — internal links resolve via docs-config.ts; examples internally coherent + runnable.
+4. completeness — flag any obviously missing option/behavior/event a reader needs.
+
+## Severity
+P0 wrong (breaks copy-paste) | P1 misleading | P2 gap | P3 polish.
+
+## Return format — a markdown table, columns EXACTLY:
+| page:line | dimension | severity | what's wrong | source evidence | proposed fix |
+- page:line = relative path + line, e.g. ag-ui/reference/event-mapping.mdx:42
+- source evidence = libs/…:line you verified against
+- proposed fix = the concrete corrected text/snippet (specific enough to apply)
+If a page is clean: | <page> | — | clean | no issues found | <source checked> | none |
+Every finding MUST cite a real source line. If a documented symbol can't be found in source, that's a P0. End with a short "Systemic notes" paragraph for any cross-page pattern.
+
+Your entire final message IS the audit result (table + systemic notes). Return only that.
+```
+
+- [ ] **Task 1 — getting-started.** Pages: `getting-started/{introduction,quickstart,installation}.mdx`. Source: `libs/ag-ui/src/public-api.ts`, `lib/provide-agent.ts`, `lib/to-agent.ts`. Dispatch; save table for Task 5.
+
+- [ ] **Task 2 — guides.** Pages: `guides/{testing,fake-agent,citations,troubleshooting,interrupts}.mdx`. Source: `libs/ag-ui/src/lib/testing/fake-agent.ts`, `lib/testing/provide-fake-agent.ts`, `lib/bridge-citations-state.ts`, `lib/to-agent.ts` + `libs/chat/src/lib/agent/*`. Dispatch; save table.
+
+- [ ] **Task 3 — concepts + reference.** Pages: `concepts/architecture.mdx`, `reference/event-mapping.mdx`. Source: `libs/ag-ui/src/lib/to-agent.ts` (+ the AG-UI event types it consumes). The event-mapping table is the priority — verify every event→signal row against `to-agent.ts`. Weight conceptual correctness for architecture. Dispatch; save table.
+
+## Task 4: Completeness sweep + langgraph-ref check
+
+**Files:** none (analysis).
+
+- [ ] **Step 1: Exports vs docs**
+
+```bash
+cd /Users/blove/repos/angular-agent-framework
+for sym in toAgent ToAgentOptions provideAgent injectAgent AgentConfig FakeAgent provideFakeAgent bridgeCitationsState; do
+  c=$(grep -rl "\b$sym\b" apps/website/content/docs/ag-ui 2>/dev/null | wc -l | tr -d ' ')
+  echo "$c  $sym"
+done | sort -n
+```
+Any export with count `0` is a **P2 completeness gap**. Record it.
+
+- [ ] **Step 2: Reverse check.** From the Task 1–3 tables, confirm every API the docs claim is exported from `@threadplane/ag-ui` appears in `libs/ag-ui/src/public-api.ts`. Any that doesn't = **P0**.
+
+- [ ] **Step 3: Verify the langgraph reference.**
+
+```bash
+cd /Users/blove/repos/angular-agent-framework
+grep -rn "@threadplane/langgraph" apps/website/content/docs/ag-ui
+```
+Confirm the single `@threadplane/langgraph` reference is a legitimate cross-adapter comparison (verify any symbol it names against `libs/langgraph/src/public-api.ts`); if it cites a nonexistent langgraph symbol, that's a finding.
+
+## Task 5: Consolidate the findings report
+
+**Files:** Create `docs/superpowers/specs/2026-06-06-ag-ui-docs-review-findings.md`
+
+- [ ] **Step 1: Re-verify borderline findings** against source; drop/correct unverified ones (prior reviews caught false alarms this way).
+
+- [ ] **Step 2: Assemble the report**
+
+```markdown
+# AG-UI Docs Technical Review — Findings
+
+**Date:** 2026-06-06
+**Pages audited:** 10  **Source verified against:** libs/ag-ui (+ chat Agent contract, AG-UI event types)
+
+## Summary
+- P0: <n>  P1: <n>  P2: <n>  P3: <n>
+- Systemic issues: <bullets>
+
+## Findings by severity
+### P0 — wrong
+### P1 — misleading
+### P2 — gap
+### P3 — polish
+
+## Structural / won't-fix-here
+- <any libs/* source bug — flagged for separate follow-up, NOT fixed here>
+- api-docs.json generator nuances (already tracked)
+
+## Fix plan
+- Single PR (split only if large). P-level cutoff: default P0+P1+P2, P3 where it's a one-line change. Structural + source items listed, not actioned.
+```
+Merge the section tables verbatim into the severity buckets; keep every source citation.
+
+- [ ] **Step 3: Commit the report**
+
+```bash
+cd /Users/blove/repos/angular-agent-framework
+git add docs/superpowers/specs/2026-06-06-ag-ui-docs-review-findings.md
+git commit -m "docs(ag-ui): technical review findings report"
+```
+
+- [ ] **Step 4: CHECKPOINT — surface the report to the user.** Present summary counts + systemic issues + the fix plan. Confirm the P-level cutoff and that structural/source items stay flagged-only, before Phase 2.
+
+---
+
+# PHASE 2 — FIX (subagent-driven)
+
+> Single fix PR off the latest `origin/main` (split into 2 only if the finding count is large). Fix grouped by section; each group's edits gated by re-verification against the cited source line + an independent accuracy review before commit. Use the Task 5 report as the source of truth.
+
+## Task 6: Fix PR
+
+**Branch:** `claude/fix-ag-ui-docs` off `origin/main`.
+**Files:** the ag-ui pages with findings (per report).
+
+- [ ] **Step 1:** Create the branch off latest `origin/main`.
+- [ ] **Step 2:** Dispatch implementer subagent(s) with the report's findings (full rows, grouped by section). Apply each proposed fix EXACTLY; re-read the cited source line before each edit; do NOT touch anything not in a finding. For MDX components, use only SUPPORTED `Callout` types (`tip`/`info`/`warning`/`danger` — NOT `note`).
+- [ ] **Step 3:** Fix-gate — `git --no-pager diff <files>`; eyeball that each change matches a report finding and there's no unrelated heading/link/component churn.
+- [ ] **Step 4:** Independent accuracy reviewer subagent; loop until clean.
+- [ ] **Step 5:** Render check — edited ag-ui routes return 200 (serve website on :3000; curl each `/docs/ag-ui/<section>/<slug>`).
+- [ ] **Step 6:** Commit (`docs(ag-ui): fix technical accuracy issues`), push, open PR, enable auto-merge (squash).
+
+## Task 7: Final verification + land planning artifacts
+
+**Files:** none (verification) + the findings report + spec/plan.
+
+- [ ] **Step 1: All 10 ag-ui routes return 200** (serve website on :3000; curl each page).
+- [ ] **Step 2:** Mark each fixed finding ✅ in `2026-06-06-ag-ui-docs-review-findings.md`; leave structural/source items open.
+- [ ] **Step 3:** Land the planning artifacts (spec + plan + resolved findings report) to main via a small doc-only PR from `claude/ag-ui-docs-technical-review` (rebased on main), enable auto-merge.
+- [ ] **Step 4: Spawn follow-ups** for any real `libs/*` source bug the report flagged.
+- [ ] **Step 5:** Confirm PRs merged (monitor; `gh pr update-branch` any that go BEHIND); sync local main; delete merged branches.
+
+---
+
+## Manual verification (before merge)
+- [ ] Every fix traces to a report finding with a source citation; no edit lacks a finding.
+- [ ] The edited ag-ui routes render; internal links resolve; no documented API attributed to the wrong package; only supported Callout types used.
+- [ ] Findings report committed; structural + source items listed, not actioned.
+
+## Self-Review (completed during planning)
+
+- **Spec coverage:** 10 pages across 4 sections audited (Tasks 1–3) ✓; four dimensions in every audit prompt, with event-mapping as the priority + architecture conceptual weighting ✓; completeness sweep + langgraph-ref check (Task 4) ✓; controller re-verification (Task 5 Step 1) ✓; one severity-ranked report at the spec'd path (Task 5) ✓; triage checkpoint (Task 5 Step 4) ✓; single fix PR grouped by section with source-cited review + render check (Task 6) ✓; final verification + planning-artifact landing + follow-ups (Task 7) ✓; out-of-scope (other libs' docs, source changes, api-docs.json generator, restructuring) honored.
+- **Placeholder scan:** No TBD/TODO. Phase 2 fix snippets are intentionally report-driven (the audit produces the exact corrected text); the gates (source re-verification, fix-gate diff, reviewer loop, render 200, supported-Callout-types) make each edit checkable. Commands have expected output.
+- **Consistency:** the ground-truth map, severity taxonomy, and row schema are defined once and referenced by every task; the section page lists in Tasks 1–3 match the spec (3+5+2 = 10); `claude/ag-ui-docs-technical-review` is the audit/report + planning-artifact branch, with a separate fix branch off `origin/main`. The supported-Callout-type guard is included (a `type="note"` 500'd a page in the langgraph review).

--- a/docs/superpowers/specs/2026-06-06-ag-ui-docs-review-findings.md
+++ b/docs/superpowers/specs/2026-06-06-ag-ui-docs-review-findings.md
@@ -5,6 +5,15 @@
 **Source verified against:** `libs/ag-ui` (esp. `lib/reducer.ts`, `lib/to-agent.ts`, `lib/testing/fake-agent.ts`) + `libs/chat` Agent contract
 **Method:** 3 parallel read-only auditors + completeness sweep; controller re-verified every finding against source.
 
+## Resolution status — ✅ ALL FINDINGS FIXED (PR #604)
+
+All 7 findings fixed in a single PR, each re-verified against the current `reducer.ts` (313-line version) + `fake-agent.ts` by an independent reviewer (PASS):
+- ✅ **P1** CUSTOM `on_interrupt` row documented; **P2** RUN_STARTED clears `interrupt`, TOOL_CALL_START → `messages` (via `parentMessageId`), MESSAGES_SNAPSHOT → `toolCalls` (by id), architecture `interrupt` bullet, installation FakeAgent `reasoningTokens`. **P3** subsumed by the per-row fixes.
+
+**Process note:** the fix branch was initially cut from a stale local `main` (whose `reducer.ts` predated the `parentMessageId`/snapshot-toolCalls handling). The implementer correctly refused #4/#5 as ungrounded against that stale source; the controller caught the staleness via a blob-hash mismatch, rebased onto current `origin/main`, and the now-valid #4/#5 were applied and verified.
+
+**Verified:** all edited routes returned HTTP 200; no `type="note"` Callout; no `libs/*` source bugs.
+
 ## Summary
 
 - **P0: 0** · **P1: 1** · **P2: 5** · **P3: 1**

--- a/docs/superpowers/specs/2026-06-06-ag-ui-docs-review-findings.md
+++ b/docs/superpowers/specs/2026-06-06-ag-ui-docs-review-findings.md
@@ -1,0 +1,57 @@
+# AG-UI Docs Technical Review — Findings
+
+**Date:** 2026-06-06
+**Pages audited:** 10 (getting-started ×3, concepts ×1, guides ×5, reference ×1)
+**Source verified against:** `libs/ag-ui` (esp. `lib/reducer.ts`, `lib/to-agent.ts`, `lib/testing/fake-agent.ts`) + `libs/chat` Agent contract
+**Method:** 3 parallel read-only auditors + completeness sweep; controller re-verified every finding against source.
+
+## Summary
+
+- **P0: 0** · **P1: 1** · **P2: 5** · **P3: 1**
+- **The ag-ui docs are in excellent shape** — all 5 **guides** are clean, and `getting-started` + `architecture` are nearly so. The findings cluster in the **event-mapping reference**, whose "Agent field" column under-reports the multi-signal effects of several AG-UI events (the event reducer is `libs/ag-ui/src/lib/reducer.ts`).
+- **No P0s; no wrong package/symbol; no broken links.** Every `@threadplane/langgraph` reference is a legitimate cross-adapter comparison. All 8 public exports are documented.
+
+---
+
+## Findings by severity
+
+### P1 — misleading
+
+| # | page:line | dim | what's wrong | source evidence | fix |
+|---|---|---|---|---|---|
+| 1 | `reference/event-mapping.mdx:28` | accuracy | `CUSTOM` event row omits the special `on_interrupt` handling — when `name === 'on_interrupt'`, the reducer sets the `interrupt` signal (resumable); other custom events emit via `events$` | `libs/ag-ui/src/lib/reducer.ts:255,261-262` (`store.interrupt.set({ id, value: parsedValue, resumable: true })`) | Expand the CUSTOM row (or add one): `CUSTOM` (`name: 'on_interrupt'`) → sets `interrupt` with the parsed value (resumable); other CUSTOM events emit on `events$` |
+
+### P2 — gap
+
+| # | page:line | dim | what's wrong | source evidence | fix |
+|---|---|---|---|---|---|
+| 2 | `getting-started/installation.mdx:83` | completeness | `FakeAgent`/`provideFakeAgent` options table omits `reasoningTokens` | `libs/ag-ui/src/lib/testing/fake-agent.ts:35` (`reasoningTokens?: string[]`) | Add row: `reasoningTokens` · `string[]` · Optional reasoning chunks emitted before the text reply (default `[]`) |
+| 3 | `reference/event-mapping.mdx:11` | completeness | `RUN_STARTED` also clears the `interrupt` signal — not listed in the Agent-field column | `reducer.ts:71-75` (`store.interrupt.set(undefined)`) | Add `interrupt` (cleared) to the RUN_STARTED effects |
+| 4 | `reference/event-mapping.mdx:21` | completeness | `TOOL_CALL_START` also updates `messages` when `parentMessageId` is present (links the call to its parent assistant message) | `reducer.ts:150-175` | Note the `messages` effect when `parentMessageId` is provided |
+| 5 | `reference/event-mapping.mdx:27` | completeness | `MESSAGES_SNAPSHOT` also merges snapshot-embedded tool calls into `toolCalls` | `reducer.ts:217-251` | Add `toolCalls` to the MESSAGES_SNAPSHOT effects |
+| 6 | `concepts/architecture.mdx:87-90` | completeness | the list of reducer-updated signals omits `interrupt` | `reducer.ts:75,262` | Add an `interrupt` bullet (cleared on `RUN_STARTED`, set by CUSTOM `on_interrupt`) |
+
+### P3 — polish
+
+| # | page:line | dim | what's wrong | source evidence | fix |
+|---|---|---|---|---|---|
+| 7 | `reference/event-mapping.mdx:9-29` | completeness | the single "Agent field" column makes multi-signal events hard to represent (root cause of #1,#3,#4,#5) | `reducer.ts` (multiple events touch several signals) | Optional: note in the table intro that some events update multiple signals; the per-row fixes above already capture the specifics |
+
+---
+
+## Structural / won't-fix-here
+
+- No `libs/*` source bugs identified.
+- `api-docs.json` generator nuances — already tracked as follow-ups from prior reviews.
+
+## Verified NON-issues (no change)
+
+- All `@threadplane/langgraph` references in ag-ui docs are legitimate cross-adapter comparisons / "use langgraph instead" notes / a migration-diff line. No broken or wrong references.
+- `guides/*` (testing, fake-agent, citations, troubleshooting, interrupts) — all clean; the "links" rows the auditor listed are all valid (no fix). `fake-agent.mdx` correctly documents `{ tokens?, reasoningTokens?, delayMs? }`.
+- All 8 public exports are documented at least once.
+
+---
+
+## Fix plan
+
+Default cutoff: **P0+P1+P2; the P3 is covered by the per-row P2 fixes** (no separate restructure needed). Single PR (the surface is small). Files touched: `reference/event-mapping.mdx`, `getting-started/installation.mdx`, `concepts/architecture.mdx`.

--- a/docs/superpowers/specs/2026-06-06-ag-ui-docs-technical-review-design.md
+++ b/docs/superpowers/specs/2026-06-06-ag-ui-docs-technical-review-design.md
@@ -1,0 +1,122 @@
+# AG-UI Docs Technical Review — Design
+
+**Date:** 2026-06-06
+**Status:** Draft for review
+**Scope:** A full technical-accuracy review of the ag-ui documentation (10 pages, ~1,210 lines), cross-referenced against library source, producing one severity-ranked findings report and shipping fixes (1 PR, split only if large). Reuses the methodology proven on the render (#590), chat (#594–597), and langgraph (#601–603) reviews.
+
+## Goal
+
+Make the ag-ui docs technically correct: every code snippet, import/package, API
+name and signature, behavioral claim, and internal link matches the
+implementation — with special attention to the **event-mapping reference**, which
+maps AG-UI protocol events to neutral `Agent` signals and must match
+`to-agent.ts`. Catch documented-but-nonexistent APIs and exported-but-undocumented
+ones. Discovery is separated from fixing; findings are triaged before any edit.
+
+This is a **docs accuracy** review. It does not change `libs/*` source and does not
+restructure the docs.
+
+## Surface under review (10 pages, all in scope)
+
+`apps/website/content/docs/ag-ui/`:
+
+- **getting-started** (3): `introduction.mdx`, `quickstart.mdx`, `installation.mdx`.
+- **concepts** (1): `architecture.mdx`.
+- **guides** (5): `testing.mdx`, `fake-agent.mdx`, `citations.mdx`, `troubleshooting.mdx`, `interrupts.mdx`.
+- **reference** (1): `event-mapping.mdx`.
+
+The ag-ui docs use `injectAgent()`/`provideAgent()` (no legacy `agent()` factory).
+
+## Ground-truth sources
+
+`libs/ag-ui/src` is authoritative. Public exports (`libs/ag-ui/src/public-api.ts`):
+`toAgent` + `ToAgentOptions`; `provideAgent`, `injectAgent`, `AgentConfig`;
+`FakeAgent`, `provideFakeAgent`; `bridgeCitationsState`.
+
+| Auditor | Pages | Ground-truth source |
+|---|---|---|
+| getting-started | `getting-started/{introduction,quickstart,installation}.mdx` | `libs/ag-ui/src` (`provideAgent`/`injectAgent`/`AgentConfig`, `toAgent`) |
+| guides | `guides/{testing,fake-agent,citations,troubleshooting,interrupts}.mdx` | `libs/ag-ui/src` (`FakeAgent`/`provideFakeAgent`, `bridgeCitationsState`, `toAgent`) + `libs/chat/src/lib/agent/*` (Agent contract) |
+| concepts + reference | `concepts/architecture.mdx`, `reference/event-mapping.mdx` | `libs/ag-ui/src/lib/to-agent.ts` (AG-UI-event → neutral-`Agent` translation — the core of event-mapping) + the AG-UI protocol event types it consumes |
+
+Verify the single `@threadplane/langgraph` reference in the ag-ui docs against
+`libs/langgraph` (it may be a legitimate cross-adapter comparison).
+
+## Methodology — two gated phases
+
+### Phase 1 — Audit (read-only, parallel)
+
+Three section audit subagents run concurrently (disjoint reads). Each is read-only
+and returns findings as rows:
+`page:line · dimension · severity · what's-wrong · source-evidence(libs/…:line) · proposed-fix`.
+
+Then a **completeness sweep**: diff `libs/ag-ui/src/public-api.ts` exports (8
+symbols) against what the docs document — flag exported-but-undocumented and
+documented-but-nonexistent.
+
+The controller re-verifies borderline/surprising findings against source (prior
+reviews caught auditor false alarms this way), consolidates one severity-ranked
+report, flags systemic issues, and **pauses at a triage checkpoint**.
+
+### Phase 2 — Fix (subagent-driven)
+
+After triage, fixes ship as **1 PR** (the surface is small); split into 2 only if
+the finding count is unexpectedly large. Fixes are grouped by section; the
+implementer re-verifies every changed snippet against the cited source line,
+re-checks internal links against `docs-config.ts`, and an independent accuracy
+reviewer confirms each fix matches source before commit. The PR ends with a
+render-200 check on the edited pages.
+
+## The four audit dimensions
+
+1. **Code-snippet accuracy** — import/package, exported symbol, signature, option
+   keys (`AgentConfig`, `ToAgentOptions`, `FakeAgent` config), types match source
+   exactly. Wrong package or nonexistent symbol = P0.
+2. **Conceptual correctness** — prose claims about the AG-UI adapter architecture,
+   the `toAgent` translation, citations bridging, interrupts, and the
+   event→signal mapping match the implementation. Runs-but-wrong-model = P1.
+   `architecture.mdx` gets conceptual-correctness weighting.
+3. **Links + runnability** — internal links resolve via `docs-config.ts`; examples
+   are internally coherent and would compile/run as written.
+4. **Completeness/gaps** — exported-but-undocumented APIs, documented-but-nonexistent
+   APIs, missing options/behaviors, thin coverage. The **event-mapping** table is
+   the priority: every documented event→signal row must match `to-agent.ts`, and
+   material events handled in source should appear.
+
+## Findings report format
+
+One report: `docs/superpowers/specs/2026-06-06-ag-ui-docs-review-findings.md`.
+
+Severity taxonomy (same as prior reviews): **P0 wrong** / **P1 misleading** /
+**P2 gap** / **P3 polish**. Each row carries a source citation. The report ends
+with a "Structural / won't-fix-here" section (any `libs/*` source bug; api-docs.json
+generator nuances already tracked) and a "Fix plan" with a P-level cutoff.
+
+## Testing & verification
+
+- **Phase 1:** every finding carries a concrete source citation; the controller
+  spot-checks + re-verifies borderline findings before trusting them.
+- **Phase 2:** each changed snippet re-verified against its cited source line;
+  internal links re-checked against `docs-config.ts`; edited pages return HTTP 200;
+  an independent accuracy reviewer signs off.
+- **Final:** the edited ag-ui routes return 200; no documented API attributed to
+  the wrong package.
+
+## Out of scope
+
+- Voice/prose-register edits (already shipped) — except where a P0/P1 fix rewrites a sentence.
+- `libs/*` **source** changes — real code bugs flagged for separate follow-ups.
+- Net-new pages/examples beyond filling documented gaps the report identifies.
+- Other libraries' docs; relocating/restructuring ag-ui pages.
+- `api-docs.json` generator nuances (already spawned as follow-ups).
+
+## Self-review notes
+
+- **Placeholder scan:** none — every section names concrete files/sources.
+- **Internal consistency:** the 3-auditor split matches the ground-truth table;
+  the single-PR default + split-if-large matches Phase 2 and the report's fix-plan;
+  event-mapping priority is stated in both the methodology and dimension 4.
+- **Scope:** small, coherent — one audit/report, 1 fix PR, triage gate between.
+- **Ambiguity:** "audit + fix" = one findings report committed, then corrections
+  shipped; the `@threadplane/langgraph` reference is verified against langgraph but
+  that lib's docs stay out of scope.


### PR DESCRIPTION
## Summary

Lands the planning artifacts for the ag-ui docs technical review (fixes shipped in #604): design spec, implementation plan, and resolved findings report (7 findings: 0 P0, 1 P1, 5 P2, 1 P3 — all fixed).

The ag-ui docs were in excellent shape — all 5 guides clean, no P0s. Findings clustered in the event-mapping reference (multi-signal effects of the AG-UI event reducer).

## Test Plan
- [x] Docs-only (superpowers planning artifacts); no app/code changes.
- [x] Findings report marked resolved with PR #604.

🤖 Generated with [Claude Code](https://claude.com/claude-code)