### PR TITLE
docs(telemetry): voice pass on guides

### DIFF
--- a/apps/website/content/docs/telemetry/guides/browser.mdx
+++ b/apps/website/content/docs/telemetry/guides/browser.mdx
@@ -1,6 +1,6 @@
 # Browser Telemetry
 
-Browser telemetry is opt-in. If your Angular app never calls `provideThreadplaneTelemetry()`, the service has no enabled config and `capture()` returns without sending.
+Browser telemetry is opt-in. If your Angular app never calls `provideThreadplaneTelemetry()`, the service has no enabled config and `capture()` returns without sending anything.
 
 ## Configure
 
@@ -32,7 +32,7 @@ The endpoint receives:
 }
 ```
 
-The browser distinct ID is generated per service instance. The source does not write it to storage.
+The browser distinct ID is generated per service instance. The source never writes it to storage.
 
 ## Prefer a sink for app-owned analytics
 
@@ -47,7 +47,7 @@ provideThreadplaneTelemetry({
 });
 ```
 
-When `sink` is present, the service does not use `endpoint` or PostHog.
+When `sink` is present, the service skips `endpoint` and PostHog entirely.
 
 ## Sampling
 
@@ -89,4 +89,4 @@ telemetry.captureStreamErrored({ transport: 'langgraph', provider: 'openai', mod
 
 Browser capture is wrapped in a `try/catch`. A sink error, fetch failure, or dynamic import failure is swallowed.
 
-That keeps telemetry from becoming part of your application control flow.
+That keeps telemetry out of your application's control flow.

--- a/apps/website/content/docs/telemetry/guides/node.mdx
+++ b/apps/website/content/docs/telemetry/guides/node.mdx
@@ -1,6 +1,6 @@
 # Node Telemetry
 
-Node telemetry lives under `@threadplane/telemetry/node`. It is intended for package lifecycle hooks and server-side adapters.
+Node telemetry lives under `@threadplane/telemetry/node`. It's built for package lifecycle hooks and server-side adapters.
 
 ```ts
 import {
@@ -23,7 +23,7 @@ import { disableTelemetry } from '@threadplane/telemetry/node';
 disableTelemetry();
 ```
 
-This sets an in-process flag. It does not mutate environment variables.
+This sets an in-process flag. It doesn't mutate environment variables.
 
 ## Capture runtime lifecycle
 
@@ -70,7 +70,7 @@ await captureStreamErrored({
 });
 ```
 
-`captureStreamErrored()` records an error class. It does not send the full error object.
+`captureStreamErrored()` records an error class. It doesn't send the full error object.
 
 ## Ingest and sampling
 
@@ -104,4 +104,4 @@ type CaptureResult =
   | { sent: false; reason: 'disabled' | 'sampled' | 'failed' };
 ```
 
-Use the result in tests or diagnostics. Do not make application correctness depend on telemetry delivery.
+Use the result in tests or diagnostics. Don't make application correctness depend on telemetry delivery.

--- a/apps/website/content/docs/telemetry/guides/privacy-and-opt-out.mdx
+++ b/apps/website/content/docs/telemetry/guides/privacy-and-opt-out.mdx
@@ -1,6 +1,6 @@
 # Privacy and Opt-Out
 
-The telemetry source has two different privacy postures.
+The telemetry source has two distinct privacy postures.
 
 Browser telemetry is off unless the app opts in. Node telemetry can send from package lifecycle hooks or server adapters unless the environment or process disables it.
 
@@ -46,7 +46,7 @@ provideThreadplaneTelemetry({ enabled: true, sink });
 
 With `enabled: false` or no provider, browser capture no-ops.
 
-The browser service sends only when application code or framework browser code calls its capture methods. It does not install a global listener.
+The browser service sends only when application code or framework browser code calls its capture methods. It never installs a global listener.
 
 ## Anonymous IDs
 
@@ -54,7 +54,7 @@ Node uses `anon_<uuid>` from `node:crypto` and caches it for the current process
 
 Browser endpoint delivery uses `browser:<uuid>` when `crypto.randomUUID()` is available, with a `Math.random()` fallback. The value is kept in the service instance.
 
-The source does not persist either ID across process restarts or browser sessions.
+The source never persists either ID across process restarts or browser sessions.
 
 ## Data minimization from source
 
@@ -64,7 +64,7 @@ Runtime lifecycle helpers send transport/provider/model style metadata. Stream e
 
 The source strips `apiKey` in the Node runtime adapter before sending.
 
-There is no source path that sends prompts, completions, message content, tool call arguments, tool call outputs, or environment variable dumps.
+No source path sends prompts, completions, message content, tool call arguments, tool call outputs, or environment variable dumps.
 
 ## Custom ingest
 


### PR DESCRIPTION
## Summary

Voice pass (6 of 7) on the telemetry docs beyond getting-started. **Prose only.**
- **browser, node, privacy-and-opt-out** guides: contractions, concrete verbs ("does not"→"never"/"skips"), tightened stiff constructions.
- **reference/events**: already a clean factual lede — unchanged (YAGNI; tables/unions untouched).

## Test Plan
- [x] Guards clean (no heading/fence/table/`<Step>`/note); headings byte-identical to `origin/main`.
- [x] All 4 telemetry routes return HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)