### PR TITLE
fix(cockpit): ag-ui examples 404 on /agent in production (base-href-aware URL)

### DIFF
--- a/cockpit/ag-ui/a2ui/angular/src/app/app.config.ts
+++ b/cockpit/ag-ui/a2ui/angular/src/app/app.config.ts
@@ -4,5 +4,5 @@ import { provideAgent } from '@threadplane/ag-ui';
 import { provideChat } from '@threadplane/chat';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideAgent({ url: '/agent' }), provideChat({})],
+  providers: [provideAgent({ url: new URL('agent', document.baseURI).pathname }), provideChat({})],
 };

--- a/cockpit/ag-ui/client-tools/angular/src/app/app.config.ts
+++ b/cockpit/ag-ui/client-tools/angular/src/app/app.config.ts
@@ -5,7 +5,7 @@ import { provideChat } from '@threadplane/chat';
 
 export const appConfig: ApplicationConfig = {
   providers: [
-    provideAgent({ url: '/agent' }),
+    provideAgent({ url: new URL('agent', document.baseURI).pathname }),
     provideChat({}),
   ],
 };

--- a/cockpit/ag-ui/interrupts/angular/src/app/app.config.ts
+++ b/cockpit/ag-ui/interrupts/angular/src/app/app.config.ts
@@ -5,7 +5,7 @@ import { provideChat } from '@threadplane/chat';
 
 export const appConfig: ApplicationConfig = {
   providers: [
-    provideAgent({ url: '/agent' }),
+    provideAgent({ url: new URL('agent', document.baseURI).pathname }),
     provideChat({}),
   ],
 };

--- a/cockpit/ag-ui/json-render/angular/src/app/app.config.ts
+++ b/cockpit/ag-ui/json-render/angular/src/app/app.config.ts
@@ -4,5 +4,5 @@ import { provideAgent } from '@threadplane/ag-ui';
 import { provideChat } from '@threadplane/chat';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideAgent({ url: '/agent' }), provideChat({})],
+  providers: [provideAgent({ url: new URL('agent', document.baseURI).pathname }), provideChat({})],
 };

--- a/cockpit/ag-ui/streaming/angular/src/app/app.config.ts
+++ b/cockpit/ag-ui/streaming/angular/src/app/app.config.ts
@@ -5,7 +5,7 @@ import { provideChat } from '@threadplane/chat';
 
 export const appConfig: ApplicationConfig = {
   providers: [
-    provideAgent({ url: '/agent' }),
+    provideAgent({ url: new URL('agent', document.baseURI).pathname }),
     provideChat({}),
   ],
 };

--- a/cockpit/ag-ui/tool-views/angular/src/app/app.config.ts
+++ b/cockpit/ag-ui/tool-views/angular/src/app/app.config.ts
@@ -5,7 +5,7 @@ import { provideChat } from '@threadplane/chat';
 
 export const appConfig: ApplicationConfig = {
   providers: [
-    provideAgent({ url: '/agent' }),
+    provideAgent({ url: new URL('agent', document.baseURI).pathname }),
     provideChat({}),
   ],
 };


### PR DESCRIPTION
**Found by production smoke** of examples.threadplane.ai: every ag-ui example's frontend loads, but sending any message dies with a Vercel `HTTP 404 NOT_FOUND` — all six apps hardcode `provideAgent({ url: '/agent' })`, an absolute path that only exists behind the local dev-server proxy. In production the apps serve under `/ag-ui/<topic>/` (base href rewritten by `assemble-examples`) and the proxy route only matches `/ag-ui/<topic>/agent`.

**Fix:** `provideAgent({ url: new URL('agent', document.baseURI).pathname })` in all six apps — resolves to `/agent` in dev (base `/`) and `/ag-ui/<topic>/agent` in production.

**Verified:** `cockpit-ag-ui-client-tools-angular` build green + e2e 3/3 (dev behavior identical). Production verification requires the examples Vercel project to rebuild after merge — I'll re-run the prod smoke then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)