### PR TITLE
fix(ci): post Claude review via GITHUB_TOKEN instead of failing OIDC

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -18,8 +18,7 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
-      pull-requests: write
-      id-token: write # claude-code-action mints its GitHub token via OIDC
+      pull-requests: write # posts review comments via the default GITHUB_TOKEN
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -30,6 +29,11 @@ jobs:
         uses: anthropics/claude-code-action@806af32823ef69c8ef357086c573a902af641307 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Post as the workflow's own GITHUB_TOKEN. Without this the action
+          # falls back to minting a GitHub App token via OIDC, which requires
+          # the Claude GitHub App installed on the repo and fails otherwise
+          # ("Could not fetch an OIDC token").
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           track_progress: true
           prompt: |
             REPO: ${{ github.repository }}


### PR DESCRIPTION
## Problem
The **Claude Review** workflow (`.github/workflows/claude-review.yml`) fails on **every** PR:

```
Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?
##[error]Action failed with error: Could not fetch an OIDC token...
```

`id-token: write` was already present, so the obvious fix was already in place — the cause is subtler.

## Root cause
The step passes `anthropic_api_key` but **no `github_token`**. In `claude-code-action` (pinned `806af328…`), `setupGitHubToken` uses `OVERRIDE_GITHUB_TOKEN` (fed by the `github_token` input) when present, and **otherwise falls through to `getOidcToken()`** — minting a GitHub App token via OIDC. That OIDC path requires the **Claude GitHub App installed on the repo** and a working exchange; without it the action throws the OIDC error before ever reviewing. Confirmed against the action's `src/github/token.ts` + `action.yml` at the pinned SHA.

## Fix
- Pass `github_token: ${{ secrets.GITHUB_TOKEN }}` → action maps it to `OVERRIDE_GITHUB_TOKEN` and **skips OIDC**, posting review comments with the workflow's own token (the job already has `pull-requests: write`).
- Drop the now-unused `id-token: write` permission.

Test-only / CI-config; the check is advisory (non-required), so it never blocked merges — but the review silently no-op'd on every PR.

## Verification
This is a `pull_request` workflow, so **this PR runs the fixed workflow on itself** — the `review` check going green (and a posted review comment) confirms the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)