### PR TITLE
feat(chat): injectThreadRouting — consistent thread persistence helper

### DIFF
--- a/apps/website/content/docs/chat/api/api-docs.json
+++ b/apps/website/content/docs/chat/api/api-docs.json
@@ -6927,6 +6927,44 @@
     "examples": []
   },
   {
+    "name": "ThreadRoutingConfig",
+    "kind": "interface",
+    "description": "",
+    "properties": [
+      {
+        "name": "navigationExtras",
+        "type": "NavigationExtras",
+        "description": "Extras merged into every navigate (default `{ queryParamsHandling: 'preserve' }`).",
+        "optional": true
+      },
+      {
+        "name": "threadId",
+        "type": "WritableSignal<string | null>",
+        "description": "The app-owned source-of-truth signal for the active thread id.",
+        "optional": false
+      },
+      {
+        "name": "threadIdFromUrl",
+        "type": "(url: string) => string | null",
+        "description": "Extract the thread id from a URL (null = bare). Default: last non-empty path segment.",
+        "optional": true
+      },
+      {
+        "name": "toCommands",
+        "type": "(id: string | null) => unknown[]",
+        "description": "Router commands for a thread id (or the bare/welcome path when null).\n Default: `(id) => (id ? ['/', id] : ['/'])`.",
+        "optional": true
+      },
+      {
+        "name": "validate",
+        "type": "(id: string) => Promise<boolean>",
+        "description": "Optional async validity check; on `false` the helper redirects to the bare path\n (`replaceUrl: true`). LangGraph apps pass `id => threads.getThread(id).then(Boolean)`.",
+        "optional": true
+      }
+    ],
+    "examples": []
+  },
+  {
     "name": "ToolCall",
     "kind": "interface",
     "description": "",
@@ -7662,6 +7700,27 @@
       "description": ""
     },
     "examples": []
