### PR TITLE
fix(ci): claude-review needs id-token: write (OIDC)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -19,6 +19,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      id-token: write # claude-code-action mints its GitHub token via OIDC
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary
The first live run of `claude-review.yml` (#699) failed: `Could not fetch an OIDC token`. `claude-code-action@v1` mints its GitHub token via OIDC, which needs `id-token: write` on the job. Adds it. (The `auto-approve` workflow worked correctly on #699.)

Without this, the genuine AI review never posts — which is what makes the paired bot-approval legitimate rather than empty. This restores the real review.

## Test Plan
- [ ] CI green
- [ ] Next PR: Claude posts a review comment (not just the bot approval)

🤖 Generated with [Claude Code](https://claude.com/claude-code)