### PR TITLE
fix(chat): chat-sidebar flexbox content layout + destroy cleanup

### DIFF
--- a/examples/ag-ui/angular/src/app/modes/sidebar-mode.component.ts
+++ b/examples/ag-ui/angular/src/app/modes/sidebar-mode.component.ts
@@ -41,19 +41,9 @@ import { WelcomeSuggestionsComponent } from './welcome-suggestions.component';
     .sidebar-mode__background {
       display: grid;
       place-items: center;
-      min-height: calc(100dvh - var(--demo-toolbar-height, 51px));
+      height: 100%;
       color: #8a92a3;
       font-size: 14px;
-    }
-    /* chat-sidebar's default content slot sets min-height: 100vh which,
-     * combined with the demo's flex column, would otherwise overflow the
-     * page. The background div above provides the visible "page" so we
-     * cap the chat-sidebar__content height to the available space. */
-    :host ::ng-deep .chat-sidebar__content {
-      /* Important: lib sets min-height: 100vh on this slot which would
-       * push the page 51px below the viewport in our flex column under
-       * the 51px toolbar. Override here. */
-      min-height: 0 !important;
     }
   `],
 })

--- a/examples/chat/angular/src/app/modes/sidebar-mode.component.ts
+++ b/examples/chat/angular/src/app/modes/sidebar-mode.component.ts
@@ -38,19 +38,9 @@ import { WelcomeSuggestionsComponent } from './welcome-suggestions.component';
     .sidebar-mode__background {
       display: grid;
       place-items: center;
-      min-height: calc(100dvh - var(--demo-toolbar-height, 51px));
+      height: 100%;
       color: #8a92a3;
       font-size: 14px;
-    }
-    /* chat-sidebar's default content slot sets min-height: 100vh which,
-     * combined with the demo's flex column, would otherwise overflow the
-     * page. The background div above provides the visible "page" so we
-     * cap the chat-sidebar__content height to the available space. */
-    :host ::ng-deep .chat-sidebar__content {
-      /* Important: lib sets min-height: 100vh on this slot which would
-       * push the page 51px below the viewport in our flex column under
-       * the 51px toolbar. Override here. */
-      min-height: 0 !important;
     }
   `],
 })

--- a/libs/chat/src/lib/compositions/chat-sidebar/chat-sidebar.component.spec.ts
+++ b/libs/chat/src/lib/compositions/chat-sidebar/chat-sidebar.component.spec.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 import { describe, it, expect, afterEach } from 'vitest';
 import { TestBed } from '@angular/core/testing';
