### PR TITLE
chore(release): bump publishable packages to 0.0.53

### DIFF
--- a/libs/a2ui/package.json
+++ b/libs/a2ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/a2ui",
-  "version": "0.0.52",
+  "version": "0.0.53",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/ag-ui/package.json
+++ b/libs/ag-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/ag-ui",
-  "version": "0.0.52",
+  "version": "0.0.53",
   "description": "AG-UI protocol adapter for @threadplane/chat — works with any AG-UI-compatible backend.",
   "keywords": ["angular", "ag-ui", "agent", "adapter", "threadplane"],
   "peerDependencies": {

--- a/libs/chat/package.json
+++ b/libs/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/chat",
-  "version": "0.0.52",
+  "version": "0.0.53",
   "exports": {
     "./chat.css": "./chat.css",
     "./themes/default-dark.css": "./themes/default-dark.css",

--- a/libs/langgraph/package.json
+++ b/libs/langgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/langgraph",
-  "version": "0.0.52",
+  "version": "0.0.53",
   "description": "LangGraph adapter for @threadplane/chat — Angular bindings for LangGraph Platform.",
   "keywords": ["angular", "langgraph", "langchain", "agent", "adapter", "threadplane"],
   "peerDependencies": {

--- a/libs/licensing/package.json
+++ b/libs/licensing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/licensing",
-  "version": "0.0.52",
+  "version": "0.0.53",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/render/package.json
+++ b/libs/render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/render",
-  "version": "0.0.52",
+  "version": "0.0.53",
   "peerDependencies": {
     "@angular/core": "^20.0.0 || ^21.0.0",
     "@angular/common": "^20.0.0 || ^21.0.0",

--- a/libs/telemetry/package.json
+++ b/libs/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/telemetry",
-  "version": "0.0.52",
+  "version": "0.0.53",
   "license": "MIT",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Synchronized patch bump of the 7 publishable `@threadplane/*` libs `0.0.52 → 0.0.53` (chat, langgraph, ag-ui, render, a2ui, licensing, telemetry).

## Ships to npm
- **#726** — KaTeX / math rendering (lazy)
- **#724** — merged consecutive reasoning steps into one pill (+ unit coverage, `<1s`→"N steps" label fix)
- **#729** — ag-ui itinerary panel (phase 1)
- **#730** — render NG0953 emit-after-destroy fix

## Mechanics
- Surgical version-line bump only — 7 files, 7 lines (matches #712/#707); no lockfile regen (avoids dropping Linux `@next/swc` bindings), no dist/JSON reformatting.
- `node scripts/verify-release-versions.mjs --tag v0.0.53` → **atomic at 0.0.53**.
- On merge, pushing tag `v0.0.53` triggers `publish.yml` (lint/test/build → verify → `nx release publish` via npm trusted publishing/OIDC).

Patch-only per the 0.0.x policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)