### PR TITLE
fix(middleware): native Node ESM imports (.js extensions) — @threadplane/middleware 0.0.2

### DIFF
--- a/libs/middleware/package.json
+++ b/libs/middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/middleware",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Backend middleware for the Threadplane client-tools capability. The /langgraph entrypoint targets LangGraph.js.",
   "keywords": ["langgraph", "agent", "client-tools", "middleware", "threadplane"],
   "license": "MIT",

--- a/libs/middleware/src/langgraph/channel.ts
+++ b/libs/middleware/src/langgraph/channel.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { Annotation } from '@langchain/langgraph';
-import type { ClientToolSpec } from './types';
+import type { ClientToolSpec } from './types.js';
 
 /**
  * State channels for the client-tools catalog. Spread into Annotation.Root so a graph

--- a/libs/middleware/src/langgraph/index.ts
+++ b/libs/middleware/src/langgraph/index.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-export type { ClientToolSpec, ClientToolsState, OpenAIFunctionTool, BaseMessage } from './types';
+export type { ClientToolSpec, ClientToolsState, OpenAIFunctionTool, BaseMessage } from './types.js';
 export {
   clientToolSpecs,
   clientToolNames,
@@ -9,6 +9,6 @@ export {
   bindClientTools,
   routeAfterAgent,
   type BindableModel,
-} from './middleware';
-export { clientToolsChannel } from './channel';
-export { clientToolsRouter } from './router';
+} from './middleware.js';
+export { clientToolsChannel } from './channel.js';
+export { clientToolsRouter } from './router.js';

--- a/libs/middleware/src/langgraph/middleware.ts
+++ b/libs/middleware/src/langgraph/middleware.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-import type { ClientToolSpec, ClientToolsState, OpenAIFunctionTool } from './types';
+import type { ClientToolSpec, ClientToolsState, OpenAIFunctionTool } from './types.js';
 
 /** Read the catalog from state.tools, falling back to state.client_tools; drop nameless. */
 function catalog(state: ClientToolsState): ClientToolSpec[] {
@@ -20,7 +20,7 @@ export function clientToolNames(state: ClientToolsState): Set<string> {
   return new Set(catalog(state).map((t) => t.name));
 }
 
-import type { BaseMessage } from './types';
+import type { BaseMessage } from './types.js';
 
 interface ToolCallLike {
   name?: string;

--- a/libs/middleware/src/langgraph/router.ts
+++ b/libs/middleware/src/langgraph/router.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
-import { routeAfterAgent } from './middleware';
-import type { ClientToolsState } from './types';
+import { routeAfterAgent } from './middleware.js';
+import type { ClientToolsState } from './types.js';
 
 /**
  * A prebuilt conditional-edge callback. serverToolNames is bound once at construction;


### PR DESCRIPTION
**Bug found while live-smoking the JS LangGraph demo against the published `0.0.1`.**

The emitted ESM `.js` files had **extensionless relative imports** (`export { … } from './middleware'`). Bundlers (vitest, esbuild, `langgraphjs dev`) tolerate this — which is why the unit/integration tests and the demo all passed — but **Node's native ESM resolver rejects it** with `ERR_MODULE_NOT_FOUND`. So `import '@threadplane/middleware/langgraph'` from plain Node ESM (or strict NodeNext TS) was broken in `0.0.1`.

### Fix
Add explicit `.js` to every relative import in the source so `tsc` emits Node-ESM-correct specifiers. Bump to **`0.0.2`**.

### Verified
- `node --input-type=module` import of the built package now loads **all 9 exports** (`0.0.1` threw `ERR_MODULE_NOT_FOUND` on the same call).
- Unit + in-process integration tests still green; lint 0 errors.

### After merge (maintainer)
Republish `@threadplane/middleware@0.0.2` (tarball provided in chat; or via the `publish-middleware-npm.yml` OIDC workflow now that the package exists). Consumers on `^0.0.1` (incl. the new `cockpit/langgraph/client-tools/node` demo) pick it up automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)