### PR TITLE
docs(render): voice pass on guides + concepts

### DIFF
--- a/apps/website/content/docs/render/guides/events.mdx
+++ b/apps/website/content/docs/render/guides/events.mdx
@@ -178,7 +178,7 @@ Handlers resolve with the same priority as other inputs:
 
 ## Action Dispatch Pattern
 
-A common pattern is to use handlers to update the state store in response to user interactions. This creates a unidirectional data flow:
+A common pattern is to use handlers to update the state store in response to user interactions. That creates a unidirectional data flow:
 
 ```
 User clicks button
@@ -188,7 +188,7 @@ User clicks button
     --> UI re-renders
 ```
 
-Here is a complete example:
+Here's a complete example:
 
 ```typescript
 const spec: Spec = {

--- a/apps/website/content/docs/render/guides/lifecycle.mdx
+++ b/apps/website/content/docs/render/guides/lifecycle.mdx
@@ -1,6 +1,6 @@
 # Render Lifecycle Signals
 
-The `@threadplane/render` library exposes per-context lifecycle signals via the `RENDER_LIFECYCLE` injection token. All five signals derive from the existing `RenderEvent` stream via `RenderLifecycleService.notify*` methods — no separate event source, no double-counting.
+The `@threadplane/render` library exposes per-context lifecycle signals via the `RENDER_LIFECYCLE` injection token. All five signals derive from the existing `RenderEvent` stream via `RenderLifecycleService.notify*` methods — they share one event source, so there's no double-counting.
 
 ## Interface
 

--- a/apps/website/content/docs/render/guides/registry.mdx
+++ b/apps/website/content/docs/render/guides/registry.mdx
@@ -1,10 +1,10 @@
 # Component Registry
 
-The component registry maps element type names from your spec to Angular component classes. It is the bridge between the declarative JSON spec and your Angular component tree.
+The component registry maps element type names from your spec to Angular component classes. It's the bridge between the declarative JSON spec and your Angular component tree.
 
 ## Creating a Registry
 
-Use `defineAngularRegistry()` to create a registry from a plain object mapping type names to component classes:
+Let's create a registry with `defineAngularRegistry()` from a plain object that maps type names to component classes:
 
 ```typescript
 import { defineAngularRegistry } from '@threadplane/render';
@@ -36,7 +36,7 @@ uiRegistry.names();             // ['Text', 'Card', 'Button', 'Container']
 
 ### Fallback Rendering
 
-When an element's type is not registered, it renders that type's configured fallback if one exists, and otherwise renders nothing. Fallbacks also fill a transient gap during rendering: while an element's state-bound props are still resolving, the library can render a fallback to give visual feedback until the real component is ready. Once the real component mounts, it stays mounted -- later re-renders never revert to the fallback.
+When an element's type isn't registered, it renders that type's configured fallback if one exists, and otherwise renders nothing. Fallbacks also fill a transient gap during rendering: while an element's state-bound props are still resolving, the library can render a fallback to give visual feedback until the real component is ready. Once the real component mounts, it stays mounted -- later re-renders never revert to the fallback.
 
 ## The Component Input Contract
 
@@ -70,7 +70,7 @@ Your component receives `label` and `size` as inputs alongside the standard inpu
 
 ## Writing a Renderable Component
 
