### PR TITLE
chore(release): bump publishable packages to 0.0.52

### DIFF
--- a/libs/a2ui/package.json
+++ b/libs/a2ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/a2ui",
-  "version": "0.0.51",
+  "version": "0.0.52",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/ag-ui/package.json
+++ b/libs/ag-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/ag-ui",
-  "version": "0.0.51",
+  "version": "0.0.52",
   "description": "AG-UI protocol adapter for @threadplane/chat — works with any AG-UI-compatible backend.",
   "keywords": ["angular", "ag-ui", "agent", "adapter", "threadplane"],
   "peerDependencies": {

--- a/libs/chat/package.json
+++ b/libs/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/chat",
-  "version": "0.0.51",
+  "version": "0.0.52",
   "exports": {
     "./chat.css": "./chat.css",
     "./themes/default-dark.css": "./themes/default-dark.css",

--- a/libs/langgraph/package.json
+++ b/libs/langgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/langgraph",
-  "version": "0.0.51",
+  "version": "0.0.52",
   "description": "LangGraph adapter for @threadplane/chat — Angular bindings for LangGraph Platform.",
   "keywords": ["angular", "langgraph", "langchain", "agent", "adapter", "threadplane"],
   "peerDependencies": {

--- a/libs/licensing/package.json
+++ b/libs/licensing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/licensing",
-  "version": "0.0.51",
+  "version": "0.0.52",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/render/package.json
+++ b/libs/render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/render",
-  "version": "0.0.51",
+  "version": "0.0.52",
   "peerDependencies": {
     "@angular/core": "^20.0.0 || ^21.0.0",
     "@angular/common": "^20.0.0 || ^21.0.0",

--- a/libs/telemetry/package.json
+++ b/libs/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/telemetry",
-  "version": "0.0.51",
+  "version": "0.0.52",
   "license": "MIT",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Release **v0.0.52** — bumps all 7 publishable `@threadplane/*` packages from 0.0.51.

## Ships
- **#709** — TypeScript DX audit: JSDoc sweep (type-guards, `getInterrupt`, `isTyping`, `mockAgent`, factories, citation APIs), config-interface member docs (`ChatConfig`/`AgentConfig`/`RenderConfig`), and formal `@example` tags on `provideAgent`/`injectAgent`.
- **Public-surface hygiene** (pre-1.0 breaking, 0 external consumers): removed internal `ICON_*`, `CHAT_MARKDOWN_STYLES`, `surfaceToSpec`, `createClientToolsCoordinator` from `@threadplane/chat`.

## Verification
- `verify-release-versions.mjs --tag v0.0.52` → atomic across all 7
- 7 libs build green; `nx release publish --groups=publishable --dry-run` → would publish to npm `latest`, tarballs valid

After merge: signed tag `v0.0.52` → `git push origin v0.0.52` (publish.yml → npm trusted publish) → `gh release create v0.0.52`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)