### PR TITLE
feat(a2ui): normalize icon names to Material Symbols ligatures (camelCase → snake_case)

### DIFF
--- a/libs/chat/src/lib/a2ui/catalog/icon.component.spec.ts
+++ b/libs/chat/src/lib/a2ui/catalog/icon.component.spec.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { describe, it, expect } from 'vitest';
-import { A2uiIconComponent } from './icon.component';
+import { A2uiIconComponent, toMaterialSymbolName } from './icon.component';
 
 describe('A2uiIconComponent', () => {
   // Display-only component: renders name() input as a <span>.
@@ -9,5 +9,26 @@ describe('A2uiIconComponent', () => {
 
   it('exports the component class', () => {
     expect(A2uiIconComponent).toBeDefined();
+  });
+});
+
+describe('toMaterialSymbolName', () => {
+  it('converts camelCase identifiers to snake_case ligatures', () => {
+    expect(toMaterialSymbolName('accountCircle')).toBe('account_circle');
+    expect(toMaterialSymbolName('shoppingCart')).toBe('shopping_cart');
+    expect(toMaterialSymbolName('moreVert')).toBe('more_vert');
+    expect(toMaterialSymbolName('visibilityOff')).toBe('visibility_off');
+    expect(toMaterialSymbolName('arrowForward')).toBe('arrow_forward');
+  });
+
+  it('passes single-word and already-snake_case names through unchanged', () => {
+    expect(toMaterialSymbolName('check')).toBe('check');
+    expect(toMaterialSymbolName('star')).toBe('star');
+    expect(toMaterialSymbolName('trending_up')).toBe('trending_up');
+  });
+
+  it('leaves non-identifier glyphs (emoji) untouched', () => {
+    expect(toMaterialSymbolName('✓')).toBe('✓');
+    expect(toMaterialSymbolName('⚠️')).toBe('⚠️');
   });
 });

--- a/libs/chat/src/lib/a2ui/catalog/icon.component.ts
+++ b/libs/chat/src/lib/a2ui/catalog/icon.component.ts
@@ -2,6 +2,20 @@
 import { Component, computed, input } from '@angular/core';
 import type { Spec } from '@json-render/core';
 
+/**
+ * Convert an icon identifier to its Material Symbols ligature form.
+ *
+ * Material Symbols ligatures are snake_case (`account_circle`, `trending_up`),
+ * but A2UI catalogs commonly emit camelCase identifiers (`accountCircle`,
+ * `shoppingCart`). Splitting on lower→upper boundaries and lowercasing maps
+ * camelCase → the matching ligature. Already-snake_case names, single words,
+ * and non-identifier glyphs (emoji) have no boundaries to split and pass
+ * through unchanged. Unknown names still fall back to the browser default.
+ */
+export function toMaterialSymbolName(name: string): string {
+  return name.replace(/([a-z0-9])([A-Z])/g, '$1_$2').toLowerCase();
+}
+
 @Component({
   selector: 'a2ui-icon',
   standalone: true,
@@ -12,7 +26,7 @@ import type { Spec } from '@json-render/core';
         [style.font-size]="size() ? size() + 'px' : '1.125rem'"
         [attr.aria-label]="name"
         role="img"
-      >{{ name }}</span>
+      >{{ glyphName() }}</span>
     }
   `,
   styles: [`
@@ -56,4 +70,7 @@ export class A2uiIconComponent {
   readonly spec = input<Spec | undefined>(undefined);
 
   protected readonly effectiveName = computed(() => this.name() ?? this.icon());
+
+  /** The effective name as a Material Symbols ligature (camelCase → snake_case). */
+  protected readonly glyphName = computed(() => toMaterialSymbolName(this.effectiveName()));
 }


### PR DESCRIPTION
## Summary

Follow-up to #720. The Material Symbols rendering shipped, but the live smoke found it wasn't actually *showcased*: A2UI catalogs emit **camelCase** icon identifiers (`accountCircle`, `shoppingCart`, `moreVert` — see the enum in `examples/chat`'s a2ui schema), while Material Symbols ligatures are **snake_case** (`account_circle`). So single-word names (`check`, `star`) rendered as glyphs but the multi-word camelCase ones rendered as raw text.

This adds a small `toMaterialSymbolName` normalizer in the Icon component (camelCase → snake_case before rendering), so the existing A2UI icon vocabulary — and any backend — renders real glyphs. Single-word / already-snake_case names and emoji pass through unchanged; the original name stays as the `aria-label`.

## Changes (libs/chat only)
- `a2ui/catalog/icon.component.ts` — exported `toMaterialSymbolName()`; template renders the normalized `glyphName()`, keeps `aria-label` = original name.
- `icon.component.spec.ts` — unit tests for the normalizer (camelCase→snake_case, passthrough, emoji).

## Verification
- `chat` test + lint + build green.
- **Live (examples/chat, A2UI mode)**: an "Account" card driven via the LLM rendered five **real Material Symbols glyphs** — `accountCircle→account_circle`, `shoppingCart→shopping_cart`, `settings`, `notifications`, `star` (each 18×18 square = glyph, not text). Screenshot in the PR thread.

Disjoint from the subagent-card work (#721).

🤖 Generated with [Claude Code](https://claude.com/claude-code)