### PR TITLE
fix(chat): inline, persistent subagent cards (F5 close-out + duplicate-card fix)

### DIFF
--- a/cockpit/ag-ui/subagents/angular/e2e/subagents.spec.ts
+++ b/cockpit/ag-ui/subagents/angular/e2e/subagents.spec.ts
@@ -17,15 +17,14 @@ interface SubagentProbe {
 }
 
 // Reads the live `agent.subagents()` projection off the cockpit host component
-// via Angular's dev-mode global. The chat-subagents primitive renders a
-// <chat-subagent-card> only while a subagent is pending/running, so the map IS
-// the data the card binds to. Under the aimock harness the run settles
-// near-instantly (started → finished within one SSE flush), so the live card
-// transits the RUNNING state below a render frame and is filtered out of the
-// DOM by the time the assistant turn finalizes — exactly the reason this spec
-// asserts on the durable projection rather than the card element. The map
-// proves the ACTIVITY snapshot/delta pipeline populated the subagent (name +
-// streamed child text) and that it settled to `complete`.
+// via Angular's dev-mode global. The spawning `task` tool call now renders
+// inline AS a <chat-subagent-card> anchored to its message, and the card
+// PERSISTS (collapsed) after the subagent completes — there is no separate
+// active-only mount, and the `task` call no longer renders a generic tool-call
+// chip. The map read here is the data the card binds to: it proves the ACTIVITY
+// snapshot/delta pipeline populated the subagent (name + streamed child text)
+// and that it settled to `complete`. The card element and this projection are
+// asserted together below (card presence/persistence + projection contents).
 async function readSubagents(page: Page): Promise<SubagentProbe> {
   return page.evaluate(() => {
     const ng = (window as unknown as { ng?: { getComponent?: (el: Element) => unknown } }).ng;
@@ -56,25 +55,25 @@ async function readSubagents(page: Page): Promise<SubagentProbe> {
 // `task` tool, the subagent LLM streams a summary, and the ag-ui server
 // converts the subagent_activity CUSTOM events into native ACTIVITY_SNAPSHOT/
 // ACTIVITY_DELTA. The @threadplane/ag-ui reducer projects the activity to
-// agent.subagents() (what chat-subagents renders as a live card) and the
-// child's research text must stay OUT of the parent's bubble.
+// agent.subagents(), which the inline <chat-subagent-card> (rendered in place of
+// the `task` tool call) binds to. The child's research text must stay OUT of the
+// parent's bubble.
 test('ag-ui subagents: orchestrator dispatches subagent cards that settle complete', async ({
   page,
 }) => {
   const bubble = await submitAndWaitForResponse(page, PROMPT);
 
-  // The orchestrator dispatched `task` subagents — the chat-tool-calls
-  // primitive renders a durable collapsible chip labeled with the tool name,
-  // unlike the active-only subagent card. Asserting it is in the DOM proves the
-  // orchestrator emitted real task tool_calls.
-  const taskChip = page.getByRole('button', { name: /called task|task/i }).first();
-  await expect(taskChip).toBeVisible({ timeout: 30_000 });
+  // The spawning `task` tool call renders inline AS a <chat-subagent-card>
+  // (replacing the generic tool-call chip), anchored to its message. Asserting
+  // the card is in the DOM proves the orchestrator emitted a real task dispatch
+  // and that it surfaced as the dedicated subagent card.
+  await expect(page.locator('chat-subagent-card').first()).toBeVisible({ timeout: 30_000 });
 
   // The live subagent-card data path populated and settled: agent.subagents()
   // carries the research subagent with its streamed child summary, now
-  // `complete`. This is the exact projection chat-subagents binds the card to.
-  // Poll until the research subagent reaches `complete` to avoid CI micro-races
-  // where signal propagation hasn't settled at the moment of the first read.
+  // `complete`. This is the exact projection the inline card binds to. Poll
+  // until the research subagent reaches `complete` to avoid CI micro-races where
+  // signal propagation hasn't settled at the moment of the first read.
   await expect
     .poll(
       async () => {
@@ -86,8 +85,18 @@ test('ag-ui subagents: orchestrator dispatches subagent cards that settle comple
     )
     .toBe('complete');
 
+  // The card PERSISTS after completion (collapsed) — there is no active-only
+  // mount, so it must still be present once the run has settled.
+  await expect(page.locator('chat-subagent-card').first()).toBeVisible();
+
   const subs = await readSubagents(page);
   expect(subs.size).toBeGreaterThan(0);
+
+  // No duplicate cards: exactly one <chat-subagent-card> per projected subagent.
+  // Under aimock the orchestrator may dispatch 1+ subagents; assert equality to
+  // the projected size rather than a hardcoded count.
+  expect(await page.locator('chat-subagent-card').count()).toBe(subs.size);
+
   const research = subs.entries.find((e) => e.name === 'research');
   expect(research, 'a research subagent should be projected').toBeTruthy();
   expect(research?.text).toContain(RESEARCH_SENTENCE);

--- a/docs/superpowers/plans/2026-06-19-subagent-card-inline-persistent.md
+++ b/docs/superpowers/plans/2026-06-19-subagent-card-inline-persistent.md
@@ -1,0 +1,132 @@
+# Inline, Persistent Subagent Cards — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`).
+
+**Goal:** Render each subagent once, anchored to its spawning `task` tool call, persisting in the transcript (running = expanded/live, done = collapsed summary) — replacing the generic tool chip. Fixes the duplicate-card framework bug + the transient-card weakness, transport-agnostically.
+
+**Architecture:** A subagent's spawning tool call already lands in the assistant message that emitted it (`resolveMessageToolCalls`). Make `chat-tool-calls` render a `chat-subagent-card` (instead of a generic chip) for any tool call whose `id` is a key in `agent.subagents()`, ungrouped. Then remove the per-message `<chat-subagents>` mount from the `<chat>` composition (the source of duplication). `chat-trace` already auto-expands `running`/`error` and collapses `done`/`pending`, so persistence + collapse-on-done come for free.
+
+**Tech Stack:** Angular 21 (signals, `@if`/`@for`, OnPush), vitest, Nx. Spec: `docs/superpowers/specs/2026-06-19-subagent-card-inline-persistent-design.md`.
+
+---
+
+## Task 1: `chat-tool-calls` renders subagent cards in place of chips
+
+**Files:**
+- Modify: `libs/chat/src/lib/primitives/chat-tool-calls/chat-tool-calls.component.ts`
+- Test: `libs/chat/src/lib/primitives/chat-tool-calls/chat-tool-calls.component.spec.ts`
+
+- [ ] **Step 1: Write the failing test.** Follow the existing spec's `setSignalInput` SIGNAL-symbol pattern and the existing fake-agent shape in this file. Build an agent whose `toolCalls()` returns `[{id:'call_t', name:'task', args:{}, status:'success'}, {id:'call_s', name:'search', args:{}, status:'success'}]`, whose `subagents()` returns a `Map` with one entry keyed `'call_t'` → a `Subagent` (`{toolCallId:'call_t', name:'research', status: signal('running'), messages: signal([{id:'m1', role:'assistant', content:'hello from research'}]), state: signal({})}`), and a message linking both ids via `toolCallIds: ['call_t','call_s']`. Assert: exactly one `chat-subagent-card` renders, it contains "research"; the `search` call still renders a `chat-tool-call-card`; and the `task` call does NOT render a generic `chat-tool-call-card`. Add a second test: two `task` subagent calls (`call_t1`, `call_t2`, both in `subagents()`) render TWO separate `chat-subagent-card`s (not one grouped strip).
+
+- [ ] **Step 2: Run it, verify it fails.** `npx nx test chat --skip-nx-cache -- chat-tool-calls` → FAIL (no `chat-subagent-card` rendered).
+
+- [ ] **Step 3: Implement.** In `chat-tool-calls.component.ts`:
+  - Import `ChatSubagentCardComponent` from `../../compositions/chat-subagent-card/chat-subagent-card.component` and add to `imports`. Import `Subagent` type from `../../agent`/`../../agent/subagent`.
+  - Add `subagent?: Subagent` to the `Group` interface.
+  - In the `groups` computed, read `const subs = this.agent().subagents?.() ?? new Map<string, Subagent>();` (read inside the computed for reactivity). When iterating `calls`, if `subs.has(tc.id)`, push a **standalone** group `{ name: tc.name, calls: [tc], subagent: subs.get(tc.id) }` and never append to/from it (a subagent call neither groups with a previous call nor accepts a following call — treat it like a grouping break). Otherwise keep the existing group/append logic.
+  - In the template, add a FIRST branch inside the `@for (group of groups())`:
+    ```html
+    @if (group.subagent) {
+      <chat-subagent-card [subagent]="group.subagent" />
+    } @else if (group.calls.length > 1 && !group.templateRef) {
+      ... existing grouped strip ...
+    } @else if (group.templateRef) { ... } @else { ... }
+    ```
+  - Keep `track $index` on the outer `@for` (already primitive).
+
+- [ ] **Step 4: Run tests.** `npx nx test chat --skip-nx-cache -- chat-tool-calls` → PASS (new + existing).
+
+- [ ] **Step 5: Commit.**
+```bash
+git add libs/chat/src/lib/primitives/chat-tool-calls/chat-tool-calls.component.ts libs/chat/src/lib/primitives/chat-tool-calls/chat-tool-calls.component.spec.ts
+git commit -m "feat(chat): chat-tool-calls renders subagent cards inline (anchored to spawning task call)"
+```
+
+---
+
+## Task 2: Remove the duplicate `<chat-subagents>` mount from the composition
+
+**Files:**
+- Modify: `libs/chat/src/lib/compositions/chat/chat.component.ts`
+- Test: `libs/chat/src/lib/compositions/chat/chat.component.spec.ts` (or the nearest existing composition spec)
+
+- [ ] **Step 1: Write the failing test.** Add a composition-level test (mirror existing composition spec setup) that mounts `<chat [agent]="agent">` with an agent whose `messages()` has TWO assistant messages, only the FIRST of which has `toolCallIds: ['call_t']`, and `subagents()` containing `call_t` (status `running`). Assert the DOM contains exactly ONE `chat-subagent-card` (today it renders twice — once per assistant message — because of the line-221 mount). If a full composition mount is too heavy in this suite, instead assert structurally that the `ai` template no longer contains a standalone `<chat-subagents>` element by rendering and querying — but prefer the behavioral one-card assertion.
+
+- [ ] **Step 2: Run it, verify it fails.** `npx nx test chat --skip-nx-cache -- chat.component` → FAIL (two cards).
+
+- [ ] **Step 3: Implement.** In `chat.component.ts`: delete the `<chat-subagents [agent]="agent()" />` line (≈221) in the `ai` message template. Remove the now-unused `ChatSubagentsComponent` import from this file's `imports` array and import statement. Do NOT remove the lib's public-API export of `ChatSubagentsComponent`.
+
+- [ ] **Step 4: Run tests.** `npx nx test chat --skip-nx-cache -- chat.component` → PASS (one card). Then `npx nx run-many -t test lint build --projects=chat --skip-nx-cache` → green.
+
+- [ ] **Step 5: Commit.**
+```bash
+git add libs/chat/src/lib/compositions/chat/chat.component.ts libs/chat/src/lib/compositions/chat/chat.component.spec.ts
+git commit -m "fix(chat): render subagent cards once via tool-calls; drop duplicate per-message mount"
+```
+
+---
+
+## Task 3: Collapsed summary shows message count (small polish)
+
+**Files:**
+- Modify: `libs/chat/src/lib/compositions/chat-subagent-card/chat-subagent-card.component.ts`
+- Test: `libs/chat/src/lib/compositions/chat-subagent-card/chat-subagent-card.component.spec.ts`
+
+**Context:** `chat-trace` hides default `<ng-content />` when collapsed but always shows `[traceMeta]`. The card's `N message(s)` count is currently in the hidden content. Move it to `[traceMeta]` so a collapsed (done) card still shows `research ✓ · N message(s)`.
+
+- [ ] **Step 1: Write the failing test.** With a `Subagent` whose `status` is `complete` and two messages, mount the card and assert the host (collapsed) still shows text matching `/2 message/`. (Today it's hidden when collapsed.)
+
+- [ ] **Step 2: Run it, verify it fails.** `npx nx test chat --skip-nx-cache -- chat-subagent-card` → FAIL.
+
+- [ ] **Step 3: Implement.** In the card template, move the `<div class="sac__count">{{ subagent().messages().length }} message(s)</div>` to be projected into the trace meta slot: add `ngProjectAs="[traceMeta]"` (or wrap as `<span traceMeta>`), matching how `chat-trace` selects `[traceMeta]`. Keep styling via `.sac__count`.
+
+- [ ] **Step 4: Run tests.** `npx nx test chat --skip-nx-cache -- chat-subagent-card` → PASS.
+
+- [ ] **Step 5: Commit.**
+```bash
+git add libs/chat/src/lib/compositions/chat-subagent-card
+git commit -m "feat(chat): show subagent message count in collapsed card summary"
+```
+
+---
+
+## Task 4: Reconcile subagent e2e (chip → card + persistence)
+
+**Files:**
+- Modify: `cockpit/ag-ui/subagents/angular/e2e/subagents.spec.ts`
+- Modify: `cockpit/chat/subagents/angular/e2e/c-subagents.spec.ts`
+- Check (no change expected): `examples/chat/angular/e2e/*.spec.ts`, any `cockpit/langgraph` subagent e2e
+
+- [ ] **Step 1: Re-scan.** `grep -rn "called task\|/task/i\|chat-subagent" cockpit/*/subagents/angular/e2e examples/chat/angular/e2e` to enumerate every chip assertion. Only the two cockpit subagent specs are expected.
+- [ ] **Step 2: Update `cockpit/ag-ui/subagents/angular/e2e/subagents.spec.ts`.** The `task` call now renders as a `chat-subagent-card`, not a `getByRole('button', { name: /called task|task/i })` chip. Replace that chip assertion with one for the card — e.g. `await expect(page.locator('chat-subagent-card').first()).toBeVisible({ timeout: 30_000 })`. Keep the `readSubagents` projection assertions (still valid). Add an assertion that the card **persists after completion** (still present once the research subagent is `complete`) and that there is no duplicate (`expect(page.locator('chat-subagent-card')).toHaveCount(<expected>)` — assert count equals the number of distinct subagents, not 2× per message). Update the stale code comments that describe the active-only/transient behavior.
+- [ ] **Step 3: Update `cockpit/chat/subagents/angular/e2e/c-subagents.spec.ts`** the same way (chip → card; note the comment at line ~16 says it does NOT assert the card "because that primitive only [renders while active]" — now it CAN and SHOULD).
+- [ ] **Step 4: Run the two e2e suites (aimock).**
+```bash
+# free ports first (per repo memory), then:
+npx nx e2e cockpit-ag-ui-subagents-angular --skip-nx-cache
+npx nx e2e cockpit-chat-subagents-angular --skip-nx-cache
+```
+Expected: green. Reconcile fixtures only if a card assertion needs a longer settle (the aimock run settles fast; assert presence/persistence, not running-state timing).
+- [ ] **Step 5: Commit.**
+```bash
+git add cockpit/ag-ui/subagents/angular/e2e/subagents.spec.ts cockpit/chat/subagents/angular/e2e/c-subagents.spec.ts
+git commit -m "test(cockpit): assert inline persistent subagent card (chip → card)"
+```
+
+---
+
+## Task 5: Verify, live re-smoke, audit-doc close-out, PR
+
+- [ ] **Step 1: Full lib gate + demo builds.** `npx nx run-many -t test lint build --projects=chat --skip-nx-cache`; build `cockpit-ag-ui-subagents-angular`, `cockpit-chat-subagents-angular`, `examples-chat-angular`, and any `cockpit-langgraph` subagent app. All green.
+- [ ] **Step 2: Live re-smoke (AG-UI, real key).** Reuse the F5 harness: `uv run uvicorn src.server:app --port 5326 --env-file <root>/.env` in `cockpit/ag-ui/subagents/python` + `nx serve cockpit-ag-ui-subagents-angular --port 4326`; drive "Plan a trip from LAX to JFK" with the high-frequency Playwright probe (sample `chat-subagent-card` count + statuses). Confirm: ONE card per subagent (no duplicates), card persists after completion, collapses to summary when done, zero NG0956. Capture screenshots. Free ports + stop servers after.
+- [ ] **Step 3: Update the audit findings doc.** In `docs/superpowers/specs/2026-06-11-ag-ui-capability-findings.md`, mark **F5 closed** with the real-defect note (card already rendered over AG-UI; the actual fix was the duplicate per-message mount + persistence). Commit.
+- [ ] **Step 4: Final review** (correctness of the subagent partition in `chat-tool-calls`; no regression to GenUI/view exclusion or grouping; card persistence + collapse; e2e green; live smoke clean).
+- [ ] **Step 5: Open PR**, arm auto-merge (`gh pr merge --squash --auto`), self-healing watcher (Monitor for `BEHIND` → `git merge origin/main`; ignore non-required `review` check).
+
+---
+
+## Self-Review
+- Coverage: subagent-aware rendering (T1), duplicate-mount removal (T2), collapsed summary (T3), e2e reconcile (T4), verify+smoke+doc+PR (T5). ✓
+- Type consistency: `Subagent` (status/messages are Signals); `agent().subagents?.()` is optional → default `new Map()`. Card uses `subagent` input (required). `track tc.id` / `track $index` primitives — no NG0956 risk.
+- Risk: subagent `task` call must be present in the message's resolved tool calls on BOTH transports — verified by the live smoke (AG-UI) + the cockpit-chat e2e (LangGraph). If a transport surfaces a subagent with no owning message tool call, its card wouldn't render → caught by Step 2/Task 4.
+- No public-API break: `ChatSubagentsComponent` stays exported; only the default composition stops mounting it.

--- a/docs/superpowers/specs/2026-06-11-ag-ui-capability-findings.md
+++ b/docs/superpowers/specs/2026-06-11-ag-ui-capability-findings.md
@@ -18,7 +18,7 @@
 | 7 | Gen-UI: a2ui | ✅ | pre-verified |
 | 8 | Gen-UI: json-render | ✅ (renders) + 🔶 F4 | interactive dashboard rendered (tabs/sliders/checkboxes); metric values show `[object Object]` — **reproduces identically on canonical prod** → shared render/graph issue, not AG-UI |
 | 9 | Theme presets + dark/light | ✅ + 🔶 F2 | toggle + URL knobs sync; itinerary panel & mode hosts stay dark in light scheme (example CSS) |
-| 10 | Research subagent | ✅ (runs) + 🔶 F5 | run completed with structured summary; renders as plain tool row — no subagent card (known adapter gap: no subagent metadata over AG-UI) |
+| 10 | Research subagent | ✅ + F5 closed | run completes with structured summary AND renders an inline, persistent `chat-subagent-card` (F5 premise refuted by live smoke; the real defect was a duplicate per-message mount — fixed 2026-06-19) |
 | 11 | Stop mid-stream | 🔴 F3 | stream halts, but a red error banner "BodyStreamBuffer was aborted" presents the user's own stop as a failure |
 | 12 | Regenerate | ✅ | replaced the aborted message; fresh complete response, no artifacts |
 | 13 | Error recovery | ✅ | e2e (pre-verified) |
@@ -41,8 +41,14 @@ User-initiated stop renders a red "BodyStreamBuffer was aborted" error banner: `
 ### F4 — json-render binds objects as text — shared render/graph issue (medium, NOT AG-UI-specific)
 Generated dashboard specs render `[object Object]` for metric values and a literal `trending_up` icon name. Reproduces byte-for-byte on `demo.threadplane.ai` (langgraph transport), so the bug is in the json-render engine's value/binding resolution (`@threadplane/render`) and/or the graph's `json_render` spec schema — not the AG-UI adapter. Track as its own fix; both demos benefit.
 
-### F5 — No subagent card over AG-UI — adapter gap (medium, known)
-The research delegation runs fine but renders as a generic tool row; the canonical demo shows a `chat-subagent` card. The AG-UI adapter doesn't surface subagent metadata (custom events → subagent sub-contract). Needs design: map the graph's subagent custom events into the chat subagent contract in `toAgent()`.
+### F5 — ✅ CLOSED (2026-06-19) — premise refuted; real defect was a duplicate mount
+**Original claim:** research delegation renders as a generic tool row, no subagent card (unlike the canonical LangGraph demo).
+
+**Live-LLM smoke refuted this.** The AG-UI adapter DOES surface subagent metadata: `subagentFor` in `libs/ag-ui/.../to-agent.ts` projects `ACTIVITY` events onto `agent.subagents()` keyed by tool-call id (the `text`→`messages` fallback handles the backend's shape), and `chat-subagent-card` rendered + streamed live (verified by screenshot: a `research` card with a `running` badge and 6.7k streamed chars). The audit's observation was a timing artifact — the card is transient (active-only) and the auditor caught it on one transport's run but not the other.
+
+**The real, transport-agnostic defect:** `<chat-subagents [agent]>` was mounted inside the per-assistant-message `ai` template in the `<chat>` composition but bound the whole agent's `subagents()`, so it re-rendered the same active cards once per assistant message → duplicate cards (and the durable trace after completion was a generic "called task" chip).
+
+**Fix (PR for `2026-06-19-subagent-card-inline-persistent`):** the spawning `task` tool call now renders **as** an inline, persistent `chat-subagent-card` in `chat-tool-calls` (running = expanded/live, done = collapsed summary), replacing the generic chip; the duplicate per-message mount is removed. Keyed on `toolCallId`, so it fixes both transports. Live re-smoke confirmed: 3 subagents → 3 cards, **0 duplicate ticks**, persist + collapse on done, **0 NG0956**, no leftover task chips.
 
 ### F6 — NG0956 console warnings during streaming — chat lib perf (low)
 Angular warns repeatedly that a tracked `@for` collection (size 1) is re-created per stream chunk (track-by-identity). Cheap fix: stable `track` keys in the streaming message list templates.
@@ -58,7 +64,7 @@ Phase 3 (branch `ag-ui-gap-closure-p3`, plan `2026-06-11-ag-ui-gap-closure-p3.md
 - **F6 ✅ (main source)** — markdown children/table rows now track by `$index`; zero NG0956 during text/reasoning streaming.
 - **F6 residual ✅ (resolved 2026-06-18)** — the json-render *spec assembly* NG0956 residual is gone. Re-grounded against current main (post #680 render-lifecycle rework + F4 + the markdown `$index` fixes): **every** `@for` in the json-render path — `cockpit/ag-ui/json-render` views, the a2ui catalog, `libs/render` core (`render-element` `track $index`, `render-spec` has no `@for`), and `libs/chat` markdown — now keys on a **primitive** (`$index` / string key / numeric value); the NG0956-prone `track <object>` pattern is absent. Confirmed by a live `cockpit-ag-ui-json-render` e2e run streaming the airline dashboard: **zero NG0956** in the console.
   - **No regression guard committed.** An e2e console-guard was prototyped but proven ineffective here: NG0956 only fires when an `@for` collection re-materializes across multiple change-detection cycles, but the aimock fixture replays the spec ~atomically (single `content`), so no `@for` re-evaluates. A negative control — forcing `track [key]` (identity) on the fixture-rendered `container` view — produced **no** NG0956, confirming the e2e harness cannot catch this class of regression. A real guard would need a **component-level** vitest test feeding a render component successive specs (simulating streaming deltas) and asserting no NG0956 across re-materialization. Deferred as optional.
-- **F5 ⏳** — subagent card over AG-UI deferred to Phase 4 (needs design: mapping graph subagent custom events into the chat subagent contract in `toAgent()`).
+- **F5 ✅ (closed 2026-06-19)** — premise refuted by live smoke (the card already rendered + streamed over AG-UI). The real defect was a transport-agnostic duplicate per-message `<chat-subagents>` mount in the `<chat>` composition. Fixed by rendering the subagent inline + persistent in `chat-tool-calls` (replacing the generic chip) and removing the duplicate mount. See `docs/superpowers/specs/2026-06-19-subagent-card-inline-persistent-design.md`.
 
 Additional follow-ups logged during Phase 3:
 - Icon rendering: the a2ui catalog icon component renders icon *names* as text (`trending_up`) — proper icon support is a new catalog feature, not built.

--- a/docs/superpowers/specs/2026-06-19-subagent-card-inline-persistent-design.md
+++ b/docs/superpowers/specs/2026-06-19-subagent-card-inline-persistent-design.md
@@ -1,0 +1,76 @@
+# Inline, Persistent Subagent Cards — Design
+
+**Status:** Approved design (brainstormed 2026-06-19). Closes capability gap **F5** with the *real* defect found by live smoke.
+
+## Background — what the live smoke established
+
+F5 in the AG-UI capability audit claimed: *"research delegation renders as a plain tool row — no subagent card, unlike the canonical LangGraph demo."* A live-LLM smoke of `cockpit/ag-ui/subagents` (real OpenAI, DOM sampled every 120ms) **refuted that premise** and surfaced a different, framework-level defect:
+
+1. **The subagent card DOES render over AG-UI** — the `research` card appeared ~10s in with a `running` badge and streamed its summary live (6,746 chars); confirmed by screenshot. The `text`→`messages` "shape mismatch" is a non-issue (the `subagentFor` fallback in `libs/ag-ui/.../to-agent.ts` handles it).
+2. **The card is transient by design** — `chat-subagents` filters to active (`pending`/`running`) only (`chat-subagents.component.ts:22`), so on completion the card vanishes and the only durable trace is a generic "called task" chip.
+3. **NEW framework bug: duplicate cards.** `<chat-subagents [agent]="agent()" />` is mounted at `chat.component.ts:221` **inside the per-assistant-message `ai` template**, yet it binds the whole agent's `subagents()` (not message-scoped). So it re-renders the same active cards **once per assistant message** — two orchestrator messages → two identical cards. Transport-agnostic; AG-UI just surfaced it first.
+
+These are one design problem: **where and how subagents render in the `<chat>` composition.**
+
+## Goal
+
+Render each subagent **once**, **anchored to its spawning tool call**, **persisting in the transcript** after completion — replacing the generic tool chip. Fixes the duplication bug, the transience, and the "durable trace is a generic chip" weakness in a single transport-agnostic change in `libs/chat`.
+
+## Design decisions (settled via brainstorm)
+
+- **Card replaces the tool chip, inline.** A `task` tool call whose `toolCallId` is a key in `agent.subagents()` renders **as** a `chat-subagent-card` in the message where the call lives — not as a generic `chat-tool-call-card`. One representation, in conversation order, persistent in history.
+- **Lifecycle:** running → **expanded** (live stream + spinner + `running` badge); completed/error → **collapsed summary** by default (`▸ research ✓ · N messages`), click to expand. Reuses the existing `<chat-trace [state]>` wrapper already inside `chat-subagent-card` (`done` state collapses).
+- **Keep `chat-subagents` as a public primitive** (it's exported) for consumers who want a standalone active-only tray, but **stop mounting it in the default `<chat>` composition.** No public-API break.
+- **Transport-agnostic:** the key is `toolCallId`, which both `@threadplane/langgraph` and `@threadplane/ag-ui` already populate in `agent.subagents()` (keyed by tool-call id). One change fixes both.
+- **Rollout:** land in `libs/chat`; verify/build all subagent demos across both transports and reconcile their e2e (chip → card).
+
+## Architecture
+
+### 1. `chat-tool-calls` becomes subagent-aware
+`libs/chat/src/lib/primitives/chat-tool-calls/chat-tool-calls.component.ts`
+
+- New input: `subagents = input<ReadonlyMap<string, Subagent>>(new Map())` (or read from `agent().subagents?.()` directly — prefer reading off the already-required `agent` input to avoid a new binding the composition must thread). Decision for the plan: **read `agent().subagents?.()`** so no composition wiring changes beyond the input it already has.
+- In the `groups` computed: partition `toolCalls()` into (a) **subagent calls** — `tc.id ∈ subagents` — and (b) normal calls. Subagent calls **bypass grouping** and each render a `<chat-subagent-card [subagent]="subagents.get(tc.id)!" />`. Normal calls keep the existing group/template/card path. Subagent calls must not be swept into a "task ×N" strip.
+- `chat-tool-calls` imports `ChatSubagentCardComponent`.
+- Ordering: render each tool call's representation in tool-call order so a subagent card sits exactly where its `task` call appears.
+
+### 2. Remove the duplicate mount
+`libs/chat/src/lib/compositions/chat/chat.component.ts`
+
+- Delete `<chat-subagents [agent]="agent()" />` at line 221 (inside the `ai` message template). Subagents now render via the subagent-aware `chat-tool-calls` already present at line 208 in the same template.
+- Drop the now-unused `ChatSubagentsComponent` import from the composition (keep the export from the lib's public API).
+
+### 3. Collapsed-on-complete card
+`libs/chat/src/lib/compositions/chat-subagent-card/chat-subagent-card.component.ts`
+
+- The card already wraps its body in `<chat-trace [state]="state()">`. Ensure `chat-trace` **collapses by default when `state==='done'`/`'error'`** and stays **expanded while `running`/`pending`**. If `chat-trace` doesn't already default-collapse on `done`, add a `defaultCollapsed` (or `collapsedWhenDone`) input wired from the card's status. Verify current `chat-trace` behavior first; prefer reusing it over new collapse logic.
+- Collapsed summary line shows: name + status glyph + `N message(s)`. Expanded shows the full nested messages (existing template).
+
+### Files
+
+- **Modify:** `libs/chat/src/lib/primitives/chat-tool-calls/chat-tool-calls.component.ts` (subagent-aware rendering)
+- **Modify:** `libs/chat/src/lib/compositions/chat/chat.component.ts` (remove per-message `<chat-subagents>` mount + import)
+- **Modify:** `libs/chat/src/lib/compositions/chat-subagent-card/chat-subagent-card.component.ts` (collapsed-on-done) — and possibly `libs/chat/src/lib/primitives/chat-trace/chat-trace.component.ts` if a default-collapse input is needed
+- **Tests:** specs for `chat-tool-calls` (subagent call → card, normal call → chip, one card per id, no duplication), `chat-subagent-card` (collapsed when done / expanded when running)
+- **e2e reconcile:** `cockpit/ag-ui/subagents/angular/e2e/subagents.spec.ts` and `cockpit/chat/subagents/angular/e2e/c-subagents.spec.ts` (both currently assert the generic `getByRole('button', { name: /called task|task/i })` chip — update to assert the `chat-subagent-card` and, for the durable case, that it persists after completion). Re-scan `examples/chat` + `cockpit/langgraph/*` subagent paths for any chip assertions.
+
+## Verification
+
+1. `nx run-many -t test lint build --projects=chat` — green (new + existing specs).
+2. Build all subagent demos: `cockpit-ag-ui-subagents-angular`, `cockpit-chat-subagents-angular`, any `cockpit-langgraph` subagent app, `examples-chat-angular`.
+3. Reconcile + run the affected e2e (aimock) — chip→card; assert exactly one card per subagent and persistence after completion.
+4. **Live re-smoke** of `cockpit/ag-ui/subagents` (real key via root `.env`, the harness set up during F5 verification): confirm **one** persistent card per subagent (no duplicates), collapsed summary after completion, and no NG0956. Capture screenshots.
+5. Final review; open PR; arm auto-merge + self-healing watcher.
+
+## Risks / edge cases
+
+- **Grouping interaction:** subagent `task` calls must bypass the "group by name" path, else multiple subagents collapse into one strip. Covered by partitioning before grouping.
+- **A subagent whose tool call is in `agent.toolCalls()` but not in any `message.tool_calls`** (transport quirk): `resolveMessageToolCalls` is the source; verify the `task` call is present per-message on both transports (AG-UI reducer links tool calls to the parent message — see prior work). If a subagent id has no owning message tool call, it would not render; flag in the plan to confirm via the live smoke.
+- **`excludeToolNames`** still applies to non-subagent tools (GenUI/view) — unchanged.
+- **NG0956:** new `@for` over partitioned calls must track by `tc.id` (primitive) — no `track <object>`.
+
+## Self-review
+
+- Coverage: duplication bug (mount move), persistence (inline card), dedup of chip (card replaces chip), collapsed-on-done (chat-trace), transport-agnostic (toolCallId), keep primitive (no API break), all-demo rollout + e2e. ✓
+- The change is contained to 3 `libs/chat` files + tests; consumers need no changes (composition reads `agent().subagents()` it already has).
+- Closes F5 with the real defect; updates the audit findings doc as part of the PR.

--- a/libs/chat/src/lib/compositions/chat-subagent-card/chat-subagent-card.component.spec.ts
+++ b/libs/chat/src/lib/compositions/chat-subagent-card/chat-subagent-card.component.spec.ts
@@ -60,6 +60,40 @@ describe('ChatSubagentCardComponent', () => {
     const toolCallEls = fixture.debugElement.queryAll(By.css('chat-tool-call-card'));
     expect(toolCallEls.length).toBe(1);
   });
+
+  it('shows the message count in the collapsed summary when complete', async () => {
+    const fakeSubagent: Subagent = {
+      toolCallId: 'tc-root',
+      name: 'Research',
+      // 'complete' → chat-trace collapses; the transcript DOM is hidden.
+      status: signal('complete'),
+      messages: signal([
+        { id: 'm1', role: 'assistant', content: 'a' },
+        { id: 'm2', role: 'assistant', content: 'b' },
+      ]),
+      toolCalls: signal([]),
+      state: signal({}),
+    };
+
+    TestBed.configureTestingModule({
+      imports: [ChatSubagentCardComponent],
+    });
+
+    const fixture = TestBed.createComponent(ChatSubagentCardComponent);
+    fixture.componentRef.setInput('subagent', fakeSubagent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    // Collapsed: the per-message transcript must NOT be rendered.
+    const msgEls = fixture.debugElement.queryAll(By.css('.sac__msg'));
+    expect(msgEls.length).toBe(0);
+
+    // ...but the count lives in the always-visible meta slot.
+    const host = fixture.nativeElement as HTMLElement;
+    const text = host.textContent ?? '';
+    expect(text).toMatch(/2 message/);
+  });
 });
 
 describe('statusColor', () => {

--- a/libs/chat/src/lib/compositions/chat-subagent-card/chat-subagent-card.component.ts
+++ b/libs/chat/src/lib/compositions/chat-subagent-card/chat-subagent-card.component.ts
@@ -69,7 +69,7 @@ function statusToTraceState(s: SubagentStatus): TraceState {
         <span class="sac__id">{{ subagent().toolCallId }}</span>
         <span class="sac__pill" [attr.data-status]="subagent().status()">{{ subagent().status() }}</span>
       </span>
-      <div class="sac__count">{{ subagent().messages().length }} message(s)</div>
+      <div class="sac__count" traceMeta>{{ subagent().messages().length }} message(s)</div>
       @for (m of subagent().messages(); track m.id) {
         <div class="sac__msg" [attr.data-role]="m.role">
           @if (m.reasoning) {

--- a/libs/chat/src/lib/compositions/chat/chat.component.spec.ts
+++ b/libs/chat/src/lib/compositions/chat/chat.component.spec.ts
@@ -16,6 +16,8 @@ import { a2uiBasicCatalog } from '../../a2ui/catalog/index';
 import { ChatGenerativeUiComponent } from '../../primitives/chat-generative-ui/chat-generative-ui.component';
 import type { Spec, StateStore } from '@json-render/core';
 import type { AgentEvent } from '../../agent/agent-event';
+import type { Subagent } from '../../agent/subagent';
+import type { ToolCall } from '../../agent';
 
 describe('ChatComponent', () => {
   it('is defined as a class', () => {
@@ -600,5 +602,49 @@ describe('ChatComponent — json-render surface store binding (composition isola
     expect(textA).not.toContain('$9.9M');
     expect(textB).toContain('$9.9M');
     expect(textB).not.toContain('$1.2M');
+  });
+});
+
+describe('ChatComponent — subagent cards render once (no duplicate per-message mount)', () => {
+  // Regression for the duplicate-subagent bug: a single running subagent must
+  // render EXACTLY ONE <chat-subagent-card>, anchored (via <chat-tool-calls>)
+  // to the assistant message that emitted its `task` tool call. The composition
+  // previously ALSO mounted <chat-subagents [agent]> inside the per-assistant-
+  // message loop, which binds the whole agent's (message-agnostic) subagents()
+  // — so the same active card rendered once PER assistant message.
+  //
+  // Setup: two assistant messages, only the FIRST carries the task call's id in
+  // toolCallIds. The agent has ONE running subagent keyed by that call id. With
+  // the correct single render, exactly one card appears. With the redundant
+  // <chat-subagents> mount, TWO appear (once per assistant bubble).
+
+  function runningSubagent(): Subagent {
+    return {
+      toolCallId: 'call_t',
+      name: 'research',
+      status: signal<'running'>('running'),
+      messages: signal([{ id: 'm1', role: 'assistant', content: 'hi' } as never]),
+      state: signal({}),
+    };
+  }
+
+  it('renders exactly one chat-subagent-card for a single running subagent', () => {
+    TestBed.configureTestingModule({});
+    const agent = mockAgent({
+      messages: [
+        { id: 'a1', role: 'assistant', content: 'first', toolCallIds: ['call_t'], extra: {} } as never,
+        { id: 'a2', role: 'assistant', content: 'second', extra: {} } as never,
+      ],
+      toolCalls: [{ id: 'call_t', name: 'task', args: {}, status: 'success' } as ToolCall],
+      withSubagents: true,
+    });
+    agent.subagents!.set(new Map<string, Subagent>([['call_t', runningSubagent()]]));
+
+    const fixture = TestBed.createComponent(ChatComponent);
+    fixture.componentRef.setInput('agent', agent);
+    fixture.detectChanges();
+
+    const host = fixture.nativeElement as HTMLElement;
+    expect(host.querySelectorAll('chat-subagent-card').length).toBe(1);
   });
 });

--- a/libs/chat/src/lib/compositions/chat/chat.component.ts
+++ b/libs/chat/src/lib/compositions/chat/chat.component.ts
@@ -26,7 +26,6 @@ import { ChatGenerativeUiComponent } from '../../primitives/chat-generative-ui/c
 import { ChatToolViewsComponent } from '../../primitives/chat-tool-views/chat-tool-views.component';
 import { ChatStreamingMdComponent } from '../../streaming/streaming-markdown.component';
 import { ChatToolCallsComponent } from '../../primitives/chat-tool-calls/chat-tool-calls.component';
-import { ChatSubagentsComponent } from '../../primitives/chat-subagents/chat-subagents.component';
 import { ChatMessageActionsComponent } from '../../primitives/chat-message-actions/chat-message-actions.component';
 import { ChatWelcomeComponent } from '../../primitives/chat-welcome/chat-welcome.component';
 import { ChatSelectComponent, type ChatSelectOption } from '../../primitives/chat-select/chat-select.component';
@@ -90,7 +89,7 @@ export function isPinned(
     ChatWindowComponent, ChatMessageListComponent, MessageTemplateDirective, ChatMessageComponent,
     ChatInputComponent, ChatTypingIndicatorComponent, ChatErrorComponent,
     ChatThreadListComponent, ChatGenerativeUiComponent,
-    ChatStreamingMdComponent, ChatToolCallsComponent, ChatToolViewsComponent, ChatSubagentsComponent, A2uiSurfaceComponent,
+    ChatStreamingMdComponent, ChatToolCallsComponent, ChatToolViewsComponent, A2uiSurfaceComponent,
     ChatMessageActionsComponent, ChatWelcomeComponent, ChatSelectComponent, ChatReasoningComponent,
     ChatScrollBubbleComponent,
   ],
@@ -218,7 +217,6 @@ export function isPinned(
                     [handlers]="handlers()"
                     (events)="onClientToolEvent($event)"
                   />
-                  <chat-subagents [agent]="agent()" />
                   @if (classified.markdown(); as md) {
                     <chat-streaming-md [content]="md" [streaming]="agent().isLoading() && i === agent().messages().length - 1" />
                   }

--- a/libs/chat/src/lib/primitives/chat-tool-calls/chat-tool-calls.component.spec.ts
+++ b/libs/chat/src/lib/primitives/chat-tool-calls/chat-tool-calls.component.spec.ts
@@ -326,3 +326,105 @@ describe('ChatToolCallsComponent — breathing room before downstream content', 
     document.body.removeChild(host);
   });
 });
+
+import type { Message as ChatMessage } from '../../agent';
+import type { Subagent } from '../../agent/subagent';
+
+@Component({
+  standalone: true,
+  imports: [ChatToolCallsComponent],
+  template: `<chat-tool-calls [agent]="agent" [message]="message" />`,
+})
+class SubagentHost {
+  agent!: Agent;
+  message?: ChatMessage;
+}
+
+describe('ChatToolCallsComponent — subagent cards anchored to spawning task call', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({ imports: [SubagentHost] });
+  });
+
+  it('renders a subagent card for the spawning task call and a tool-call card for the sibling', () => {
+    const agent = mockAgent({
+      withSubagents: true,
+      toolCalls: [
+        { id: 'call_t', name: 'task', args: {}, status: 'success' as never },
+        { id: 'call_s', name: 'search', args: {}, status: 'success' as never },
+      ],
+    });
+    const sub: Subagent = {
+      toolCallId: 'call_t',
+      name: 'research',
+      status: signal('running'),
+      messages: signal([{ id: 'm1', role: 'assistant', content: 'hello from research' }]),
+      state: signal({}),
+    };
+    agent.subagents!.set(new Map([['call_t', sub]]));
+
+    const fixture = TestBed.createComponent(SubagentHost);
+    fixture.componentInstance.agent = agent;
+    fixture.componentInstance.message = {
+      id: 'a1',
+      role: 'assistant',
+      content: '',
+      toolCallIds: ['call_t', 'call_s'],
+    };
+    fixture.detectChanges();
+
+    const cards = fixture.nativeElement.querySelectorAll('chat-subagent-card');
+    expect(cards.length).toBe(1);
+    expect(cards[0].textContent).toContain('research');
+
+    // The sibling search call still renders a generic tool-call card.
+    const toolCards = fixture.nativeElement.querySelectorAll('chat-tool-call-card');
+    expect(toolCards.length).toBe(1);
+
+    // The task call does NOT render a generic tool-call card.
+    const fullText = fixture.nativeElement.textContent ?? '';
+    expect(fullText).toContain('search');
+  });
+
+  it('renders two separate subagent cards for two task calls (not collapsed into one strip)', () => {
+    const agent = mockAgent({
+      withSubagents: true,
+      toolCalls: [
+        { id: 'call_t1', name: 'task', args: {}, status: 'success' as never },
+        { id: 'call_t2', name: 'task', args: {}, status: 'success' as never },
+      ],
+    });
+    const sub1: Subagent = {
+      toolCallId: 'call_t1',
+      name: 'research_one',
+      status: signal('running'),
+      messages: signal([{ id: 'm1', role: 'assistant', content: 'one' }]),
+      state: signal({}),
+    };
+    const sub2: Subagent = {
+      toolCallId: 'call_t2',
+      name: 'research_two',
+      status: signal('running'),
+      messages: signal([{ id: 'm2', role: 'assistant', content: 'two' }]),
+      state: signal({}),
+    };
+    agent.subagents!.set(new Map([
+      ['call_t1', sub1],
+      ['call_t2', sub2],
+    ]));
+
+    const fixture = TestBed.createComponent(SubagentHost);
+    fixture.componentInstance.agent = agent;
+    fixture.componentInstance.message = {
+      id: 'a1',
+      role: 'assistant',
+      content: '',
+      toolCallIds: ['call_t1', 'call_t2'],
+    };
+    fixture.detectChanges();
+
+    const cards = fixture.nativeElement.querySelectorAll('chat-subagent-card');
+    expect(cards.length).toBe(2);
+    // Not collapsed into a grouped strip.
+    expect(fixture.nativeElement.querySelectorAll('[data-group="true"]').length).toBe(0);
+  });
+});

--- a/libs/chat/src/lib/primitives/chat-tool-calls/chat-tool-calls.component.ts
+++ b/libs/chat/src/lib/primitives/chat-tool-calls/chat-tool-calls.component.ts
@@ -5,8 +5,9 @@ import {
   computed, contentChildren, input, signal,
 } from '@angular/core';
 import { NgTemplateOutlet } from '@angular/common';
-import type { Agent, Message, ToolCall } from '../../agent';
+import type { Agent, Message, ToolCall, Subagent } from '../../agent';
 import { ChatToolCallCardComponent, type ToolCallInfo } from '../../compositions/chat-tool-call-card/chat-tool-call-card.component';
+import { ChatSubagentCardComponent } from '../../compositions/chat-subagent-card/chat-subagent-card.component';
 import { ChatToolCallTemplateDirective } from './chat-tool-call-template.directive';
 import { summarizeGroup as defaultSummarizeGroup } from './group-summary';
 import { resolveMessageToolCalls } from './resolve-message-tool-calls';
@@ -15,12 +16,14 @@ interface Group {
   name: string;
   calls: ToolCall[];
   templateRef?: ChatToolCallTemplateDirective;
+  /** Present when this group anchors a subagent spawned by its (single) task call. */
+  subagent?: Subagent;
 }
 
 @Component({
   selector: 'chat-tool-calls',
   standalone: true,
-  imports: [NgTemplateOutlet, ChatToolCallCardComponent],
+  imports: [NgTemplateOutlet, ChatToolCallCardComponent, ChatSubagentCardComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   styles: [`
     :host { display: block; margin-bottom: 20px; }
@@ -54,7 +57,9 @@ interface Group {
   `],
   template: `
     @for (group of groups(); track $index) {
-      @if (group.calls.length > 1 && !group.templateRef) {
+      @if (group.subagent) {
+        <chat-subagent-card [subagent]="group.subagent" />
+      } @else if (group.calls.length > 1 && !group.templateRef) {
         <!-- Default grouped strip -->
         @let expanded = expandedGroups().has($index);
         <div class="ctc__group" [attr.data-group]="true" [attr.data-expanded]="expanded">
@@ -119,14 +124,23 @@ export class ChatToolCallsComponent {
   readonly groups = computed((): Group[] => {
     const excludeSet = new Set(this.excludeToolNames());
     const calls = this.toolCalls().filter(tc => !excludeSet.has(tc.name));
+    const subs = this.agent().subagents?.() ?? new Map<string, Subagent>();
     const groupingMode = this.grouping();
     const registry = this.templateRegistry();
     const wildcard = registry.get('*');
     const out: Group[] = [];
     for (const tc of calls) {
+      // A tool call that spawned a subagent renders as a standalone subagent
+      // card anchored to that call. It never groups with adjacent calls, on
+      // either side: it is its own group and carries a `subagent`, so the next
+      // call can't append to it (a subagent group is never a group target).
+      if (subs.has(tc.id)) {
+        out.push({ name: tc.name, calls: [tc], subagent: subs.get(tc.id) });
+        continue;
+      }
       const tpl = registry.get(tc.name) ?? wildcard;
       const last = out[out.length - 1];
-      const sameName = last && last.name === tc.name;
+      const sameName = last && !last.subagent && last.name === tc.name;
       const canGroup = groupingMode === 'auto' && sameName;
       if (canGroup) {
         last.calls.push(tc);


### PR DESCRIPTION
## Summary

Closes capability gap **F5** — and fixes a real, transport-agnostic framework defect a live smoke uncovered along the way.

**F5's premise was wrong.** A live-LLM smoke of `cockpit/ag-ui/subagents` showed the AG-UI adapter *does* render and stream a `chat-subagent-card` (the audit's "renders as a plain tool row, no card" was a timing artifact of the transient active-only card). The real defect: `<chat-subagents [agent]>` was mounted **inside the per-assistant-message `ai` template** of the `<chat>` composition but bound the whole agent's `subagents()`, so it re-rendered the same active cards **once per assistant message** → duplicate cards. After completion the only durable trace was a generic "called task" chip.

**The fix:** the spawning `task` tool call now renders **as** an inline `chat-subagent-card` in `chat-tool-calls` — anchored to its message, replacing the generic chip. Running = expanded/live, completed = collapsed summary (`▸ research ✓ · 1 message`). The duplicate per-message `<chat-subagents>` mount is removed. Keyed on `toolCallId`, so it fixes **both** transports; `ChatSubagentsComponent` stays exported as a primitive.

## Changes (all in `libs/chat`)
- `chat-tool-calls`: renders a `chat-subagent-card` (ungrouped) for any tool call whose id is in `agent.subagents()`; normal calls unchanged.
- `chat` composition: dropped the duplicate per-message `<chat-subagents>` mount.
- `chat-subagent-card`: message count moved to the always-visible `chat-trace` meta slot so the collapsed (done) summary shows it.
- e2e: `cockpit/ag-ui/subagents` now asserts the card (presence + persistence + no-duplicate `== subs.size`) instead of the generic chip.

## Verification
- `nx run-many -t test lint build --projects=chat` — green (new TDD specs in all three components).
- Built all affected demos: cockpit ag-ui/chat subagents + examples chat/ag-ui — green.
- e2e: `cockpit-ag-ui-subagents` (card-asserted) + `cockpit-chat-subagents` — green.
- **Live re-smoke** (real OpenAI, AG-UI): 3 subagents → **3 cards, 0 duplicate ticks**, persist + collapse-on-done, **0 NG0956**, 0 leftover task chips. Before/after screenshots in the thread.

## Notes
- LangGraph `agent.subagents()` doesn't populate under aimock replay (atomic replay omits subgraph namespace events), so the inline card can't be e2e-asserted on the chat cockpit — same documented limitation as the transient card; it works live (the canonical `examples/chat` already renders LangGraph subagent cards live). No regression there: the `task` call falls back to a generic chip under aimock exactly as before.

Spec: `docs/superpowers/specs/2026-06-19-subagent-card-inline-persistent-design.md` · Plan: `docs/superpowers/plans/2026-06-19-subagent-card-inline-persistent.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)