-Here is a complete example of a component designed to work with the rendering system:
+Here's a complete component designed to work with the rendering system:
 
 ```typescript
 import { Component, ChangeDetectionStrategy, input } from '@angular/core';
@@ -197,7 +197,7 @@ This enables deeply nested component trees -- containers render their children, 
 
 ## Providing the Registry
 
-You can provide the registry in two ways:
+Let's provide the registry. You have two ways to do it:
 
 <Tabs>
 <Tab label="Global (provideRender)">

--- a/apps/website/content/docs/render/guides/specs.mdx
+++ b/apps/website/content/docs/render/guides/specs.mdx
@@ -1,6 +1,6 @@
 # Specs
 
-A spec is the JSON object that describes your entire UI tree. It tells `@threadplane/render` what to render, how to wire state, and when to show or hide elements.
+A spec is the JSON object that describes your entire UI tree. It tells `@threadplane/render` what to render, how to wire state, and when to show or hide an element.
 
 ## Spec Format
 
@@ -29,7 +29,7 @@ const spec: Spec = {
 | `state` | `object` | (Optional) Initial state used to create an internal state store when no external store is provided |
 
 <Callout type="info" title="Flat element map">
-Elements are stored in a flat map rather than a nested tree. Parent-child relationships are expressed through the `children` property, which contains keys pointing to other elements in the map. This design enables efficient lookups and makes specs easy to generate from server-side tools.
+Elements are stored in a flat map rather than a nested tree. Parent-child relationships are expressed through the `children` property, which contains keys pointing to other elements in the map. This keeps lookups fast and makes specs easy to generate from server-side tools.
 </Callout>
 
 ## UIElement Properties
@@ -235,7 +235,7 @@ When an element has `repeat`, visibility evaluation is handled differently -- al
 
 ## Complete Example
 
-Here is a spec that combines children, state expressions, conditional rendering, and repeat loops:
+Let's put it together. Here's a spec that combines children, state expressions, conditional rendering, and repeat loops:
 
 ```typescript
 const spec: Spec = {

--- a/apps/website/content/docs/render/guides/state-store.mdx
+++ b/apps/website/content/docs/render/guides/state-store.mdx
@@ -14,7 +14,7 @@ const store = signalStateStore({
 });
 ```
 
-The function accepts an optional initial state object (defaults to `{}`). It returns a `StateStore` that uses Angular Signals internally, so any state changes automatically trigger Angular's change detection.
+The function accepts an optional initial state object (defaults to `{}`). It returns a `StateStore` that uses Angular Signals internally, so any state change automatically triggers Angular's change detection.
 
 ## JSON Pointer Paths
 
@@ -55,7 +55,7 @@ store.get('/missing');    // undefined
 
 ### Single Value
 
-Use `set()` to write a single value. The store performs an immutable update -- it clones the path to the target and sets the new value. If the new value is referentially equal to the current value, the update is skipped.
+Use `set()` to write a single value. The store performs an immutable update -- it clones the path to the target and sets the new value. If the new value is referentially equal to the current one, the update is skipped.
 
 ```typescript
 store.set('/user/name', 'Bob');
@@ -112,7 +112,7 @@ Under the hood, `signalStateStore()` wraps the state in an Angular `signal()`. T
 
 - Components using `OnPush` change detection automatically update when the state changes
 - Props resolved via `$state` expressions in specs are re-evaluated when the underlying signal updates
-- The store integrates seamlessly with Angular's reactivity model -- no RxJS or manual subscription management needed
+- The store fits Angular's reactivity model -- no RxJS or manual subscription management needed
 
 ```typescript
 // In a spec, $state props are automatically reactive
@@ -141,7 +141,7 @@ Array.isArray(store.get('/items')); // true
 
 ## Providing the Store
 
-You can provide a store in three ways. `RenderSpecComponent` resolves the store using this priority chain:
+Let's wire the store in. You have three ways to provide one, and `RenderSpecComponent` resolves it using this priority chain:
 
 <Steps>
 <Step title="Input (highest priority)">


### PR DESCRIPTION
## Summary

Voice pass (3 of 7) on the render docs beyond getting-started. **Prose only.**

- **guides ×5** (registry, state-store, specs, events, lifecycle): contractions, "Let's" lead-ins, trimmed hype ("seamlessly"→"fits"), one-thought-per-line.
- **concepts ×1** (json-render-vs-a2ui): already firmly in-voice — unchanged (YAGNI).
- **api ×5** (reference): already terse — unchanged (YAGNI-hard).

## Test Plan
- [x] Heading/fence/table/`<Step>`/note guard clean; headings byte-identical to `origin/main`.
- [x] Independent voice review: GUARDRAILS PASS + VOICE PASS.
- [x] All 11 render routes return HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)