### PR TITLE
docs(a2ui): voice pass on guides

### DIFF
--- a/apps/website/content/docs/a2ui/guides/message-protocol.mdx
+++ b/apps/website/content/docs/a2ui/guides/message-protocol.mdx
@@ -106,7 +106,7 @@ A user interacts — clicks the Button — and the client sends an `A2uiActionMe
 {"version":"v1","action":{"name":"bookingSubmit","surfaceId":"booking","sourceComponentId":"submit","timestamp":"2026-06-05T12:34:56.789Z","context":{"origin":{"literalString":"LAX"},"dest":{"literalString":"JFK"}},"label":"Search flights"}}
 ```
 
-Two details worth pinning down, because the inbound and outbound shapes differ:
+Two details are worth pinning down, because the inbound and outbound shapes differ:
 
 - **Context flips from list to map.** The inbound Button's `action.context` is a *list* of `{ key, value }` entries, where each `value` is still a dynamic value (often a `{ path }`). The outbound message's `action.context` is a *map* keyed by those keys, with each value already a wrapped literal — the path references resolved against the current model and re-wrapped (here `{ path: '/origin' }` became `{ literalString: 'LAX' }`).
 - **`label` is derived.** It comes from the source component's authored text — for a Button-with-Text-child, the child Text's literal string ("Search flights"). It's optional; the transcript renderer uses it to label the user bubble, and backends may ignore it.

--- a/apps/website/content/docs/a2ui/reference/schema.mdx
+++ b/apps/website/content/docs/a2ui/reference/schema.mdx
@@ -1,6 +1,6 @@
 # A2UI Schema
 
-The `@threadplane/a2ui` schema is a TypeScript model of the protocol shapes used by the framework. It is useful as a contract for agent output and custom integrations, but it is not a runtime validator.
+The `@threadplane/a2ui` schema is a TypeScript model of the protocol shapes the framework uses. It's a contract for agent output and custom integrations, but it's not a runtime validator.
 
 ## Dynamic values
 


### PR DESCRIPTION
## Summary

Voice pass (5 of 7) on the a2ui docs beyond getting-started. **Prose only.** These pages were freshly authored and already largely in-voice, so the pass is minimal:
- **message-protocol**: a one-word grammatical tightening.
- **reference/schema**: warmed the intro lede with contractions (type blocks/tables untouched).
- **data-model, adapters-and-validation, reference/parser-resolver-guards**: already in-voice — unchanged (YAGNI).

## Test Plan
- [x] Guards clean (no heading/fence/table/`<Step>`/note); headings byte-identical to `origin/main`.
- [x] All 5 a2ui routes return HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)