### PR TITLE
ci(ag-ui): bake GOOGLE_MAPS_API_KEY + Map ID into the demo deploy build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -912,6 +912,13 @@ jobs:
         run: npm ci
       - name: Build and assemble ag-ui demo
         if: steps.ag_ui_changed.outputs.changed == 'true'
+        env:
+          # Baked into the SPA bundle by inject-env at build time. Without the
+          # key the App-mode map toggle is disabled in prod. The key ships in
+          # the public bundle (normal for Maps JS) — restrict it by HTTP
+          # referrer in the Google Cloud console. The Map ID is not a secret.
+          GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
+          GOOGLE_MAPS_MAP_ID: 86d464ea7d5306034fe2a254
         run: npx tsx scripts/assemble-ag-ui-demo.ts
       - name: Deploy ag-ui demo SPA to Vercel (production)
         if: steps.ag_ui_changed.outputs.changed == 'true'


### PR DESCRIPTION
## What

The App-mode map cockpit (#747) is invisible on the deployed demo: the `ag-ui-demo-deploy` job builds with no Maps env, so `inject-env` bakes an **empty key** into the bundle — verified against prod (`ag-ui.threadplane.ai` `main-*.js` ships `googleMaps:""`), which disables the App-mode toggle.

This passes `GOOGLE_MAPS_API_KEY` (new repo secret) and the non-secret Map ID (`86d464ea7d5306034fe2a254`) to the assemble step.

## Required follow-ups (not in this PR)

1. **Add the repo secret** (owner action): `gh secret set GOOGLE_MAPS_API_KEY` with the key from the root `.env`.
2. **Re-add HTTP-referrer restrictions** on the key in Google Cloud console (they were removed during local debugging): `https://ag-ui.threadplane.ai/*` + `http://localhost:*`. The key ships in the public bundle, so referrer restriction is the security boundary.
3. **Rollout**: the deploy job only fires when `examples/ag-ui/**` changes — the next ag-ui PR to land (e.g. #746) will roll the key-enabled bundle out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)