### PR TITLE
docs(ag-ui): regenerate api-docs for AgUiAgent.subagents (unblock website build)

### DIFF
--- a/apps/website/content/docs/ag-ui/api/api-docs.json
+++ b/apps/website/content/docs/ag-ui/api/api-docs.json
@@ -476,8 +476,8 @@
       {
         "name": "subagents",
         "type": "Signal<Map<string, Subagent>>",
-        "description": "",
-        "optional": true
+        "description": "Subagent activities (activityType==='subagent') projected to the neutral\n Subagent contract, keyed by messageId. Narrows the base Agent's optional\n `subagents?` to a concrete signal for AG-UI consumers.",
+        "optional": false
       },
       {
         "name": "submit",


### PR DESCRIPTION
F5 (#668) added a documented `subagents: Signal<Map<string, Subagent>>` to `AgUiAgent` but didn't regenerate `apps/website/content/docs/ag-ui/api/api-docs.json`; the Website build's api-docs drift-guard failed on main. Pure regen (`npm run generate-api-docs`).

Note: the cockpit bundle-budget, examples/chat e2e, and canonical-demo CI failures on main are **pre-existing** (already red on #666) — not from F5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)