### PR TITLE
fix(langgraph): unblock release — empty-stream mock fails lint

### DIFF
--- a/libs/langgraph/src/lib/agent.fn.spec.ts
+++ b/libs/langgraph/src/lib/agent.fn.spec.ts
@@ -918,7 +918,9 @@ describe('agent — LANGGRAPH_CLIENT_OPTIONS resolution (no mock transport)', ()
       search: vi.fn().mockResolvedValue([]),
     },
     runs: {
-      stream: vi.fn().mockReturnValue((async function* () {})()),
+      stream: vi.fn().mockReturnValue((async function* () {
+        /* empty stream — construction-only tests assert wiring, not events */
+      })()),
     },
   };
 


### PR DESCRIPTION
## Summary
A release dry-run (`Publish` workflow, dry-run mode) failed at `langgraph:lint`:

```
agent.fn.spec.ts:921  error  Unexpected empty async generator function  @typescript-eslint/no-empty-function
```

The construction-only test stub used `(async function* () {})()`. The rule flags the empty body as an error, which fails the publish path's fresh lint (`--skip-nx-cache`). Normal CI was green because `ci.yml` lint runs cached **and isn't a required status check**, so the error reached `main` (via #681).

Fix documents the empty generator body so the rule passes — behaviour unchanged (still yields no events).

## Test Plan
- [x] `npx nx lint langgraph --skip-nx-cache` → passes (was failing)
- [ ] CI green
- [ ] Re-run Publish dry-run on updated main → fully green before cutting v0.0.50

🤖 Generated with [Claude Code](https://claude.com/claude-code)