### PR TITLE
ci: cap Vercel deploy jobs at 30min (prevent concurrency lockups)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,6 +229,7 @@ jobs:
 
   cockpit-deploy-smoke:
     name: Cockpit — deploy smoke dry-run
+    timeout-minutes: 30 # fail fast instead of blocking the main concurrency group on a hang
     needs: ci-scope
     if: github.event_name == 'push' || needs.ci-scope.outputs.cockpit_deploy_smoke == 'true'
     runs-on: ubuntu-latest
@@ -595,6 +596,7 @@ jobs:
 
   deploy:
     name: Deploy → Vercel
+    timeout-minutes: 30 # fail fast instead of blocking the main concurrency group on a hang
     needs:
       [
         library,
@@ -783,6 +785,7 @@ jobs:
 
   demo-deploy:
     name: Canonical demo → Vercel
+    timeout-minutes: 30 # fail fast instead of blocking the main concurrency group on a hang
     needs: [examples-chat-smoke, examples-chat-e2e]
     runs-on: ubuntu-latest
     if: ${{ always() && !cancelled() && github.ref == 'refs/heads/main' && github.event_name == 'push' }}
@@ -859,6 +862,7 @@ jobs:
 
   ag-ui-demo-deploy:
     name: ag-ui demo → Vercel
+    timeout-minutes: 30 # fail fast instead of blocking the main concurrency group on a hang
     needs: [examples-ag-ui-e2e]
     runs-on: ubuntu-latest
     if: ${{ always() && !cancelled() && github.ref == 'refs/heads/main' && github.event_name == 'push' }}


### PR DESCRIPTION
## Summary
Add `timeout-minutes: 30` to the four Vercel deploy jobs in `ci.yml` (`Deploy → Vercel`, `Canonical demo → Vercel`, `ag-ui demo → Vercel`, `Cockpit — deploy smoke dry-run`), which previously had no timeout (GitHub's 6h default).

## Why
The main CI concurrency group is `cancel-in-progress: false` (intentional — don't kill a deploy mid-flight), so a single hung job blocks **all** later runs and deploys in the group. Today a `Deploy → Vercel` job hung for ~4 hours and froze main deploys. A 30-min cap (legitimate deploys take ~12 min) turns a hang into a fast failure instead of a multi-hour lockup.

Not touching the concurrency semantics or strengthening anything else — just bounding the failure mode.

## Test Plan
- [ ] CI green; deploys still complete within the cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)