### PR TITLE
docs(readme): add OpenSSF Best Practices badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@
   <a href="https://scorecard.dev/viewer/?uri=github.com/cacheplane/angular-agent-framework">
     <img alt="OpenSSF Scorecard" src="https://api.scorecard.dev/projects/github.com/cacheplane/angular-agent-framework/badge" />
   </a>
+  <a href="https://www.bestpractices.dev/projects/13316">
+    <img alt="OpenSSF Best Practices" src="https://www.bestpractices.dev/projects/13316/badge" />
+  </a>
 </p>
 
 ---


### PR DESCRIPTION
Adds the OpenSSF Best Practices badge ([project 13316](https://www.bestpractices.dev/projects/13316)) to the README badge row, matching the existing HTML style. OSSF Scorecard's CII-Best-Practices check reads this on the next scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)