### PR TITLE
docs(licensing): enhancement pass — examples, gaps, clarity

### DIFF
--- a/apps/website/content/docs/licensing/getting-started/introduction.mdx
+++ b/apps/website/content/docs/licensing/getting-started/introduction.mdx
@@ -18,6 +18,8 @@ The main entry point exports:
 | `inferNoncommercial()` | returns a default noncommercial hint from `NODE_ENV` |
 | `LICENSE_PUBLIC_KEY` | bundled public key |
 
+This table covers the functions and the bundled key, not the full export list. The package also exports the supporting types — `LicenseClaims`, `LicenseTier`, `LicenseStatus`, `VerifyResult`/`VerifyReason`, `EvaluateResult`/`EvaluateOptions`, `RunLicenseCheckOptions`, and `EmitNagOptions`. See the [API reference](../reference/api.mdx) for the full type surface.
+
 `@noble/ed25519` is the only peer dependency.
 
 ## Token model
@@ -68,3 +70,9 @@ The higher-level check is built not to block app startup:
 - no network request is made by the licensing check.
 
 The code returns statuses instead of throwing for normal license states. For me, that's the right default here: you get to decide what a missing or expired license means for your app instead of having the check make that call for you. The tradeoff is that nothing stops a consumer from ignoring the status entirely. `@threadplane/chat` treats it as a warning and visibility mechanism, not an app kill switch.
+
+## Next steps
+
+- [Quickstart](./quickstart.mdx) — a runnable round-trip: sign, verify, and evaluate a token end to end.
+- [Setup](../guides/setup.mdx) — consume the check via `provideChat()` or call `runLicenseCheck()` directly.
+- [API reference](../reference/api.mdx) — the full type surface.

--- a/apps/website/content/docs/licensing/getting-started/quickstart.mdx
+++ b/apps/website/content/docs/licensing/getting-started/quickstart.mdx
@@ -1,0 +1,62 @@
+# Quickstart
+
+This page strings the whole API together into one runnable round-trip. Paste it into a Node script (or REPL) and run it. It mints a token, verifies it offline, and evaluates the result into a status — no network, no real license needed.
+
+You need `@threadplane/licensing` and its only peer dependency, `@noble/ed25519`:
+
+```bash
+npm install @threadplane/licensing @noble/ed25519
+```
+
+## A full round-trip
+
+```ts
+import * as ed from '@noble/ed25519';
+import {
+  signLicense,
+  verifyLicense,
+  evaluateLicense,
+  type LicenseClaims,
+} from '@threadplane/licensing';
+
+// 1. Generate an Ed25519 keypair. In production the minting service owns the
+//    private key; the public key is what `verifyLicense()` consumes.
+const privateKey = ed.utils.randomPrivateKey();
+const publicKey = await ed.getPublicKeyAsync(privateKey);
+
+// 2. Build claims and sign them into a compact token.
+const nowSec = Math.floor(Date.now() / 1000);
+const claims: LicenseClaims = {
+  sub: 'cus_123',
+  tier: 'developer_seat',
+  iat: nowSec,
+  exp: nowSec + 60 * 60 * 24 * 365, // one year out
+  seats: 1,
+};
+const token = await signLicense(claims, privateKey);
+
+// 3. Offline-verify the signature against the public key.
+const verified = await verifyLicense(token, publicKey);
+console.log(verified.ok); // true
+
+// 4. Evaluate the verify result into a status.
+console.log(evaluateLicense(verified, { nowSec }).status); // 'licensed'
+
+// 5. Sign a token that already expired to see the time-based statuses.
+const expiredToken = await signLicense({ ...claims, exp: nowSec - 60 }, privateKey);
+const expiredVerified = await verifyLicense(expiredToken, publicKey);
+// Expired but inside the 14-day grace window:
+console.log(evaluateLicense(expiredVerified, { nowSec }).status); // 'grace'
+// Outside the grace window (push `nowSec` past exp + grace):
+console.log(
+  evaluateLicense(expiredVerified, { nowSec: nowSec + 60 * 60 * 24 * 30 }).status,
+); // 'expired'
+```
+
+`signLicense()` here stands in for the minting service. Real consumers never sign — they verify a token they were issued against `LICENSE_PUBLIC_KEY`, the public key baked into the package.
+
+## Next steps
+
+- [Setup](../guides/setup.mdx) — consume the check via `provideChat()` or call `runLicenseCheck()` directly.
+- [CI and offline use](../guides/ci-and-offline.mdx) — verify and sign without network access.
+- [API reference](../reference/api.mdx) — the full type surface.

