### PR TITLE
chore(chat): clear pre-existing chat:lint debt

### DIFF
--- a/libs/chat/eslint.config.mjs
+++ b/libs/chat/eslint.config.mjs
@@ -42,6 +42,16 @@ export default [
     },
   },
   {
+    // Non-null assertions are acceptable in test code: the test author
+    // controls the fixtures, so a wrong assumption surfaces as a test
+    // failure rather than a production bug. The rule stays strict for
+    // library source (the `**/*.ts` block above).
+    files: ['**/*.spec.ts'],
+    rules: {
+      '@typescript-eslint/no-non-null-assertion': 'off',
+    },
+  },
+  {
     files: ['**/*.html'],
     // Override or add rules here
     rules: {},

--- a/libs/chat/src/lib/a2ui/surface.component.spec.ts
+++ b/libs/chat/src/lib/a2ui/surface.component.spec.ts
@@ -5,7 +5,6 @@ import { TestBed } from '@angular/core/testing';
 import { A2uiSurfaceComponent } from './surface.component';
 import type { A2uiSurfaceState } from './surface-store';
 import { createA2uiSurfaceStore } from './surface-store';
-import type { A2uiViews } from './views';
 import { a2uiBasicCatalog } from './catalog';
 
 @Component({ standalone: true, selector: 'a2ui-test-real', template: '<span data-role="real"></span>', changeDetection: ChangeDetectionStrategy.OnPush })

--- a/libs/chat/src/lib/compositions/chat-approval-card/chat-approval-card.component.spec.ts
+++ b/libs/chat/src/lib/compositions/chat-approval-card/chat-approval-card.component.spec.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-import { Component, signal } from '@angular/core';
+import { Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { ChatApprovalCardComponent } from './chat-approval-card.component';


### PR DESCRIPTION
## Summary

`chat:lint` has been failing on **pre-existing** debt whenever a PR makes the `@threadplane/chat` library "affected" (it most recently red-flagged CI on #600, #608, and #614). The debt is latent on `main` because docs-only PRs don't make `chat` affected — but every chat-touching PR trips it. This clears it:

- **54 `no-non-null-assertion` warnings** in `libs/chat/src/lib/a2ui/*.spec.ts` → add a scoped `**/*.spec.ts` ESLint override in `libs/chat/eslint.config.mjs` allowing non-null assertions **in test code only**. The rule stays strict for library source (the `**/*.ts` block). Non-null assertions are legitimate in tests, where the author controls the fixtures and a wrong assumption surfaces as a test failure, not a production bug.
- **2 dead imports** (`A2uiViews`, `signal`) → removed.

`npx nx lint chat` now passes with **zero warnings**; `npx nx test chat` stays green.

## Test Plan
- [x] `nx lint chat` — success, 0 warnings (was 56)
- [x] `nx test chat --run` — green (the 2 import removals don't affect behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)