### PR TITLE
docs(a2ui): document A2uiTheme fields in schema reference

### DIFF
--- a/apps/website/content/docs/a2ui/reference/schema.mdx
+++ b/apps/website/content/docs/a2ui/reference/schema.mdx
@@ -178,6 +178,16 @@ interface A2uiSurface {
 }
 ```
 
+`A2uiTheme` carries optional, agent-supplied presentation hints:
+
+```ts
+interface A2uiTheme {
+  primaryColor?: string;
+  iconUrl?: string;
+  agentDisplayName?: string;
+}
+```
+
 This shape is not constrained to the wire format. Do not assume an agent sends it directly.
 
 ## Outbound action messages


### PR DESCRIPTION
## Summary

Per-lib PR (2 of 3) from the small-libs docs technical review. The a2ui docs were nearly clean (schema/parser/resolver references verified accurate). Single P2: `reference/schema.mdx` referenced `theme?: A2uiTheme` in `A2uiSurface` without documenting `A2uiTheme`'s fields. Added the interface (`primaryColor?`, `iconUrl?`, `agentDisplayName?`) per `libs/a2ui/src/lib/types.ts:5-9`.

Dropped a false-alarm finding (an auditor wrongly claimed `@threadplane/chat`/`@threadplane/render` don't exist).

## Test Plan
- [x] `A2uiTheme` fields match `libs/a2ui/src/lib/types.ts:5-9`.
- [x] All 7 a2ui routes return HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)