### PR TITLE
chore(release): bump publishable packages to 0.0.50

### DIFF
--- a/libs/a2ui/package.json
+++ b/libs/a2ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/a2ui",
-  "version": "0.0.49",
+  "version": "0.0.50",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/ag-ui/package.json
+++ b/libs/ag-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/ag-ui",
-  "version": "0.0.49",
+  "version": "0.0.50",
   "description": "AG-UI protocol adapter for @threadplane/chat — works with any AG-UI-compatible backend.",
   "keywords": ["angular", "ag-ui", "agent", "adapter", "threadplane"],
   "peerDependencies": {

--- a/libs/chat/package.json
+++ b/libs/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/chat",
-  "version": "0.0.49",
+  "version": "0.0.50",
   "exports": {
     "./chat.css": "./chat.css",
     "./themes/default-dark.css": "./themes/default-dark.css",

--- a/libs/langgraph/package.json
+++ b/libs/langgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/langgraph",
-  "version": "0.0.49",
+  "version": "0.0.50",
   "description": "LangGraph adapter for @threadplane/chat — Angular bindings for LangGraph Platform.",
   "keywords": ["angular", "langgraph", "langchain", "agent", "adapter", "threadplane"],
   "peerDependencies": {

--- a/libs/licensing/package.json
+++ b/libs/licensing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/licensing",
-  "version": "0.0.49",
+  "version": "0.0.50",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/render/package.json
+++ b/libs/render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/render",
-  "version": "0.0.49",
+  "version": "0.0.50",
   "peerDependencies": {
     "@angular/core": "^20.0.0 || ^21.0.0",
     "@angular/common": "^20.0.0 || ^21.0.0",

--- a/libs/telemetry/package.json
+++ b/libs/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/telemetry",
-  "version": "0.0.49",
+  "version": "0.0.50",
   "license": "MIT",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Atomic lockstep bump (`fixed` release group) for the **client-tools release**.

### Necessity audit vs v0.0.49 (per Brian's ask)
| Package | Changed? | What |
|---|---|---|
| `@threadplane/chat` | ✅ 22 non-test files | `tools()`/`action`/`view`/`ask`, `Agent.clientTools`, executor + coordinator, ChatComponent `[clientTools]`; **new peer dep `zod ^3.25.0`** |
| `@threadplane/render` | ✅ 6 | `RenderViewEntry.schema/description`, `injectRenderHost()` (`set`/`emit`/`result`), `RenderResultEvent`; **removed** the `a2ui:datamodel:` string protocol |
| `@threadplane/ag-ui` | ✅ 5 | `clientTools` (native `RunAgentInput.tools` + ToolMessage re-run), streamed `TOOL_CALL_ARGS` accumulation fix, ask-card freeze; **new peer dep `@ag-ui/core`** |
| `@threadplane/langgraph` | ✅ 3 | `clientTools` (catalog via `client_tools` input + ToolMessage re-run), ask-card freeze |
| `@threadplane/a2ui` | ➖ unchanged | version-only republish (atomic group) |
| `@threadplane/licensing` | ➖ unchanged | version-only republish |
| `@threadplane/telemetry` | ➖ unchanged | version-only republish |

### Verified locally
- `scripts/verify-release-versions.mjs --tag v0.0.50` → atomic ✅
- All 7 build green; `nx release publish --groups=publishable --dry-run` → 7× "Would publish" ✅
- Built `dist/libs/chat` carries the client-tools typings + `zod` peer dep.

### After merge (maintainer)
```bash
git checkout main && git pull
git tag v0.0.50 && git push origin v0.0.50   # ← triggers the Publish workflow (irreversible npm writes)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)