### PR TITLE
fix(examples/ag-ui): a2ui surfaces render over ag-ui (closes #616)

### DIFF
--- a/examples/ag-ui/angular/e2e/a2ui-single-bubble.spec.ts
+++ b/examples/ag-ui/angular/e2e/a2ui-single-bubble.spec.ts
@@ -2,16 +2,10 @@
 import { test, expect } from '@playwright/test';
 import { sendPromptAndWait } from './test-helpers';
 
-// KNOWN GAP (tracked): a2ui generative-UI surfaces do not yet render over the
-// AG-UI transport. Over ag-ui the `render_a2ui_surface` tool call is surfaced as
-// a tool-call chip (it never becomes an <a2ui-surface>), so this assertion fails
-// — whereas all message/streaming/markdown specs pass, confirming basic
-// transport parity. Adding the @threadplane/ag-ui `customEvents` signal (#606)
-// was necessary but not sufficient; closing this needs a focused fix in the
-// chat a2ui render path (the tool-views registry / partial-args bridge / wrapped-
-// content classifier over ag-ui). Marked fixme so the suite stays green while the
-// gap is its own investigation. Tracked in issue #616.
-test.fixme('a2ui single bubble: one assistant bubble carries the rendered surface', async ({ page }) => {
+// a2ui generative-UI parity over AG-UI: the wrapped a2ui content reaches the
+// chat composition over ag-ui identically to langgraph; the surface mounts once
+// the host binds a `views` catalog (`[views]` on <chat>). See issue #616.
+test('a2ui single bubble: one assistant bubble carries the rendered surface', async ({ page }) => {
   await sendPromptAndWait(page, 'Demo: render a feedback form');
 
   // After the assistant turn finalizes, the surface element is in the DOM.

--- a/examples/ag-ui/angular/src/app/app.html
+++ b/examples/ag-ui/angular/src/app/app.html
@@ -3,5 +3,5 @@
     <h1>AG-UI Chat</h1>
     <p>The Threadplane chat UI over the AG-UI transport.</p>
   </header>
-  <chat main [agent]="agent" class="ag-ui-demo__chat" />
+  <chat main [agent]="agent" [views]="catalog" class="ag-ui-demo__chat" />
 </main>

--- a/examples/ag-ui/angular/src/app/app.ts
+++ b/examples/ag-ui/angular/src/app/app.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { injectAgent } from '@threadplane/ag-ui';
-import { ChatComponent } from '@threadplane/chat';
+import { ChatComponent, a2uiBasicCatalog } from '@threadplane/chat';
 
 @Component({
   selector: 'app-root',
@@ -12,4 +12,8 @@ import { ChatComponent } from '@threadplane/chat';
 })
 export class App {
   protected readonly agent = injectAgent();
+  // The a2ui-surface render block in <chat> is gated on a truthy `views`
+  // catalog — without it, a2ui surfaces parse but never mount and the
+  // render_a2ui_surface tool call shows only as a tool chip (issue #616).
+  protected readonly catalog = a2uiBasicCatalog();
 }


### PR DESCRIPTION
## Summary

Closes #616. a2ui generative-UI surfaces now render over the AG-UI transport — **full a2ui parity, e2e-tested (9/9)**.

## Root cause (not an adapter bug)
The `<chat>` a2ui-surface render block is gated on a truthy `views` catalog:
```
@if (classified.type() === 'a2ui' && views(); as catalog) { <a2ui-surface ... /> }
```
The simplified single-conversation ag-ui host (Part 2a) omitted `[views]`, so a2ui surfaces parsed correctly but **never mounted** — `render_a2ui_surface` fell through to a tool-call chip. The wrapped `---a2ui_JSON---` content reaches the composition identically over both transports (verified: graph `emit_generated_surface` node → ag-ui `MESSAGES_SNAPSHOT` → reducer preserves content → classifier sets `type==='a2ui'`). The catalog binding was the sole blocker — `examples/chat` wires it via its embed-mode (whose in-code comment documents this exact failure mode).

## Fix
- `app.ts`: `protected readonly catalog = a2uiBasicCatalog();`
- `app.html`: `<chat main [agent]="agent" [views]="catalog" .../>`
- Un-fixme `a2ui-single-bubble.spec.ts` — now passes.

Entirely in the example app; `libs/chat` / `libs/ag-ui` / the graph are correct as-is.

## Note (separate, lower priority)
The `customEvents`→`partialBridge` path (#606) feeds `liveSurfaceStore`, but the template renders from the classifier's `a2uiSurfaces()` store — so *progressive* a2ui streaming currently renders nothing (the final surface is what mounts). a2ui renders correctly on turn finalize; live token-by-token surface building is a future refinement, not required for parity.

## Test plan
- [x] `nx e2e examples-ag-ui-angular` — **9 passed** (incl. a2ui-single-bubble) via aimock replay.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)