### PR TITLE
docs(telemetry): document ngaf:runtime_request_created event + captureRuntimeRequestCreated()

### DIFF
--- a/apps/website/content/docs/telemetry/guides/browser.mdx
+++ b/apps/website/content/docs/telemetry/guides/browser.mdx
@@ -71,6 +71,13 @@ telemetry.captureRuntimeInstanceCreated({
   model: 'gpt-4.1',
 });
 
+telemetry.captureRuntimeRequestCreated({
+  transport: 'langgraph',
+  requestType: 'stream',
+  provider: 'openai',
+  model: 'gpt-4.1',
+});
+
 telemetry.captureStreamStarted({ transport: 'langgraph', provider: 'openai', model: 'gpt-4.1' });
 telemetry.captureStreamEnded({ transport: 'langgraph', provider: 'openai', model: 'gpt-4.1', durationMs: 1200 });
 telemetry.captureStreamErrored({ transport: 'langgraph', provider: 'openai', model: 'gpt-4.1', error });

--- a/apps/website/content/docs/telemetry/guides/node.mdx
+++ b/apps/website/content/docs/telemetry/guides/node.mdx
@@ -5,6 +5,7 @@ Node telemetry lives under `@threadplane/telemetry/node`. It is intended for pac
 ```ts
 import {
   captureRuntimeInstanceCreated,
+  captureRuntimeRequestCreated,
   captureStreamStarted,
   captureStreamEnded,
   captureStreamErrored,
@@ -36,6 +37,17 @@ await captureRuntimeInstanceCreated({
 ```
 
 The `RuntimeInstanceTelemetry` type includes `apiKey`, but the adapter strips it before sending. Do not pass secrets as telemetry properties anyway.
+
+Use `captureRuntimeRequestCreated()` when a runtime issues a request. The `RuntimeRequestTelemetry` type requires `transport` and `requestType`; `provider` and `model` are optional.
+
+```ts
+await captureRuntimeRequestCreated({
+  transport: 'langgraph',
+  requestType: 'stream',
+  provider: 'openai',
+  model: 'gpt-4.1',
+});
+```
 
 ## Capture streams
 

--- a/apps/website/content/docs/telemetry/reference/events.mdx
+++ b/apps/website/content/docs/telemetry/reference/events.mdx
@@ -12,6 +12,7 @@ type ThreadplaneEvent = ThreadplaneNodeEvent | ThreadplaneBrowserEvent;
 type ThreadplaneNodeEvent =
   | 'ngaf:postinstall'
   | 'ngaf:runtime_instance_created'
+  | 'ngaf:runtime_request_created'
   | 'ngaf:stream_started'
   | 'ngaf:stream_ended'
   | 'ngaf:stream_errored';
@@ -21,6 +22,7 @@ type ThreadplaneNodeEvent =
 | ------------------------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
 | `ngaf:postinstall`              | package postinstall script | `pkg`, `version`, `node`, `node_version`, `os`, `arch`, `global_install`, package-manager fields when npm exposes them |
 | `ngaf:runtime_instance_created` | Node adapter helper        | `transport`, `provider`, `model`, `angularVersion`; `apiKey` is removed                                                |
+| `ngaf:runtime_request_created`  | Node adapter helper        | `transport`, `requestType`, `provider`, `model` (`provider` and `model` optional)                                     |
 | `ngaf:stream_started`           | Node adapter helper        | `provider`, `model`, optional fields in the input object                                                               |
 | `ngaf:stream_ended`             | Node adapter helper        | `provider`, `model`, `durationMs` when supplied                                                                        |
 | `ngaf:stream_errored`           | Node adapter helper        | stream properties plus `errorClass`                                                                                    |
@@ -42,6 +44,7 @@ type ThreadplaneTelemetryEvent =
   | 'ngaf:browser_provided'
   | 'ngaf:browser_chat_init'
   | 'ngaf:runtime_instance_created'
+  | 'ngaf:runtime_request_created'
   | 'ngaf:stream_started'
   | 'ngaf:stream_ended'
   | 'ngaf:stream_errored';


### PR DESCRIPTION
## Summary

Per-lib PR (3 of 3) from the small-libs docs technical review. Two P2 completeness gaps: the `ngaf:runtime_request_created` event and its `captureRuntimeRequestCreated()` capture method exist in source but were undocumented.

- **`reference/events.mdx`:** added `ngaf:runtime_request_created` to the `ThreadplaneNodeEvent` + `ThreadplaneTelemetryEvent` unions and the events table (payload `transport`, `requestType`, optional `provider`/`model`).
- **`guides/browser.mdx` + `guides/node.mdx`:** documented `captureRuntimeRequestCreated()` (import + usage), matching the node `RuntimeRequestTelemetry` and browser service signatures.

Verified against `shared/events.ts:4`, `browser/tokens.ts:7`, `browser/service.ts:83`, `node/adapter.ts:17-36`, `node/index.ts:7` (and independently corroborated by the generated `api-docs.json`).

## Test Plan
- [x] Every field/event/method name matched to source by the implementer.
- [x] All 5 telemetry routes return HTTP 200; no `type="note"` Callout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)