+  },
+  {
+    "name": "injectThreadRouting",
+    "kind": "function",
+    "description": "Bind an app-owned `activeThreadId` signal to the URL — restore on load, stamp on change,\nvalidate-or-redirect, with a bare URL meaning \"no thread\" (welcome). URL is the source of\ntruth; nothing is written to localStorage. Must be called in an injection context.",
+    "signature": "injectThreadRouting(config: ThreadRoutingConfig): void",
+    "params": [
+      {
+        "name": "config",
+        "type": "ThreadRoutingConfig",
+        "description": "",
+        "optional": false
+      }
+    ],
+    "returns": {
+      "type": "void",
+      "description": ""
+    },
+    "examples": [
+      "```ts\nexport const ACTIVE_THREAD = signal<string | null>(null);\n// providers: provideAgent({ threadId: ACTIVE_THREAD, onThreadId: id => ACTIVE_THREAD.set(id) })\nconst threads = inject(LangGraphThreadsAdapter);\ninjectThreadRouting({ threadId: ACTIVE_THREAD, validate: id => threads.getThread(id).then(Boolean) });\n```"
+    ]
   },
   {
     "name": "isAbortError",

--- a/apps/website/content/docs/chat/guides/thread-routing.mdx
+++ b/apps/website/content/docs/chat/guides/thread-routing.mdx
@@ -1,0 +1,182 @@
+# Thread Routing
+
+`injectThreadRouting()` binds an app-owned active-thread signal to the Angular Router: it restores the thread id from the URL on load, stamps signal changes back into the URL, validates stale links, and treats a bare URL as "no thread" (the welcome state). **The URL is the sole source of truth — nothing is written to localStorage**, so links remain shareable without any extra plumbing.
+
+## What it does
+
+| Behavior | Detail |
+|---|---|
+| Restore on load | Reads the thread id from the URL on startup and seeds the signal |
+| Signal → URL | When the signal changes (e.g. after the agent allocates a new thread), navigates to the matching URL |
+| URL → signal | On every `NavigationEnd` keeps the signal in sync with the current URL |
+| Validate stale links | If `validate` returns `false`, redirects to the bare path (`replaceUrl: true`) |
+| Bare URL = welcome | When the URL holds no thread segment, the signal is `null` and the chat shows its welcome state |
+
+Because the URL carries the id, browser reload, forward/back, and shared links all land in the correct conversation — as long as the backend has a durable store (see [When to use it](#when-to-use-it) below).
+
+## Canonical usage
+
+The `examples/chat` app is the reference implementation. The pattern has three moving pieces:
+
+**1. A module-scope signal**
+
+```typescript
+// app.config.ts (or a shared token file)
+import { signal } from '@angular/core';
+
+export const ACTIVE_THREAD = signal<string | null>(null);
+```
+
+The signal lives at module scope (outside any class) so `provideAgent()` — which runs at provider registration time, before component construction — can reference it directly. A component-class field would not exist yet when the provider config is evaluated.
+
+**2. `provideAgent()` wires the signal**
+
+```typescript
+// app.config.ts
+import { ApplicationConfig } from '@angular/core';
+import { provideAgent } from '@threadplane/langgraph';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideAgent({
+      apiUrl: 'https://your-langgraph-server/api',
+      assistantId: 'chat',
+      threadId: ACTIVE_THREAD,
+      onThreadId: (id) => ACTIVE_THREAD.set(id),
+    }),
+  ],
+};
+```
+
+- `threadId: ACTIVE_THREAD` — the adapter watches this signal; changing it switches threads.
+- `onThreadId` — called when the adapter auto-creates a new thread. Setting the signal here lets the `signal → URL` effect in `injectThreadRouting` pick up the new id and stamp it into the URL automatically.
+
+**3. `injectThreadRouting()` in the shell component**
+
+```typescript
+// shell.component.ts
+import { Component, inject } from '@angular/core';
+import { LangGraphThreadsAdapter } from '@threadplane/langgraph';
+import { injectThreadRouting } from '@threadplane/chat';
+import { ACTIVE_THREAD } from '../app.config';
+
+@Component({ /* ... */ })
+export class ShellComponent {
+  private readonly threads = inject(LangGraphThreadsAdapter);
+
+  constructor() {
+    injectThreadRouting({
+      threadId: ACTIVE_THREAD,
+      validate: (id) => this.threads.getThread(id).then(Boolean),
+    });
+  }
+}
+```
+
+Call `injectThreadRouting()` inside the constructor (or any injection context such as a factory function). It must run in an injection context because it calls `inject(Router)` internally.
+
+The `validate` callback receives a candidate id whenever one appears in the URL. If the thread no longer exists on the server (deleted, expired, or from a different environment) the helper redirects to the bare path with `replaceUrl: true`, which replaces the stale URL in history rather than pushing a new entry.
+
+## Custom URL shapes
+
+The defaults (`/` for welcome, `/<threadId>` for a thread) work for simple apps. For mode-prefixed or nested paths, supply `toCommands` and `threadIdFromUrl`:
+
+```typescript
+// examples/chat pattern: /embed, /embed/<id>, /popup/<id>, /sidebar/<id>
+const MODES = ['embed', 'popup', 'sidebar'] as const;
+type DemoMode = (typeof MODES)[number];
+
+function parseUrl(url: string): { mode: DemoMode; threadId: string | null } {
+  const segs = url.split('?')[0].split('#')[0].split('/').filter(Boolean);
+  const mode = (MODES as readonly string[]).includes(segs[0])
+    ? (segs[0] as DemoMode)
+    : 'embed';
+  const threadId = segs[1]?.length ? segs[1] : null;
+  return { mode, threadId };
+}
+
+// Inside the shell constructor — `this.mode()` reads the current mode signal:
+injectThreadRouting({
+  threadId: ACTIVE_THREAD,
+  threadIdFromUrl: (url) => parseUrl(url).threadId,
+  toCommands: (id) => (id ? ['/', this.mode(), id] : ['/', this.mode()]),
+  validate: (id) => this.threads.getThread(id).then(Boolean),
+});
+```
+
+`threadIdFromUrl` extracts the id from any URL the router lands on. `toCommands` builds the router-navigate command array for a given id (or `null` for the bare path). Both receive the current URL string and thread id respectively; neither needs to touch the router directly.
+
+## Full API reference
+
+```typescript
+import { injectThreadRouting, type ThreadRoutingConfig } from '@threadplane/chat';
+
+export interface ThreadRoutingConfig {
+  /** App-owned signal that is the source of truth for the active thread. */
+  threadId: WritableSignal<string | null>;
+  /** Build router commands for a thread id (null = welcome/bare path).
+   *  Default: (id) => id ? ['/', id] : ['/'] */
+  toCommands?: (id: string | null) => unknown[];
+  /** Extract a thread id from a URL string (null = no thread).
+   *  Default: the last non-empty path segment. */
+  threadIdFromUrl?: (url: string) => string | null;
+  /** Async check; on false, redirect to the bare path (replaceUrl: true).
+   *  Omit when the backend has no thread-lookup endpoint. */
+  validate?: (id: string) => Promise<boolean>;
+  /** Extras merged into every navigate call.
+   *  Default: { queryParamsHandling: 'preserve' } */
+  navigationExtras?: NavigationExtras;
+}
+
+function injectThreadRouting(config: ThreadRoutingConfig): void;
+```
+
+## When to use it
+
+URL-as-source-of-truth thread routing is the right choice when two conditions are both true:
+
+1. **The user sees and can share the URL.** A standalone app at its own domain or route is the typical case. If the app runs inside an iframe (e.g. an embedded docs widget) and the URL is never surfaced to the user, URL persistence adds friction without benefit — keep the active thread in an in-memory signal instead.
+
+2. **The backend can actually restore the conversation from the id.** LangGraph with a Postgres or Redis checkpointer satisfies this. An in-process `MemorySaver` does not — a restored id points at ephemeral state that disappears on server restart, so the UI would show an empty welcome surface even though the URL looks correct.
+
+The underlying principle: **persistence UI should match what the backend can actually restore.** When the backend is stateless, don't surface stateful affordances like bookmarkable thread URLs.
+
+**Use `injectThreadRouting()` when:**
+- Building a standalone chat app at a user-visible URL
+- The backend uses a durable checkpointer (Postgres, Redis, Neon, etc.)
+- You want reload-survival, shareable links, and validated stale-link redirects for free
+
+**Keep threads in memory / ephemeral when:**
+- The app is embedded and the URL is not user-visible
+- The server is stateless or uses an in-memory `MemorySaver`
+- The chat is a short-lived session and persistence would be surprising to users
+
+<Callout type="info" title="AG-UI backends">
+The AG-UI protocol is event-stream-only — it does not define a server-side thread-lookup endpoint, so `validate` is not available. When using `@threadplane/ag-ui`, pass no `validate` callback and manage thread switching at the host-service level before the agent boots. See [AG-UI architecture](/docs/ag-ui/concepts/architecture) for details.
+</Callout>
+
+## What's next
+
+<CardGroup cols={3}>
+  <Card
+    title="LangGraph Persistence"
+    icon="database"
+    href="/docs/langgraph/guides/persistence"
+  >
+    Server-side thread store and checkpoint configuration.
+  </Card>
+  <Card
+    title="Writing an Adapter"
+    icon="plug"
+    href="/docs/chat/guides/writing-an-adapter"
+  >
+    Implement custom adapters that support thread switching.
+  </Card>
+  <Card
+    title="Lifecycle Signals"
+    icon="activity"
+    href="/docs/chat/guides/lifecycle"
+  >
+    Per-instance signals for debugging and telemetry.
+  </Card>
+</CardGroup>

--- a/apps/website/src/lib/docs-config.ts
+++ b/apps/website/src/lib/docs-config.ts
@@ -166,6 +166,7 @@ export const docsConfig: DocsLibrary[] = [
           { title: 'Streaming', slug: 'streaming', section: 'guides' },
           { title: 'Configuration', slug: 'configuration', section: 'guides' },
           { title: 'Writing an Adapter', slug: 'writing-an-adapter', section: 'guides' },
+          { title: 'Thread Routing', slug: 'thread-routing', section: 'guides' },
           { title: 'Lifecycle Signals', slug: 'lifecycle', section: 'guides' },
         ],
       },

--- a/docs/superpowers/plans/2026-06-18-thread-routing-helper.md
+++ b/docs/superpowers/plans/2026-06-18-thread-routing-helper.md
@@ -1,0 +1,324 @@
+# Thread-Routing Helper Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`).
+
+**Goal:** Extract `examples/chat`'s hand-rolled URL↔threadId sync into a reusable, adapter-neutral `injectThreadRouting()` in `@threadplane/chat`, then adopt it in the LangGraph thread demos so they survive reload + are shareable.
+
+**Architecture:** The app owns the `activeThreadId` signal (so `provideAgent` can reference it); `injectThreadRouting(config)`, called in the shell's injection context, binds that signal to the Angular Router (restore-on-load, signal→URL stamp, validate-or-redirect, bare=welcome).
+
+**Tech Stack:** Angular 21 (signals, `toSignal`, `effect`, Router), vitest, Nx. No backcompat constraint.
+
+**Reference spec:** `docs/superpowers/specs/2026-06-18-thread-routing-helper-design.md`.
+
+---
+
+## Task 1: `injectThreadRouting` helper (TDD)
+
+**Files:**
+- Create: `libs/chat/src/lib/routing/thread-routing.ts`
+- Create: `libs/chat/src/lib/routing/thread-routing.spec.ts`
+- Modify: `libs/chat/src/public-api.ts`
+
+- [ ] **Step 1: Write the failing test** — `thread-routing.spec.ts`. Use Angular's Router testing. Cover: URL→signal restore on init; signal→URL navigate on change; `validate` false → redirect to bare with `replaceUrl`; bare URL → null signal (no navigate); custom `toCommands`/`threadIdFromUrl` round-trip.
+```ts
+// SPDX-License-Identifier: MIT
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { signal, type WritableSignal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { provideRouter, Router } from '@angular/router';
+import { Component } from '@angular/core';
+import { injectThreadRouting } from './thread-routing';
+
+@Component({ template: '' })
+class Blank {}
+
+function setup(threadId: WritableSignal<string | null>, cfg: Partial<Parameters<typeof injectThreadRouting>[0]> = {}) {
+  TestBed.configureTestingModule({
+    providers: [provideRouter([{ path: '**', component: Blank }])],
+  });
+  const router = TestBed.inject(Router);
+  return { router };
+}
+
+describe('injectThreadRouting', () => {
+  beforeEach(() => TestBed.resetTestingModule());
+
+  it('restores the signal from the URL on init', async () => {
+    const threadId = signal<string | null>(null);
+    TestBed.configureTestingModule({ providers: [provideRouter([{ path: '**', children: [] } as never])] });
+    const router = TestBed.inject(Router);
+    await router.navigateByUrl('/abc123');
+    TestBed.runInInjectionContext(() => injectThreadRouting({ threadId }));
+    TestBed.tick?.();
+    expect(threadId()).toBe('abc123');
+  });
+
+  it('navigates to the thread path when the signal changes', async () => {
+    const threadId = signal<string | null>(null);
+    TestBed.configureTestingModule({ providers: [provideRouter([{ path: '**', children: [] } as never])] });
+    const router = TestBed.inject(Router);
+    const navSpy = vi.spyOn(router, 'navigate');
+    TestBed.runInInjectionContext(() => injectThreadRouting({ threadId }));
+    threadId.set('xyz');
+    TestBed.tick?.();
+    expect(navSpy).toHaveBeenCalledWith(['/', 'xyz'], expect.objectContaining({ queryParamsHandling: 'preserve' }));
+  });
+
+  it('redirects to bare when validate() rejects the id', async () => {
+    const threadId = signal<string | null>(null);
+    TestBed.configureTestingModule({ providers: [provideRouter([{ path: '**', children: [] } as never])] });
+    const router = TestBed.inject(Router);
+    await router.navigateByUrl('/dead');
+    const navSpy = vi.spyOn(router, 'navigate');
+    TestBed.runInInjectionContext(() =>
+      injectThreadRouting({ threadId, validate: async () => false }),
+    );
+    await Promise.resolve();
+    TestBed.tick?.();
+    expect(navSpy).toHaveBeenCalledWith(['/'], expect.objectContaining({ replaceUrl: true }));
+  });
+
+  it('treats a bare URL as no thread (null, no navigate)', async () => {
+    const threadId = signal<string | null>(null);
+    TestBed.configureTestingModule({ providers: [provideRouter([{ path: '**', children: [] } as never])] });
+    const router = TestBed.inject(Router);
+    await router.navigateByUrl('/');
+    TestBed.runInInjectionContext(() => injectThreadRouting({ threadId }));
+    TestBed.tick?.();
+    expect(threadId()).toBeNull();
+  });
+
+  it('uses custom toCommands/threadIdFromUrl (mode-prefixed) round-trip', async () => {
+    const threadId = signal<string | null>(null);
+    TestBed.configureTestingModule({ providers: [provideRouter([{ path: '**', children: [] } as never])] });
+    const router = TestBed.inject(Router);
+    await router.navigateByUrl('/embed/t1');
+    const navSpy = vi.spyOn(router, 'navigate');
+    TestBed.runInInjectionContext(() =>
+      injectThreadRouting({
+        threadId,
+        threadIdFromUrl: (u) => u.split('?')[0].split('/').filter(Boolean)[1] ?? null,
+        toCommands: (id) => (id ? ['/', 'embed', id] : ['/', 'embed']),
+      }),
+    );
+    TestBed.tick?.();
+    expect(threadId()).toBe('t1');
+    threadId.set('t2');
+    TestBed.tick?.();
+    expect(navSpy).toHaveBeenCalledWith(['/', 'embed', 't2'], expect.anything());
+  });
+});
+```
+NOTE: the exact TestBed flush API in this repo's Angular 21 may be `TestBed.tick()` or `await router navigation + fixture.detectChanges()`. Adjust the flush mechanism to what the repo uses (check an existing router-using chat spec). The ASSERTIONS are the contract; adapt the harness plumbing so they run.
+
+- [ ] **Step 2: Run — expect FAIL** (`npx nx test chat --skip-nx-cache -- thread-routing`): module missing.
+
+- [ ] **Step 3: Implement** — `libs/chat/src/lib/routing/thread-routing.ts`. Generalize the three effects from `examples/chat`'s `demo-shell.component.ts` (`urlState`/`urlThreadId` + the URL→signal effect at ~165, the signal→URL effect at ~202, and the validation/redirect effect at ~189):
+```ts
+// SPDX-License-Identifier: MIT
+import { effect, inject, untracked, type WritableSignal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { Router, NavigationEnd, type NavigationExtras } from '@angular/router';
+import { filter, map, startWith } from 'rxjs/operators';
+
+export interface ThreadRoutingConfig {
+  /** The app-owned source-of-truth signal for the active thread id. */
+  threadId: WritableSignal<string | null>;
+  /** Router commands for a thread id (or the bare/welcome path when null).
+   *  Default: `(id) => (id ? ['/', id] : ['/'])`. */
+  toCommands?: (id: string | null) => unknown[];
+  /** Extract the thread id from a URL (null = bare). Default: last non-empty path segment. */
+  threadIdFromUrl?: (url: string) => string | null;
+  /** Optional async validity check; on `false` the helper redirects to the bare path
+   *  (`replaceUrl: true`). LangGraph apps pass `id => threads.getThread(id).then(Boolean)`. */
+  validate?: (id: string) => Promise<boolean>;
+  /** Extras merged into every navigate (default `{ queryParamsHandling: 'preserve' }`). */
+  navigationExtras?: NavigationExtras;
+}
+
+const defaultFromUrl = (url: string): string | null => {
+  const seg = url.split('?')[0].split('#')[0].split('/').filter(Boolean);
+  return seg.length ? seg[seg.length - 1] : null;
+};
+const defaultToCommands = (id: string | null): unknown[] => (id ? ['/', id] : ['/']);
+
+/**
+ * Bind an app-owned `activeThreadId` signal to the URL — restore on load, stamp on change,
+ * validate-or-redirect, with a bare URL meaning "no thread" (welcome). URL is the source of
+ * truth; nothing is written to localStorage. Must be called in an injection context.
+ *
+ * @example
+ * ```ts
+ * export const ACTIVE_THREAD = signal<string | null>(null);
+ * // providers: provideAgent({ threadId: ACTIVE_THREAD, onThreadId: id => ACTIVE_THREAD.set(id) })
+ * const threads = inject(LangGraphThreadsAdapter);
+ * injectThreadRouting({ threadId: ACTIVE_THREAD, validate: id => threads.getThread(id).then(Boolean) });
+ * ```
+ */
+export function injectThreadRouting(config: ThreadRoutingConfig): void {
+  const router = inject(Router);
+  const fromUrl = config.threadIdFromUrl ?? defaultFromUrl;
+  const toCommands = config.toCommands ?? defaultToCommands;
+  const extras: NavigationExtras = config.navigationExtras ?? { queryParamsHandling: 'preserve' };
+
+  // URL → signal (re-fires on every NavigationEnd: back/forward, programmatic nav).
+  const urlThreadId = toSignal(
+    router.events.pipe(
+      filter((e): e is NavigationEnd => e instanceof NavigationEnd),
+      map((e) => fromUrl(e.urlAfterRedirects)),
+      startWith(fromUrl(router.url)),
+    ),
+    { initialValue: fromUrl(router.url) },
+  );
+
+  // Seed the signal from the URL once, then keep it in sync.
+  config.threadId.set(urlThreadId());
+
+  effect(() => {
+    const urlId = urlThreadId();
+    if (urlId !== untracked(() => config.threadId())) config.threadId.set(urlId);
+  });
+
+  // signal → URL.
+  effect(() => {
+    const id = config.threadId();
+    const urlId = untracked(() => urlThreadId());
+    if (id !== urlId) void router.navigate(toCommands(id), extras);
+  });
+
+  // validate stale ids → redirect to bare.
+  if (config.validate) {
+    const validate = config.validate;
+    effect(() => {
+      const id = urlThreadId();
+      if (!id) return;
+      void validate(id).then((ok) => {
+        if (!ok && untracked(() => urlThreadId()) === id) {
+          void router.navigate(toCommands(null), { ...extras, replaceUrl: true });
+        }
+      });
+    });
+  }
+}
+```
+
+- [ ] **Step 4: Run — expect PASS** (`npx nx test chat --skip-nx-cache -- thread-routing`). Fix the harness flush plumbing until the 5 assertions pass.
+
+- [ ] **Step 5: Export** — in `libs/chat/src/public-api.ts` add:
+```ts
+export { injectThreadRouting } from './lib/routing/thread-routing';
+export type { ThreadRoutingConfig } from './lib/routing/thread-routing';
+```
+
+- [ ] **Step 6: Verify + commit.**
+```bash
+npx nx run-many -t test lint build --projects=chat --skip-nx-cache   # green
+git add libs/chat/src/lib/routing libs/chat/src/public-api.ts
+git commit -m "feat(chat): injectThreadRouting — reusable URL<->active-threadId binding"
+```
+
+---
+
+## Task 2: Refactor `examples/chat` onto the helper
+
+**Files:** `examples/chat/angular/src/app/shell/demo-shell.component.ts`
+
+- [ ] **Step 1: Replace the hand-rolled sync.** Read the shell. It has module-scope `threadIdState`, a `urlState`/`urlThreadId` `toSignal`, a `parseUrl(mode + threadId)`, the URL→signal effect, the signal→URL effect (mode-prefixed commands), and a `getThread`-based validation/redirect effect. Replace the three thread effects + the `threadIdSignal` seeding with a single `injectThreadRouting` call, passing `toCommands`/`threadIdFromUrl` that preserve the mode prefix and `validate` via `threadsSvc.getThread`. KEEP: the `mode` computed (still needed for the UI + mode-switch nav), the knob query-param effects (unrelated), the `threadActions` adapter, `refreshOnRunEnd`, the route UrlMatcher (unchanged). `threadIdSignal` becomes the app-owned `threadIdState` passed to the helper.
+```ts
+injectThreadRouting({
+  threadId: threadIdState,
+  threadIdFromUrl: (u) => parseUrl(u).threadId,
+  toCommands: (id) => (id ? ['/', this.mode(), id] : ['/', this.mode()]),
+  validate: (id) => this.threadsSvc.getThread(id).then(Boolean),
+});
+```
+Keep `parseUrl` (used by `mode` computed + `threadIdFromUrl`). Delete the now-redundant URL→signal, signal→URL, and validation effects + the `urlThreadId` private signal if only used by them (keep `urlState`/`mode`).
+NOTE: `this.mode()` inside `toCommands` — `mode` is derived from the URL; on a thread-switch the mode hasn't changed, so commands stay in the current mode. Confirm `mode` is readable at helper-call time (it is — it's a computed on `urlState`).
+
+- [ ] **Step 2: Verify build + the thread-routing e2e stays green.**
+```bash
+npx nx build examples-chat-angular --skip-nx-cache
+# free ports 4200/4201/2024 first
+npx nx e2e examples-chat-angular --skip-nx-cache -- --grep "thread|route|url"
+```
+Expected: PASS — load thread route, switch updates URL, back/forward, agent-allocated id survives. If no thread-routing e2e exists, run the full examples-chat e2e and confirm no regression; note coverage.
+
+- [ ] **Step 3: Commit.**
+```bash
+git add examples/chat/angular/src/app/shell/demo-shell.component.ts
+git commit -m "refactor(examples/chat): adopt injectThreadRouting (delete hand-rolled URL<->thread sync)"
+```
+
+---
+
+## Task 3: Adopt in the cockpit thread demos
+
+**Files:**
+- `cockpit/chat/threads/angular/src/app/*` (component + app.config + routes)
+- `cockpit/langgraph/persistence/angular/src/app/*`
+
+- [ ] **Step 1: `cockpit/chat/threads`.** It uses an in-memory `activeThreadIdState` signal + `LangGraphThreadsAdapter`. Add a route param if the app has no router (use a simple `/:threadId?` route or a UrlMatcher), wire `provideAgent({ threadId: activeThreadIdState, onThreadId: id => activeThreadIdState.set(id) })` (likely already present), and in the component call `injectThreadRouting({ threadId: activeThreadIdState, validate: id => threadsSvc.getThread(id).then(Boolean) })`. The thread now survives reload + is shareable. Keep the sidenav/thread-list wiring + `threadActions`.
+
+- [ ] **Step 2: `cockpit/langgraph/persistence`.** Adopt the helper the same way. ALSO replace the ad-hoc `onThreadId` list-tracking (`threadsState` built manually in the callback) with `LangGraphThreadsAdapter.threads()` (inject the adapter, use its signal for the picker, drop the manual counter). `onThreadId` now only sets the active-thread signal (the helper handles the URL; the adapter handles the list).
+
+- [ ] **Step 3: Verify builds.**
+```bash
+npx nx run-many -t build --projects=cockpit-chat-threads-angular,cockpit-langgraph-persistence-angular --skip-nx-cache
+```
+
+- [ ] **Step 4: Reload-survival e2e for one app.** Add/extend an e2e for `cockpit/chat/threads`: send a message (thread auto-created → URL stamped), reload the page, assert the conversation is restored (messages present) from the URL. Free ports first; run `npx nx e2e cockpit-chat-threads-angular`. If the cockpit app has no e2e harness, note that and rely on the examples/chat e2e + the unit tests for the helper.
+
+- [ ] **Step 5: Commit.**
+```bash
+git add cockpit/chat/threads/angular cockpit/langgraph/persistence/angular
+git commit -m "feat(cockpit): adopt injectThreadRouting in threads + persistence demos (reload-survival + adapter list)"
+```
+
+---
+
+## Task 4: AG-UI spike → conditional wire
+
+**Files:** `examples/ag-ui/angular/*` (only if the spike is positive)
+
+- [ ] **Step 1: Spike.** Determine whether the itinerary AG-UI server restores a conversation when `HttpAgent` is constructed with a prior `threadId`. Read `examples/ag-ui/python/src/*` (does it persist messages/state keyed by thread id?) and the AG-UI client `HttpAgent` threadId handling. Optionally serve + manually verify (start a thread, note its id, reload with the id, see if history returns). Write your finding.
+
+- [ ] **Step 2a: If positive** — wire `examples/ag-ui` like the LangGraph apps: app-owned `ACTIVE_THREAD` signal, `provideAgent({ url, threadId: ACTIVE_THREAD, /* onThreadId if AG-UI exposes it */ })`, and `injectThreadRouting({ threadId: ACTIVE_THREAD })` (no `validate` unless AG-UI offers a getThread). Build + smoke.
+
+- [ ] **Step 2b: If negative** — do NOT add thread UI. Add a one-paragraph note in `examples/ag-ui/angular` (a code comment in the shell + a line in the thread-routing doc) stating the AG-UI itinerary server does not persist conversations by thread id, so the demo is intentionally ephemeral.
+
+- [ ] **Step 3: Commit** (whichever path).
+```bash
+git add examples/ag-ui/angular docs
+git commit -m "test(examples/ag-ui): <wire thread routing | document intentional ephemerality> per AG-UI thread-persistence spike"
+```
+
+---
+
+## Task 5: Thread-routing docs guide
+
+**Files:** a new guide under `apps/website/content/docs/` (chat or langgraph guides section — match where thread/sidenav docs live).
+
+- [ ] **Step 1: Write the guide.** Document URL-as-source-of-truth + `injectThreadRouting`: the app-owned signal + `provideAgent` wiring, the helper call, `toCommands`/`threadIdFromUrl` for custom paths, `validate` for stale links, and the doctrine (no localStorage for the active thread; bare = welcome). Include the canonical snippet. Reference the existing `2026-05-20-url-thread-routing-design.md` doctrine. If the docs render `api-docs.json`, regenerate so `injectThreadRouting` appears.
+
+- [ ] **Step 2: Commit.**
+```bash
+git add apps/website/content/docs
+git commit -m "docs: thread-routing guide (injectThreadRouting + URL-as-source-of-truth)"
+```
+
+---
+
+## Task 6: Full verification + review + PR
+
+- [ ] **Step 1: Full gate.** `npx nx run-many -t test lint build --projects=chat --skip-nx-cache`; build the adopting apps (`examples-chat-angular`, `cockpit-chat-threads-angular`, `cockpit-langgraph-persistence-angular`, and `examples-ag-ui-angular` if wired). e2e green where run.
+- [ ] **Step 2: Final whole-implementation code review** (most-capable): helper correctness (no URL↔signal loop; validate race uses the untracked re-check; bare=welcome; defaults), the examples/chat refactor is behavior-identical, the cockpit adoptions don't regress, no internal-type leak in the public `injectThreadRouting`/`ThreadRoutingConfig`.
+- [ ] **Step 3: Open PR** against main, regenerate `api-docs` + commit if changed, enable auto-merge; if `BEHIND`, update from main (the self-healing pattern) and re-verify.
+- [ ] **Step 4: Finish** via `superpowers:finishing-a-development-branch`.
+
+---
+
+## Self-Review (against the spec)
+
+- **Coverage:** helper + tests + export (Task 1) ✓; examples/chat refactor (Task 2) ✓; cockpit adoption incl. persistence→adapter-list (Task 3) ✓; AG-UI verify-then-decide (Task 4) ✓; docs (Task 5) ✓; verify+PR (Task 6) ✓.
+- **Type consistency:** `injectThreadRouting`, `ThreadRoutingConfig` (`threadId`/`toCommands`/`threadIdFromUrl`/`validate`/`navigationExtras`) used consistently; defaults (`defaultFromUrl`/`defaultToCommands`) match the spec.
+- **No placeholders:** helper implementation is complete; the one harness-flush detail (`TestBed.tick` vs fixture) is explicitly flagged for the implementer to match the repo, with the assertions as the fixed contract; the AG-UI branch is conditional-by-design, not a TBD.

--- a/docs/superpowers/specs/2026-06-18-thread-routing-helper-design.md
+++ b/docs/superpowers/specs/2026-06-18-thread-routing-helper-design.md
@@ -1,0 +1,122 @@
+# Consistent Thread Persistence — `injectThreadRouting` Design
+
+**Status:** Approved (brainstorm) — ready for implementation plan
+**Date:** 2026-06-18
+**Scope:** `@threadplane/chat` (new neutral helper) + adoption in the LangGraph-backed thread demos; an AG-UI spike.
+
+## Problem
+
+Thread persistence is reinvented per app. `examples/chat` has a robust ~100-line URL-as-source-of-truth implementation hand-rolled in its shell; every other thread-aware app either reinvents it in-memory (lost on reload) or uses an ad-hoc pattern.
+
+Audit matrix:
+
+| App | Survives reload / shareable | Mechanism | List source |
+|-----|------|-----------|-------------|
+| `examples/chat` ⭐ | yes | URL-as-source-of-truth (hand-rolled, ~100 lines) + validation | `LangGraphThreadsAdapter` |
+| `examples/ag-ui` | no (ephemeral) | knobs in query-params only; no `threadId` | none |
+| `cockpit/chat/threads` | no | in-memory signal | `LangGraphThreadsAdapter` |
+| `cockpit/langgraph/persistence` | no | in-memory signal + ad-hoc `onThreadId` list tracking | derived manually |
+| `cockpit/chat/messages`, `cockpit/langgraph/memory` | n/a | single-session feature demos | — |
+
+The library already ships the thread *list/CRUD* toolkit (`LangGraphThreadsAdapter`, `ChatSidenavComponent`, `Thread`, `ThreadActionAdapter`, `getThread`). The missing, duplicated piece is the **URL ↔ active-threadId binding + restore-on-reload**. Neither of the two reference frameworks studied ships URL routing — they leave it to the app and keep the active thread id as a single owned signal with the server authoritative for messages. So providing a thin, adapter-neutral routing helper is a genuine value-add, not a re-implementation.
+
+## Goals
+
+1. One reusable helper that binds a URL segment ↔ an app-owned `activeThreadId` signal, with restore-on-reload, signal→URL stamping, optional validation, and the "bare URL = welcome / no thread" convention.
+2. Adapter-neutral (works for any adapter whose `provideAgent` accepts a `threadId` signal + `onThreadId` callback — both LangGraph and AG-UI do).
+3. Refactor `examples/chat` onto it (behavior-identical) and adopt it in the lagging LangGraph thread demos so they survive reload and are shareable.
+4. Make URL-as-source-of-truth the documented canonical pattern.
+
+Non-goals (YAGNI): a thread *list* abstraction (the adapter already provides it); localStorage persistence of the active thread (rejected — breaks shareability, per the existing `2026-05-20-url-thread-routing-design.md`); auto-creating a thread on load (the agent stamps the id on first message — implicit→explicit).
+
+## Architecture
+
+The helper is the URL-binding logic only. The app **owns** the `activeThreadId` signal (module- or token-scope, because `provideAgent` runs at provider-decoration time and must reference it before the component instance exists — the same constraint `examples/chat` already lives with). The helper, called in the shell's injection context, wires that signal to the Angular `Router`.
+
+### Component — `injectThreadRouting(config)` (`libs/chat/src/lib/routing/thread-routing.ts`, new)
+
+```ts
+export interface ThreadRoutingConfig {
+  /** The app-owned source-of-truth signal for the active thread id. */
+  threadId: WritableSignal<string | null>;
+  /** Build the router commands for a thread id (or the bare/welcome path when null).
+   *  Default: `(id) => (id ? ['/', id] : ['/'])`. */
+  toCommands?: (id: string | null) => unknown[];
+  /** Extract the thread id from a URL (null = bare/welcome). Default: last non-empty
+   *  path segment. */
+  threadIdFromUrl?: (url: string) => string | null;
+  /** Optional async validity check. When it resolves false, the helper redirects to the
+   *  bare path (`replaceUrl: true`). LangGraph apps pass `id => threads.getThread(id).then(Boolean)`. */
+  validate?: (id: string) => Promise<boolean>;
+  /** Router navigation extras merged into every navigate (default `{ queryParamsHandling: 'preserve' }`). */
+  navigationExtras?: NavigationExtras;
+}
+
+/** Bind an app-owned `activeThreadId` signal to the URL: restore on load, stamp on change,
+ *  validate-or-redirect. Must be called in an Angular injection context (sets up effects). */
+export function injectThreadRouting(config: ThreadRoutingConfig): void;
+```
+
+Internals (extracted from `examples/chat` `demo-shell.component.ts`, generalized):
+- **URL → signal** effect: tracks the router URL (via `toSignal` of `NavigationEnd`), parses `threadIdFromUrl`, and if it differs from `untracked(threadId)` sets the signal. Untracked read prevents the imperative-write loop.
+- **signal → URL** effect: when `threadId()` changes (agent `onThreadId` stamp, or sidenav switch), `router.navigate(toCommands(id), navigationExtras)`.
+- **Validation** effect (only if `validate` provided): on a non-null URL thread id, `await validate(id)`; if false, navigate to `toCommands(null)` with `replaceUrl: true` (handles 404/422 stale links).
+- Bare URL (`threadIdFromUrl` → null) leaves `threadId` null = welcome; never creates a thread.
+
+Defaults make the simplest case (`/:threadId`) zero-config; `examples/chat`'s mode-prefixed paths (`/embed/<id>`) are expressed via `toCommands`/`threadIdFromUrl`.
+
+### App wiring pattern (documented, ~3 lines beyond providers)
+
+```ts
+export const ACTIVE_THREAD = signal<string | null>(null);          // app-owned source of truth
+
+// app.config / component providers:
+provideAgent({ assistantId, threadId: ACTIVE_THREAD, onThreadId: (id) => ACTIVE_THREAD.set(id) });
+
+// shell component (injection context):
+const threads = inject(LangGraphThreadsAdapter);
+injectThreadRouting({ threadId: ACTIVE_THREAD, validate: (id) => threads.getThread(id).then(Boolean) });
+```
+
+## Adoption
+
+- **`examples/chat`** — refactor the shell onto `injectThreadRouting` using `toCommands`/`threadIdFromUrl` for the mode-prefixed paths; delete the hand-rolled effects + `parseUrl`. Behavior identical (proven by the existing thread-routing e2e). This is the reference adoption.
+- **`cockpit/chat/threads`** — replace the in-memory `activeThreadIdState` wiring with the helper (gains reload-survival + shareable URLs). Add a route param if the app currently has none.
+- **`cockpit/langgraph/persistence`** — adopt the helper AND switch from ad-hoc `onThreadId` list tracking to `LangGraphThreadsAdapter.threads()`, so it stops modeling a divergent list pattern.
+- **Feature-focused demos** (`cockpit/chat/messages`, `cockpit/langgraph/memory`) — unchanged (single-session is correct).
+- **`examples/ag-ui` (spike)** — first verify the itinerary AG-UI server restores a conversation when `HttpAgent` is constructed with a prior `threadId` (check `examples/ag-ui/python` + the AG-UI protocol/thread handling). If it does: wire `examples/ag-ui` onto the same helper (`provideAgent({ url, threadId, ... })` + `injectThreadRouting`). If it does not: leave it ephemeral and add a one-paragraph note in the app/docs stating the server doesn't persist by thread, so the choice is intentional.
+
+## Docs
+
+A short guide (`apps/website/content/docs/.../thread-routing.mdx` or the chat guides section) documenting URL-as-source-of-truth + `injectThreadRouting`, superseding the demo-only pattern. Reference the `2026-05-20-url-thread-routing-design.md` doctrine (no localStorage for the active thread; bare = welcome; validate stale links).
+
+## Error handling & edge cases
+
+- **Stale/deleted thread in URL:** `validate` false → redirect to bare with `replaceUrl: true` (no history entry for the dead link).
+- **Agent auto-creates a thread (first message):** `onThreadId` sets the signal → signal→URL effect stamps `/<id>` (or `/<mode>/<id>`). The async gap between submit and the id arriving is handled by the untracked read (no loop), exactly as today.
+- **Back/forward navigation:** URL→signal effect re-syncs; agent reconnects to the URL's thread.
+- **No `validate` provided:** the helper trusts the URL id (fine for adapters without a getThread; the agent connect will surface a backend error via the now-structured `AgentError`).
+- **Bare path on load:** welcome state, `threadId` stays null, no thread created.
+
+## Testing strategy
+
+- **Unit (`thread-routing.spec.ts`):** with a `RouterTestingHarness`/mock Router — URL→signal restore on init; signal→URL navigate on change; `validate` false → redirect to bare (`replaceUrl`); bare URL → null signal (no navigate, no create); custom `toCommands`/`threadIdFromUrl` (mode-prefixed) round-trips.
+- **`examples/chat` e2e:** the existing thread-routing e2e must stay green through the refactor (load thread route, switch updates URL, back/forward, agent-allocated id survives the nav gap).
+- **One cockpit thread-restore e2e:** for `cockpit/chat/threads` (or persistence) — create/switch a thread, reload, assert the conversation is restored from the URL.
+- Existing chat unit suite + the adopting apps build green; build the adopting apps.
+
+## Files touched
+
+- `libs/chat/src/lib/routing/thread-routing.ts` *(new)* — `injectThreadRouting`, `ThreadRoutingConfig`.
+- `libs/chat/src/lib/routing/thread-routing.spec.ts` *(new)*.
+- `libs/chat/src/public-api.ts` — export `injectThreadRouting`, `ThreadRoutingConfig`.
+- `examples/chat/angular/src/app/shell/demo-shell.component.ts` — refactor onto the helper (net deletion).
+- `cockpit/chat/threads/angular/src/app/*` + `cockpit/langgraph/persistence/angular/src/app/*` — adopt helper; persistence app switches to the threads adapter list; add route param(s) where missing.
+- `examples/ag-ui/angular/*` — conditional (spike outcome).
+- Docs: a thread-routing guide.
+
+## Risks
+
+- **`examples/chat` refactor regressing the URL doctrine.** Mitigated by keeping behavior identical and gating on the existing thread-routing e2e; the helper is a straight extraction.
+- **Per-app route shapes differ** (mode-prefixed vs plain). Mitigated by the `toCommands`/`threadIdFromUrl` config; defaults cover the plain case.
+- **AG-UI spike may be negative** (server doesn't restore by thread) — acceptable; the verify-then-decide scope makes that an explicit, documented outcome rather than dead UI.

--- a/docs/superpowers/specs/2026-06-18-thread-routing-helper-design.md
+++ b/docs/superpowers/specs/2026-06-18-thread-routing-helper-design.md
@@ -78,13 +78,22 @@ const threads = inject(LangGraphThreadsAdapter);
 injectThreadRouting({ threadId: ACTIVE_THREAD, validate: (id) => threads.getThread(id).then(Boolean) });
 ```
 
+## The consistency principle (corrected during implementation)
+
+The audit initially read the cockpit demos as "lagging." Investigation during implementation corrected this: **the cockpit demos are iframe-embedded** inside the docs site (`apps/cockpit` renders each as a `ThemedFrame`; the demo's own URL is never in the user's address bar and is never bookmarked/shared). They also have **no Angular Router** by design. URL-as-source-of-truth is therefore the *wrong* model for them — adding it would be dead, confusing UI.
+
+So the consistent story is not "every demo persists threads identically." It is:
+
+- **Standalone, router-owning apps with a user-shareable URL** (`examples/*`) → use `injectThreadRouting` (URL-as-source-of-truth: survives reload, shareable, validated).
+- **Embedded docs demos** (`cockpit/*`) → an in-memory active-thread signal is correct; their job is to teach one capability, not to be a shareable app. `cockpit/langgraph/persistence`'s manual `onThreadId` thread-list tracking is **intentional pedagogy** (its guide teaches that exact pattern), not a divergence to "fix."
+
+The helper exists so any *future* standalone app gets URL persistence in a few lines instead of ~100 — and so the doctrine is documented rather than living only in one demo's shell.
+
 ## Adoption
 
-- **`examples/chat`** — refactor the shell onto `injectThreadRouting` using `toCommands`/`threadIdFromUrl` for the mode-prefixed paths; delete the hand-rolled effects + `parseUrl`. Behavior identical (proven by the existing thread-routing e2e). This is the reference adoption.
-- **`cockpit/chat/threads`** — replace the in-memory `activeThreadIdState` wiring with the helper (gains reload-survival + shareable URLs). Add a route param if the app currently has none.
-- **`cockpit/langgraph/persistence`** — adopt the helper AND switch from ad-hoc `onThreadId` list tracking to `LangGraphThreadsAdapter.threads()`, so it stops modeling a divergent list pattern.
-- **Feature-focused demos** (`cockpit/chat/messages`, `cockpit/langgraph/memory`) — unchanged (single-session is correct).
-- **`examples/ag-ui` (spike)** — first verify the itinerary AG-UI server restores a conversation when `HttpAgent` is constructed with a prior `threadId` (check `examples/ag-ui/python` + the AG-UI protocol/thread handling). If it does: wire `examples/ag-ui` onto the same helper (`provideAgent({ url, threadId, ... })` + `injectThreadRouting`). If it does not: leave it ephemeral and add a one-paragraph note in the app/docs stating the server doesn't persist by thread, so the choice is intentional.
+- **`examples/chat`** — refactor the shell onto `injectThreadRouting` using `toCommands`/`threadIdFromUrl` for the mode-prefixed paths; delete the hand-rolled effects. Behavior identical (proven by the existing `url-routing` e2e). This is the reference adoption. ✅ done
+- **`cockpit/*` demos** — **intentionally unchanged** (iframe-embedded, no router; in-memory is correct). Documented as a deliberate distinction, not an oversight.
+- **`examples/ag-ui` (spike)** — `examples/ag-ui` IS a standalone app, so it's the one remaining adoption candidate. First verify the itinerary AG-UI server restores a conversation when `HttpAgent` is constructed with a prior `threadId` (check `examples/ag-ui/python` + the AG-UI protocol/thread handling). If it does: wire `examples/ag-ui` onto the helper. If it does not: leave it ephemeral and add a one-paragraph note stating the server doesn't persist by thread, so the choice is intentional.
 
 ## Docs
 

--- a/examples/ag-ui/angular/src/app/app.config.ts
+++ b/examples/ag-ui/angular/src/app/app.config.ts
@@ -18,6 +18,17 @@ export const appConfig: ApplicationConfig = {
     provideZonelessChangeDetection(),
     provideRouter(routes),
     provideThreadplaneTelemetry(environment.telemetry),
+    // Thread persistence intentionally omitted: the itinerary AG-UI server
+    // uses an in-process MemorySaver (examples/ag-ui/python/src/server.py)
+    // that is wiped on every server restart, so restoring by threadId would
+    // not return prior conversation history. Additionally, the AG-UI protocol
+    // sends the full client-side message list on every runAgent() call, meaning
+    // the HttpAgent constructs each turn from what the client already holds —
+    // there is no server-side "snapshot replay on connect" for this transport.
+    // Standalone LangGraph apps backed by a durable checkpointer use
+    // injectThreadRouting (see examples/chat); for AG-UI to adopt it the server
+    // would need a persistent store (e.g. SqliteSaver / PostgresSaver) so
+    // reloading a prior threadId actually returns prior history.
     provideAgent({ url: environment.agentUrl }),
     provideChat({ license: environment.license }),
     // The frontend-owned itinerary is a single shared instance: the panel,

--- a/examples/chat/angular/src/app/shell/demo-shell.component.ts
+++ b/examples/chat/angular/src/app/shell/demo-shell.component.ts
@@ -22,6 +22,7 @@ import {
   ChatSidenavScrimComponent,
   ChatHistorySearchPaletteComponent,
   ChatSelectComponent,
+  injectThreadRouting,
   type ChatSidenavMode,
   type InterruptAction,
   type ThreadMatch,
@@ -150,22 +151,15 @@ export class DemoShell {
       void this.threadsSvc.refresh();
     });
 
-    // URL → signal. When the URL's threadId changes (paste link, back/
-    // forward, programmatic navigation), reflect it into threadIdSignal.
-    // Tracks ONLY the URL — the signal read is untracked so this effect
-    // does not re-fire when the signal is set imperatively (e.g. by the
-    // agent's onThreadId callback during the stamp-in-progress async gap
-    // before the URL catches up).
-    //
-    // No localStorage fallback: URL is the source of truth. Bare-mode URLs
-    // (`/embed`, `/popup`, `/sidebar`) explicitly mean "no active thread"
-    // — the welcome state. Mode-switch UI uses `onModeChange` to preserve
-    // the active thread across mode boundaries via URL navigation.
-    effect(() => {
-      const urlId = this.urlThreadId();
-      if (urlId !== untracked(() => this.threadIdSignal())) {
-        this.threadIdSignal.set(urlId);
-      }
+    // Thread routing: binds threadIdState ↔ URL. Restores id from URL on
+    // load, stamps signal changes into the URL, and validates thread ids
+    // (redirecting to the bare mode path on 404). Replaces the three
+    // hand-rolled effects that previously lived here.
+    injectThreadRouting({
+      threadId: threadIdState,
+      threadIdFromUrl: (u) => parseUrl(u).threadId,
+      toCommands: (id) => (id ? ['/', this.mode(), id] : ['/', this.mode()]),
+      validate: (id) => this.threadsSvc.getThread(id).then(Boolean),
     });
 
     // URL → knob signals. Tracks urlState() so it re-fires on every
@@ -176,34 +170,6 @@ export class DemoShell {
     effect(() => {
       void this.urlState();
       untracked(() => this.hydrateFromQuery());
-    });
-
-    // Validate URL thread ids whenever they appear. Decoupled from the
-    // sync effect above: on initial load the signal is hydrated from
-    // the URL synchronously (field initializer), so the sync guard
-    // would skip validation. This effect runs once per distinct id,
-    // including the initial one. Cache last-validated to avoid
-    // re-hitting the server on signal flips that round-trip the same
-    // id back through.
-    let lastValidated: string | null = null;
-    effect(() => {
-      const urlId = this.urlThreadId();
-      if (urlId && urlId !== lastValidated) {
-        lastValidated = urlId;
-        void this.validateUrlThreadId(urlId);
-      }
-    });
-
-    // signal → URL. When the agent auto-creates a thread, the sidenav
-    // switches threads, or onNewThread fires, push the new id into the
-    // URL. Skips when the URL already matches (also breaks the loop).
-    // Preserves query params so knob state survives the thread hop.
-    effect(() => {
-      const sigId = this.threadIdSignal();
-      const { mode, threadId: urlId } = this.urlState();
-      if (sigId === urlId) return;
-      const cmds: unknown[] = sigId ? ['/', mode, sigId] : ['/', mode];
-      void this.router.navigate(cmds as string[], { queryParamsHandling: 'preserve' });
     });
 
     // Refresh threads list when an agent run completes. The backend writes
@@ -241,7 +207,6 @@ export class DemoShell {
   );
 
   protected readonly mode = computed<DemoMode>(() => this.urlState().mode);
-  private readonly urlThreadId = computed<string | null>(() => this.urlState().threadId);
 
   /**
    * Source of truth for the model picker. The shell owns it; the
@@ -359,20 +324,14 @@ export class DemoShell {
     { value: 'material-light', label: 'Material light' },
   ]);
 
-  /** Active thread id. URL is the sole source of truth (see urlState
-   *  above); this signal initialises from the URL on construction and is
-   *  kept in sync by the bidirectional effects in the constructor. The
-   *  agent watches this signal directly.
+  /** Active thread id. URL is the sole source of truth; seeded from the
+   *  URL on construction and kept in sync by `injectThreadRouting` (called
+   *  in the constructor). The agent watches this signal via the module-level
+   *  `threadIdState` reference in `provideAgent({...})`.
    *
    *  Mode switches that should preserve the active thread go through
    *  `onModeChange`, which navigates to `/<next-mode>/<id>` directly. */
-  // Alias the module-level signal the agent provider watches (see
-  // @Component providers), so the component's URL-sync logic and the agent
-  // share one source of truth. Seed it from the current URL.
-  protected readonly threadIdSignal = ((): typeof threadIdState => {
-    threadIdState.set(parseUrl(this.router.url).threadId);
-    return threadIdState;
-  })();
+  protected readonly threadIdSignal = threadIdState;
 
   /** Title of the currently-selected thread, or 'New chat' if none. The
    *  Python graph writes thread.metadata.title from the first user message
@@ -532,20 +491,6 @@ export class DemoShell {
     if (project !== null && project !== this.selectedProjectId()) {
       this.selectedProjectId.set(project);
     }
-  }
-
-  /** Silently redirect to the bare mode path when the URL's threadId
-   *  resolves to a 404. Uses `replaceUrl: true` so the back button
-   *  doesn't reload the broken link. Non-404 errors propagate from
-   *  the adapter as-is (genuine transport failures shouldn't be
-   *  swallowed). */
-  private async validateUrlThreadId(threadId: string): Promise<void> {
-    const thread = await this.threadsSvc.getThread(threadId);
-    if (thread) return;
-    if (this.threadIdSignal() === threadId) {
-      this.threadIdSignal.set(null);
-    }
-    await this.router.navigate(['/', this.mode()], { replaceUrl: true });
   }
 
   onModelChange(next: string): void {

--- a/libs/chat/package.json
+++ b/libs/chat/package.json
@@ -17,6 +17,7 @@
     "@angular/core": "^20.0.0 || ^21.0.0",
     "@angular/common": "^20.0.0 || ^21.0.0",
     "@angular/platform-browser": "^20.0.0 || ^21.0.0",
+    "@angular/router": "^20.0.0 || ^21.0.0",
     "@threadplane/licensing": "*",
     "@threadplane/render": "*",
     "@threadplane/a2ui": "*",

--- a/libs/chat/src/lib/routing/thread-routing.spec.ts
+++ b/libs/chat/src/lib/routing/thread-routing.spec.ts
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: MIT
+import { signal } from '@angular/core';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { provideRouter, Router } from '@angular/router';
+import { Component } from '@angular/core';
+import { injectThreadRouting } from './thread-routing';
+
+// Minimal stub component needed for provideRouter routes.
+@Component({ template: '', standalone: true })
+class StubComponent {}
+
+const baseRoutes = [
+  { path: ':threadId', component: StubComponent },
+  { path: '', pathMatch: 'full' as const, component: StubComponent },
+];
+
+describe('injectThreadRouting', () => {
+  let router: Router;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideRouter(baseRoutes)],
+    });
+    router = TestBed.inject(Router);
+  });
+
+  // 1. URL → signal restore on init
+  it('restores threadId from URL on init', async () => {
+    await router.navigateByUrl('/abc123');
+    const threadId = signal<string | null>(null);
+
+    TestBed.runInInjectionContext(() => {
+      injectThreadRouting({ threadId });
+    });
+
+    // Seed is synchronous — no flush needed.
+    expect(threadId()).toBe('abc123');
+  });
+
+  // 2. signal → URL
+  it('navigates when threadId signal changes', async () => {
+    await router.navigateByUrl('/');
+    const threadId = signal<string | null>(null);
+    const navigateSpy = vi.spyOn(router, 'navigate');
+
+    TestBed.runInInjectionContext(() => {
+      injectThreadRouting({ threadId });
+      // Flush any initial effects before mutating.
+      TestBed.flushEffects();
+    });
+
+    // Change the signal value.
+    threadId.set('xyz');
+    TestBed.flushEffects();
+
+    expect(navigateSpy).toHaveBeenCalledWith(
+      ['/', 'xyz'],
+      expect.objectContaining({ queryParamsHandling: 'preserve' }),
+    );
+  });
+
+  // 3. validate false → redirect to bare path
+  it('redirects to bare path when validate returns false', async () => {
+    await router.navigateByUrl('/dead');
+    const threadId = signal<string | null>(null);
+    const validate = async () => false;
+
+    const navigateSpy = vi.spyOn(router, 'navigate');
+
+    TestBed.runInInjectionContext(() => {
+      injectThreadRouting({ threadId, validate });
+      TestBed.flushEffects();
+    });
+
+    // Wait for the async validate promise to resolve.
+    await new Promise<void>((r) => setTimeout(r, 0));
+
+    expect(navigateSpy).toHaveBeenCalledWith(
+      ['/'],
+      expect.objectContaining({ replaceUrl: true }),
+    );
+  });
+
+  // 4. bare URL → null, no thread-path navigate
+  it('sets threadId to null for bare URL and does not navigate to a thread path', async () => {
+    await router.navigateByUrl('/');
+    const threadId = signal<string | null>('old-value');
+
+    const navigateSpy = vi.spyOn(router, 'navigate');
+
+    TestBed.runInInjectionContext(() => {
+      injectThreadRouting({ threadId });
+      TestBed.flushEffects();
+    });
+
+    expect(threadId()).toBeNull();
+    // Should not have navigated to any thread path (navigate may have been
+    // called for bare→bare but must not contain a thread id segment).
+    const threadPathCalls = navigateSpy.mock.calls.filter(
+      ([cmds]) => Array.isArray(cmds) && cmds.some((c) => c && c !== '/'),
+    );
+    expect(threadPathCalls).toHaveLength(0);
+  });
+});
+
+// 5. custom toCommands + threadIdFromUrl (mode-prefixed /embed/<id>)
+// Uses its own describe so we can configure its own TestBed with embed routes.
+describe('injectThreadRouting — custom toCommands/threadIdFromUrl', () => {
+  let router: Router;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([
+          { path: 'embed', component: StubComponent },
+          { path: 'embed/:threadId', component: StubComponent },
+          { path: '', pathMatch: 'full' as const, component: StubComponent },
+        ]),
+      ],
+    });
+    router = TestBed.inject(Router);
+  });
+
+  it('uses custom threadIdFromUrl and toCommands', async () => {
+    await router.navigateByUrl('/embed/t1');
+    const threadId = signal<string | null>(null);
+    const threadIdFromUrl = (u: string): string | null =>
+      u.split('?')[0].split('/').filter(Boolean)[1] ?? null;
+    const toCommands = (id: string | null): unknown[] =>
+      id ? ['/', 'embed', id] : ['/', 'embed'];
+
+    const navigateSpy = vi.spyOn(router, 'navigate');
+
+    TestBed.runInInjectionContext(() => {
+      injectThreadRouting({ threadId, threadIdFromUrl, toCommands });
+      // Flush initial effects before mutating.
+      TestBed.flushEffects();
+    });
+
+    // Restore is synchronous.
+    expect(threadId()).toBe('t1');
+
+    // Now change the signal and flush — should navigate to /embed/t2.
+    threadId.set('t2');
+    TestBed.flushEffects();
+
+    expect(navigateSpy).toHaveBeenCalledWith(
+      ['/', 'embed', 't2'],
+      expect.objectContaining({ queryParamsHandling: 'preserve' }),
+    );
+  });
+});

