### PR TITLE
fix(ci): prevent shell injection via github.head_ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,11 @@ jobs:
       - run: npm run generate-api-docs
       - name: Commit generated API docs to same-repo PR
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          # Bind the attacker-controllable PR branch name to an env var so it is
+          # passed as a literal value, never interpolated into the script text
+          # (prevents shell injection — OSSF Scorecard Dangerous-Workflow).
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           if git diff --quiet -- apps/website/content/docs/*/api/api-docs.json; then
             echo "Generated API docs are already committed."
@@ -126,7 +131,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add apps/website/content/docs/*/api/api-docs.json
           git commit -m "chore(docs): regenerate api docs"
-          git push origin "HEAD:${{ github.head_ref }}"
+          git push origin "HEAD:$HEAD_REF"
       - name: Verify generated API docs are committed
         run: git diff --exit-code -- apps/website/content/docs/*/api/api-docs.json
       - run: npx nx build website


### PR DESCRIPTION
## Summary
Resolves the OSSF Scorecard **Dangerous-Workflow** finding (`ci.yml:119`, score 0 → 10): the api-docs commit-back step interpolated the attacker-controllable PR branch name `github.head_ref` directly into a `run:` shell command (`git push origin "HEAD:${{ github.head_ref }}"`).

Fix binds it to an `env:` var and references `"$HEAD_REF"`, so the value is passed literally and can't break out of the shell context.

## Test Plan
- [ ] CI green
- [ ] After merge: Scorecard Dangerous-Workflow → 10

🤖 Generated with [Claude Code](https://claude.com/claude-code)