### PR TITLE
docs(contributing): make AI-review-comment handling an explicit convention

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,12 @@ not a required check and never blocks a merge. A second workflow
 Scorecard's Code-Review check reads from the reviews API. The maintainer still
 merges every PR.
 
+Because the review is advisory, **handling its comments is a convention, not a
+gate**: before arming auto-merge, the author reads each AI comment and either
+addresses it in a follow-up commit or replies on the thread with the reason for
+deferring/declining. Don't merge past unread review comments — the check going
+green (or red) says nothing about whether the comments were considered.
+
 This credits Code-Review via automation rather than peer review, because the
 project is currently single-maintainer. OSSF documentation suggests
 automated/AI reviews may not be intended to count toward this check; the current


### PR DESCRIPTION
## What

Codifies how we handle the advisory AI code review's comments, per a process decision: **convention, not a gate.**

The `claude-review.yml` review is advisory — it never blocks merge — so its comments can be silently inherited or ignored (and a flaky red `review` check can even *look* like a blocker while enforcing nothing). This adds one paragraph to the existing Code-review section of `CONTRIBUTING.md`:

> Before arming auto-merge, the author reads each AI comment and either addresses it in a follow-up commit or replies on the thread with the reason for deferring/declining. Don't merge past unread review comments — the check going green (or red) says nothing about whether the comments were considered.

## Why convention over enforcement

We explicitly chose the lowest-friction option (over required-conversation-resolution or making the review check required), because the review workflow has been flaky (`success → action_required → failure` across recent commits) and we don't want merges coupled to its reliability. The norm lives in docs; discipline applies it.

Docs-only. No code or workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)