### PR TITLE
docs(langgraph): fix snippet accuracy vs 0.0.49 API

### DIFF
--- a/apps/website/content/docs/langgraph/concepts/agent-architecture.mdx
+++ b/apps/website/content/docs/langgraph/concepts/agent-architecture.mdx
@@ -277,7 +277,7 @@ const completedTools = computed(() =>
   agent.toolCalls().filter((tool) => tool.status === 'complete')
 );
 
-// Each entry has: name, args, result, duration
+// Each entry has: id, name, args, status, result, error
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
@@ -285,7 +285,6 @@ const completedTools = computed(() =>
       <details>
         <summary>
           {{ call.name }}
-          <span class="duration">{{ call.duration }}ms</span>
         </summary>
         <div class="args">
           <h4>Input</h4>
@@ -417,11 +416,11 @@ interface OrchestratorState {
 
     <aside class="agent-panel">
       <h3>Active Delegated Work</h3>
-      @for (tool of activeTools(); track tool.toolCallId ?? tool.name) {
+      @for (tool of activeTools(); track tool.id) {
         <app-agent-card
           [name]="tool.name"
-          [status]="tool.state"
-          [input]="tool.input" />
+          [status]="tool.status"
+          [input]="tool.args" />
       }
     </aside>
 
@@ -524,7 +523,7 @@ export class AgentComponent {
 | Agent exceeds recursion limit | Graph raises `GraphRecursionError` | `error()` fires with recursion message |
 
 <Callout type="warning" title="Recursion limits">
-LangGraph defaults to 25 recursion steps. If your agent loops between `model` and `tools` more than 25 times, it stops with a `GraphRecursionError`. Increase the limit in production with `graph.compile(recursion_limit=50)` or redesign the agent to converge faster.
+LangGraph defaults to 25 recursion steps. If your agent loops between `model` and `tools` more than 25 times, it stops with a `GraphRecursionError`. Increase the limit in production by passing it in the run config — `graph.invoke(input, config={"recursion_limit": 50})` — or redesign the agent to converge faster.
 </Callout>
 
 ## Checkpointing and Debugging

--- a/apps/website/content/docs/langgraph/guides/interrupts.mdx
+++ b/apps/website/content/docs/langgraph/guides/interrupts.mdx
@@ -399,7 +399,7 @@ export class DeployApprovalComponent {
     return (step.completed.length / step.total_steps) * 100;
   });
 
-  allInterrupts = computed(() => this.agent.interrupts());
+  allInterrupts = computed(() => this.agent.langGraphInterrupts());
 
   approveStep() {
     this.agent.submit({ resume: { approved: true } });


### PR DESCRIPTION
Fixes accuracy errors found during the docs enhancement audit — snippets that didn't compile/run against the real `@threadplane/* 0.0.49` API (ToolCall fields, recursion_limit, interrupts()). Kept separate from the enhancement PRs per plan.

Each fix verified against lib source / @json-render/core types; TS snippets typecheck against published 0.0.49. From the findings report's accuracy follow-up section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)