### PR TITLE
ci(release-provenance): set top-level DO_NOT_TRACK=1 to satisfy workflow guard

### DIFF
--- a/.github/workflows/release-provenance.yml
+++ b/.github/workflows/release-provenance.yml
@@ -7,6 +7,9 @@ on:
 permissions:
   contents: read
 
+env:
+  DO_NOT_TRACK: '1'
+
 jobs:
   build-artifacts:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

The supply-chain-hardening guard added in #684 (`scripts/ci-workflow.spec.mjs`) asserts every workflow declares a top-level `env: DO_NOT_TRACK: '1'`, but `release-provenance.yml` was missed. As a result the **"Validate CI workflow guards"** step (inside the `CI scope` job) fails on **every** PR, which cascades into the `CI — required` gate and blocks all merges.

This adds the one missing `env` block, matching the convention in `ci.yml`. The guard test now passes **11/11** locally (`node --test scripts/ci-workflow.spec.mjs`).

No behavior change — `DO_NOT_TRACK=1` is a telemetry opt-out the guard already requires across the workflow suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)