### PR TITLE
ci: pin Docker base images + global npm installs (Pinned-Dependencies)

### DIFF
--- a/.github/workflows/deploy-ag-ui.yml
+++ b/.github/workflows/deploy-ag-ui.yml
@@ -45,7 +45,7 @@ jobs:
           fi
 
       - name: Install Railway CLI
-        run: npm install -g @railway/cli@4
+        run: npm install -g @railway/cli@4.68.0
 
       - name: Deploy
         working-directory: deployments/ag-ui-dev

--- a/.github/workflows/publish-middleware-npm.yml
+++ b/.github/workflows/publish-middleware-npm.yml
@@ -78,7 +78,8 @@ jobs:
 
       # Trusted publishing requires npm CLI 11.5.1+.
       - name: Upgrade npm to support trusted publishing
-        run: npm install -g npm@latest
+        # Pinned (Scorecard Pinned-Dependencies); must stay >= 11.5.1. Bump as needed.
+        run: npm install -g npm@11.17.0
 
       - name: Lint, test, build middleware
         run: npx nx run-many -t lint,test,build --projects=middleware --skip-nx-cache

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,8 @@ jobs:
       # is 10.x which has partial OIDC support but doesn't fully implement
       # the trusted-publishing flow against npm registry's OIDC endpoint.
       - name: Upgrade npm to support trusted publishing
-        run: npm install -g npm@latest
+        # Pinned (Scorecard Pinned-Dependencies); must stay >= 11.5.1. Bump as needed.
+        run: npm install -g npm@11.17.0
 
       - name: Lint, test, build publishable projects
         env:

--- a/deployments/ag-ui-dev/Dockerfile
+++ b/deployments/ag-ui-dev/Dockerfile
@@ -1,12 +1,12 @@
 # Multi-stage build for the ag-ui-dev FastAPI runtime.
 # Stage 1 installs Python deps into a user-site so we can copy them
 # into a slim runner without build tooling.
-FROM python:3.12-slim AS builder
+FROM python:3.12-slim@sha256:d764629ce0ddd8c71fd371e9901efb324a95789d2315a47db7e4d27e78f1b0e9 AS builder
 WORKDIR /build
 COPY requirements.txt .
 RUN pip install --user --no-cache-dir -r requirements.txt
 
-FROM python:3.12-slim
+FROM python:3.12-slim@sha256:d764629ce0ddd8c71fd371e9901efb324a95789d2315a47db7e4d27e78f1b0e9
 WORKDIR /app
 
 # curl is needed by entrypoint.sh's watchdog.

--- a/examples/ag-ui/python/Dockerfile
+++ b/examples/ag-ui/python/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build for the ag-ui demo backend (examples/ag-ui).
-FROM python:3.12-slim AS builder
+FROM python:3.12-slim@sha256:d764629ce0ddd8c71fd371e9901efb324a95789d2315a47db7e4d27e78f1b0e9 AS builder
 WORKDIR /build
 COPY requirements.txt .
 # Strip uv's editable self-reference (`-e .` / local file:// paths): the build
@@ -10,7 +10,7 @@ COPY requirements.txt .
 RUN grep -vE '^-e |^\. |^\.$|file://' requirements.txt > /tmp/deps.txt \
   && pip install --user --no-cache-dir -r /tmp/deps.txt
 
-FROM python:3.12-slim
+FROM python:3.12-slim@sha256:d764629ce0ddd8c71fd371e9901efb324a95789d2315a47db7e4d27e78f1b0e9
 WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends curl \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
Addresses 7 of the OSSF Scorecard **Pinned-Dependencies** findings (score 7):
- `python:3.12-slim` → `@sha256` digest in both ag-ui Dockerfiles (current live digest)
- `npm@latest` → `npm@11.17.0` (stays ≥ 11.5.1 for trusted publishing)
- `@railway/cli@4` → `@railway/cli@4.68.0`

**Intentionally skipped** (documented in the commit): pip `--require-hashes` (brittle — platform-specific hashes risk breaking the Railway Docker builds) and the 10 `downloadThenRun` hits, which are `curl … | python3` JSON-parsing calls in non-CI dev e2e recording scripts (false positives, not code download).

## Test Plan
- [ ] CI green (Docker builds still succeed)
- [ ] Next Scorecard run: Pinned-Dependencies rises from 7

🤖 Generated with [Claude Code](https://claude.com/claude-code)