### PR TITLE
fix(render): close NG0953 emit-after-destroy leak in render-spec teardown

### DIFF
--- a/libs/render/src/lib/render-spec.component.spec.ts
+++ b/libs/render/src/lib/render-spec.component.spec.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Component, input } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import type { Spec } from '@json-render/core';
@@ -185,5 +185,89 @@ describe('RenderSpecComponent — event emission', () => {
       expect(events).toHaveLength(1);
       expect(events[0].type).toBe('stateChange');
     });
+  });
+});
+
+// --- NG0953 regression: emit-after-destroy during streaming view teardown ---
+
+import { Component as SpecCmp, input as specInput } from '@angular/core';
+import { RenderSpecComponent } from './render-spec.component';
+import { defineAngularRegistry as defineReg } from './define-angular-registry';
+
+/** A `view`-tool component shaped like the AG-UI itinerary `day_card`. */
+@SpecCmp({
+  selector: 'render-day-card-view',
+  standalone: true,
+  template: '<div class="day-card">Day {{ day() }}</div>',
+})
+class DayCardViewComponent {
+  readonly day = specInput<number>(0);
+  readonly places = specInput<string[]>([]);
+}
+
+@SpecCmp({
+  selector: 'streaming-view-host',
+  standalone: true,
+  imports: [RenderSpecComponent],
+  template: '<render-spec [spec]="spec" [registry]="registry" />',
+})
+class StreamingViewHost {
+  readonly registry = defineReg({ day_card: DayCardViewComponent });
+  spec: Spec = {
+    root: 'card',
+    elements: { card: { type: 'day_card', props: { day: 1, places: [] } } },
+  } as Spec;
+}
+
+/**
+ * During live-LLM streaming the chat tool-view host mounts and tears down the
+ * `render-spec` for a `view` tool repeatedly as tokens arrive. On teardown,
+ * RenderSpecComponent's `onDestroy` emits a `destroyed` spec-lifecycle event.
+ * If that emit reaches the `events` OutputEmitterRef AFTER Angular has marked
+ * it destroyed, dev mode logs NG0953. Aimock fixture-replay e2e renders the
+ * view as a single atomic snapshot, so it never exercises this mount/teardown
+ * churn — hence this unit-level regression.
+ *
+ * NG0953 is surfaced as a `console.error` (Angular's reactive error reporter),
+ * so we spy on BOTH console.error and console.warn to be implementation-robust.
+ */
+describe('RenderSpecComponent — NG0953 emit-after-destroy (streaming teardown)', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+  afterEach(() => {
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  /** Any NG0953 (`destroyed OutputRef`) report across error/warn channels. */
+  function ng0953Reports(): string[] {
+    return [...errorSpy.mock.calls, ...warnSpy.mock.calls]
+      .map((call) => call.map((a) => (a instanceof Error ? a.message : String(a))).join(' '))
+      .filter(
+        (msg) => msg.includes('NG0953') || msg.includes('destroyed `OutputRef`'),
+      );
+  }
+
+  it('does not emit through the destroyed OutputRef when the view-tool host tears down', () => {
+    TestBed.configureTestingModule({ imports: [StreamingViewHost] });
+    const fx = TestBed.createComponent(StreamingViewHost);
+    fx.detectChanges(); // mounts render-spec → emits spec 'mounted'
+    fx.destroy(); // teardown → spec onDestroy emits 'destroyed'
+    expect(ng0953Reports()).toEqual([]);
+  });
+
+  it('survives repeated mount/teardown churn (token-stream re-materialization)', () => {
+    TestBed.configureTestingModule({ imports: [StreamingViewHost] });
+    for (let i = 0; i < 3; i++) {
+      const fx = TestBed.createComponent(StreamingViewHost);
+      fx.detectChanges();
+      fx.destroy();
+    }
+    expect(ng0953Reports()).toEqual([]);
   });
 });

--- a/libs/render/src/lib/render-spec.component.spec.ts
+++ b/libs/render/src/lib/render-spec.component.spec.ts
@@ -10,6 +10,7 @@ import { signalStateStore } from './signal-state-store';
 import { provideRender, RENDER_CONFIG } from './provide-render';
 import { provideViews, VIEW_REGISTRY } from './provide-views';
 import { views } from './views';
+import { RenderSpecComponent } from './render-spec.component';
 
 // --- Test component ---
 
@@ -190,29 +191,25 @@ describe('RenderSpecComponent — event emission', () => {
 
 // --- NG0953 regression: emit-after-destroy during streaming view teardown ---
 
-import { Component as SpecCmp, input as specInput } from '@angular/core';
-import { RenderSpecComponent } from './render-spec.component';
-import { defineAngularRegistry as defineReg } from './define-angular-registry';
-
 /** A `view`-tool component shaped like the AG-UI itinerary `day_card`. */
-@SpecCmp({
+@Component({
   selector: 'render-day-card-view',
   standalone: true,
   template: '<div class="day-card">Day {{ day() }}</div>',
 })
 class DayCardViewComponent {
-  readonly day = specInput<number>(0);
-  readonly places = specInput<string[]>([]);
+  readonly day = input<number>(0);
+  readonly places = input<string[]>([]);
 }
 
-@SpecCmp({
-  selector: 'streaming-view-host',
+@Component({
   standalone: true,
   imports: [RenderSpecComponent],
-  template: '<render-spec [spec]="spec" [registry]="registry" />',
+  template: '<render-spec [spec]="spec" [registry]="registry" (events)="events.push($event)" />',
 })
 class StreamingViewHost {
-  readonly registry = defineReg({ day_card: DayCardViewComponent });
+  readonly registry = defineAngularRegistry({ day_card: DayCardViewComponent });
+  readonly events: RenderEvent[] = [];
   spec: Spec = {
     root: 'card',
     elements: { card: { type: 'day_card', props: { day: 1, places: [] } } },
@@ -257,8 +254,25 @@ describe('RenderSpecComponent — NG0953 emit-after-destroy (streaming teardown)
     TestBed.configureTestingModule({ imports: [StreamingViewHost] });
     const fx = TestBed.createComponent(StreamingViewHost);
     fx.detectChanges(); // mounts render-spec → emits spec 'mounted'
-    fx.destroy(); // teardown → spec onDestroy emits 'destroyed'
+    fx.destroy(); // teardown → spec onDestroy tries to emit 'destroyed'
     expect(ng0953Reports()).toEqual([]);
+
+    // The spec 'destroyed' lifecycle event is emitted only from onDestroy,
+    // by which point Angular has torn down the `events` output. It was never
+    // deliverable (the emit is what produced NG0953) — so suppressing it is
+    // not a behavioral change. Assert it stays intentionally undelivered.
+    const host = fx.componentInstance;
+    expect(
+      host.events.filter(
+        (e) => e.type === 'lifecycle' && e.event === 'destroyed' && e.scope === 'spec',
+      ),
+    ).toEqual([]);
+    // The 'mounted' event, emitted while alive, still reaches consumers.
+    expect(
+      host.events.some(
+        (e) => e.type === 'lifecycle' && e.event === 'mounted' && e.scope === 'spec',
+      ),
+    ).toBe(true);
   });
 
   it('survives repeated mount/teardown churn (token-stream re-materialization)', () => {

--- a/libs/render/src/lib/render-spec.component.ts
+++ b/libs/render/src/lib/render-spec.component.ts
@@ -72,10 +72,27 @@ export class RenderSpecComponent implements OnInit {
 
   private destroyed = false;
 
+  /**
+   * True once this component is destroyed OR mid-teardown. Reads the live
+   * `DestroyRef` state, which Angular flips at the very START of view
+   * teardown — BEFORE any `onDestroy` hook runs, and crucially before the
+   * `events` OutputEmitterRef's own destroy hook marks itself dead.
+   *
+   * The manual `destroyed` flag alone is set too late: it flips inside our
+   * own `onDestroy` callback (below), which runs AFTER the output's destroy
+   * hook. That left the final `destroyed`-lifecycle emit — and any late async
+   * handler/store emit racing teardown — slipping through to an already-dead
+   * OutputEmitterRef → dev-mode NG0953. Gating every emit on
+   * `destroyRef.destroyed` closes that window. See guarded-emit.ts.
+   */
+  private isDestroyed(): boolean {
+    return this.destroyed || this.destroyRef.destroyed;
+  }
+
   /** Guarded OutputRef emit — no-ops after destroy (NG0953). */
   private readonly guardedEmit = makeGuardedEmit<RenderEvent>(
     (e) => this.events.emit(e),
-    () => this.destroyed,
+    () => this.isDestroyed(),
   );
 
   /** Internal store, lazily created once and reused across spec changes. */
@@ -138,7 +155,7 @@ export class RenderSpecComponent implements OnInit {
    * lifecycle service (single tap point — all events flow through here). */
   private readonly emitTapped = (event: RenderEvent): void => {
     this.guardedEmit(event);
-    if (this.destroyed || !this.lifecycle) return;
+    if (this.isDestroyed() || !this.lifecycle) return;
     switch (event.type) {
       case 'lifecycle':
         this.lifecycle.notifyLifecycle({
@@ -188,8 +205,11 @@ export class RenderSpecComponent implements OnInit {
     });
 
     this.destroyRef.onDestroy(() => {
-      this.emitTapped({ type: 'lifecycle', event: 'destroyed', scope: 'spec' });
+      // Mark destroyed BEFORE emitting: by now Angular has already torn down
+      // the `events` output, so the guard must suppress this final emit too
+      // (otherwise NG0953). The lifecycle service ignores 'destroyed' anyway.
       this.destroyed = true;
+      this.emitTapped({ type: 'lifecycle', event: 'destroyed', scope: 'spec' });
     });
   }
 


### PR DESCRIPTION
## Problem

During live-LLM streaming in the AG-UI demo (`examples/ag-ui/angular`), Angular dev mode logged a warning on every assistant turn that rendered a `view` tool (e.g. the itinerary `day_card`):

```
NG0953: Unexpected emit for destroyed OutputRef. The owning directive/component is destroyed.
```

Reproduced by sending "Add Sainte-Chapelle to Day 1" with a real OpenAI key — as the streaming turn tears down/recreates the tool-view component, an `OutputRef` emits after destroy. Dev-mode-only (not user-visible, not an error), but it signals a lifecycle leak.

## Root cause

`RenderSpecComponent` emits a `destroyed` spec-lifecycle event from its own `onDestroy` callback. The existing guard (`guarded-emit.ts`) keyed off a **manual `destroyed` flag set _inside_ that callback** — which runs *after* the `events` `OutputEmitterRef`'s own destroy hook (registered earlier, during field init). So at emit time the output was already torn down while the manual flag was still `false`, and the emit slipped through → NG0953. The same window exposed any late async-handler/store emit racing teardown.

## Fix

Gate every guarded emit on the **live `DestroyRef.destroyed`** (public API since Angular 21), which Angular flips at the very *start* of view teardown — before any `onDestroy` hook and before the output's destroy hook. The manual flag is also set before the final emit as belt-and-suspenders. The chat tool-view hosts only forward `render-spec`'s events, so suppressing the source protects the whole chain transitively (full render suite now reports **0** NG0953, including a pre-existing leak in an unrelated test).

## Test

Aimock fixture-replay e2e renders the view as a single atomic snapshot, so it never exercises the mount/teardown churn real token streaming produces. Added a unit regression that mounts `<render-spec>` for a `day_card`-shaped `view` and asserts that teardown — and repeated mount/teardown churn — produces no NG0953 across `console.error`/`console.warn`. Confirmed red before the fix (1 report on single teardown, 3 on churn), green after.

- `npx nx test render` → 98 passed
- `npx nx lint render` → 0 errors
- `npx nx build render` → ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)