### PR TITLE
ci: align stray checkout pins to v6.0.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -969,7 +969,7 @@ jobs:
     if: github.event_name == 'push' || needs.ci-scope.outputs.posthog == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Detect PostHog-relevant changes

--- a/.github/workflows/publish-middleware-python.yml
+++ b/.github/workflows/publish-middleware-python.yml
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2


### PR DESCRIPTION
## Summary
Two jobs still pinned `actions/checkout@v4.3.1` (ci.yml `posthog-sync-plan`, `publish-middleware-python.yml`) while the rest of the repo is on `v6.0.2`. Aligns them — keeps a single checkout version across all workflows.

Also serves as the live verification of `claude-review` (fixed in #700): expect a genuine Claude review comment **and** a `github-actions[bot]` approval.

## Test Plan
- [ ] CI green
- [ ] Claude posts a review comment (verifies #700 fix)
- [ ] Bot approval recorded

🤖 Generated with [Claude Code](https://claude.com/claude-code)