--- a/apps/website/content/docs/licensing/guides/ci-and-offline.mdx
+++ b/apps/website/content/docs/licensing/guides/ci-and-offline.mdx
@@ -34,12 +34,20 @@ await runLicenseCheck({
 Use `verifyLicense()` and `evaluateLicense()` directly when network access is unavailable or unwanted.
 
 ```ts
-import { evaluateLicense, verifyLicense } from '@threadplane/licensing';
+import {
+  LICENSE_PUBLIC_KEY,
+  evaluateLicense,
+  verifyLicense,
+} from '@threadplane/licensing';
+
+const publicKey = LICENSE_PUBLIC_KEY;
+const token = process.env['THREADPLANE_LICENSE'] ?? '';
 
 const verified = await verifyLicense(token, publicKey);
 const result = evaluateLicense(verified, {
   nowSec: Math.floor(Date.now() / 1000),
 });
+console.log(result.status);
 ```
 
 This doesn't emit warnings. The higher-level `runLicenseCheck()` helper can emit warnings, but it never makes network requests.
@@ -49,7 +57,25 @@ This doesn't emit warnings. The higher-level `runLicenseCheck()` helper can emit
 `signLicense()` is exported for token minting and tests:
 
 ```ts
-import { signLicense } from '@threadplane/licensing';
+import * as ed from '@noble/ed25519';
+import {
+  signLicense,
+  type LicenseClaims,
+} from '@threadplane/licensing';
+
+// Generate a keypair. The public key is what `verifyLicense()` consumes;
+// the private key never leaves the minting side.
+const privateKey = ed.utils.randomPrivateKey();
+const publicKey = await ed.getPublicKeyAsync(privateKey);
+
+const nowSec = Math.floor(Date.now() / 1000);
+const claims: LicenseClaims = {
+  sub: 'cus_123',
+  tier: 'team',
+  iat: nowSec,
+  exp: nowSec + 60 * 60 * 24 * 365, // one year out
+  seats: 5,
+};
 
 const token = await signLicense(claims, privateKey);
 ```

--- a/apps/website/content/docs/licensing/guides/setup.mdx
+++ b/apps/website/content/docs/licensing/guides/setup.mdx
@@ -1,5 +1,9 @@
 # Setup
 
+## Getting a token
+
+A license token comes from a Threadplane plan — grab one from [threadplane.ai/pricing](https://threadplane.ai/pricing). Once you have it, paste it into `environment.threadplaneLicense` or set `THREADPLANE_LICENSE` in your environment, and the rest of this page wires it up. The nag warnings the library emits point at the same URL.
+
 Most applications don't import `@threadplane/licensing` directly. `@threadplane/chat` calls `runLicenseCheck()` from `provideChat()` when you pass a license token.
 
 Chat exposes a `license` option:
@@ -30,6 +34,38 @@ const status = await runLicenseCheck({
 ```
 
 `runLicenseCheck()` returns the evaluated `LicenseStatus`.
+
+To see the status in action without a real token, mint one inline with `signLicense()` and log what `runLicenseCheck()` resolves to:
+
+```ts
+import * as ed from '@noble/ed25519';
+import { signLicense, runLicenseCheck } from '@threadplane/licensing';
+
+// Stand-in for the minting service: a throwaway keypair.
+const privateKey = ed.utils.randomPrivateKey();
+const publicKey = await ed.getPublicKeyAsync(privateKey);
+
+const nowSec = Math.floor(Date.now() / 1000);
+const token = await signLicense(
+  {
+    sub: 'cus_123',
+    tier: 'developer_seat',
+    iat: nowSec,
+    exp: nowSec + 60 * 60 * 24 * 365,
+    seats: 1,
+  },
+  privateKey,
+);
+
+const status = await runLicenseCheck({
+  package: '@threadplane/example',
+  token,
+  publicKey,
+});
+console.log(status); // 'licensed'
+```
+
+In production you verify against `LICENSE_PUBLIC_KEY` instead of a throwaway key, and the token comes from your environment — not from `signLicense()`.
 
 ## Warnings
 

--- a/apps/website/src/lib/docs-config.ts
+++ b/apps/website/src/lib/docs-config.ts
@@ -328,6 +328,7 @@ export const docsConfig: DocsLibrary[] = [
         color: 'blue',
         pages: [
           { title: 'Introduction', slug: 'introduction', section: 'getting-started' },
+          { title: 'Quick Start', slug: 'quickstart', section: 'getting-started' },
         ],
       },
       {


### PR DESCRIPTION
Implements approved enhancement findings for `licensing` — Phase 2 of the docs enhancement assessment.

- **7 findings**: added/strengthened runnable code examples, filled gaps, clarity + structure fixes.
- New TypeScript examples **typecheck against published `@threadplane/* 0.0.49`**.
- Prose + examples only; no lib source changed; existing headings byte-identical (added headings only).
- Accuracy errors found during the audit are routed to a **separate** follow-up, not folded in.

Findings report: `docs/superpowers/specs/2026-06-08-docs-enhancement-findings.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)