+import { EnvironmentInjector, createEnvironmentInjector, runInInjectionContext } from '@angular/core';
 import { ChatSidebarComponent } from './chat-sidebar.component';
 
 describe('ChatSidebarComponent', () => {
@@ -54,6 +55,36 @@ describe('ChatSidebarComponent — edge-claim attribute', () => {
       TestBed.flushEffects();
       expect(document.documentElement.hasAttribute('data-threadplane-chat-sidebar')).toBe(false);
     });
+  });
+
+  it('removes the <html> claim when the sidebar is DESTROYED while open', () => {
+    // Regression: unmounting an open sidebar (e.g. switching demo modes) must
+    // not leave data-threadplane-chat-sidebar="open" stuck on <html>, or peer
+    // panels keep reserving --ngaf-chat-occupy-right and a phantom gap persists.
+    TestBed.configureTestingModule({});
+    const parent = TestBed.inject(EnvironmentInjector);
+    const child = createEnvironmentInjector([], parent);
+    let sidebar!: ChatSidebarComponent;
+    runInInjectionContext(child, () => {
+      sidebar = new ChatSidebarComponent();
+    });
+    sidebar.openWindow();
+    TestBed.flushEffects();
+    expect(document.documentElement.getAttribute('data-threadplane-chat-sidebar')).toBe('open');
+    // Destroy the injector that owns the component's effects (simulates unmount).
+    child.destroy();
+    expect(document.documentElement.hasAttribute('data-threadplane-chat-sidebar')).toBe(false);
+  });
+
+  it('flex layout: host is a flex row with threaded height (no hardcoded 100vh content)', () => {
+    // Angular rewrites :host → [_nghost-%COMP%] and appends [_ngcontent-%COMP%]
+    // to class selectors, so match those forms (see the panel/launcher tests).
+    const styles = (ChatSidebarComponent as unknown as { ɵcmp: { styles: string[] } }).ɵcmp.styles.join('\n');
+    // Host is a flex row (the only host block carrying display:flex).
+    expect(styles).toMatch(/\[_nghost-%COMP%\][^{]*\{[^}]*display:\s*flex/);
+    // The content slot fills via flex (not a hardcoded viewport height).
+    expect(styles).toMatch(/\.chat-sidebar__content[^{]*\{[^}]*flex:\s*1\s+1\s+auto/);
+    expect(styles).not.toMatch(/min-height:\s*100vh/);
   });
 
   it('panel CSS reads PEER --ngaf-chat-debug-claim-bottom (not aggregate)', () => {

--- a/libs/chat/src/lib/compositions/chat-sidebar/chat-sidebar.component.ts
+++ b/libs/chat/src/lib/compositions/chat-sidebar/chat-sidebar.component.ts
@@ -27,9 +27,20 @@ import { CHAT_HOST_TOKENS, ensureChatRootStyles } from '../../styles/chat-tokens
     '[attr.data-open]': 'open() ? "true" : "false"',
   },
   styles: [CHAT_HOST_TOKENS, `
-    :host { display: block; }
-    .chat-sidebar__content { transition: margin-right 300ms ease; min-height: 100vh; }
-    :host([data-push="true"][data-open="true"]) .chat-sidebar__content { margin-right: 28rem; }
+    /* Flex row so the projected main content fills the area beside the panel
+       and inherits the host's height (no hardcoded 100vh). Consumers thread
+       height: 100% from their layout down to <chat-sidebar>; the content slot
+       then fills it via flex. */
+    :host { display: flex; height: 100%; min-height: 0; }
+    .chat-sidebar__content {
+      flex: 1 1 auto;
+      min-width: 0;
+      min-height: 0;
+      transition: margin-right 300ms ease;
+    }
+    :host([data-push="true"][data-open="true"]) .chat-sidebar__content {
+      margin-right: var(--ngaf-chat-sidebar-width-drawer, 28rem);
+    }
     @media (max-width: 640px) {
       :host([data-push="true"][data-open="true"]) .chat-sidebar__content { margin-right: 0; }
     }
@@ -37,7 +48,7 @@ import { CHAT_HOST_TOKENS, ensureChatRootStyles } from '../../styles/chat-tokens
       position: fixed;
       top: 0; right: 0;
       bottom: var(--ngaf-chat-debug-claim-bottom, 0);
-      width: 28rem;
+      width: var(--ngaf-chat-sidebar-width-drawer, 28rem);
       background: var(--ngaf-chat-bg);
       border-left: 1px solid var(--ngaf-chat-separator);
       box-shadow: -8px 0 32px rgba(0,0,0,.08);
@@ -156,7 +167,7 @@ export class ChatSidebarComponent {
     ensureChatRootStyles();
     // Publish the right-edge claim while the panel is open. Peer panels
     // (e.g. chat-debug) read --ngaf-chat-occupy-right to leave room.
-    effect(() => {
+    effect((onCleanup) => {
       if (typeof document === 'undefined') return;
       const html = document.documentElement;
       if (this.open()) {
@@ -164,6 +175,11 @@ export class ChatSidebarComponent {
       } else {
         delete html.dataset['threadplaneChatSidebar'];
       }
+      // Clear the global claim when the sidebar is destroyed (not just closed).
+      // Without this, unmounting while open (e.g. switching demo modes) leaves
+      // data-threadplane-chat-sidebar="open" stuck on <html>, so peer panels
+      // keep reserving --ngaf-chat-occupy-right and a phantom gap persists.
+      onCleanup(() => { delete html.dataset['threadplaneChatSidebar']; });
     });
     effect((onCleanup) => {
       const closeOnEscape = this.closeOnEscape();


### PR DESCRIPTION
## What

Dogfooding the AG-UI App-mode map cockpit (PR #738) surfaced two real DX gaps in the `<chat-sidebar>` composition. This fixes them in the lib so the main content area beside the panel is easy to fill, and simplifies the example consumers onto it.

### 1. Flexbox content layout (no hardcoded heights)
`<chat-sidebar>`'s content slot was `min-height: 100vh` off a `display: block` host — so filling the area to the left of the panel required `::ng-deep` overrides in every consumer. Now:
- `:host { display: flex; height: 100% }` — a flex row at threaded height (consumers thread `height: 100%` down their layout).
- `.chat-sidebar__content { flex: 1 1 auto; min-height: 0 }` — fills the available area, no magic `100vh`.
- The push margin + panel width read `--ngaf-chat-sidebar-width-drawer` instead of a literal `28rem`.

### 2. Destroy cleanup (phantom right-edge gap)
The `<html data-threadplane-chat-sidebar="open">` claim was only cleared on *close*, never on *destroy*. Unmounting an open sidebar (e.g. switching demo modes) left it stuck, so peer panels kept reserving `--ngaf-chat-occupy-right` — a phantom blank strip. Added effect `onCleanup` to clear it on destroy.

### Consumers
Removed the now-obsolete `::ng-deep .chat-sidebar__content { min-height: 0 !important }` workaround from the examples/chat + examples/ag-ui sidebar-modes; the projected background fills via `height: 100%`.

## Verify
- chat-sidebar spec: added regression tests for **destroy-clears-the-claim** and the **flex layout shape** (6/6 pass).
- `nx lint` + `nx build` green for `chat`, `examples-chat-angular`, `examples-ag-ui-angular`.
- Live (real browser, examples/chat `/sidebar`): host `display: flex`; content + background fill the area below the toolbar (879px), **no overflow** (`bodyScrollH == winH`); open pushes content to 701px, close restores full width and clears the `<html>` claim.

## Follow-up
PR #738 (AG-UI map cockpit) will rebase onto this to drop its absolute-positioning + occupy-var hacks and put the map directly in the sidebar's content slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)