### PR TITLE
chore(release): bump publishable packages to 0.0.51

### DIFF
--- a/libs/a2ui/package.json
+++ b/libs/a2ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/a2ui",
-  "version": "0.0.50",
+  "version": "0.0.51",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/ag-ui/package.json
+++ b/libs/ag-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/ag-ui",
-  "version": "0.0.50",
+  "version": "0.0.51",
   "description": "AG-UI protocol adapter for @threadplane/chat — works with any AG-UI-compatible backend.",
   "keywords": ["angular", "ag-ui", "agent", "adapter", "threadplane"],
   "peerDependencies": {

--- a/libs/chat/package.json
+++ b/libs/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/chat",
-  "version": "0.0.50",
+  "version": "0.0.51",
   "exports": {
     "./chat.css": "./chat.css",
     "./themes/default-dark.css": "./themes/default-dark.css",

--- a/libs/langgraph/package.json
+++ b/libs/langgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/langgraph",
-  "version": "0.0.50",
+  "version": "0.0.51",
   "description": "LangGraph adapter for @threadplane/chat — Angular bindings for LangGraph Platform.",
   "keywords": ["angular", "langgraph", "langchain", "agent", "adapter", "threadplane"],
   "peerDependencies": {

--- a/libs/licensing/package.json
+++ b/libs/licensing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/licensing",
-  "version": "0.0.50",
+  "version": "0.0.51",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/render/package.json
+++ b/libs/render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/render",
-  "version": "0.0.50",
+  "version": "0.0.51",
   "peerDependencies": {
     "@angular/core": "^20.0.0 || ^21.0.0",
     "@angular/common": "^20.0.0 || ^21.0.0",

--- a/libs/telemetry/package.json
+++ b/libs/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/telemetry",
-  "version": "0.0.50",
+  "version": "0.0.51",
   "license": "MIT",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
Version bump 0.0.50 → 0.0.51 for the 7 publishable `@threadplane/*` libs ahead of cutting the release. Inter-lib peerDeps are `"*"` so no range updates needed; `verify-release-versions --tag v0.0.51` passes (atomic).

Ships the lib work merged since v0.0.50 (structured AgentError, injectThreadRouting, subagent cards, TS DX pass, JSDoc). The tag push after merge triggers npm publish (provenance) + the now-verified SLSA release-provenance flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)