### PR TITLE
ci(claude-review): grant id-token: write so the review bot works

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -19,6 +19,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      id-token: write # claude-code-action fetches an OIDC token to auth its comment posting
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary

The advisory **Claude Review** bot (`anthropics/claude-code-action`, `track_progress: true`) has failed on **every** run since it was added — each dies in ~23s with:

> Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?

The `review` job granted `contents: read` + `pull-requests: write` but not **`id-token: write`**, which the action needs to authenticate its comment posting. This adds it (one line). It's a `pull_request` workflow (not `pull_request_target`), so `ANTHROPIC_API_KEY` is still never exposed to fork PRs, and `id-token` for forks remains restricted by GitHub.

## Forcing function

This PR is the live test: because `pull_request` runs the workflow from the PR head, **this PR's own Claude Review run uses the fixed workflow** — so a posted review comment on this PR confirms the automation works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)