### PR TITLE
docs(licensing): voice pass on guides

### DIFF
--- a/apps/website/content/docs/licensing/guides/ci-and-offline.mdx
+++ b/apps/website/content/docs/licensing/guides/ci-and-offline.mdx
@@ -2,7 +2,7 @@
 
 License verification is offline. `verifyLicense(token, publicKey)` parses the compact token, checks the Ed25519 signature, and returns claims when the signature is valid.
 
-No network call is needed to know whether a token is signed correctly.
+You don't need a network call to know whether a token is signed correctly.
 
 ## CI
 
@@ -42,7 +42,7 @@ const result = evaluateLicense(verified, {
 });
 ```
 
-This does not emit warnings. The higher-level `runLicenseCheck()` helper can emit warnings, but it does not make network requests.
+This doesn't emit warnings. The higher-level `runLicenseCheck()` helper can emit warnings, but it never makes network requests.
 
 ## Signing tokens
 
@@ -56,4 +56,4 @@ const token = await signLicense(claims, privateKey);
 
 It signs the UTF-8 JSON payload with Ed25519 and returns the compact token format expected by `verifyLicense()`.
 
-Do not ship private keys in application code. Verification needs only the public key.
+Don't ship private keys in application code. Verification needs only the public key.

--- a/apps/website/content/docs/licensing/guides/setup.mdx
+++ b/apps/website/content/docs/licensing/guides/setup.mdx
@@ -1,8 +1,8 @@
 # Setup
 
-Most applications do not import `@threadplane/licensing` directly. `@threadplane/chat` calls `runLicenseCheck()` from `provideChat()` when you pass a license token.
+Most applications don't import `@threadplane/licensing` directly. `@threadplane/chat` calls `runLicenseCheck()` from `provideChat()` when you pass a license token.
 
-For example, chat exposes a `license` option:
+Chat exposes a `license` option:
 
 ```ts
 provideChat({ license: environment.threadplaneLicense });
@@ -12,7 +12,7 @@ When no token is supplied, the licensing helper can evaluate the environment as 
 
 ## Direct use
 
-Use the direct API when you are building a package inside the framework or a custom integration that needs the same behavior.
+Use the direct API when you're building a package inside the framework, or a custom integration that needs the same behavior.
 
 ```ts
 import {
@@ -68,12 +68,12 @@ It returns:
 - `false` when `NODE_ENV` is `"production"`;
 - `false` when there is no `process` global.
 
-This is only a default hint. Callers can pass `isNoncommercial` explicitly.
+It's only a default hint. Callers can pass `isNoncommercial` explicitly.
 
 ## Gotchas
 
 `runLicenseCheck()` is idempotent for identical `package` and `token` values. A repeated call with the same key returns `licensed` without re-running the check.
 
-That keeps repeated provider initialization quiet, but it means package authors should not use repeated calls with identical inputs as a status polling mechanism.
+That keeps repeated provider initialization quiet, but it means package authors shouldn't use repeated calls with identical inputs to poll for status.
 
-`verifyLicense()` does not check time. Pair it with `evaluateLicense()` when you need expiration and grace behavior.
+`verifyLicense()` doesn't check time. Pair it with `evaluateLicense()` when you need expiration and grace behavior.

--- a/apps/website/content/docs/licensing/reference/api.mdx
+++ b/apps/website/content/docs/licensing/reference/api.mdx
@@ -1,6 +1,6 @@
 # Licensing API
 
-This page documents the public exports from `@threadplane/licensing`.
+The public exports from `@threadplane/licensing`.
 
 ## Types
 


### PR DESCRIPTION
## Summary

Voice pass (7 of 7 — final lib) on the licensing docs beyond getting-started. **Prose only.**
- **setup, ci-and-offline** guides: contractions, concrete verbs ("never makes network requests", "Don't ship private keys"), trimmed filler.
- **reference/api**: intro lede tightened; signatures/tables/type blocks untouched (YAGNI-hard). `process.env['X']` bracket-access preserved.

## Test Plan
- [x] Guards clean; headings byte-identical to `origin/main`; env-access untouched.
- [x] All 3 licensing routes return HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)