### PR TITLE
fix(examples): derive assemble-examples list from the capability registry (drift guard)

### DIFF
--- a/scripts/assemble-examples.ts
+++ b/scripts/assemble-examples.ts
@@ -11,49 +11,23 @@
 import { execSync } from 'child_process';
 import { cpSync, mkdirSync, rmSync, existsSync, writeFileSync, readFileSync } from 'fs';
 import { resolve } from 'path';
+import { capabilities as registryCapabilities } from '../apps/cockpit/scripts/capability-registry';
 
 const root = resolve(__dirname, '..');
 const deployDir = resolve(root, 'deploy/examples');
 const skipBuild = process.argv.includes('--skip-build');
 
-const capabilities = [
-  { product: 'langgraph', topic: 'streaming' },
-  { product: 'langgraph', topic: 'persistence' },
-  { product: 'langgraph', topic: 'interrupts' },
-  { product: 'langgraph', topic: 'memory' },
-  { product: 'langgraph', topic: 'durable-execution' },
-  { product: 'langgraph', topic: 'subgraphs' },
-  { product: 'langgraph', topic: 'time-travel' },
-  { product: 'langgraph', topic: 'deployment-runtime' },
-  { product: 'deep-agents', topic: 'planning' },
-  { product: 'deep-agents', topic: 'filesystem' },
-  { product: 'deep-agents', topic: 'subagents' },
-  { product: 'deep-agents', topic: 'memory' },
-  { product: 'deep-agents', topic: 'skills' },
-  { product: 'deep-agents', topic: 'sandboxes' },
-  { product: 'render', topic: 'spec-rendering' },
-  { product: 'render', topic: 'element-rendering' },
-  { product: 'render', topic: 'state-management' },
-  { product: 'render', topic: 'registry' },
-  { product: 'render', topic: 'repeat-loops' },
-  { product: 'render', topic: 'computed-functions' },
-  { product: 'chat', topic: 'messages' },
-  { product: 'chat', topic: 'input' },
-  { product: 'chat', topic: 'interrupts' },
-  { product: 'chat', topic: 'tool-calls' },
-  { product: 'chat', topic: 'subagents' },
-  { product: 'chat', topic: 'threads' },
-  { product: 'chat', topic: 'timeline' },
-  { product: 'chat', topic: 'generative-ui' },
-  { product: 'chat', topic: 'debug' },
-  { product: 'chat', topic: 'theming' },
-  { product: 'chat', topic: 'a2ui' },
-  { product: 'ag-ui', topic: 'interrupts' },
-  { product: 'ag-ui', topic: 'streaming' },
-  { product: 'ag-ui', topic: 'tool-views' },
-  { product: 'ag-ui', topic: 'json-render' },
-  { product: 'ag-ui', topic: 'a2ui' },
-];
+// Derive the staged-example list from the capability registry — the single
+// source of truth (every entry has an `angularProject` that builds to
+// `dist/cockpit/<product>/<topic>/angular`). Hardcoding it previously let new
+// caps (tool-views, json-render, a2ui) silently 404 in production because they
+// were added to the registry but never to this list. The Railway deploy
+// generator already derives from the registry; this keeps the frontend deploy
+// in lockstep so a registry cap can never be missed again.
+const capabilities = registryCapabilities.map((c) => ({
+  product: c.product,
+  topic: c.topic,
+}));
 
 if (!skipBuild) {
   console.log(`Building all ${capabilities.length} Angular apps...`);


### PR DESCRIPTION
## Summary

Follow-up to #619. The production smoke revealed the three new AG-UI examples never deployed — partly because `scripts/assemble-examples.ts` (which stages apps into the `threadplane-examples` Vercel deploy) **hardcoded** the capability list and had drifted: `tool-views`, `json-render`, and `a2ui` were added to the capability registry but never to this list, so their frontends 404'd.

This derives the staged list from the **capability registry** — the documented single source of truth ("Used by serve, build, test, and deploy scripts"), already used by the Railway deploy generator. Now a new cockpit cap is automatically included in the examples deploy; the list can't drift again.

## Verified
- Derives all **36** caps, incl. ag-ui `interrupts, streaming, tool-views, json-render, a2ui`.
- The `../apps/cockpit/scripts/capability-registry` import resolves; the script runs past list derivation (the build-output guard then fires only because `--skip-build` skipped the 36-app build, which production performs first).

## Not covered here (your infra)
The `threadplane-examples` Vercel project's **build trigger / Ignored Build Step** is a dashboard setting (the repo's root `vercel.json` builds the website, a different project). It didn't rebuild on #619's scripts-only change — so a manual redeploy of `threadplane-examples` is still needed to publish the 3 frontends; this PR just ensures the *contents* are correct and drift-proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)