### PR TITLE
docs(render): fix snippet accuracy vs 0.0.49 API

### DIFF
--- a/apps/website/content/docs/render/api/define-angular-registry.mdx
+++ b/apps/website/content/docs/render/api/define-angular-registry.mdx
@@ -12,7 +12,7 @@ import { defineAngularRegistry } from '@threadplane/render';
 
 ```typescript
 function defineAngularRegistry(
-  componentMap: Record<string, AngularComponentRenderer>,
+  componentMap: Record<string, AngularComponentRenderer | RenderViewEntry>,
 ): AngularRegistry;
 ```
 
@@ -20,9 +20,18 @@ function defineAngularRegistry(
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `componentMap` | `Record<string, AngularComponentRenderer>` | An object mapping type name strings to Angular component classes |
+| `componentMap` | `Record<string, AngularComponentRenderer \| RenderViewEntry>` | An object mapping type name strings to Angular component classes, or to `{ component, fallback? }` objects |
 
-`AngularComponentRenderer` is defined as `Type<unknown>` -- any Angular component class.
+`AngularComponentRenderer` is defined as `Type<unknown>` -- any Angular component class. Each entry can be a bare component class or a `RenderViewEntry` object:
+
+```typescript
+interface RenderViewEntry {
+  component: AngularComponentRenderer;
+  fallback?: AngularComponentRenderer;
+}
+```
+
+Use the object form to configure a custom per-entry fallback (see [Per-Component Fallbacks](#per-component-fallbacks) below). A bare component class is shorthand for `{ component }` paired with the library's default fallback.
 
 ### Returns
 
@@ -118,15 +127,33 @@ An entry that omits `fallback` -- including every bare-component entry like `Tex
 
 ## Internal Behavior
 
-The function converts the input object to an internal `Map<string, AngularComponentRenderer>` for O(1) lookups:
+The function normalizes each input entry into a `{ component, fallback }` pair and stores them in an internal `Map` for O(1) lookups. A bare component class is paired with `DefaultFallbackComponent`; an object entry keeps its own `fallback` or falls back to the default:
 
 ```typescript
-function defineAngularRegistry(
-  componentMap: Record<string, AngularComponentRenderer>,
-): AngularRegistry {
-  const map = new Map(Object.entries(componentMap));
+function normalize(
+  entry: AngularComponentRenderer | RenderViewEntry,
+): NormalizedEntry {
+  // Bare Type — register with the default fallback.
+  if (typeof entry === 'function') {
+    return { component: entry, fallback: DefaultFallbackComponent };
+  }
+  // Object form — preserve component; use configured fallback or default.
   return {
-    get: (name: string) => map.get(name),
+    component: entry.component,
+    fallback: entry.fallback ?? DefaultFallbackComponent,
+  };
+}
+
+function defineAngularRegistry(
+  componentMap: Record<string, AngularComponentRenderer | RenderViewEntry>,
+): AngularRegistry {
+  const map = new Map<string, NormalizedEntry>();
+  for (const [name, entry] of Object.entries(componentMap)) {
+    map.set(name, normalize(entry));
+  }
+  return {
+    get: (name: string) => map.get(name)?.component,
+    getFallback: (name: string) => map.get(name)?.fallback,
     names: () => [...map.keys()],
   };
 }

--- a/apps/website/content/docs/render/api/provide-render.mdx
+++ b/apps/website/content/docs/render/api/provide-render.mdx
@@ -39,7 +39,7 @@ interface RenderConfig {
 |----------|------|-------------|
 | `registry` | `AngularRegistry` | Default component registry for all `<render-spec>` instances |
 | `store` | `StateStore` | Default state store for all `<render-spec>` instances |
-| `functions` | `Record<string, ComputedFunction>` | Default computed functions for `$fn` prop expressions |
+| `functions` | `Record<string, ComputedFunction>` | Default computed functions for `$computed` prop expressions |
 | `handlers` | `Record<string, Handler>` | Default event handlers for action dispatch |
 
 All properties are optional. Only provide the defaults you need.

--- a/apps/website/content/docs/render/api/render-spec-component.mdx
+++ b/apps/website/content/docs/render/api/render-spec-component.mdx
@@ -38,7 +38,7 @@ export class MyComponent {
 | `spec` | `Spec \| null` | `null` | The json-render spec to render. When `null`, nothing is rendered. |
 | `registry` | `AngularRegistry \| undefined` | `undefined` | Component registry mapping element types to Angular components. |
 | `store` | `StateStore \| undefined` | `undefined` | State store for reactive prop resolution. |
-| `functions` | `Record<string, ComputedFunction> \| undefined` | `undefined` | Computed functions for `$fn` prop expressions. |
+| `functions` | `Record<string, ComputedFunction> \| undefined` | `undefined` | Computed functions for `$computed` prop expressions. |
 | `handlers` | `Record<string, (params: Record<string, unknown>) => unknown \| Promise<unknown>> \| undefined` | `undefined` | Event handlers invoked when components call `emit()`. |
 | `loading` | `boolean` | `false` | Whether the spec is currently streaming. Passed to all rendered components as the `loading` input. |
 

--- a/apps/website/content/docs/render/getting-started/introduction.mdx
+++ b/apps/website/content/docs/render/getting-started/introduction.mdx
@@ -29,7 +29,7 @@ The library resolves `Text` from your component registry, evaluates the `$state`
 
 ## How It Relates to @json-render/core
 
-`@json-render/core` provides the spec format and the evaluation engine -- it resolves prop expressions (`$state`, `$item`, `$index`, `$bindState`, `$fn`), evaluates visibility conditions, and resolves bindings. It is framework-agnostic and has no Angular dependency.
+`@json-render/core` provides the spec format and the evaluation engine -- it resolves prop expressions (`$state`, `$item`, `$index`, `$bindState`, `$computed`), evaluates visibility conditions, and resolves bindings. It is framework-agnostic and has no Angular dependency.
 
 `@threadplane/render` is the Angular adapter layer. It provides:
 

--- a/apps/website/content/docs/render/guides/specs.mdx
+++ b/apps/website/content/docs/render/guides/specs.mdx
@@ -110,22 +110,20 @@ props: {
 }
 ```
 
-### $fn -- Computed Function
+### $computed -- Computed Function
 
 Calls a registered computed function with the given arguments:
 
 ```typescript
 props: {
   label: {
-    $fn: {
-      name: 'uppercase',
-      args: { text: { $state: '/name' } }
-    }
+    $computed: 'uppercase',
+    args: { text: { $state: '/name' } }
   },
 }
 ```
 
-The `name` references a function you register in a `functions` map. Each function is a `ComputedFunction` from `@json-render/core` -- `(args: Record<string, unknown>) => unknown`. The `args` object is resolved first (so `{ $state: '/name' }` becomes the current value at `/name`), then passed to your function:
+The `$computed` value names a function you register in a `functions` map. Each function is a `ComputedFunction` from `@json-render/core` -- `(args: Record<string, unknown>) => unknown`. The `args` object is resolved first (so `{ $state: '/name' }` becomes the current value at `/name`), then passed to your function:
 
 ```typescript
 import type { ComputedFunction } from '@json-render/core';
@@ -154,7 +152,7 @@ provideRender({
 });
 ```
 
-With either wiring, the `$fn` expression above resolves `label` to the uppercased value of `/name`. The input takes priority over the `provideRender()` config when both are present.
+With either wiring, the `$computed` expression above resolves `label` to the uppercased value of `/name`. The input takes priority over the `provideRender()` config when both are present.
 
 ## Children
 


### PR DESCRIPTION
Fixes accuracy errors found during the docs enhancement audit — snippets that didn't compile/run against the real `@threadplane/* 0.0.49` API ($fn → $computed, registry internals). Kept separate from the enhancement PRs per plan.

Each fix verified against lib source / @json-render/core types; TS snippets typecheck against published 0.0.49. From the findings report's accuracy follow-up section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)