### PR TITLE
fix(examples): drop redundant subagents sidebar tray in canonical demo (post-#711 dedup)

### DIFF
--- a/cockpit/ag-ui/subagents/angular/src/app/subagents.component.ts
+++ b/cockpit/ag-ui/subagents/angular/src/app/subagents.component.ts
@@ -12,8 +12,8 @@ import { ExampleChatLayoutComponent } from '@threadplane/example-layouts';
  * subagent-specific wiring is needed in the component: when the orchestrator
  * dispatches a `task` tool call, the backend converts the subagent_activity
  * CUSTOM events into native AG-UI ACTIVITY events, the @threadplane/ag-ui
- * reducer projects them onto `agent.subagents()`, and <chat> renders a
- * <chat-subagents> live card for each running subagent.
+ * reducer projects them onto `agent.subagents()`, and <chat> renders each
+ * dispatch inline as a persistent `chat-subagent-card`.
  *
  * Demonstrates the chat-runtime decoupling: same <chat> composition as the
  * LangGraph cockpit, AG-UI runtime instead of LangGraph.

--- a/examples/chat/angular/src/app/shell/demo-shell.component.css
+++ b/examples/chat/angular/src/app/shell/demo-shell.component.css
@@ -143,18 +143,6 @@
   border-radius: var(--ngaf-chat-radius-card, 10px);
 }
 
-.demo-shell__subagents {
-  position: fixed;
-  left: 50%;
-  bottom: 96px;
-  transform: translateX(-50%);
-  z-index: 997;
-  width: min(640px, calc(100vw - 32px));
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
 .demo-shell__theme-toggle {
   width: 28px;
   height: 28px;

--- a/examples/chat/angular/src/app/shell/demo-shell.component.html
+++ b/examples/chat/angular/src/app/shell/demo-shell.component.html
@@ -119,11 +119,6 @@
         <chat-interrupt-panel [agent]="agent" (action)="onInterruptAction($event)" />
       </div>
     }
-    @if (agent.subagents && agent.subagents().size > 0) {
-      <div class="demo-shell__subagents" role="region" aria-label="Active subagents">
-        <chat-subagents [agent]="agent" />
-      </div>
-    }
   </div>
 
   <chat-history-search-palette

--- a/examples/chat/angular/src/app/shell/demo-shell.component.ts
+++ b/examples/chat/angular/src/app/shell/demo-shell.component.ts
@@ -18,7 +18,6 @@ import { DEMO_AGENT_REF, type DemoState } from './agent-ref';
 import { ThreadplaneTelemetryService } from '@threadplane/telemetry/browser';
 import {
   ChatInterruptPanelComponent,
-  ChatSubagentsComponent,
   ChatSidenavComponent,
   ChatSidenavScrimComponent,
   ChatHistorySearchPaletteComponent,
@@ -72,7 +71,6 @@ function parseUrl(url: string): { mode: DemoMode; threadId: string | null } {
   imports: [
     RouterOutlet,
     ChatInterruptPanelComponent,
-    ChatSubagentsComponent,
     ChatSidenavComponent,
     ChatSidenavScrimComponent,
     ChatHistorySearchPaletteComponent,


### PR DESCRIPTION
## Summary

Found in a proactive consistency sweep after #711. The `<chat>` composition now renders each subagent inline as a **persistent `chat-subagent-card`**. But the canonical `examples/chat` demo-shell still mounted a separate active-only `<chat-subagents>` "Active subagents" sidebar tray — so during a research-subagent run the subagent showed in **two places** (inline card + sidebar tray).

This removes the redundant tray, matching the fix #718 already applied to `cockpit/chat/subagents`. Subagents now show once: inline + persistent.

## Changes
- `demo-shell.component.html` — removed the `<chat-subagents>` block.
- `demo-shell.component.ts` — removed the now-unused `ChatSubagentsComponent` import + imports-array entry (`subagentToolNames: ['research']` stays — it still drives the inline cards).
- `demo-shell.component.css` — removed the orphaned `.demo-shell__subagents` rule.
- `cockpit/ag-ui/subagents` — refreshed a stale doc comment ("renders a `<chat-subagents>` live card" → "renders each dispatch inline as a persistent `chat-subagent-card`").

## Verification
- `examples-chat-angular` lint + build — green.
- `examples-chat-angular` e2e — green (research-subagent still asserts the inline `chat-subagent-card`; no e2e asserted on the removed tray).

A read-only sweep also confirmed the rest is clean: a2ui Material Symbols font is present in all 4 a2ui-rendering demos and no other surface renders a2ui icons; #705's welcome-copy pass is consistent across all 13+2 apps; and no other app double-displays subagents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)