### PR TITLE
docs(chat): clarify injectThreadRouting usage prerequisites

### DIFF
--- a/apps/website/content/docs/chat/guides/thread-routing.mdx
+++ b/apps/website/content/docs/chat/guides/thread-routing.mdx
@@ -2,7 +2,9 @@
 
 `injectThreadRouting()` binds an app-owned active-thread signal to the Angular Router: it restores the thread id from the URL on load, stamps signal changes back into the URL, validates stale links, and treats a bare URL as "no thread" (the welcome state). **The URL is the sole source of truth — nothing is written to localStorage**, so links remain shareable without any extra plumbing.
 
-> Call `injectThreadRouting()` from an injection context (a component constructor or field initializer), and declare the active-thread signal at module scope so your `provideAgent({ threadId })` provider can reference it.
+<Callout type="info" title="Prerequisites">
+  Call `injectThreadRouting()` from an injection context (a component constructor or field initializer), and declare the active-thread signal at module scope so your `provideAgent({ threadId })` provider can reference it.
+</Callout>
 
 ## What it does
 

--- a/apps/website/content/docs/chat/guides/thread-routing.mdx
+++ b/apps/website/content/docs/chat/guides/thread-routing.mdx
@@ -2,6 +2,8 @@
 
 `injectThreadRouting()` binds an app-owned active-thread signal to the Angular Router: it restores the thread id from the URL on load, stamps signal changes back into the URL, validates stale links, and treats a bare URL as "no thread" (the welcome state). **The URL is the sole source of truth — nothing is written to localStorage**, so links remain shareable without any extra plumbing.
 
+> Call `injectThreadRouting()` from an injection context (a component constructor or field initializer), and declare the active-thread signal at module scope so your `provideAgent({ threadId })` provider can reference it.
+
 ## What it does
 
 | Behavior | Detail |


### PR DESCRIPTION
Adds a one-line callout to the thread-routing guide: call `injectThreadRouting()` from an injection context and declare the active-thread signal at module scope (so the `provideAgent({ threadId })` provider can reference it).

Doubles as the verification PR for the now-fixed Claude Review bot (non-workflow change, so the action's workflow-change safety guard won't skip it).