### PR TITLE
ci(renovate): run continuously instead of Monday-only

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,6 @@
     ":dependencyDashboard",
     ":semanticCommits"
   ],
-  "schedule": ["before 9am on monday"],
   "prConcurrentLimit": 5,
   "packageRules": [
     {


### PR DESCRIPTION
## Summary
Removes the `"schedule": ["before 9am on monday"]` restriction from `renovate.json` so Renovate opens dependency/digest PRs as soon as it scans, rather than holding them until Monday morning. Lets us verify the integration immediately after install.

## Test Plan
- [ ] CI green
- [ ] After merge: Renovate opens its Dependency Dashboard + first PRs without waiting for the weekly window

🤖 Generated with [Claude Code](https://claude.com/claude-code)