### PR TITLE
fix(examples/chat): import vitest globals in e2e-overrides spec (unbreak app build / main red)

### DIFF
--- a/examples/chat/angular/src/app/shell/e2e-overrides.spec.ts
+++ b/examples/chat/angular/src/app/shell/e2e-overrides.spec.ts
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: MIT
+import { describe, it, expect, afterEach } from 'vitest';
 import { e2eClientOptions } from './e2e-overrides';
 
 const KEY = 'THREADPLANE_E2E_MAX_RETRIES';


### PR DESCRIPTION
## Hotfix — main is red at `3c45540f` (#677 merge)

`examples/chat` `tsconfig.app.json` includes `src/**/*.ts` with `types: []`, so the Angular **app build** type-checks every spec. `e2e-overrides.spec.ts` (added in #677) used **ambient** `describe`/`it`/`expect`/`afterEach`:

```
TS2593: Cannot find name 'describe'.
TS2304: Cannot find name 'afterEach' / 'it' / 'expect'.
→ Application bundle generation failed
→ Server at http://localhost:4200/ did not become ready within 120000ms
→ all 4 examples/chat e2e shards fail + Canonical demo → Vercel
```

`nx test` (vitest) masked it locally — only the app build (`nx serve`) compiles specs under `tsconfig.app.json`. Fix: import the globals from `vitest` explicitly, matching every existing spec.

Verified: `nx build examples-chat-angular` now completes (was failing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)