### PR TITLE
ci(scorecard): wire SCORECARD_TOKEN for Branch-Protection check

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -28,6 +28,10 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
+          # Read-only PAT (Administration: read) so Scorecard can evaluate the
+          # Branch-Protection check, which the default GITHUB_TOKEN cannot read.
+          # Falls back gracefully (check stays inconclusive) if the secret is unset.
+          repo_token: ${{ secrets.SCORECARD_TOKEN }}
           publish_results: true
       - name: Upload artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2


### PR DESCRIPTION
## Summary
Passes `repo_token: ${{ secrets.SCORECARD_TOKEN }}` to the OSSF Scorecard action so it can read branch-protection settings (the default `GITHUB_TOKEN` cannot). Resolves the currently-inconclusive **Branch-Protection** check, raising the Scorecard aggregate.

Requires a repo secret `SCORECARD_TOKEN` — a fine-grained PAT with **Administration: read-only** (+ Contents/Metadata read) on this repo. If the secret is unset, the action falls back gracefully and the check stays inconclusive (no failure).

## Test Plan
- [ ] CI green
- [ ] After secret is added + next Scorecard run: Branch-Protection scored (not inconclusive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)