--- a/libs/chat/src/lib/routing/thread-routing.ts
+++ b/libs/chat/src/lib/routing/thread-routing.ts
@@ -69,12 +69,15 @@ export function injectThreadRouting(config: ThreadRoutingConfig): void {
     if (id !== urlId) void router.navigate(toCommands(id), extras);
   });
 
-  // validate stale ids → redirect to bare.
+  // validate stale ids → redirect to bare. Memoize the last id checked so
+  // re-visiting the same thread (A → B → A) doesn't re-hit the backend.
   if (config.validate) {
     const validate = config.validate;
+    let lastValidated: string | null = null;
     effect(() => {
       const id = urlThreadId();
-      if (!id) return;
+      if (!id || id === lastValidated) return;
+      lastValidated = id;
       void validate(id).then((ok) => {
         if (!ok && untracked(() => urlThreadId()) === id) {
           void router.navigate(toCommands(null), { ...extras, replaceUrl: true });

--- a/libs/chat/src/lib/routing/thread-routing.ts
+++ b/libs/chat/src/lib/routing/thread-routing.ts
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT
+import { effect, inject, untracked, type WritableSignal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { Router, NavigationEnd, type NavigationExtras } from '@angular/router';
+import { filter, map, startWith } from 'rxjs/operators';
+
+export interface ThreadRoutingConfig {
+  /** The app-owned source-of-truth signal for the active thread id. */
+  threadId: WritableSignal<string | null>;
+  /** Router commands for a thread id (or the bare/welcome path when null).
+   *  Default: `(id) => (id ? ['/', id] : ['/'])`. */
+  toCommands?: (id: string | null) => unknown[];
+  /** Extract the thread id from a URL (null = bare). Default: last non-empty path segment. */
+  threadIdFromUrl?: (url: string) => string | null;
+  /** Optional async validity check; on `false` the helper redirects to the bare path
+   *  (`replaceUrl: true`). LangGraph apps pass `id => threads.getThread(id).then(Boolean)`. */
+  validate?: (id: string) => Promise<boolean>;
+  /** Extras merged into every navigate (default `{ queryParamsHandling: 'preserve' }`). */
+  navigationExtras?: NavigationExtras;
+}
+
+const defaultFromUrl = (url: string): string | null => {
+  const seg = url.split('?')[0].split('#')[0].split('/').filter(Boolean);
+  return seg.length ? seg[seg.length - 1] : null;
+};
+const defaultToCommands = (id: string | null): unknown[] => (id ? ['/', id] : ['/']);
+
+/**
+ * Bind an app-owned `activeThreadId` signal to the URL — restore on load, stamp on change,
+ * validate-or-redirect, with a bare URL meaning "no thread" (welcome). URL is the source of
+ * truth; nothing is written to localStorage. Must be called in an injection context.
+ *
+ * @example
+ * ```ts
+ * export const ACTIVE_THREAD = signal<string | null>(null);
+ * // providers: provideAgent({ threadId: ACTIVE_THREAD, onThreadId: id => ACTIVE_THREAD.set(id) })
+ * const threads = inject(LangGraphThreadsAdapter);
+ * injectThreadRouting({ threadId: ACTIVE_THREAD, validate: id => threads.getThread(id).then(Boolean) });
+ * ```
+ */
+export function injectThreadRouting(config: ThreadRoutingConfig): void {
+  const router = inject(Router);
+  const fromUrl = config.threadIdFromUrl ?? defaultFromUrl;
+  const toCommands = config.toCommands ?? defaultToCommands;
+  const extras: NavigationExtras = config.navigationExtras ?? { queryParamsHandling: 'preserve' };
+
+  const urlThreadId = toSignal(
+    router.events.pipe(
+      filter((e): e is NavigationEnd => e instanceof NavigationEnd),
+      map((e) => fromUrl(e.urlAfterRedirects)),
+      startWith(fromUrl(router.url)),
+    ),
+    { initialValue: fromUrl(router.url) },
+  );
+
+  // Seed the signal from the URL once.
+  config.threadId.set(urlThreadId());
+
+  // URL → signal.
+  effect(() => {
+    const urlId = urlThreadId();
+    if (urlId !== untracked(() => config.threadId())) config.threadId.set(urlId);
+  });
+
+  // signal → URL.
+  effect(() => {
+    const id = config.threadId();
+    const urlId = untracked(() => urlThreadId());
+    if (id !== urlId) void router.navigate(toCommands(id), extras);
+  });
+
+  // validate stale ids → redirect to bare.
+  if (config.validate) {
+    const validate = config.validate;
+    effect(() => {
+      const id = urlThreadId();
+      if (!id) return;
+      void validate(id).then((ok) => {
+        if (!ok && untracked(() => urlThreadId()) === id) {
+          void router.navigate(toCommands(null), { ...extras, replaceUrl: true });
+        }
+      });
+    });
+  }
+}

--- a/libs/chat/src/public-api.ts
+++ b/libs/chat/src/public-api.ts
@@ -86,6 +86,10 @@ export { ChatCitationsCardComponent } from './lib/primitives/chat-citations/chat
 // DI provider
 export { provideChat, CHAT_CONFIG } from './lib/provide-chat';
 
+// Routing utilities
+export { injectThreadRouting } from './lib/routing/thread-routing';
+export type { ThreadRoutingConfig } from './lib/routing/thread-routing';
+
 // Lifecycle
 export { CHAT_LIFECYCLE } from './lib/lifecycle';
 export type { ChatLifecycle } from './lib/lifecycle';


### PR DESCRIPTION
## Summary

Makes thread persistence consistent by extracting `examples/chat`'s ~100-line hand-rolled URL↔thread-id sync into a reusable, adapter-neutral **`injectThreadRouting()`** in `@threadplane/chat`, and documenting *when* it applies.

## What it does
`injectThreadRouting({ threadId, toCommands?, threadIdFromUrl?, validate?, navigationExtras? })` binds an app-owned `WritableSignal<string | null>` to the Angular Router: restore-on-load, signal→URL stamp, validate-or-redirect, **bare URL = no thread (welcome)**. URL is the sole source of truth — nothing in localStorage, so links stay shareable. (Provably cycle-free; `validate` memoizes the last-checked id.)

## Scope (corrected during implementation)
The audit first read several demos as "lagging"; investigation corrected the framing:
- **Standalone, router-owning apps** (`examples/chat`) → use the helper. **Refactored `examples/chat` onto it (−55 lines), behavior-identical (its `url-routing` e2e stays 8/8).**
- **Embedded docs demos** (`cockpit/*`) → **intentionally untouched** — they're iframe-embedded with no router and non-shareable URLs, so URL-as-source-of-truth is the wrong model; in-memory is correct (and `cockpit/langgraph/persistence`'s manual tracking is deliberate pedagogy).
- **`examples/ag-ui`** → spiked and left **ephemeral by design** (documented): its itinerary server uses a non-durable in-process `MemorySaver` and AG-UI is forward-only (no history replay on connect), so restoring by threadId would return nothing. Wiring it would be dead UI.

## Also
- A docs guide (`chat/guides/thread-routing.mdx`) covering the API **and the decision** (standalone+durable vs embedded/stateless).
- `@angular/router` declared in the chat lib's peer deps.

## Validation
- chat test + lint + build green (864 tests; 5 new helper unit tests; 0 lint errors).
- `examples/chat` + `examples/ag-ui` build green; the `url-routing` e2e (deep-link load, mode-switch preserves thread, ephemeral hydration) stays green through the refactor.
- Final review: no blocking issues; the one Important finding (dropped validate-memo) fixed in this PR.

Spec + plan under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
