### PR TITLE
chore(deployments): resync ag-ui-dev bundle (client-tools import rename)

### DIFF
--- a/deployments/ag-ui-dev/deps/client_tools/docs/guide.md
+++ b/deployments/ag-ui-dev/deps/client_tools/docs/guide.md
@@ -18,7 +18,7 @@ Declare client tools in the Angular app using `tools()`, `action()`, `view()`,
 and `ask()` from `@threadplane/chat`, with schemas authored in `zod/v4`. Pass
 the registry to `<chat [clientTools]="...">`. On the backend, declare a `tools`
 channel in your LangGraph `State`, call `bind_client_tools(llm, [], state)` from
-`threadplane_client_tools`, and route unconditionally to `END` — there are no
+`threadplane.middleware.langgraph`, and route unconditionally to `END` — there are no
 server-side tool implementations.
 </Prompt>
 
@@ -108,14 +108,23 @@ export class WeatherCardComponent {
 `ConfirmBookingComponent` is mounted. The model fills the `summary` input; the
 user responds by clicking Confirm or Cancel. The component calls
 `injectRenderHost().result(value)` — that value becomes the `ToolMessage`
-content that resumes the run:
+content that resumes the run.
+
+Once the ask resolves, the adapter writes the emitted result back onto the local
+tool call; `chat-tool-views` then spreads `{ ...args, ...result, status }` back
+into the component's inputs. The component declares an optional `confirmed`
+input (defaulting to `undefined`) and uses it to decide whether to render the
+interactive card or a frozen, button-less resolved state:
 
 ```typescript
 // confirm-booking.component.ts
+import { input } from '@angular/core';
 import { injectRenderHost } from '@threadplane/render';
 
 export class ConfirmBookingComponent {
   readonly summary = input<string>();
+  /** Spread back onto props after the ask resolves (undefined while interactive). */
+  readonly confirmed = input<boolean | undefined>(undefined);
   private readonly host = injectRenderHost();
 
   protected respond(confirmed: boolean): void {
@@ -124,13 +133,45 @@ export class ConfirmBookingComponent {
 }
 ```
 
+The template branches on `confirmed()` to freeze the card once resolved:
+
+```html
+@if (confirmed() === undefined) {
+  <div class="cb">
+    <p class="cb__summary">{{ summary() }}</p>
+    <div class="cb__actions">
+      <button type="button" (click)="respond(true)">Confirm</button>
+      <button type="button" (click)="respond(false)">Cancel</button>
+    </div>
+  </div>
+} @else if (confirmed() === true) {
+  <div class="cb cb--resolved">
+    <p class="cb__summary">Booking confirmed ✓</p>
+  </div>
+} @else {
+  <div class="cb cb--resolved">
+    <p class="cb__summary">Booking cancelled</p>
+  </div>
+}
+```
+
+<Tip>
+The `confirmed` input is `undefined` for the entire interactive lifetime of the
+card — buttons are live. The moment the user clicks, `host.result({ confirmed })`
+is called, the adapter resolves the tool call and writes the emitted value back
+onto the stored tool call, and `chat-tool-views` re-renders the component with
+`confirmed` set to the user's choice. Declare the input with a default of
+`undefined` (not `required`) so Angular does not throw when it is absent on the
+first render.
+</Tip>
+
 </Step>
 <Step title="Declare the State and bind client tools (backend)">
 
 The backend graph must declare a `tools` channel in its `State` so that
 `ag-ui-langgraph`'s merged client catalog is retained across the turn. The
 `agent` node calls `bind_client_tools(llm, [], state)` from
-`threadplane_client_tools`, which binds the client stubs (no server
+`threadplane.middleware.langgraph`, which binds the client stubs (no server
 implementation) onto the model for this invocation:
 
 ```python
@@ -142,7 +183,7 @@ from langgraph.graph.message import add_messages
 from langgraph.checkpoint.memory import MemorySaver
 from typing_extensions import Annotated, TypedDict
 
-from threadplane_client_tools import bind_client_tools
+from threadplane.middleware.langgraph import bind_client_tools
 
 class State(TypedDict):
     # `tools` holds the client tool catalog ag-ui-langgraph merges in from

--- a/deployments/ag-ui-dev/deps/client_tools/pyproject.toml
+++ b/deployments/ag-ui-dev/deps/client_tools/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "ag-ui-langgraph>=0.0.25",
     "fastapi>=0.110",
     "uvicorn[standard]>=0.29",
-    "threadplane-client-tools>=0.0.1",
+    "threadplane-middleware>=0.0.1",
 ]
 
 [build-system]
@@ -18,3 +18,6 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src"]
+
+[tool.uv.sources]
+threadplane-middleware = { path = "../../../../packages/threadplane-middleware", editable = true }

--- a/deployments/ag-ui-dev/deps/client_tools/src/graph.py
+++ b/deployments/ag-ui-dev/deps/client_tools/src/graph.py
@@ -17,7 +17,7 @@ from langgraph.graph.message import add_messages
 from langgraph.checkpoint.memory import MemorySaver
 from typing_extensions import Annotated, TypedDict
 
-from threadplane.client_tools import bind_client_tools
+from threadplane.middleware.langgraph import bind_client_tools
 
 PROMPTS_DIR = Path(__file__).parent.parent / "prompts"
 

--- a/deployments/ag-ui-dev/deps/client_tools/uv.lock
+++ b/deployments/ag-ui-dev/deps/client_tools/uv.lock
@@ -175,7 +175,7 @@ dependencies = [
     { name = "langchain-openai" },
     { name = "langgraph" },
     { name = "langsmith" },
-    { name = "threadplane-client-tools" },
+    { name = "threadplane-middleware" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -186,7 +186,7 @@ requires-dist = [
     { name = "langchain-openai", specifier = ">=0.3" },
     { name = "langgraph", specifier = ">=0.3" },
     { name = "langsmith", specifier = ">=0.2" },
-    { name = "threadplane-client-tools", specifier = ">=0.0.1" },
+    { name = "threadplane-middleware", editable = "../../../../packages/threadplane-middleware" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.29" },
 ]
 
@@ -951,17 +951,21 @@ wheels = [
 ]
 
 [[package]]
-name = "threadplane-client-tools"
+name = "threadplane-middleware"
 version = "0.0.1"
-source = { registry = "https://pypi.org/simple" }
+source = { editable = "../../../../packages/threadplane-middleware" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2b/6d/142e2686892859dd9fae080a08e0173f4adad0e25566de8ce3bcf569e844/threadplane_client_tools-0.0.1.tar.gz", hash = "sha256:9fbc7aab0167145f56f5caddb667ad56df9bd847b681d80243085d2c6f1a8ac3", size = 95499, upload-time = "2026-06-10T00:29:44.847Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5b/b7/6ca34dd8d642477e8558f1f9d2616ebe0b8189c44807af7f5e369867b1dc/threadplane_client_tools-0.0.1-py3-none-any.whl", hash = "sha256:0a898f4bd89101305fe0f9fd3e254902f0ddaadd41ab40a25bd4980c499bf3b8", size = 4288, upload-time = "2026-06-10T00:29:43.748Z" },
+
+[package.metadata]
+requires-dist = [
+    { name = "langchain-core", specifier = ">=0.3.0" },
+    { name = "langgraph", specifier = ">=0.3.0" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=8" },
 ]
+provides-extras = ["test"]
 
 [[package]]
 name = "tiktoken"


### PR DESCRIPTION
The deploy drift guard failed on main: `cockpit/ag-ui/client-tools` moved `bind_client_tools` to `threadplane.middleware.langgraph` (middleware rename) but `deployments/ag-ui-dev/` was never regenerated. Pure generator output (`npx tsx scripts/generate-ag-ui-deployment-config.ts`), idempotent. Unblocks the AG-UI Railway deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)