### PR TITLE
fix(ci): SLSA release upload — --clobber flag order

### DIFF
--- a/.github/workflows/release-provenance.yml
+++ b/.github/workflows/release-provenance.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Upload tarballs to the release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${{ github.event.release.tag_name }}" -- release-artifacts/*.tgz --clobber
+        run: gh release upload "${{ github.event.release.tag_name }}" --clobber -- release-artifacts/*.tgz
 
   provenance:
     needs: [build-artifacts]


### PR DESCRIPTION
## Summary
The first real run of `release-provenance.yml` (v0.0.50) failed at *Upload tarballs to the release*:
```
gh release upload "v0.0.50" -- release-artifacts/*.tgz --clobber
no matches found for `--clobber`
```
A `--` separator was placed before the file glob, so `gh` treated the trailing `--clobber` as a filename. Fix moves `--clobber` before the `--` (flag first, files after the separator). The npm publish (separate workflow) was unaffected; this only blocked the GitHub-Release SLSA attestation.

## Test Plan
- [ ] CI green
- [ ] Re-fire release-provenance for v0.0.50 → build-artifacts + provenance both succeed → `*.intoto.jsonl` attached to the release

🤖 Generated with [Claude Code](https://claude.com/claude-code)