### PR TITLE
docs(ag-ui): voice pass on guides + concepts

### DIFF
--- a/apps/website/content/docs/ag-ui/guides/citations.mdx
+++ b/apps/website/content/docs/ag-ui/guides/citations.mdx
@@ -2,7 +2,7 @@
 
 `@threadplane/ag-ui` can copy citations from AG-UI state onto chat messages.
 
-The bridge is intentionally simple: put citations under `state.citations`, keyed by message id. When a `STATE_SNAPSHOT` or `STATE_DELTA` arrives, the adapter merges matching citations onto `messages`.
+The bridge is deliberately simple: put citations under `state.citations`, keyed by message id. When a `STATE_SNAPSHOT` or `STATE_DELTA` arrives, the adapter merges matching citations onto `messages`.
 
 ## State shape
 

--- a/apps/website/content/docs/ag-ui/guides/fake-agent.mdx
+++ b/apps/website/content/docs/ag-ui/guides/fake-agent.mdx
@@ -1,6 +1,6 @@
 # Fake Agent
 
-`FakeAgent` is an in-process AG-UI `AbstractAgent` for frontend work when a backend is not ready.
+`FakeAgent` is an in-process AG-UI `AbstractAgent` for frontend work when the backend isn't ready yet.
 
 It emits a canned stream:
 
@@ -11,7 +11,7 @@ It emits a canned stream:
 5. `TEXT_MESSAGE_END`
 6. `RUN_FINISHED`
 
-It is for demos, story-like development, and tests. It is not a production transport.
+It's for demos, story-like development, and tests. It's not a production transport.
 
 ## Use the provider
 
@@ -98,6 +98,6 @@ That gives you the same `Agent` contract as `provideFakeAgent()`.
 
 `FakeAgent` does not call a model, execute tools, persist history, or simulate interrupts.
 
-It is deliberately small. Use it to keep UI work moving, not to validate backend behavior.
+It's deliberately small. Use it to keep UI work moving, not to validate backend behavior.
 
 For backend integration, test against your real AG-UI endpoint and the event map in [Event Mapping](/docs/ag-ui/reference/event-mapping).

--- a/apps/website/content/docs/ag-ui/guides/interrupts.mdx
+++ b/apps/website/content/docs/ag-ui/guides/interrupts.mdx
@@ -1,6 +1,10 @@
 # Interrupts (Human-in-the-Loop)
 
-Interrupts let your AG-UI agent pause mid-run and hand control to a human. The agent proposes an action, the run freezes, your Angular UI shows an approval dialog, the user decides, and the agent resumes with the human's decision. This guide covers the AG-UI adapter specifics. For the broader conceptual model — lifecycle stages, timeout strategies, typed payloads — see the [LangGraph interrupts guide](/docs/langgraph/guides/interrupts).
+Interrupts let your AG-UI agent pause mid-run and hand control to a human.
+
+The agent proposes an action, the run freezes, your Angular UI shows an approval dialog, the user decides, and the agent resumes with the human's decision.
+
+This guide covers the AG-UI adapter specifics. For the broader conceptual model — lifecycle stages, timeout strategies, typed payloads — see the [LangGraph interrupts guide](/docs/langgraph/guides/interrupts).
 
 ## The Wire Format
 


### PR DESCRIPTION
## Summary

Voice pass (4 of 7) on the ag-ui docs beyond getting-started. **Prose only.** The ag-ui docs were already in strong voice, so the pass is light:
- **fake-agent, citations, interrupts** guides: contractions + one-thought-per-line (split a run-on interrupts intro).
- **testing, troubleshooting, architecture, reference/event-mapping**: already in-voice — unchanged (YAGNI; event-mapping table untouched).

## Test Plan
- [x] Guards clean (no heading/fence/table/`<Step>`/note); headings byte-identical to `origin/main`.
- [x] All 7 ag-ui routes return HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)