### PR TITLE
fix(cockpit): stop c-input demo double-submitting the user message

### DIFF
--- a/cockpit/chat/input/angular/src/app/input.component.ts
+++ b/cockpit/chat/input/angular/src/app/input.component.ts
@@ -62,7 +62,10 @@ import { injectAgent } from '@threadplane/langgraph';
           </chat-message-list>
         </div>
         <div class="px-4 py-2" style="background: var(--ngaf-chat-bg);">
-          <chat-input [agent]="agent" placeholder="Try typing here..." (submitted)="submitMessage($event)" />
+          <!-- chat-input submits to [agent] itself; (submitted) is a
+               notification only — re-submitting it here would double the
+               user message. -->
+          <chat-input [agent]="agent" placeholder="Try typing here..." />
         </div>
       </div>
       <div sidebar class="p-4 space-y-4" style="background: var(--ngaf-chat-bg); color: var(--ngaf-chat-text);">
@@ -94,8 +97,4 @@ export class InputComponent {
   protected readonly streamStatus = computed(() => this.agent.status());
   protected readonly isLoading = computed(() => this.agent.isLoading());
   protected readonly messageContent = messageContent;
-
-  submitMessage(content: string) {
-    this.agent.submit({ message: content });
-  }
 }


### PR DESCRIPTION
## What

The `cockpit/chat/input` demo (`app-input`) submitted every user turn **twice**, producing a phantom third `chat-message` in the list.

## Root cause

`<chat-input [agent]="agent">` already submits to its bound agent inside the primitive's `onSubmit()` and emits `(submitted)` purely as a *post-submit notification*. The demo also handled `(submitted)` by calling `agent.submit()` again:

```ts
<chat-input [agent]="agent" (submitted)="submitMessage($event)" />
// ...
submitMessage(content: string) { this.agent.submit({ message: content }); }
```

So each "Hello" produced two user messages with distinct ids → 3 `chat-message` elements where the e2e expects 2.

## Fix

Drop the redundant `(submitted)` handler and the `submitMessage` method. The `[agent]` binding is the single submit path. Added a short comment so the pattern isn't reintroduced.

## Verification

- `nx e2e cockpit-chat-input-angular` → **2 passed** (the `chat-message-list renders both turns` / `toHaveCount(2)` assertion now green).
- `nx lint`/`build` for `cockpit-chat-input-angular` → green.

This is a pre-existing demo bug, surfaced (not caused) by the subagent-card work in #721 — fixed separately as requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)