### PR TITLE
fix: close AG-UI audit gaps F1–F4 + F6 (composer clear, light scheme, graceful stop, json-render values, markdown tracking)

### DIFF
--- a/apps/website/content/docs/chat/api/api-docs.json
+++ b/apps/website/content/docs/chat/api/api-docs.json
@@ -2154,6 +2154,12 @@
         "optional": false
       },
       {
+        "name": "normalizedSpec",
+        "type": "Signal<Spec | null>",
+        "description": "The bound spec with schema-documented `{ statePath }` prop refs\nrewritten to engine-native `{ $bindState }` + `_bindings` so values\nresolve against the state store instead of interpolating as\n\"[object Object]\" (F4).",
+        "optional": false
+      },
+      {
         "name": "registry",
         "type": "InputSignal<AngularRegistry | undefined>",
         "description": "",
@@ -2392,6 +2398,19 @@
         "signature": "focusTextarea(): void",
         "description": "",
         "params": []
+      },
+      {
+        "name": "onInput",
+        "signature": "onInput(event: Event): void",
+        "description": "Sync the textarea's value into the signal on user input. A direct\n [value]/(input) pair is used instead of ngModel: NgModel does not\n reliably write a programmatic clear back to the view under zoneless\n + OnPush, leaving sent text visible in the composer (audit F1).",
+        "params": [
+          {
+            "name": "event",
+            "type": "Event",
+            "description": "",
+            "optional": false
+          }
+        ]
       },
       {
         "name": "onKeydown",
@@ -2780,6 +2799,12 @@
         "name": "agent",
         "type": "InputSignal<Agent>",
         "description": "",
+        "optional": false
+      },
+      {
+        "name": "clientTools",
+        "type": "InputSignal<Readonly<Record<string, ClientToolDef>> | undefined>",
+        "description": "Frontend-declared client tools forwarded to the inner `<chat>`.",
         "optional": false
       },
       {
@@ -3275,6 +3300,12 @@
         "name": "agent",
         "type": "InputSignal<Agent>",
         "description": "",
+        "optional": false
+      },
+      {
+        "name": "clientTools",
+        "type": "InputSignal<Readonly<Record<string, ClientToolDef>> | undefined>",
+        "description": "Frontend-declared client tools forwarded to the inner `<chat>`.",
         "optional": false
       },
       {
@@ -4702,7 +4733,7 @@
   {
     "name": "MarkdownChildrenComponent",
     "kind": "class",
-    "description": "Recursively dispatches a parent node's children through the markdown view\nregistry. Each child's `type` is looked up in the registry; the resolved\ncomponent is rendered with `[node]` bound to that child.\n\nIdentity-preserving: `track $any(child)` keys on the JS reference of the\nchild node. Because @cacheplane/partial-markdown preserves node identity\nacross pushes, unchanged subtrees never re-render.",
+    "description": "Recursively dispatches a parent node's children through the markdown view\nregistry. Each child's `type` is looked up in the registry; the resolved\ncomponent is rendered with `[node]` bound to that child.\n\nPosition-stable: `track $index` avoids NG0956 re-creation warnings that\noccur when the markdown pipeline re-parses content on every stream delta,\nproducing new child object references even for unchanged nodes.",
     "params": [],
     "examples": [],
     "properties": [

--- a/cockpit/ag-ui/json-render/angular/src/app/json-render.component.ts
+++ b/cockpit/ag-ui/json-render/angular/src/app/json-render.component.ts
@@ -2,6 +2,7 @@
 import { Component } from '@angular/core';
 import { ChatComponent, ChatWelcomeSuggestionComponent, views } from '@threadplane/chat';
 import { injectAgent } from '@threadplane/ag-ui';
+import { signalStateStore } from '@threadplane/render';
 import { ExampleChatLayoutComponent } from '@threadplane/example-layouts';
 import { StatCardComponent } from './views/stat-card.component';
 import { ContainerComponent } from './views/container.component';
@@ -30,7 +31,7 @@ const WELCOME_SUGGESTIONS = [
   imports: [ChatComponent, ChatWelcomeSuggestionComponent, ExampleChatLayoutComponent],
   template: `
     <example-chat-layout>
-      <chat main [agent]="agent" [views]="dashboardViews" class="flex-1 min-w-0">
+      <chat main [agent]="agent" [views]="dashboardViews" [store]="dashStore" class="flex-1 min-w-0">
         <div chatWelcomeSuggestions>
           @for (s of suggestions; track s.value) {
             <chat-welcome-suggestion [label]="s.label" [value]="s.value" (selected)="send($event)" />
@@ -44,5 +45,10 @@ export class JsonRenderComponent {
   protected readonly agent = injectAgent();
   protected readonly dashboardViews = dashboardViews;
   protected readonly suggestions = WELCOME_SUGGESTIONS;
+  /**
+   * Explicit shared store: backend state (STATE_SNAPSHOT) syncs into it via
+   * the chat composition, so every dashboard surface reads live values.
+   */
+  protected readonly dashStore = signalStateStore({});
   protected send(text: string): void { void this.agent.submit({ message: text }); }
 }

--- a/cockpit/ag-ui/json-render/python/docs/guide.md
+++ b/cockpit/ag-ui/json-render/python/docs/guide.md
@@ -10,18 +10,19 @@ as the backend updates the data.
 </Summary>
 
 <Prompt>
-Render a backend-authored dashboard with `@threadplane/chat` over the AG-UI adapter. Register your view components in the `views` map and pass it to `<chat>`. Have the agent emit a json-render spec (with `$state` bindings) as the assistant message content, and put the data the spec binds to in the LangGraph graph state so `ag-ui-langgraph` emits it as a `STATE_SNAPSHOT`. The chat composition resolves the bindings automatically.
+Render a backend-authored dashboard with `@threadplane/chat` over the AG-UI adapter. Register your view components in the `views` map and pass it to `<chat>`, along with an explicit `[store]` — the composition syncs incoming agent state into that store, and the spec's `$state` bindings resolve against it. Have the agent emit a json-render spec (with `$state` bindings) as the assistant message content, and put the data the spec binds to in the LangGraph graph state so `ag-ui-langgraph` emits it as a `STATE_SNAPSHOT`.
 </Prompt>
 
 <Steps>
 <Step title="Register the view components">
 
-Build a `views` registry keyed by the component types your spec will reference, and pass it to `<chat>`:
+Build a `views` registry keyed by the component types your spec will reference, and pass it to `<chat>` together with an explicit store. Without a `[store]`, each render surface seeds its own isolated store from the spec — the explicit store is what lets backend state (`STATE_SNAPSHOT`) reach the dashboard bindings:
 
 ```typescript
 // json-render.component.ts
 import { ChatComponent, views } from '@threadplane/chat';
 import { injectAgent } from '@threadplane/ag-ui';
+import { signalStateStore } from '@threadplane/render';
 import { StatCardComponent } from './views/stat-card.component';
 import { DashboardGridComponent } from './views/dashboard-grid.component';
 // …line-chart, bar-chart, data-grid, container
@@ -31,10 +32,13 @@ const dashboardViews = views({
   dashboard_grid: DashboardGridComponent,
   // …
 });
+
+// In the component class:
+readonly dashStore = signalStateStore({});
 ```
 
 ```html
-<chat main [agent]="agent" [views]="dashboardViews" />
+<chat main [agent]="agent" [views]="dashboardViews" [store]="dashStore" />
 ```
 
 </Step>
@@ -76,8 +80,8 @@ data prop uses a `$state` binding rather than a literal:
 This is the AG-UI-native part. Instead of pushing data through a side channel,
 put it in the **graph state** — `ag-ui-langgraph` emits the state object as a
 `STATE_SNAPSHOT`, the adapter writes it to the agent's `state` signal, and the
-chat composition syncs it into the render store where the `$state` bindings
-resolve:
+chat composition syncs it into the explicit `[store]` you passed, where the
+`$state` bindings resolve:
 
 ```python
 # graph.py — emit_state returns the accumulated tool data into state

--- a/cockpit/ag-ui/json-render/python/src/graph.py
+++ b/cockpit/ag-ui/json-render/python/src/graph.py
@@ -17,8 +17,9 @@ until the LLM returns no tool_calls (cap _MAX_TOOL_ITERATIONS per turn).
 
 emit_state walks the message history for this turn and returns the tool
 results as top-level state fields — ag-ui-langgraph emits them as
-STATE_SNAPSHOT; the Angular chat-lib effect syncs them into the render
-store, where the spec's $state bindings resolve them.
+STATE_SNAPSHOT; the Angular chat-lib effect syncs them into the explicit
+[store] the app passes to <chat>, where the spec's $state bindings
+resolve them.
 """
 
 import json

--- a/cockpit/chat/generative-ui/angular/src/app/generative-ui.component.ts
+++ b/cockpit/chat/generative-ui/angular/src/app/generative-ui.component.ts
@@ -2,6 +2,7 @@
 import { Component } from '@angular/core';
 import { ChatComponent, ChatWelcomeSuggestionComponent, views } from '@threadplane/chat';
 import { injectAgent } from '@threadplane/langgraph';
+import { signalStateStore } from '@threadplane/render';
 import { ExampleChatLayoutComponent } from '@threadplane/example-layouts';
 
 import { StatCardComponent } from './views/stat-card.component';
@@ -31,7 +32,7 @@ const WELCOME_SUGGESTIONS = [
   imports: [ChatComponent, ChatWelcomeSuggestionComponent, ExampleChatLayoutComponent],
   template: `
     <example-chat-layout>
-      <chat main [agent]="agent" [views]="dashboardViews" class="flex-1 min-w-0">
+      <chat main [agent]="agent" [views]="dashboardViews" [store]="dashStore" class="flex-1 min-w-0">
         <div chatWelcomeSuggestions>
           @for (s of suggestions; track s.value) {
             <chat-welcome-suggestion
@@ -49,6 +50,12 @@ export class GenerativeUiComponent {
   protected readonly agent = injectAgent();
   protected readonly dashboardViews = dashboardViews;
   protected readonly suggestions = WELCOME_SUGGESTIONS;
+
+  /**
+   * Explicit shared store: backend graph state syncs into it via the chat
+   * composition, so every dashboard surface reads live values.
+   */
+  protected readonly dashStore = signalStateStore({});
 
   protected send(text: string): void {
     void this.agent.submit({ message: text });

--- a/docs/superpowers/plans/2026-06-11-ag-ui-gap-closure-p3.md
+++ b/docs/superpowers/plans/2026-06-11-ag-ui-gap-closure-p3.md
@@ -1,0 +1,605 @@
+# AG-UI Gap Closure Phase 3 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close audit gaps F1, F2, F3, F4, F6 from `docs/superpowers/specs/2026-06-11-ag-ui-capability-findings.md` (F5 — subagent card — is deferred to Phase 4 design).
+
+**Architecture:** Three small library fixes (`@threadplane/chat` chat-input binding, `@threadplane/ag-ui` abort handling, chat markdown track expressions), one example-level fix (`data-color-scheme` parity with the canonical shell), and one bounded investigate-then-fix (json-render object values, shared with the canonical demo). Each fix lands TDD-first where a test can express it.
+
+**Tech Stack:** Angular 21 signals (zoneless, OnPush), vitest + TestBed for lib units, Playwright + aimock for e2e, nx for gates.
+
+**Branch:** `ag-ui-gap-closure-p3` off `origin/main` (the worktree's current branch holds the merged findings PR #660 — do not stack on it).
+
+**Context for the engineer:**
+- The audit evidence and root-cause notes live in `docs/superpowers/specs/2026-06-11-ag-ui-capability-findings.md`. Read it first.
+- F1 was probed live: after Enter-submit, `chat-input`'s `messageText()` signal is `""` but the DOM textarea still shows the text. The `[ngModel]`/`(ngModelChange)` pair fails to write the programmatic clear back to the view (zoneless + OnPush). Reproduces on production `demo.threadplane.ai` mid-thread.
+- F2 root cause: `examples/ag-ui/angular/src/styles.css` keys the page scheme off `html[data-color-scheme]`, but `AgUiShell` only sets `data-theme` + `data-threadplane-chat-theme`. The canonical shell sets `data-color-scheme` in both its runtime effect (`examples/chat/angular/src/app/shell/demo-shell.component.ts:133`) and an index.html pre-bootstrap script. The ag-ui example has neither.
+- F3 root cause: `stop()` calls `source.abortRun()`; the AG-UI HttpAgent then invokes `onRunFailed({error: "BodyStreamBuffer was aborted"})`, and the adapter's handler unconditionally sets `status: 'error'`.
+- F6: identity-tracked `@for` in `libs/chat/src/lib/markdown/markdown-children.component.ts:31` (`track $any(child)`) and `libs/chat/src/lib/markdown/views/markdown-table.component.ts:20` (`track $any(row)`). Markdown re-parses every stream delta, producing new child objects each time → NG0956 + full DOM re-creation per chunk.
+
+---
+
+### Task 0: Branch setup
+
+- [ ] **Step 1: Create the phase branch off latest main**
+
+```bash
+cd /Users/blove/repos/angular-agent-framework/.claude/worktrees/ag-ui-demo-toolbar
+git fetch origin main
+git checkout -b ag-ui-gap-closure-p3 origin/main
+```
+
+Expected: `Switched to a new branch 'ag-ui-gap-closure-p3'`.
+
+---
+
+### Task 1: F2 — `data-color-scheme` parity (example-level)
+
+**Files:**
+- Modify: `examples/ag-ui/angular/src/app/shell/ag-ui-shell.component.ts` (theme/scheme effect, ~line 140)
+- Modify: `examples/ag-ui/angular/src/index.html` (add pre-bootstrap script)
+- Modify: `examples/ag-ui/angular/e2e/toolbar.spec.ts` (regression assertion)
+
+- [ ] **Step 1: Write the failing e2e assertion**
+
+Append to `examples/ag-ui/angular/e2e/toolbar.spec.ts`:
+
+```ts
+test('light scheme flips the page background (data-color-scheme parity)', async ({ page }) => {
+  await openDemo(page, '/embed?scheme=light&theme=default-light');
+  await expect(page.locator('html')).toHaveAttribute('data-color-scheme', 'light');
+  // The page background var must resolve to the light value, not the dark default.
+  const bg = await page.evaluate(() =>
+    getComputedStyle(document.documentElement).getPropertyValue('--demo-page-bg').trim(),
+  );
+  expect(bg).toBe('#ffffff');
+});
+```
+
+- [ ] **Step 2: Run it to make sure it fails**
+
+Run (aimock harness — see `examples/ag-ui/angular/e2e/README.md`; kill any orphaned uvicorn on :8000 / serve first, `NX_DAEMON=false`):
+
+```bash
+NX_DAEMON=false npx nx e2e examples-ag-ui-angular-e2e --grep "data-color-scheme parity"
+```
+
+Expected: FAIL — `data-color-scheme` attribute missing.
+
+- [ ] **Step 3: Set the attribute in the shell effect**
+
+In `examples/ag-ui/angular/src/app/shell/ag-ui-shell.component.ts`, the constructor effect currently reads:
+
+```ts
+    // Reflect theme + scheme onto <html> exactly like the canonical shell.
+    effect(() => {
+      const html = this.document.documentElement;
+      html.setAttribute('data-theme', this.theme());
+      const scheme = this.colorScheme();
+      html.setAttribute('data-threadplane-chat-theme', scheme);
+```
+
+Add the page-scheme attribute alongside the chat one:
+
+```ts
+    // Reflect theme + scheme onto <html> exactly like the canonical shell.
+    effect(() => {
+      const html = this.document.documentElement;
+      html.setAttribute('data-theme', this.theme());
+      const scheme = this.colorScheme();
+      html.setAttribute('data-threadplane-chat-theme', scheme);
+      html.setAttribute('data-color-scheme', scheme);
+```
+
+- [ ] **Step 4: Add the pre-bootstrap script to index.html**
+
+Replace the `<head>` of `examples/ag-ui/angular/src/index.html` with (mirrors the canonical script; note the ag-ui persistence key):
+
+```html
+  <head>
+    <meta charset="utf-8" />
+    <title>AG-UI Chat — Threadplane Example</title>
+    <base href="/" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script>
+      // Pre-bootstrap color-scheme apply: read persisted palette and set
+      // both `data-color-scheme` (drives the demo page bg/text) and
+      // `data-threadplane-chat-theme` (drives the chat lib's internal theming)
+      // BEFORE stylesheets load to avoid FOUC. The AgUiShell effect
+      // takes over at runtime once Angular bootstraps.
+      (function () {
+        try {
+          var raw = localStorage.getItem('threadplane-ag-ui-demo:palette');
+          var scheme = 'dark';
+          if (raw) {
+            var p = JSON.parse(raw);
+            if (p && (p.colorScheme === 'light' || p.colorScheme === 'dark')) {
+              scheme = p.colorScheme;
+            }
+          }
+          document.documentElement.setAttribute('data-color-scheme', scheme);
+          document.documentElement.setAttribute('data-threadplane-chat-theme', scheme);
+        } catch (e) { /* localStorage blocked — defaults apply */ }
+      })();
+    </script>
+    <link rel="icon" type="image/x-icon" href="favicon.ico" />
+  </head>
+```
+
+- [ ] **Step 5: Run the e2e spec to verify it passes**
+
+```bash
+NX_DAEMON=false npx nx e2e examples-ag-ui-angular-e2e --grep "data-color-scheme parity"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add examples/ag-ui/angular/src/app/shell/ag-ui-shell.component.ts examples/ag-ui/angular/src/index.html examples/ag-ui/angular/e2e/toolbar.spec.ts
+git commit -m "fix(examples/ag-ui): set data-color-scheme so light mode reaches the page chrome (F2)"
+```
+
+---
+
+### Task 2: F1 — chat-input clears the textarea after submit (`@threadplane/chat`)
+
+**Files:**
+- Modify: `libs/chat/src/lib/primitives/chat-input/chat-input.component.ts`
+- Test: `libs/chat/src/lib/primitives/chat-input/chat-input.component.spec.ts`
+- Modify: `examples/ag-ui/angular/e2e/send-receive.spec.ts` (integration regression)
+
+- [ ] **Step 1: Write the failing unit test**
+
+Append to the component-level describe blocks in `chat-input.component.spec.ts` (the file already imports `TestBed`, `ChatInputComponent`, and `mockAgent`; follow the file's existing component-test setup — use `fixture.componentRef.setInput('agent', agent)`):
+
+```ts
+describe('ChatInputComponent — clears view on submit (F1 regression)', () => {
+  it('empties both the signal and the textarea DOM value after Enter submit', async () => {
+    const agent = mockAgent();
+    TestBed.configureTestingModule({ imports: [ChatInputComponent] });
+    const fixture = TestBed.createComponent(ChatInputComponent);
+    fixture.componentRef.setInput('agent', agent);
+    fixture.detectChanges();
+
+    const textarea: HTMLTextAreaElement =
+      fixture.nativeElement.querySelector('textarea');
+    // Simulate real typing: set the DOM value and fire the input event.
+    textarea.value = 'hello world';
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    fixture.detectChanges();
+    expect(fixture.componentInstance.messageText()).toBe('hello world');
+
+    // Enter-key submit (the (keydown.enter) path).
+    textarea.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
+    );
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(agent.submitCalls).toHaveLength(1);
+    expect(fixture.componentInstance.messageText()).toBe('');
+    // The DOM must reflect the clear — this is the bug: ngModel never
+    // writes the programmatic '' back to the view.
+    expect(textarea.value).toBe('');
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails on the DOM assertion**
+
+```bash
+npx nx test chat -- --run --testNamePattern "F1 regression"
+```
+
+Expected: FAIL on `expect(textarea.value).toBe('')` (received `'hello world'`).
+
+- [ ] **Step 3: Replace the ngModel pair with direct value/input bindings**
+
+In `libs/chat/src/lib/primitives/chat-input/chat-input.component.ts`:
+
+a) Remove `import { FormsModule } from '@angular/forms';` and remove `FormsModule` from the component's `imports: [...]` array (it exists solely for this textarea).
+
+b) In the template, replace:
+
+```html
+        <textarea
+          #textareaEl
+          class="chat-input__textarea"
+          [ngModel]="messageText()"
+          (ngModelChange)="messageText.set($event)"
+          name="messageText"
+```
+
+with:
+
+```html
+        <textarea
+          #textareaEl
+          class="chat-input__textarea"
+          [value]="messageText()"
+          (input)="onInput($event)"
+```
+
+c) Add the handler next to `onSubmit()`:
+
+```ts
+  /** Sync the textarea's value into the signal on user input. A direct
+   *  [value]/(input) pair is used instead of ngModel: NgModel does not
+   *  reliably write a programmatic clear back to the view under zoneless
+   *  + OnPush, leaving sent text visible in the composer (audit F1). */
+  protected onInput(event: Event): void {
+    this.messageText.set((event.target as HTMLTextAreaElement).value);
+  }
+```
+
+d) Belt-and-braces in `onSubmit()` so the DOM clears even if the `[value]`
+binding short-circuits (signal already `''` from a race):
+
+```ts
+  onSubmit(): void {
+    const submitted = submitMessage(this.agent(), this.messageText());
+    if (submitted !== null) {
+      this.submitted.emit(submitted);
+      this.messageText.set('');
+      const el = this.textareaEl()?.nativeElement;
+      if (el) el.value = '';
+      requestAnimationFrame(() => this.textareaEl()?.nativeElement.focus());
+    }
+  }
+```
+
+- [ ] **Step 4: Run the chat test suite**
+
+```bash
+npx nx test chat -- --run
+```
+
+Expected: all PASS, including the new F1 test. If other specs referenced `FormsModule` behavior of chat-input (e.g. setting model values via ngModel), update them to dispatch `input` events instead.
+
+- [ ] **Step 5: Add the integration regression to e2e**
+
+In `examples/ag-ui/angular/e2e/send-receive.spec.ts`, add a spec that types like a user (not `fill`, which masked this bug):
+
+```ts
+test('composer clears after Enter-key send (F1 regression)', async ({ page }) => {
+  await openDemo(page);
+  const input = page.getByRole('textbox', { name: /message|prompt/i });
+  await input.pressSequentially('say hi briefly');
+  await page.keyboard.press('Enter');
+  await expect(input).toHaveValue('');
+});
+```
+
+(Adjust `openDemo` import to match the file's existing helpers.)
+
+- [ ] **Step 6: Run the e2e spec**
+
+```bash
+NX_DAEMON=false npx nx e2e examples-ag-ui-angular-e2e --grep "F1 regression"
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add libs/chat/src/lib/primitives/chat-input/chat-input.component.ts libs/chat/src/lib/primitives/chat-input/chat-input.component.spec.ts examples/ag-ui/angular/e2e/send-receive.spec.ts
+git commit -m "fix(chat): chat-input clears the textarea after submit (F1)
+
+ngModel does not write a programmatic clear back to the view under
+zoneless + OnPush, so sent text stayed in the composer. Bind
+[value]/(input) directly and drop FormsModule."
+```
+
+---
+
+### Task 3: F3 — graceful stop in `@threadplane/ag-ui`
+
+**Files:**
+- Modify: `libs/ag-ui/src/lib/to-agent.ts`
+- Test: `libs/ag-ui/src/lib/to-agent.spec.ts` (StubAgent harness with `failRun()` + `abortRun` spy already exists at the top of the file)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `to-agent.spec.ts` (match the file's existing construction of `toAgent` from `StubAgent` — see neighboring tests for the exact cast):
+
+```ts
+describe('stop() — graceful cancellation (F3)', () => {
+  it('treats an abort-induced onRunFailed as cancellation, not error', async () => {
+    const source = new StubAgent();
+    // Keep the run in flight so stop() races it like a real stream.
+    let resolveRun!: () => void;
+    source.runAgent.mockImplementation(
+      () => new Promise<{ result: undefined; newMessages: [] }>((res) => {
+        resolveRun = () => res({ result: undefined, newMessages: [] });
+      }),
+    );
+    const agent = toAgent(source as never);
+
+    const pending = agent.submit({ message: 'long story' });
+    await agent.stop!();
+    expect(source.abortRun).toHaveBeenCalledTimes(1);
+
+    // HttpAgent surfaces the abort as a run failure.
+    source.failRun(new Error('BodyStreamBuffer was aborted'));
+    resolveRun();
+    await pending;
+
+    expect(agent.status()).toBe('idle');
+    expect(agent.error()).toBeNull();
+    expect(agent.isLoading()).toBe(false);
+  });
+
+  it('still surfaces real failures as errors after a previous stop', async () => {
+    const source = new StubAgent();
+    const agent = toAgent(source as never);
+
+    // A stop on an earlier run must not swallow later genuine failures.
+    await agent.stop!();
+    await agent.submit({ message: 'hi' }); // resets the abort flag
+    source.failRun(new Error('boom'));
+
+    expect(agent.status()).toBe('error');
+    expect(agent.error()).toBeInstanceOf(Error);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify the first test fails**
+
+```bash
+npx nx test ag-ui -- --run --testNamePattern "graceful cancellation"
+```
+
+Expected: first test FAILS (`status()` is `'error'`); second may pass already.
+
+- [ ] **Step 3: Implement abort-aware failure handling**
+
+In `libs/ag-ui/src/lib/to-agent.ts`:
+
+a) Near `let activeRun ...` add:
+
+```ts
+  // Set by stop(); lets run-failure handlers distinguish a user-initiated
+  // abort (graceful cancel) from a genuine stream failure.
+  let abortRequested = false;
+
+  function isAbortError(error: unknown): boolean {
+    return error instanceof Error
+      && (error.name === 'AbortError' || /abort/i.test(error.message));
+  }
+
+  /** Returns true (and finalizes the store as idle) for stop()-induced failures. */
+  function settleIfAborted(error: unknown): boolean {
+    if (!abortRequested || !isAbortError(error)) return false;
+    abortRequested = false;
+    store.status.set('idle');
+    store.isLoading.set(false);
+    // Not a failure: leave store.error null and close out telemetry as a
+    // normal finish so the aborted run doesn't count as errored.
+    if (activeRun) finishRunTelemetry(activeRun);
+    return true;
+  }
+```
+
+(If `finishRunTelemetry(activeRun)` double-fires when the submit catch also settles, guard with the same `run.errored`-style idempotence the existing helpers use — read them and keep telemetry emitted at most once per run.)
+
+b) In the subscriber:
+
+```ts
+    onRunFailed({ error }) {
+      if (settleIfAborted(error)) return;
+      store.status.set('error');
+      store.isLoading.set(false);
+      store.error.set(error);
+      failRunTelemetry(error);
+    },
+```
+
+c) In **both** catch blocks inside `submit` (normal and resume paths):
+
+```ts
+        } catch (err) {
+          if (!settleIfAborted(err)) {
+            store.status.set('error');
+            store.isLoading.set(false);
+            store.error.set(err);
+            failRunTelemetry(err, run);
+          }
+        }
+```
+
+d) Reset the flag at the start of each run (top of `submit`, before either path):
+
+```ts
+      abortRequested = false;
+```
+
+e) Set it in `stop()`:
+
+```ts
+    stop: async () => {
+      abortRequested = true;
+      source.abortRun();
+    },
+```
+
+- [ ] **Step 4: Run the ag-ui suite**
+
+```bash
+npx nx test ag-ui -- --run
+```
+
+Expected: all PASS (132+ tests including the two new ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add libs/ag-ui/src/lib/to-agent.ts libs/ag-ui/src/lib/to-agent.spec.ts
+git commit -m "fix(ag-ui): treat stop()-induced aborts as graceful cancellation (F3)
+
+abortRun() makes the AG-UI client report onRunFailed('BodyStreamBuffer
+was aborted'), which rendered a red error banner for a user-initiated
+stop. Track abort intent and settle the store as idle instead."
+```
+
+---
+
+### Task 4: F6 — stable track expressions in streaming markdown
+
+**Files:**
+- Modify: `libs/chat/src/lib/markdown/markdown-children.component.ts:31`
+- Modify: `libs/chat/src/lib/markdown/views/markdown-table.component.ts:20`
+
+- [ ] **Step 1: Switch identity tracking to positional tracking**
+
+Markdown re-parses on every stream delta, so child objects are always new — identity tracking re-creates the whole subtree per chunk (NG0956 observed throughout the audit). Position is the stable key here.
+
+In `markdown-children.component.ts:31` change:
+
+```html
+    @for (child of children(); track $any(child)) {
+```
+
+to:
+
+```html
+    @for (child of children(); track $index) {
+```
+
+In `views/markdown-table.component.ts:20` change:
+
+```html
+        @for (row of bodyRows(); track $any(row)) {
+```
+
+to:
+
+```html
+        @for (row of bodyRows(); track $index) {
+```
+
+(If either file has a sibling inner `@for` with identity tracking on the same re-parsed objects — e.g. row cells — apply the same change; do not touch loops keyed on `.id`/`.key`/`.value`.)
+
+- [ ] **Step 2: Run the chat suite (markdown specs cover these views)**
+
+```bash
+npx nx test chat -- --run
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add libs/chat/src/lib/markdown/markdown-children.component.ts libs/chat/src/lib/markdown/views/markdown-table.component.ts
+git commit -m "perf(chat): track markdown children by index, not identity (F6)
+
+Re-parsed markdown produces new child objects every stream delta;
+identity tracking re-created the DOM subtree per chunk (NG0956)."
+```
+
+---
+
+### Task 5: F4 — json-render `[object Object]` values (bounded investigate-then-fix)
+
+**Files (investigation entry points):**
+- Read: `examples/ag-ui/python/src/schemas/json_render.py` (what value shapes the graph instructs the model to emit — note line ~37: "`state` is the initial state model. Keys are paths; values are initial values")
+- Read: `libs/render/src/lib/internals/prop-signal.ts` (prop resolution context — how component props bind to spec/state values)
+- Read: the json-render view host in `libs/chat` — locate with `grep -rn "json-render\|jsonRender" libs/chat/src/lib --include="*.ts" | grep -v spec`
+- Test: colocated `.spec.ts` next to whichever file owns the bug
+
+**Symptom (from the audit):** dashboard specs render `[object Object]` for metric values ("Total Revenue", "Revenue target:", search default) and a literal icon name `trending_up` as text. Reproduces identically on the production canonical demo, so the bug is in the shared render pipeline or the spec schema/prompt — NOT the AG-UI adapter.
+
+- [ ] **Step 1: Capture a minimal failing spec**
+
+Build a minimal spec fixture matching what the graph emits (read `json_render.py` to get the exact component vocabulary — e.g. a metric/text node whose value is an object like `{ "path": "/metrics/total" }` or `{ "value": 1200000, "format": "currency" }`). Write a unit test in the owning component/engine spec that renders the fixture and asserts the resolved text is the scalar (e.g. `"1200000"` or the state value at the path), not `"[object Object]"`.
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+```bash
+npx nx test render -- --run --testNamePattern "object value"   # or `chat`, wherever the test landed
+```
+
+Expected: FAIL showing `[object Object]`.
+
+- [ ] **Step 3: Decide the fix location by this rule**
+
+- If the schema (json_render.py / the JSON Schema it embeds) **documents** object-shaped values (`{path}` refs or `{value, format}`), the renderer must resolve them: implement resolution in the prop/value path (`prop-signal.ts` or the leaf view) — dereference `path` against the spec state store, apply `format` when present, and fall back to `String(value)` only for scalars.
+- If the schema says values are **scalars** and the model is hallucinating objects, fix the schema/prompt in `examples/ag-ui/python/src/schemas/json_render.py` AND its cockpit twin (`grep -rln "json_render" examples/chat/python cockpit 2>/dev/null` — cockpit examples are standalone copies; update each, never share). Add a renderer-side `String()` guard for graceful degradation either way.
+- The icon-name-as-text symptom (`trending_up`) follows the same rule: either the renderer must map icon nodes to an icon view, or the schema must not offer icons it can't render. If icon support turns out to be a missing *feature* (not a binding bug), note it in the findings doc as follow-up and do NOT build an icon system in this task.
+
+**Escalation rule:** if the fix requires redesigning the spec schema or adding a new component catalog, STOP after Step 2, write findings to the task report, and return status BLOCKED with what you learned — do not expand scope.
+
+- [ ] **Step 4: Implement minimal fix, re-run the failing test**
+
+```bash
+npx nx test render -- --run && npx nx test chat -- --run
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A libs/render libs/chat examples
+git commit -m "fix(render): resolve object-shaped json-render values to scalars (F4)"
+```
+
+(Adjust scope/message to where the fix actually landed.)
+
+---
+
+### Task 6: Gates, live smoke, PR
+
+- [ ] **Step 1: Library gates**
+
+```bash
+npx nx run-many -t lint,test,build -p chat,ag-ui,render
+```
+
+Expected: all green.
+
+- [ ] **Step 2: Example build (strict:false example builds catch different errors — build before claiming green)**
+
+```bash
+npx nx build examples-ag-ui-angular
+```
+
+Expected: green.
+
+- [ ] **Step 3: Full ag-ui e2e (aimock)**
+
+```bash
+NX_DAEMON=false npx nx e2e examples-ag-ui-angular-e2e
+```
+
+Expected: all specs green (13+ including the two new regressions). Kill any live-serve processes holding :8000/:4201 first — e2e and live serve must not share ports.
+
+- [ ] **Step 4: Live-LLM Chrome smoke (required gate before merge)**
+
+Start the real backend + app (real `OPENAI_API_KEY` from root `.env`), then verify in Chrome:
+1. Light scheme: itinerary panel + popup/sidebar mode hosts go light.
+2. Type a message + Enter: composer clears (embed AND popup).
+3. Send a long prompt, click stop mid-stream: stream halts, NO red error banner, send button returns to idle.
+4. `genui=json-render` + "Build me a revenue dashboard": metric values render as numbers/strings, not `[object Object]` (if F4's fix was schema-side, expect improvement on fresh runs only).
+5. Console: no NG0956 warnings during streaming.
+
+- [ ] **Step 5: PR + merge on green**
+
+```bash
+git push -u origin ag-ui-gap-closure-p3
+gh pr create --title "fix: close AG-UI audit gaps F1-F4, F6 (composer clear, light scheme, graceful stop, json-render values, markdown tracking)" --body "<summarize per-gap fixes + evidence; link docs/superpowers/specs/2026-06-11-ag-ui-capability-findings.md>"
+gh pr merge --auto --squash <PR#>
+```
+
+---
+
+## Self-review notes
+
+- Spec coverage: F1→Task 2, F2→Task 1, F3→Task 3, F4→Task 5, F6→Task 4; F5 explicitly deferred (Phase 4). Verification matrix re-run is Task 6 Step 4.
+- Type consistency: `settleIfAborted`/`isAbortError`/`abortRequested` are defined and used only in Task 3; `onInput` defined and referenced only in Task 2.
+- Known risk: Task 5 is investigate-then-fix with an explicit escalation rule instead of pretending the fix is known.

--- a/docs/superpowers/specs/2026-06-11-ag-ui-capability-findings.md
+++ b/docs/superpowers/specs/2026-06-11-ag-ui-capability-findings.md
@@ -47,11 +47,17 @@ The research delegation runs fine but renders as a generic tool row; the canonic
 ### F6 — NG0956 console warnings during streaming — chat lib perf (low)
 Angular warns repeatedly that a tracked `@for` collection (size 1) is re-created per stream chunk (track-by-identity). Cheap fix: stable `track` keys in the streaming message list templates.
 
-## Proposed gap-closure order (Phase 3+)
+## Gap-closure status (updated 2026-06-12, Phase 3)
 
-1. **P3a — F2** example CSS (small, no lib surface).
-2. **P3b — F1** chat-input clear-on-send (lib, TDD; affects every consumer).
-3. **P3c — F3** ag-ui adapter graceful stop (lib, TDD; parity).
-4. **P3d — F4** json-render value binding (shared; fixes canonical prod too).
-5. **P3e — F5** subagent card over AG-UI (adapter design + impl).
-6. **P3f — F6** track-by keys (cleanup).
+Phase 3 (branch `ag-ui-gap-closure-p3`, plan `2026-06-11-ag-ui-gap-closure-p3.md`) closed F1, F2, F3, F4, and the main F6 source — each TDD'd, two-stage reviewed, and re-verified in a live Chrome smoke against the real backend:
+
+- **F1 ✅** — chat-input binds `[value]`/`(input)` directly (FormsModule dropped, `@angular/forms` peer removed from `@threadplane/chat`); composer verified clearing live, including mid-stream sends. The `name="messageText"` attribute was preserved for cockpit selectors.
+- **F2 ✅** — AgUiShell sets `data-color-scheme` + index.html pre-bootstrap script; page chrome (itinerary panel, mode hosts) verified light live.
+- **F3 ✅** — adapter settles abort-shaped failures as graceful cancellation on BOTH delivery paths (`onRunFailed` AND the synthesized `RUN_ERROR` event — the second path was caught only by the live smoke, not the stub harness). No banner on stop, verified live.
+- **F4 ✅** — json-render `{statePath}` props are normalized to the `$bindState` dialect + `_bindings` in `chat-generative-ui`; surfaces are store-isolated per instance unless a consumer passes an explicit `[store]` (the two cockpit dashboard capabilities now opt in explicitly — backend STATE_SNAPSHOT state requires an explicit store by design, matching a2ui). Live dashboard renders real values; zero `[object Object]`.
+- **F6 ✅ (main source)** — markdown children/table rows now track by `$index`; zero NG0956 during text/reasoning streaming. **Residual:** a handful of NG0956 warnings still fire during json-render *spec assembly* streaming; the source is not any identity-tracked `@for` in libs/chat, libs/render, or the example (all audited) — follow-up to pinpoint (likely inside the spec re-materialization path).
+- **F5 ⏳** — subagent card over AG-UI deferred to Phase 4 (needs design: mapping graph subagent custom events into the chat subagent contract in `toAgent()`).
+
+Additional follow-ups logged during Phase 3:
+- Icon rendering: the a2ui catalog icon component renders icon *names* as text (`trending_up`) — proper icon support is a new catalog feature, not built.
+- json-render normalizer handles top-level `{statePath}` props only (matches the documented schema); nested occurrences from model drift would still stringify.

--- a/docs/superpowers/specs/2026-06-11-ag-ui-capability-findings.md
+++ b/docs/superpowers/specs/2026-06-11-ag-ui-capability-findings.md
@@ -19,7 +19,7 @@
 | 8 | Gen-UI: json-render | ✅ (renders) + 🔶 F4 | interactive dashboard rendered (tabs/sliders/checkboxes); metric values show `[object Object]` — **reproduces identically on canonical prod** → shared render/graph issue, not AG-UI |
 | 9 | Theme presets + dark/light | ✅ + 🔶 F2 | toggle + URL knobs sync; itinerary panel & mode hosts stay dark in light scheme (example CSS) |
 | 10 | Research subagent | ✅ (runs) + 🔶 F5 | run completed with structured summary; renders as plain tool row — no subagent card (known adapter gap: no subagent metadata over AG-UI) |
-| 11 | Stop mid-stream | 🔴 F3 | stream halts, but: red error banner "BodyStreamBuffer was aborted" + stray "Success" text appended to the truncated message |
+| 11 | Stop mid-stream | 🔴 F3 | stream halts, but a red error banner "BodyStreamBuffer was aborted" presents the user's own stop as a failure |
 | 12 | Regenerate | ✅ | replaced the aborted message; fresh complete response, no artifacts |
 | 13 | Error recovery | ✅ | e2e (pre-verified) |
 | 14 | Client tools — embed | ✅ | #655 e2e (3 specs) |
@@ -35,8 +35,8 @@ Every conversation-state send leaves the sent text in the textarea. Probed live:
 ### F2 — Light scheme not honored by example chrome (low, example-level)
 `examples/ag-ui` itinerary panel (#655) and the popup/sidebar mode host backgrounds use hardcoded dark colors; with `scheme=light` the toolbar+chat go light but the panel and mode hosts stay dark. Fix with theme-aware CSS keyed off `data-threadplane-chat-theme`.
 
-### F3 — Stop surfaces as error + stray text — `@threadplane/ag-ui` adapter (high)
-User-initiated stop renders a red "BodyStreamBuffer was aborted" error banner and appended a stray "Success" item to the truncated message. The adapter should treat AbortError as graceful cancellation (no error state) and finalize the partial message without appending terminal-event artifacts. Canonical LangGraph stop is graceful — parity gap.
+### F3 — Stop surfaces as an error — `@threadplane/ag-ui` adapter (high)
+User-initiated stop renders a red "BodyStreamBuffer was aborted" error banner: `source.abortRun()` makes the underlying AG-UI client invoke `onRunFailed`, and the adapter's handler unconditionally sets `status: 'error'` + `error`. Fix: `stop()` sets an abort-requested flag; `onRunFailed`/submit-catch treat abort errors (flag set, or `AbortError`/abort-message) as graceful cancellation — status `idle`, no error, distinct telemetry. Canonical LangGraph stop is graceful — parity gap. (An earlier note about stray "Success" text was a misread: it was the final streamed delta "Succe|ssive…" truncated mid-word by the abort — expected.)
 
 ### F4 — json-render binds objects as text — shared render/graph issue (medium, NOT AG-UI-specific)
 Generated dashboard specs render `[object Object]` for metric values and a literal `trending_up` icon name. Reproduces byte-for-byte on `demo.threadplane.ai` (langgraph transport), so the bug is in the json-render engine's value/binding resolution (`@threadplane/render`) and/or the graph's `json_render` spec schema — not the AG-UI adapter. Track as its own fix; both demos benefit.

--- a/examples/ag-ui/angular/e2e/send-receive.spec.ts
+++ b/examples/ag-ui/angular/e2e/send-receive.spec.ts
@@ -15,6 +15,14 @@ test('hi: assistant bubble renders non-empty text from the replayed fixture', as
   expect(finalText.trim()).toMatch(/hi/i);
 });
 
+test('composer clears after Enter-key send (F1 regression)', async ({ page }) => {
+  await openDemo(page);
+  const input = page.getByRole('textbox', { name: /message|prompt/i });
+  await input.pressSequentially('say hi briefly');
+  await page.keyboard.press('Enter');
+  await expect(input).toHaveValue('');
+});
+
 test('send and receive: input clears, user renders immediately, stream completes idle', async ({
   page,
 }) => {

--- a/examples/ag-ui/angular/e2e/toolbar.spec.ts
+++ b/examples/ag-ui/angular/e2e/toolbar.spec.ts
@@ -31,3 +31,13 @@ test('toolbar submit still streams (state merge does not break runs)', async ({ 
   const assistant = page.locator('chat-message').filter({ hasText: /./ }).last();
   await expect(assistant).toBeVisible({ timeout: 30_000 });
 });
+
+test('light scheme flips the page background (data-color-scheme parity)', async ({ page }) => {
+  await openDemo(page, '/embed?scheme=light&theme=default-light');
+  await expect(page.locator('html')).toHaveAttribute('data-color-scheme', 'light');
+  // The page background var must resolve to the light value, not the dark default.
+  const bg = await page.evaluate(() =>
+    getComputedStyle(document.documentElement).getPropertyValue('--demo-page-bg').trim(),
+  );
+  expect(bg).toBe('#ffffff');
+});

--- a/examples/ag-ui/angular/src/app/shell/ag-ui-shell.component.ts
+++ b/examples/ag-ui/angular/src/app/shell/ag-ui-shell.component.ts
@@ -142,6 +142,7 @@ export class AgUiShell {
       html.setAttribute('data-theme', this.theme());
       const scheme = this.colorScheme();
       html.setAttribute('data-threadplane-chat-theme', scheme);
+      html.setAttribute('data-color-scheme', scheme);
       const t = this.theme();
       if (t === 'default-dark' || t === 'default-light') {
         const next = scheme === 'light' ? 'default-light' : 'default-dark';

--- a/examples/ag-ui/angular/src/index.html
+++ b/examples/ag-ui/angular/src/index.html
@@ -5,6 +5,27 @@
     <title>AG-UI Chat — Threadplane Example</title>
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script>
+      // Pre-bootstrap color-scheme apply: read persisted palette and set
+      // both `data-color-scheme` (drives the demo page bg/text) and
+      // `data-threadplane-chat-theme` (drives the chat lib's internal theming)
+      // BEFORE stylesheets load to avoid FOUC. The AgUiShell effect
+      // takes over at runtime once Angular bootstraps.
+      (function () {
+        try {
+          var raw = localStorage.getItem('threadplane-ag-ui-demo:palette');
+          var scheme = 'dark';
+          if (raw) {
+            var p = JSON.parse(raw);
+            if (p && (p.colorScheme === 'light' || p.colorScheme === 'dark')) {
+              scheme = p.colorScheme;
+            }
+          }
+          document.documentElement.setAttribute('data-color-scheme', scheme);
+          document.documentElement.setAttribute('data-threadplane-chat-theme', scheme);
+        } catch (e) { /* localStorage blocked — defaults apply */ }
+      })();
+    </script>
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
   </head>
   <body>

--- a/libs/ag-ui/src/lib/to-agent.spec.ts
+++ b/libs/ag-ui/src/lib/to-agent.spec.ts
@@ -271,6 +271,46 @@ describe('toAgent', () => {
     });
   });
 
+  describe('stop() — graceful cancellation (F3)', () => {
+    it('treats an abort-induced onRunFailed as cancellation, not error', async () => {
+      const source = new StubAgent();
+      // Keep the run in flight so stop() races it like a real stream.
+      let resolveRun!: () => void;
+      source.runAgent.mockImplementation(
+        () => new Promise((res) => {
+          resolveRun = () => res({ result: undefined, newMessages: [] });
+        }),
+      );
+      const agent = toAgent(source as never);
+
+      const pending = agent.submit({ message: 'long story' });
+      await agent.stop!();
+      expect(source.abortRun).toHaveBeenCalledTimes(1);
+
+      // HttpAgent surfaces the abort as a run failure.
+      source.failRun(new Error('BodyStreamBuffer was aborted'));
+      resolveRun();
+      await pending;
+
+      expect(agent.status()).toBe('idle');
+      expect(agent.error()).toBeNull();
+      expect(agent.isLoading()).toBe(false);
+    });
+
+    it('still surfaces real failures as errors after a previous stop', async () => {
+      const source = new StubAgent();
+      const agent = toAgent(source as never);
+
+      // A stop on an earlier run must not swallow later genuine failures.
+      await agent.stop!();
+      await agent.submit({ message: 'hi' }); // submit resets the abort flag
+      source.failRun(new Error('boom'));
+
+      expect(agent.status()).toBe('error');
+      expect(agent.error()).toBeInstanceOf(Error);
+    });
+  });
+
   describe('regenerate()', () => {
     it('truncates messages inclusive of user (userIdx+1) and re-runs without re-appending', async () => {
       const stub = new StubAgent();

--- a/libs/ag-ui/src/lib/to-agent.spec.ts
+++ b/libs/ag-ui/src/lib/to-agent.spec.ts
@@ -297,6 +297,56 @@ describe('toAgent', () => {
       expect(agent.isLoading()).toBe(false);
     });
 
+    it('treats an abort-shaped RUN_ERROR event as cancellation, not error', async () => {
+      const source = new StubAgent();
+      let resolveRun!: () => void;
+      source.runAgent.mockImplementation(
+        () => new Promise((res) => {
+          resolveRun = () => res({ result: undefined, newMessages: [] });
+        }),
+      );
+      const agent = toAgent(source as never);
+
+      const pending = agent.submit({ message: 'long story' });
+      await agent.stop!();
+
+      // The real HttpAgent also surfaces the abort as a RUN_ERROR event
+      // through the event stream (not just onRunFailed).
+      source.emit({ type: 'RUN_ERROR', message: 'BodyStreamBuffer was aborted' } as never);
+      resolveRun();
+      await pending;
+
+      expect(agent.status()).toBe('idle');
+      expect(agent.error()).toBeNull();
+      expect(agent.isLoading()).toBe(false);
+    });
+
+    it('handles duplicate abort delivery (RUN_ERROR event THEN onRunFailed) gracefully', async () => {
+      const source = new StubAgent();
+      let resolveRun!: () => void;
+      source.runAgent.mockImplementation(
+        () => new Promise((res) => {
+          resolveRun = () => res({ result: undefined, newMessages: [] });
+        }),
+      );
+      const agent = toAgent(source as never);
+
+      const pending = agent.submit({ message: 'long story' });
+      await agent.stop!();
+
+      // First delivery: via the event stream
+      source.emit({ type: 'RUN_ERROR', message: 'BodyStreamBuffer was aborted' } as never);
+      // Second delivery: via onRunFailed (same abort)
+      source.failRun(new Error('BodyStreamBuffer was aborted'));
+      resolveRun();
+      await pending;
+
+      // Duplicate delivery must NOT flip status back to error
+      expect(agent.status()).toBe('idle');
+      expect(agent.error()).toBeNull();
+      expect(agent.isLoading()).toBe(false);
+    });
+
     it('still surfaces real failures as errors after a previous stop', async () => {
       const source = new StubAgent();
       const agent = toAgent(source as never);

--- a/libs/ag-ui/src/lib/to-agent.spec.ts
+++ b/libs/ag-ui/src/lib/to-agent.spec.ts
@@ -359,6 +359,66 @@ describe('toAgent', () => {
       expect(agent.status()).toBe('error');
       expect(agent.error()).toBeInstanceOf(Error);
     });
+
+    it('stop → regenerate → stop does NOT wedge the store in streaming', async () => {
+      const source = new StubAgent();
+
+      // Run A: make runAgent hang so we can stop it mid-flight.
+      let resolveRunA!: () => void;
+      source.runAgent.mockImplementationOnce(
+        () => new Promise((res) => {
+          resolveRunA = () => res({ result: undefined, newMessages: [] });
+        }),
+      );
+      const agent = toAgent(source as never);
+
+      // Submit run A and emit a complete assistant message before stop.
+      const pendingA = agent.submit({ message: 'first question' });
+      source.emit({ type: 'RUN_STARTED' } as BaseEvent);
+      source.emit({ type: 'TEXT_MESSAGE_START', messageId: 'ai-1', role: 'assistant' } as unknown as BaseEvent);
+      source.emit({ type: 'TEXT_MESSAGE_CONTENT', messageId: 'ai-1', delta: 'reply' } as unknown as BaseEvent);
+      source.emit({ type: 'TEXT_MESSAGE_END', messageId: 'ai-1' } as unknown as BaseEvent);
+      source.emit({ type: 'RUN_FINISHED' } as BaseEvent);
+
+      // Stop run A (abortSettled becomes true after this).
+      await agent.stop!();
+      source.failRun(new Error('BodyStreamBuffer was aborted'));
+      resolveRunA();
+      await pendingA;
+
+      // Run A settled: idle, no error.
+      expect(agent.status()).toBe('idle');
+      expect(agent.error()).toBeNull();
+
+      // There must be an assistant message at index 1 (user[0], assistant[1]).
+      expect(agent.messages()).toHaveLength(2);
+      expect(agent.messages()[1].role).toBe('assistant');
+
+      // Run B (regenerate): hang so we can stop it too.
+      let resolveRunB!: () => void;
+      source.runAgent.mockImplementationOnce(
+        () => new Promise((res) => {
+          resolveRunB = () => res({ result: undefined, newMessages: [] });
+        }),
+      );
+
+      const pendingB = agent.regenerate(1);
+
+      // Simulate the regeneration run starting (status → running, isLoading → true).
+      source.emit({ type: 'RUN_STARTED' } as BaseEvent);
+      expect(agent.isLoading()).toBe(true);
+
+      // Stop the regeneration mid-flight.
+      await agent.stop!();
+      source.failRun(new Error('BodyStreamBuffer was aborted'));
+      resolveRunB();
+      await pendingB;
+
+      // CRITICAL: must NOT be wedged in streaming/running/isLoading.
+      expect(agent.status()).toBe('idle');
+      expect(agent.error()).toBeNull();
+      expect(agent.isLoading()).toBe(false);
+    });
   });
 
   describe('regenerate()', () => {

--- a/libs/ag-ui/src/lib/to-agent.ts
+++ b/libs/ag-ui/src/lib/to-agent.ts
@@ -86,6 +86,34 @@ export function toAgent(source: AbstractAgent, options: ToAgentOptions = {}): Ag
   const telemetryProperties = { transport: 'ag-ui' as const, surface: 'to_agent' };
   let activeRun: { startedAt: number; errored: boolean } | null = null;
 
+  // Set by stop(); lets run-failure handlers distinguish a user-initiated
+  // abort (graceful cancel) from a genuine stream failure.
+  let abortRequested = false;
+
+  function isAbortError(error: unknown): boolean {
+    return error instanceof Error
+      && (error.name === 'AbortError' || /abort/i.test(error.message));
+  }
+
+  /** Settles the store as idle for stop()-induced failures; returns true if handled. */
+  function settleIfAborted(error: unknown): boolean {
+    if (!abortRequested || !isAbortError(error)) return false;
+    abortRequested = false;
+    store.status.set('idle');
+    store.isLoading.set(false);
+    // Not a failure: leave store.error null and close out telemetry as a
+    // normal finish so the aborted run doesn't count as errored.
+    const run = activeRun;
+    if (run) {
+      finishRunTelemetry(run);
+      // Mark errored so any subsequent finishRunTelemetry/failRunTelemetry
+      // call on the same run object (e.g. from submit's try block resolving
+      // after the abort) is a no-op — telemetry fires at most once per run.
+      run.errored = true;
+    }
+    return true;
+  }
+
   // Build the client-tools capability. catalogAsAgUiTools() is used below to
   // thread the catalog into every runAgent() call.
   const clientToolsCap = createClientToolsCapability(source, store);
@@ -145,6 +173,7 @@ export function toAgent(source: AbstractAgent, options: ToAgentOptions = {}): Ag
       reduceEvent(event, store);
     },
     onRunFailed({ error }) {
+      if (settleIfAborted(error)) return;
       store.status.set('error');
       store.isLoading.set(false);
       store.error.set(error);
@@ -165,6 +194,9 @@ export function toAgent(source: AbstractAgent, options: ToAgentOptions = {}): Ag
     clientTools:  clientToolsCap,
 
     submit: async (input: AgentSubmitInput, _opts?: AgentSubmitOptions) => {
+      // Reset abort flag so a new submit doesn't swallow genuine failures.
+      abortRequested = false;
+
       if (input.resume !== undefined) {
         // Resume path: clear the pending interrupt and replay the run with the
         // resume payload forwarded to the LangGraph backend via AG-UI's
@@ -180,10 +212,12 @@ export function toAgent(source: AbstractAgent, options: ToAgentOptions = {}): Ag
           });
           finishRunTelemetry(run);
         } catch (err) {
-          store.status.set('error');
-          store.isLoading.set(false);
-          store.error.set(err);
-          failRunTelemetry(err, run);
+          if (!settleIfAborted(err)) {
+            store.status.set('error');
+            store.isLoading.set(false);
+            store.error.set(err);
+            failRunTelemetry(err, run);
+          }
         }
         return;
       }
@@ -205,16 +239,17 @@ export function toAgent(source: AbstractAgent, options: ToAgentOptions = {}): Ag
         await source.runAgent(tools.length > 0 ? { tools } : undefined);
         finishRunTelemetry(run);
       } catch (err) {
-        // If the run was aborted via stop(), abortRun() resolves the promise
-        // rather than rejecting — but catch any unexpected errors here.
-        store.status.set('error');
-        store.isLoading.set(false);
-        store.error.set(err);
-        failRunTelemetry(err, run);
+        if (!settleIfAborted(err)) {
+          store.status.set('error');
+          store.isLoading.set(false);
+          store.error.set(err);
+          failRunTelemetry(err, run);
+        }
       }
     },
 
     stop: async () => {
+      abortRequested = true;
       source.abortRun();
     },
 

--- a/libs/ag-ui/src/lib/to-agent.ts
+++ b/libs/ag-ui/src/lib/to-agent.ts
@@ -90,6 +90,14 @@ export function toAgent(source: AbstractAgent, options: ToAgentOptions = {}): Ag
   // abort (graceful cancel) from a genuine stream failure.
   let abortRequested = false;
 
+  // Set to true the first time settleIfAborted() handles an abort error for the
+  // current run. The AG-UI client can surface the same abort via both the event
+  // stream (RUN_ERROR event) AND onRunFailed — abortSettled lets the second
+  // delivery see through as a no-op rather than re-writing store state or
+  // triggering a real error path. Both flags are reset together at the top of
+  // submit() so the next run starts clean.
+  let abortSettled = false;
+
   function isAbortError(error: unknown): boolean {
     return error instanceof Error
       && (error.name === 'AbortError' || /abort/i.test(error.message));
@@ -97,8 +105,13 @@ export function toAgent(source: AbstractAgent, options: ToAgentOptions = {}): Ag
 
   /** Settles the store as idle for stop()-induced failures; returns true if handled. */
   function settleIfAborted(error: unknown): boolean {
+    // If we already settled this abort (duplicate delivery — e.g. RUN_ERROR
+    // event THEN onRunFailed), just swallow without touching the store again.
+    if (abortSettled && isAbortError(error)) return true;
+
     if (!abortRequested || !isAbortError(error)) return false;
     abortRequested = false;
+    abortSettled = true;
     store.status.set('idle');
     store.isLoading.set(false);
     // Not a failure: leave store.error null and close out telemetry as a
@@ -170,6 +183,13 @@ export function toAgent(source: AbstractAgent, options: ToAgentOptions = {}): Ag
   // This subscription lives for the lifetime of `source`.
   source.subscribe({
     onEvent({ event }) {
+      // The AG-UI client surfaces a user-initiated abort both as a
+      // RUN_ERROR event (here) and via onRunFailed; guard the event path too
+      // so the reducer never marks a deliberate stop as an error.
+      if (event.type === 'RUN_ERROR') {
+        const message = (event as { message?: string }).message ?? '';
+        if (settleIfAborted(new Error(message))) return;
+      }
       reduceEvent(event, store);
     },
     onRunFailed({ error }) {
@@ -194,8 +214,10 @@ export function toAgent(source: AbstractAgent, options: ToAgentOptions = {}): Ag
     clientTools:  clientToolsCap,
 
     submit: async (input: AgentSubmitInput, _opts?: AgentSubmitOptions) => {
-      // Reset abort flag so a new submit doesn't swallow genuine failures.
+      // Reset both abort flags so a new submit starts clean and genuine
+      // failures after a previous stop are never swallowed.
       abortRequested = false;
+      abortSettled = false;
 
       if (input.resume !== undefined) {
         // Resume path: clear the pending interrupt and replay the run with the

--- a/libs/ag-ui/src/lib/to-agent.ts
+++ b/libs/ag-ui/src/lib/to-agent.ts
@@ -106,8 +106,15 @@ export function toAgent(source: AbstractAgent, options: ToAgentOptions = {}): Ag
   /** Settles the store as idle for stop()-induced failures; returns true if handled. */
   function settleIfAborted(error: unknown): boolean {
     // If we already settled this abort (duplicate delivery — e.g. RUN_ERROR
-    // event THEN onRunFailed), just swallow without touching the store again.
-    if (abortSettled && isAbortError(error)) return true;
+    // event THEN onRunFailed), defensively re-apply the idle settle so any
+    // state written between the two deliveries (e.g. RUN_STARTED from a new
+    // run that started before flags were reset) is corrected. Telemetry is
+    // not re-emitted — the guard returns true to suppress further processing.
+    if (abortSettled && isAbortError(error)) {
+      store.status.set('idle');
+      store.isLoading.set(false);
+      return true;
+    }
 
     if (!abortRequested || !isAbortError(error)) return false;
     abortRequested = false;
@@ -279,6 +286,12 @@ export function toAgent(source: AbstractAgent, options: ToAgentOptions = {}): Ag
       if (store.isLoading()) {
         throw new Error('Cannot regenerate while agent is loading another response');
       }
+      // Reset abort flags so a regenerate starts clean, exactly like submit().
+      // Without this, flags left over from a prior stop() would cause the
+      // duplicate-delivery guard in settleIfAborted() to silently swallow the
+      // abort error without settling, wedging the store in streaming/running.
+      abortRequested = false;
+      abortSettled = false;
       const msgs = store.messages();
       const target = msgs[assistantMessageIndex];
       if (!target || target.role !== 'assistant') {
@@ -314,10 +327,12 @@ export function toAgent(source: AbstractAgent, options: ToAgentOptions = {}): Ag
         await source.runAgent(regenTools.length > 0 ? { tools: regenTools } : undefined);
         finishRunTelemetry(run);
       } catch (err) {
-        store.status.set('error');
-        store.isLoading.set(false);
-        store.error.set(err);
-        failRunTelemetry(err, run);
+        if (!settleIfAborted(err)) {
+          store.status.set('error');
+          store.isLoading.set(false);
+          store.error.set(err);
+          failRunTelemetry(err, run);
+        }
       }
     },
   };

--- a/libs/chat/CHANGELOG.md
+++ b/libs/chat/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- **`@angular/forms` peer dependency removed:** `chat-input` now binds its textarea with a direct `[value]`/`(input)` pair (fixes the composer keeping sent text under zoneless + OnPush). `@threadplane/chat` no longer requires `@angular/forms` — consumers may drop it unless they use it themselves.
 - **Public API trim:** `@threadplane/chat` no longer re-exports `provideViews` / `VIEW_REGISTRY` from `@threadplane/render`. Consumers using `<render-spec>` / `<render-element>` directly should import from `@threadplane/render`. For chat's markdown view overrides, provide `MARKDOWN_VIEW_REGISTRY` directly using `overrideViews(cacheplaneMarkdownViews, { … })` from `@threadplane/render` — the previously-documented `provideViews(withViews(…))` pattern never actually drove rendering.
 - **License:** `@threadplane/chat` is dual-licensed under PolyForm Noncommercial 1.0.0 (free noncommercial use) or a Threadplane Commercial license (production use inside a for-profit context).
 

--- a/libs/chat/CHANGELOG.md
+++ b/libs/chat/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - **`@angular/forms` peer dependency removed:** `chat-input` now binds its textarea with a direct `[value]`/`(input)` pair (fixes the composer keeping sent text under zoneless + OnPush). `@threadplane/chat` no longer requires `@angular/forms` — consumers may drop it unless they use it themselves.
+- **json-render store isolation:** `<chat>`'s json-render message surfaces no longer fall back to the conversation-wide internal store — each surface self-seeds from its spec's `state` unless you pass an explicit `[store]`. Pass `[store]` (e.g. `signalStateStore({})`) when dashboards should receive backend agent state (STATE_SNAPSHOT) or share live values across surfaces; same-key dashboards in different messages are now isolated by default. Tool views (`chat-tool-views`) keep the previous shared-store behavior.
 - **Public API trim:** `@threadplane/chat` no longer re-exports `provideViews` / `VIEW_REGISTRY` from `@threadplane/render`. Consumers using `<render-spec>` / `<render-element>` directly should import from `@threadplane/render`. For chat's markdown view overrides, provide `MARKDOWN_VIEW_REGISTRY` directly using `overrideViews(cacheplaneMarkdownViews, { … })` from `@threadplane/render` — the previously-documented `provideViews(withViews(…))` pattern never actually drove rendering.
 - **License:** `@threadplane/chat` is dual-licensed under PolyForm Noncommercial 1.0.0 (free noncommercial use) or a Threadplane Commercial license (production use inside a for-profit context).
 

--- a/libs/chat/README.md
+++ b/libs/chat/README.md
@@ -36,7 +36,6 @@ npm install @threadplane/chat
 ```
 @angular/core              ^20.0.0 || ^21.0.0
 @angular/common            ^20.0.0 || ^21.0.0
-@angular/forms             ^20.0.0 || ^21.0.0
 @angular/platform-browser  ^20.0.0 || ^21.0.0
 @threadplane/licensing     *
 @threadplane/render        *

--- a/libs/chat/package.json
+++ b/libs/chat/package.json
@@ -16,7 +16,6 @@
     "zod": "^3.25.0",
     "@angular/core": "^20.0.0 || ^21.0.0",
     "@angular/common": "^20.0.0 || ^21.0.0",
-    "@angular/forms": "^20.0.0 || ^21.0.0",
     "@angular/platform-browser": "^20.0.0 || ^21.0.0",
     "@threadplane/licensing": "*",
     "@threadplane/render": "*",

--- a/libs/chat/src/lib/compositions/chat/chat.component.spec.ts
+++ b/libs/chat/src/lib/compositions/chat/chat.component.spec.ts
@@ -11,7 +11,10 @@ import { createContentClassifier, type ContentClassifier } from '../../streaming
 import { mockAgent } from '../../testing/mock-agent';
 import { createPartialArgsBridge } from '../../a2ui/partial-args-bridge';
 import { createA2uiSurfaceStore } from '../../a2ui/surface-store';
-import { signalStateStore } from '@threadplane/render';
+import { signalStateStore, toRenderRegistry, views } from '@threadplane/render';
+import { a2uiBasicCatalog } from '../../a2ui/catalog/index';
+import { ChatGenerativeUiComponent } from '../../primitives/chat-generative-ui/chat-generative-ui.component';
+import type { Spec, StateStore } from '@json-render/core';
 import type { AgentEvent } from '../../agent/agent-event';
 
 describe('ChatComponent', () => {
@@ -491,5 +494,111 @@ describe('ChatComponent — no bubble-level GenUI skeleton', () => {
     const src = fs.readFileSync(path.join(here, 'chat.component.ts'), 'utf8');
     expect(src.includes('chat-genui-skeleton')).toBe(false);
     expect(src.includes('ChatGenuiSkeletonComponent')).toBe(false);
+  });
+});
+
+describe('ChatComponent — json-render surface store binding (composition isolation pin)', () => {
+  // Pins the one-line template binding on <chat-generative-ui>:
+  //
+  //     [store]="store()"
+  //
+  // The composition must hand each json-render surface ONLY the explicit
+  // consumer store — never resolvedStore()'s conversation-wide internal
+  // fallback. Full ChatComponent template rendering is not feasible under
+  // vitest JIT (see the left-flash notes above), so we pin the binding by
+  // extracting the LIVE expression from the template source, evaluating it on
+  // a real ChatComponent instance (exactly the value the template passes to
+  // every surface), and mounting two real <chat-generative-ui> surfaces whose
+  // specs carry an OVERLAPPING state key with different values.
+  //
+  // Fails-on-revert reasoning: with the correct binding, no consumer store is
+  // set, so the evaluated expression is undefined and each surface self-seeds
+  // a per-instance store → isolation. If the binding is reverted to
+  // resolvedStore(), both surfaces receive the SAME internal store (views are
+  // bound, so the fallback is active): the first surface seeds /totalRevenue
+  // and the second surface — which never seeded that path itself — must not
+  // clobber it, so it renders the FIRST message's value and the assertions
+  // below go red.
+
+  const contentA = JSON.stringify({
+    root: 'kpi',
+    elements: { kpi: { type: 'Text', props: { text: { statePath: '/totalRevenue' } } } },
+    state: { totalRevenue: '$1.2M' },
+  });
+  const contentB = JSON.stringify({
+    root: 'kpi',
+    elements: { kpi: { type: 'Text', props: { text: { statePath: '/totalRevenue' } } } },
+    state: { totalRevenue: '$9.9M' },
+  });
+
+  /** Extract the `[store]` binding expression from the `<chat-generative-ui>`
+   * element in the composition template (e.g. `store` or `resolvedStore`). */
+  function extractSurfaceStoreBinding(src: string): string {
+    const start = src.indexOf('<chat-generative-ui');
+    expect(start).toBeGreaterThan(-1);
+    const element = src.slice(start, src.indexOf('/>', start));
+    const match = /\[store\]="([A-Za-z_$][\w$]*)\(\)"/.exec(element);
+    if (!match) throw new Error('no [store]="fn()" binding found on <chat-generative-ui>');
+    return match[1];
+  }
+
+  it('two spec messages with overlapping state keys render their OWN values (isolation)', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const url = await import('node:url');
+    const here = path.dirname(url.fileURLToPath(import.meta.url));
+    const src = fs.readFileSync(path.join(here, 'chat.component.ts'), 'utf8');
+    const bindingFn = extractSurfaceStoreBinding(src);
+
+    TestBed.configureTestingModule({ imports: [ChatGenerativeUiComponent] });
+    const injector = TestBed.inject(Injector);
+
+    // Classify both assistant message contents exactly as the template does.
+    const classifierA = createContentClassifier();
+    classifierA.update(contentA);
+    const classifierB = createContentClassifier();
+    classifierB.update(contentB);
+    expect(classifierA.type()).toBe('json-render');
+    expect(classifierB.type()).toBe('json-render');
+    const specA = classifierA.spec() as Spec;
+    const specB = classifierB.spec() as Spec;
+    expect(specA).toBeTruthy();
+    expect(specB).toBeTruthy();
+
+    // Real composition instance carrying the two assistant spec messages,
+    // with [views] bound so the internal-store fallback would be ACTIVE if
+    // the surface binding were ever pointed back at resolvedStore().
+    let surfaceStore: StateStore | undefined;
+    runInInjectionContext(injector, () => {
+      const comp = new ChatComponent();
+      setSignalInput(comp.agent, mockAgent({
+        messages: [new AIMessage(contentA), new AIMessage(contentB)],
+      }));
+      setSignalInput(comp.views, views({}));
+      // Sanity: the internal fallback IS available — the isolation asserted
+      // below must come from the binding choice, not from a missing store.
+      expect(comp.resolvedStore()).toBeTruthy();
+      // Evaluate the template's actual binding expression for the surfaces.
+      surfaceStore = (comp as unknown as Record<string, () => StateStore | undefined>)[bindingFn]();
+    });
+
+    function mountSurface(spec: Spec): string {
+      const fixture = TestBed.createComponent(ChatGenerativeUiComponent);
+      fixture.componentRef.setInput('registry', toRenderRegistry(a2uiBasicCatalog()));
+      fixture.componentRef.setInput('store', surfaceStore);
+      fixture.componentRef.setInput('spec', spec);
+      fixture.detectChanges();
+      TestBed.flushEffects();
+      fixture.detectChanges();
+      return (fixture.nativeElement as HTMLElement).textContent ?? '';
+    }
+
+    const textA = mountSurface(specA);
+    const textB = mountSurface(specB);
+
+    expect(textA).toContain('$1.2M');
+    expect(textA).not.toContain('$9.9M');
+    expect(textB).toContain('$9.9M');
+    expect(textB).not.toContain('$1.2M');
   });
 });

--- a/libs/chat/src/lib/compositions/chat/chat.component.ts
+++ b/libs/chat/src/lib/compositions/chat/chat.component.ts
@@ -223,10 +223,16 @@ export function isPinned(
                     <chat-streaming-md [content]="md" [streaming]="agent().isLoading() && i === agent().messages().length - 1" />
                   }
                   @if (classified.spec(); as spec) {
+                    <!-- Pass ONLY the explicit consumer store (may be
+                         undefined) — never the conversation-wide internal
+                         fallback. Without a consumer store, render-spec
+                         self-seeds a per-instance store from spec.state so
+                         same-key dashboards across messages stay isolated
+                         (a2ui parity). -->
                     <chat-generative-ui
                       [spec]="spec"
                       [registry]="renderRegistry()"
-                      [store]="resolvedStore()"
+                      [store]="store()"
                       [handlers]="handlers()"
                       [loading]="agent().isLoading()"
                       (events)="onSpecEvent($event, i)"

--- a/libs/chat/src/lib/markdown/markdown-children.component.ts
+++ b/libs/chat/src/lib/markdown/markdown-children.component.ts
@@ -18,9 +18,9 @@ import { MARKDOWN_VIEW_REGISTRY } from './markdown-view-registry';
  * registry. Each child's `type` is looked up in the registry; the resolved
  * component is rendered with `[node]` bound to that child.
  *
- * Identity-preserving: `track $any(child)` keys on the JS reference of the
- * child node. Because @cacheplane/partial-markdown preserves node identity
- * across pushes, unchanged subtrees never re-render.
+ * Position-stable: `track $index` avoids NG0956 re-creation warnings that
+ * occur when the markdown pipeline re-parses content on every stream delta,
+ * producing new child object references even for unchanged nodes.
  */
 @Component({
   selector: 'chat-md-children',
@@ -28,7 +28,7 @@ import { MARKDOWN_VIEW_REGISTRY } from './markdown-view-registry';
   imports: [NgComponentOutlet],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    @for (child of children(); track $any(child)) {
+    @for (child of children(); track $index) {
       @let comp = resolve(child);
       @if (comp) {
         <ng-container *ngComponentOutlet="comp; inputs: { node: child }" />

--- a/libs/chat/src/lib/markdown/views/markdown-table.component.ts
+++ b/libs/chat/src/lib/markdown/views/markdown-table.component.ts
@@ -17,7 +17,7 @@ import { MarkdownTableRowComponent } from './markdown-table-row.component';
         }
       </thead>
       <tbody>
-        @for (row of bodyRows(); track $any(row)) {
+        @for (row of bodyRows(); track $index) {
           <chat-md-table-row [node]="row" />
         }
       </tbody>

--- a/libs/chat/src/lib/primitives/chat-generative-ui/chat-generative-ui.component.spec.ts
+++ b/libs/chat/src/lib/primitives/chat-generative-ui/chat-generative-ui.component.spec.ts
@@ -88,9 +88,10 @@ describe('ChatGenerativeUiComponent — statePath resolution (F4)', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({ imports: [ChatGenerativeUiComponent] });
     fixture = TestBed.createComponent(ChatGenerativeUiComponent);
-    // The chat composition passes its own (initially EMPTY) shared store —
-    // replicate that so spec.state seeding is exercised, not render-spec's
-    // internal store creation.
+    // An EXPLICIT consumer-provided store (initially EMPTY) — replicate that
+    // so spec.state seeding is exercised, not render-spec's internal store
+    // creation. (The chat composition itself no longer passes its internal
+    // store; only a consumer-supplied store reaches this input.)
     store = signalStateStore({});
     fixture.componentRef.setInput('registry', toRenderRegistry(a2uiBasicCatalog()));
     fixture.componentRef.setInput('store', store);
@@ -143,6 +144,106 @@ describe('ChatGenerativeUiComponent — statePath resolution (F4)', () => {
     fixture.componentRef.setInput('spec', { ...statePathSpec } as Spec);
     render();
     expect(store.get('/minRevenue')).toBe(42000);
+  });
+
+  it('overwrites component-seeded partial chunk values when fuller state streams in', () => {
+    // First emission carries a partial streaming chunk of the value.
+    fixture.componentRef.setInput('spec', {
+      ...statePathSpec,
+      state: { totalRevenue: '$1.', minRevenue: 25000 },
+    } as unknown as Spec);
+    render();
+    expect(store.get('/totalRevenue')).toBe('$1.');
+
+    // Re-emit with the fuller value — the component wrote '$1.' itself, so
+    // it is safe to overwrite (only USER edits are preserved).
+    fixture.componentRef.setInput('spec', { ...statePathSpec } as Spec);
+    const text = render();
+    expect(store.get('/totalRevenue')).toBe('$1.2M');
+    expect(text).toContain('$1.2M');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Store isolation vs. sharing across component instances.
+//
+// Without a consumer store, each <chat-generative-ui> must be fully isolated:
+// render-spec self-seeds a per-instance internal store from spec.state, so two
+// dashboards with overlapping state keys (e.g. /totalRevenue on every message
+// of a conversation) never collide. This is the regression test for the bug
+// where the chat composition's conversation-wide internal store was passed to
+// every surface. An EXPLICIT consumer store, by contrast, intentionally has
+// shared/live semantics across all surfaces bound to it.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Spec like statePathSpec but with a different value model for /totalRevenue. */
+const otherStatePathSpec = {
+  ...statePathSpec,
+  state: { totalRevenue: '$9.9M', minRevenue: 75000 },
+} as unknown as Spec;
+
+describe('ChatGenerativeUiComponent — store isolation across instances', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({ imports: [ChatGenerativeUiComponent] });
+  });
+
+  function createInstance(spec: Spec, store?: StateStore): ComponentFixture<ChatGenerativeUiComponent> {
+    const fixture = TestBed.createComponent(ChatGenerativeUiComponent);
+    fixture.componentRef.setInput('registry', toRenderRegistry(a2uiBasicCatalog()));
+    if (store) fixture.componentRef.setInput('store', store);
+    fixture.componentRef.setInput('spec', spec);
+    return fixture;
+  }
+
+  function render(fixture: ComponentFixture<ChatGenerativeUiComponent>): string {
+    fixture.detectChanges();
+    TestBed.flushEffects();
+    fixture.detectChanges();
+    return (fixture.nativeElement as HTMLElement).textContent ?? '';
+  }
+
+  it('isolates instances WITHOUT a consumer store — overlapping paths never collide', () => {
+    const a = createInstance(statePathSpec);
+    const b = createInstance(otherStatePathSpec);
+    const textA = render(a);
+    const textB = render(b);
+
+    // Each instance renders ITS OWN spec.state values for the same paths.
+    expect(textA).toContain('$1.2M');
+    expect(textA).not.toContain('$9.9M');
+    expect(textB).toContain('$9.9M');
+    expect(textB).not.toContain('$1.2M');
+
+    // A user edit inside one surface must not leak into the other.
+    const sliderA = (a.nativeElement as HTMLElement).querySelector(
+      'input[type="range"]',
+    ) as HTMLInputElement;
+    sliderA.value = '30000';
+    sliderA.dispatchEvent(new Event('input'));
+    render(a);
+    expect(render(b)).toContain('Min revenue (USD): 75000');
+  });
+
+  it('shares one EXPLICIT consumer store across instances — first seeder wins, values are live', () => {
+    const shared = signalStateStore({});
+    const a = createInstance(statePathSpec, shared);
+    const textA = render(a);
+    expect(textA).toContain('$1.2M');
+
+    // Second instance binds the SAME store with different spec.state for the
+    // same paths. The paths are already populated (and not by THIS instance),
+    // so it must not clobber them: both surfaces show the shared values.
+    const b = createInstance(otherStatePathSpec, shared);
+    const textB = render(b);
+    expect(shared.get('/totalRevenue')).toBe('$1.2M');
+    expect(shared.get('/minRevenue')).toBe(25000);
+    expect(textB).toContain('$1.2M');
+    expect(textB).not.toContain('$9.9M');
+
+    // Live semantics: a write to the shared store is reflected in BOTH.
+    shared.set('/totalRevenue', '$3.0M');
+    expect(render(a)).toContain('$3.0M');
+    expect(render(b)).toContain('$3.0M');
   });
 });
 

--- a/libs/chat/src/lib/primitives/chat-generative-ui/chat-generative-ui.component.spec.ts
+++ b/libs/chat/src/lib/primitives/chat-generative-ui/chat-generative-ui.component.spec.ts
@@ -1,7 +1,12 @@
 // SPDX-License-Identifier: MIT
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { signal, computed } from '@angular/core';
-import type { Spec } from '@json-render/core';
+import { TestBed, type ComponentFixture } from '@angular/core/testing';
+import type { Spec, StateStore } from '@json-render/core';
+import { signalStateStore, toRenderRegistry } from '@threadplane/render';
+import { a2uiBasicCatalog } from '../../a2ui/catalog/index';
+import { ChatGenerativeUiComponent } from './chat-generative-ui.component';
+import { normalizeJsonRenderSpec } from './normalize-json-render-spec';
 
 const makeSpec = (root = 'root'): Spec =>
   ({ root, elements: { root: { type: 'div', props: {} } } } as any);
@@ -43,5 +48,140 @@ describe('ChatGenerativeUiComponent — spec input', () => {
   it('loading can be set to true', () => {
     const loading$ = signal<boolean>(true);
     expect(loading$()).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// F4: json-render specs use the schema-documented `{ statePath: "/x" }` shape
+// for state-bound props (the prompt in the example backends says:
+//   props: { value: { statePath: "/name" } }
+// and `state` carries the initial values). @json-render/core only resolves
+// `$state`/`$bindState` expressions, so the raw object fell through to the
+// view component and interpolated as the literal string "[object Object]".
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Spec fixture derived from the documented schema shapes (json_render.py):
+ * a Text KPI bound via statePath + a Slider whose value/label bind via
+ * statePath, with `state` carrying the initial value model. */
+const statePathSpec = {
+  root: 'col',
+  elements: {
+    col: { type: 'Column', props: { gap: 'medium' }, children: ['kpi', 'min'] },
+    kpi: { type: 'Text', props: { text: { statePath: '/totalRevenue' }, usageHint: 'h3' } },
+    min: {
+      type: 'Slider',
+      props: {
+        label: 'Min revenue (USD)',
+        value: { statePath: '/minRevenue' },
+        minValue: 0,
+        maxValue: 100000,
+      },
+    },
+  },
+  state: { totalRevenue: '$1.2M', minRevenue: 25000 },
+} as unknown as Spec;
+
+describe('ChatGenerativeUiComponent — statePath resolution (F4)', () => {
+  let fixture: ComponentFixture<ChatGenerativeUiComponent>;
+  let store: StateStore;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ imports: [ChatGenerativeUiComponent] });
+    fixture = TestBed.createComponent(ChatGenerativeUiComponent);
+    // The chat composition passes its own (initially EMPTY) shared store —
+    // replicate that so spec.state seeding is exercised, not render-spec's
+    // internal store creation.
+    store = signalStateStore({});
+    fixture.componentRef.setInput('registry', toRenderRegistry(a2uiBasicCatalog()));
+    fixture.componentRef.setInput('store', store);
+    fixture.componentRef.setInput('spec', statePathSpec);
+  });
+
+  function render(): string {
+    fixture.detectChanges();
+    TestBed.flushEffects();
+    fixture.detectChanges();
+    return (fixture.nativeElement as HTMLElement).textContent ?? '';
+  }
+
+  it('never renders "[object Object]" for statePath-bound props', () => {
+    const text = render();
+    expect(text).not.toContain('[object Object]');
+  });
+
+  it('resolves Text.text bound via statePath against spec.state', () => {
+    const text = render();
+    expect(text).toContain('$1.2M');
+  });
+
+  it('resolves Slider value bound via statePath (label shows the number)', () => {
+    const text = render();
+    expect(text).toContain('Min revenue (USD): 25000');
+  });
+
+  it('seeds spec.state into the provided store', () => {
+    render();
+    expect(store.get('/totalRevenue')).toBe('$1.2M');
+    expect(store.get('/minRevenue')).toBe(25000);
+  });
+
+  it('writes slider input back to the bound state path', () => {
+    render();
+    const slider = (fixture.nativeElement as HTMLElement).querySelector(
+      'input[type="range"]',
+    ) as HTMLInputElement;
+    expect(slider).toBeTruthy();
+    slider.value = '30000';
+    slider.dispatchEvent(new Event('input'));
+    expect(store.get('/minRevenue')).toBe(30000);
+  });
+
+  it('does not clobber user-modified state when the spec re-emits', () => {
+    render();
+    store.set('/minRevenue', 42000);
+    // Re-emit the same spec object graph (streaming re-materializes specs).
+    fixture.componentRef.setInput('spec', { ...statePathSpec } as Spec);
+    render();
+    expect(store.get('/minRevenue')).toBe(42000);
+  });
+});
+
+describe('normalizeJsonRenderSpec', () => {
+  it('rewrites { statePath } props to $bindState + _bindings', () => {
+    const out = normalizeJsonRenderSpec(statePathSpec);
+    const kpi = out.elements['kpi'] as { props: Record<string, unknown> };
+    expect(kpi.props['text']).toEqual({ $bindState: '/totalRevenue' });
+    const min = out.elements['min'] as { props: Record<string, unknown> };
+    expect(min.props['value']).toEqual({ $bindState: '/minRevenue' });
+    expect(min.props['_bindings']).toEqual({ value: '/minRevenue' });
+  });
+
+  it('leaves scalar props untouched', () => {
+    const out = normalizeJsonRenderSpec(statePathSpec);
+    const min = out.elements['min'] as { props: Record<string, unknown> };
+    expect(min.props['label']).toBe('Min revenue (USD)');
+    expect(min.props['minValue']).toBe(0);
+  });
+
+  it('returns the same reference when no statePath props exist', () => {
+    const plain = {
+      root: 'a',
+      elements: { a: { type: 'Text', props: { text: 'hello' } } },
+      state: {},
+    } as unknown as Spec;
+    expect(normalizeJsonRenderSpec(plain)).toBe(plain);
+  });
+
+  it('ignores objects that merely contain a statePath key among others', () => {
+    const spec = {
+      root: 'a',
+      elements: {
+        a: { type: 'Text', props: { text: { statePath: '/x', other: 1 } } },
+      },
+      state: {},
+    } as unknown as Spec;
+    const out = normalizeJsonRenderSpec(spec);
+    const a = out.elements['a'] as { props: Record<string, unknown> };
+    expect(a.props['text']).toEqual({ statePath: '/x', other: 1 });
   });
 });

--- a/libs/chat/src/lib/primitives/chat-generative-ui/chat-generative-ui.component.ts
+++ b/libs/chat/src/lib/primitives/chat-generative-ui/chat-generative-ui.component.ts
@@ -6,6 +6,7 @@ import {
   effect,
   input,
   output,
+  untracked,
   ChangeDetectionStrategy,
 } from '@angular/core';
 import type { Spec, StateStore } from '@json-render/core';
@@ -58,27 +59,36 @@ export class ChatGenerativeUiComponent {
   private readonly seeded = new Map<string, unknown>();
 
   constructor() {
-    // Seed `spec.state` (the schema's "initial state model") into the
-    // store. When the chat composition supplies its shared store, it is
-    // initially EMPTY — render-spec only seeds spec.state into its own
-    // internal store when no store input is given — so without this,
-    // statePath/$bindState props would resolve to undefined.
+    // Seed `spec.state` (the schema's "initial state model") into an
+    // EXPLICIT consumer-provided store, which is typically EMPTY at first —
+    // without this, statePath/$bindState props would resolve to undefined.
+    // A consumer-provided store intentionally has shared/live semantics
+    // across surfaces: every surface bound to it reads (and writes) the same
+    // state, so the first surface to seed a path wins. When NO store input
+    // is given, this effect is a no-op and render-spec self-seeds its own
+    // per-instance internal store from spec.state, keeping surfaces with
+    // overlapping state keys isolated from each other (a2ui parity).
     effect(() => {
       const s = this.spec();
       const store = this.store();
       const state = s?.state as Record<string, unknown> | undefined;
       if (!state || !store) return;
-      for (const [key, value] of Object.entries(state)) {
-        const path = key.startsWith('/') ? key : `/${key}`;
-        const current = store.get(path);
-        const untouched =
-          current === undefined ||
-          (this.seeded.has(path) && current === this.seeded.get(path));
-        if (untouched) {
-          if (current !== value) store.set(path, value);
-          this.seeded.set(path, value);
+      // Untracked: store reads/writes must not become dependencies — the
+      // effect re-runs on spec/store-identity changes only, not on every
+      // write to the (possibly shared) store.
+      untracked(() => {
+        for (const [key, value] of Object.entries(state)) {
+          const path = key.startsWith('/') ? key : `/${key}`;
+          const current = store.get(path);
+          const untouched =
+            current === undefined ||
+            (this.seeded.has(path) && current === this.seeded.get(path));
+          if (untouched) {
+            if (current !== value) store.set(path, value);
+            this.seeded.set(path, value);
+          }
         }
-      }
+      });
     });
   }
 }

--- a/libs/chat/src/lib/primitives/chat-generative-ui/chat-generative-ui.component.ts
+++ b/libs/chat/src/lib/primitives/chat-generative-ui/chat-generative-ui.component.ts
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 import {
   Component,
+  computed,
+  effect,
   input,
   output,
   ChangeDetectionStrategy,
@@ -11,6 +13,7 @@ import type { AngularRegistry, RenderEvent } from '@threadplane/render';
 import { RenderSpecComponent } from '@threadplane/render';
 import { CHAT_HOST_TOKENS } from '../../styles/chat-tokens';
 import { CHAT_GENERATIVE_UI_STYLES } from '../../styles/chat-generative-ui.styles';
+import { normalizeJsonRenderSpec } from './normalize-json-render-spec';
 
 @Component({
   selector: 'chat-generative-ui',
@@ -19,9 +22,9 @@ import { CHAT_GENERATIVE_UI_STYLES } from '../../styles/chat-generative-ui.style
   changeDetection: ChangeDetectionStrategy.OnPush,
   styles: [CHAT_HOST_TOKENS, CHAT_GENERATIVE_UI_STYLES],
   template: `
-    @if (spec()) {
+    @if (normalizedSpec()) {
       <render-spec
-        [spec]="spec()"
+        [spec]="normalizedSpec()"
         [registry]="registry()"
         [store]="store()"
         [handlers]="handlers()"
@@ -38,4 +41,44 @@ export class ChatGenerativeUiComponent {
   readonly handlers = input<Record<string, (params: Record<string, unknown>) => unknown | Promise<unknown>> | undefined>(undefined);
   readonly loading = input<boolean>(false);
   readonly events = output<RenderEvent>();
+
+  /** The bound spec with schema-documented `{ statePath }` prop refs
+   * rewritten to engine-native `{ $bindState }` + `_bindings` so values
+   * resolve against the state store instead of interpolating as
+   * "[object Object]" (F4). */
+  protected readonly normalizedSpec = computed(() => {
+    const s = this.spec();
+    return s ? normalizeJsonRenderSpec(s) : null;
+  });
+
+  /** Last value this component seeded per state path. Lets the seeding
+   * effect distinguish "still the value we wrote (possibly a partial
+   * chunk from streaming — safe to overwrite with the newer one)" from
+   * "user edited it via a bound control — leave it alone". */
+  private readonly seeded = new Map<string, unknown>();
+
+  constructor() {
+    // Seed `spec.state` (the schema's "initial state model") into the
+    // store. When the chat composition supplies its shared store, it is
+    // initially EMPTY — render-spec only seeds spec.state into its own
+    // internal store when no store input is given — so without this,
+    // statePath/$bindState props would resolve to undefined.
+    effect(() => {
+      const s = this.spec();
+      const store = this.store();
+      const state = s?.state as Record<string, unknown> | undefined;
+      if (!state || !store) return;
+      for (const [key, value] of Object.entries(state)) {
+        const path = key.startsWith('/') ? key : `/${key}`;
+        const current = store.get(path);
+        const untouched =
+          current === undefined ||
+          (this.seeded.has(path) && current === this.seeded.get(path));
+        if (untouched) {
+          if (current !== value) store.set(path, value);
+          this.seeded.set(path, value);
+        }
+      }
+    });
+  }
 }

--- a/libs/chat/src/lib/primitives/chat-generative-ui/normalize-json-render-spec.ts
+++ b/libs/chat/src/lib/primitives/chat-generative-ui/normalize-json-render-spec.ts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+import type { Spec, UIElement } from '@json-render/core';
+
+/**
+ * The json-render schema prompt shipped with the example backends documents
+ * state-bound props as `{ statePath: "/path" }` (the A2UI binding dialect —
+ * see `examples/<example>/python/src/schemas/json_render.py`). The
+ * @json-render/core
+ * prop resolver only understands `$state`/`$bindState` expressions, so a raw
+ * `{ statePath }` object would fall through to the view component unresolved
+ * and interpolate as the literal string "[object Object]".
+ *
+ * `normalizeJsonRenderSpec` rewrites each top-level `{ statePath: p }` prop
+ * to the engine-native `{ $bindState: p }` AND records it in the element's
+ * `_bindings` map (prop name → path) so the a2ui catalog components can
+ * write user input back to the state store — mirroring exactly what
+ * `surfaceToSpec` does for A2UI path refs.
+ */
+interface StatePathRef {
+  statePath: string;
+}
+
+function isStatePathRef(value: unknown): value is StatePathRef {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    typeof (value as Record<string, unknown>)['statePath'] === 'string' &&
+    Object.keys(value).length === 1
+  );
+}
+
+/** Rewrites schema-documented `{ statePath }` prop refs to `$bindState` +
+ * `_bindings`. Returns the input reference unchanged when no rewriting is
+ * needed (keeps downstream memoization intact). */
+export function normalizeJsonRenderSpec(spec: Spec): Spec {
+  const sourceElements = (spec.elements ?? {}) as Record<string, UIElement>;
+  let specChanged = false;
+  const elements: Record<string, UIElement> = {};
+
+  for (const [id, el] of Object.entries(sourceElements)) {
+    const rawProps = el?.props as Record<string, unknown> | undefined;
+    if (!rawProps) {
+      elements[id] = el;
+      continue;
+    }
+
+    let elementChanged = false;
+    const props: Record<string, unknown> = {};
+    const bindings: Record<string, string> = {};
+
+    for (const [key, value] of Object.entries(rawProps)) {
+      if (isStatePathRef(value)) {
+        props[key] = { $bindState: value.statePath };
+        bindings[key] = value.statePath;
+        elementChanged = true;
+      } else {
+        props[key] = value;
+      }
+    }
+
+    if (elementChanged) {
+      // Merge with any model-emitted `_bindings` (never observed, but cheap
+      // to preserve) — rewritten paths win.
+      const existing = (rawProps['_bindings'] ?? {}) as Record<string, string>;
+      props['_bindings'] = { ...existing, ...bindings };
+      elements[id] = { ...el, props } as UIElement;
+      specChanged = true;
+    } else {
+      elements[id] = el;
+    }
+  }
+
+  return specChanged ? ({ ...spec, elements } as Spec) : spec;
+}

--- a/libs/chat/src/lib/primitives/chat-input/chat-input.component.spec.ts
+++ b/libs/chat/src/lib/primitives/chat-input/chat-input.component.spec.ts
@@ -136,3 +136,35 @@ describe('ChatInputComponent', () => {
     expect(textarea.style.height).not.toBe('');
   });
 });
+
+describe('ChatInputComponent — clears view on submit (F1 regression)', () => {
+  it('empties both the signal and the textarea DOM value after Enter submit', async () => {
+    const agent = mockAgent();
+    TestBed.configureTestingModule({ imports: [ChatInputComponent] });
+    const fixture = TestBed.createComponent(ChatInputComponent);
+    fixture.componentRef.setInput('agent', agent);
+    fixture.detectChanges();
+
+    const textarea: HTMLTextAreaElement =
+      fixture.nativeElement.querySelector('textarea');
+    // Simulate real typing: set the DOM value and fire the input event.
+    textarea.value = 'hello world';
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    fixture.detectChanges();
+    expect(fixture.componentInstance.messageText()).toBe('hello world');
+
+    // Enter-key submit (the (keydown.enter) path).
+    textarea.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
+    );
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(agent.submitCalls).toHaveLength(1);
+    expect(fixture.componentInstance.messageText()).toBe('');
+    // The DOM must reflect the clear — this is the bug: ngModel never
+    // writes the programmatic '' back to the view.
+    expect(textarea.value).toBe('');
+  });
+});

--- a/libs/chat/src/lib/primitives/chat-input/chat-input.component.spec.ts
+++ b/libs/chat/src/lib/primitives/chat-input/chat-input.component.spec.ts
@@ -138,13 +138,18 @@ describe('ChatInputComponent', () => {
 });
 
 describe('ChatInputComponent — clears view on submit (F1 regression)', () => {
-  it('empties both the signal and the textarea DOM value after Enter submit', async () => {
-    const agent = mockAgent();
+  let fixture: ComponentFixture<ChatInputComponent>;
+  let agent: ReturnType<typeof mockAgent>;
+
+  beforeEach(() => {
+    agent = mockAgent();
     TestBed.configureTestingModule({ imports: [ChatInputComponent] });
-    const fixture = TestBed.createComponent(ChatInputComponent);
+    fixture = TestBed.createComponent(ChatInputComponent);
     fixture.componentRef.setInput('agent', agent);
     fixture.detectChanges();
+  });
 
+  it('empties both the signal and the textarea DOM value after Enter submit', async () => {
     const textarea: HTMLTextAreaElement =
       fixture.nativeElement.querySelector('textarea');
     // Simulate real typing: set the DOM value and fire the input event.
@@ -163,8 +168,10 @@ describe('ChatInputComponent — clears view on submit (F1 regression)', () => {
 
     expect(agent.submitCalls).toHaveLength(1);
     expect(fixture.componentInstance.messageText()).toBe('');
-    // The DOM must reflect the clear — this is the bug: ngModel never
-    // writes the programmatic '' back to the view.
+    // The DOM must reflect the clear. (Historical bug: ngModel never wrote
+    // the programmatic '' back to the view in real browsers. In jsdom both
+    // the [value] binding and the explicit el.value='' clear satisfy this;
+    // the Playwright e2e regression covers the real-browser path.)
     expect(textarea.value).toBe('');
   });
 });

--- a/libs/chat/src/lib/primitives/chat-input/chat-input.component.ts
+++ b/libs/chat/src/lib/primitives/chat-input/chat-input.component.ts
@@ -11,7 +11,6 @@ import {
   ElementRef,
   ChangeDetectionStrategy,
 } from '@angular/core';
-import { FormsModule } from '@angular/forms';
 import type { Agent } from '../../agent';
 import { CHAT_HOST_TOKENS } from '../../styles/chat-tokens';
 import { CHAT_INPUT_STYLES } from '../../styles/chat-input.styles';
@@ -33,7 +32,7 @@ export function submitMessage(
 @Component({
   selector: 'chat-input',
   standalone: true,
-  imports: [FormsModule],
+  imports: [],
   changeDetection: ChangeDetectionStrategy.OnPush,
   styles: [CHAT_HOST_TOKENS, CHAT_INPUT_STYLES],
   template: `
@@ -45,9 +44,8 @@ export function submitMessage(
         <textarea
           #textareaEl
           class="chat-input__textarea"
-          [ngModel]="messageText()"
-          (ngModelChange)="messageText.set($event)"
-          name="messageText"
+          [value]="messageText()"
+          (input)="onInput($event)"
           [placeholder]="placeholder()"
           (keydown.enter)="onKeydown($any($event))"
           (compositionstart)="composing.set(true)"
@@ -149,8 +147,18 @@ export class ChatInputComponent {
     if (submitted !== null) {
       this.submitted.emit(submitted);
       this.messageText.set('');
+      const el = this.textareaEl()?.nativeElement;
+      if (el) el.value = '';
       requestAnimationFrame(() => this.textareaEl()?.nativeElement.focus());
     }
+  }
+
+  /** Sync the textarea's value into the signal on user input. A direct
+   *  [value]/(input) pair is used instead of ngModel: NgModel does not
+   *  reliably write a programmatic clear back to the view under zoneless
+   *  + OnPush, leaving sent text visible in the composer (audit F1). */
+  protected onInput(event: Event): void {
+    this.messageText.set((event.target as HTMLTextAreaElement).value);
   }
 
   /** Abort the current streaming response (if the adapter supports it). */

--- a/libs/chat/src/lib/primitives/chat-input/chat-input.component.ts
+++ b/libs/chat/src/lib/primitives/chat-input/chat-input.component.ts
@@ -52,6 +52,7 @@ export function submitMessage(
           (compositionend)="composing.set(false)"
           (focus)="focused.set(true)"
           (blur)="focused.set(false)"
+          name="messageText"
           rows="1"
           aria-label="Type a message"
         ></textarea>


### PR DESCRIPTION
Phase 3 of the AG-UI demo toolbar campaign — closes the in-scope gaps from the Phase 2 capability audit (`docs/superpowers/specs/2026-06-11-ag-ui-capability-findings.md`, plan in `docs/superpowers/plans/2026-06-11-ag-ui-gap-closure-p3.md`). Each fix landed TDD-first with two-stage review, and the whole branch was re-verified in a live Chrome smoke against a real OpenAI backend.

## Fixes

- **F1 — composer kept sent text** (`@threadplane/chat`): `chat-input` now binds `[value]`/`(input)` directly; NgModel never wrote the programmatic clear back to the view under zoneless + OnPush (reproduced on the production canonical demo). FormsModule dropped; **`@angular/forms` peer dependency removed** (CHANGELOG'd). `name="messageText"` preserved for cockpit selectors. New unit + `pressSequentially` e2e regressions.
- **F2 — light scheme didn't reach the page chrome** (examples/ag-ui): AgUiShell now sets `data-color-scheme` and index.html gained the canonical pre-bootstrap script; e2e-pinned.
- **F3 — stop rendered an error banner** (`@threadplane/ag-ui`): user aborts settle as graceful cancellation on **both** delivery paths — `onRunFailed` and the synthesized `RUN_ERROR` event (the second path was caught only by the live smoke). Also fixes a stop→regenerate→stop sequence that wedged the loading state (flags now reset in `regenerate()` too).
- **F4 — json-render `[object Object]` values** (shared, also reproduced on prod): the schema documents `{statePath}` bindings but only the A2UI path translated them; `chat-generative-ui` now normalizes them to the `$bindState` dialect + `_bindings` and seeds spec state. **Consumer-visible semantics change (CHANGELOG'd):** json-render surfaces are store-isolated per instance — pass an explicit `[store]` for backend-state-driven or shared dashboards (both cockpit dashboard capabilities now do; `chat-tool-views` keeps the previous shared-store behavior). Composition-level test pins the isolation.
- **F6 — NG0956 during streaming** (`@threadplane/chat`): markdown children/table rows track by `$index` (re-parsed nodes are new objects every delta). Residual warnings during json-render spec assembly are logged as follow-up in the findings doc.

## Verification

- `nx run-many -t lint,test,build -p chat,ag-ui,render` green (chat 845+, ag-ui 30 incl. new wedge/abort tests)
- `nx build examples-ag-ui-angular` + full ag-ui e2e green (18 specs incl. 2 new regressions); cockpit json-render e2e green (restored STATE_SNAPSHOT KPI assertion)
- Live Chrome smoke vs real backend: light chrome ✅, composer clears ✅ (incl. mid-stream), stop with no banner ✅, dashboard renders real values ✅, interrupt Accept round-trip ✅

Follow-ups (logged in the findings doc): F5 subagent card over AG-UI (Phase 4 design), residual NG0956 in spec assembly, a2ui icon catalog support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)