### PR TITLE
fix(ag-ui): advanced markers ignore clicks — set gmpClickable

### DIFF
--- a/examples/ag-ui/angular/src/app/map-canvas.component.ts
+++ b/examples/ag-ui/angular/src/app/map-canvas.component.ts
@@ -45,6 +45,7 @@ const PARIS_CENTER: google.maps.LatLngLiteral = { lat: 48.8566, lng: 2.3522 };
             [position]="m.position"
             [content]="m.content"
             [title]="m.stop.place"
+            [options]="advancedMarkerOptions"
             (mapClick)="onMarkerClick(m.stop)"
           />
         }
@@ -94,6 +95,12 @@ export class MapCanvasComponent {
     disableDefaultUI: true,
     zoomControl: true,
     clickableIcons: false,
+  };
+  // AdvancedMarkerElement is NOT clickable by default (unlike the legacy
+  // Marker) — without gmpClickable it never fires click/gmp-click, so the
+  // wrapper's (mapClick) output stays silent and the info window can't open.
+  protected readonly advancedMarkerOptions: google.maps.marker.AdvancedMarkerElementOptions = {
+    gmpClickable: true,
   };
 
   private readonly googleMap = viewChild(GoogleMap);


### PR DESCRIPTION
Marker clicks on the App-mode map did nothing (no info window / focus / Remove). Regression from the AdvancedMarkerElement migration: legacy `Marker` is clickable by default, `AdvancedMarkerElement` is **not** — without `gmpClickable: true` it never fires `click`/`gmp-click`, so `(mapClick)` stays silent. The "use gmp-click" console hint was the symptom.

Fix: pass `{ gmpClickable: true }` via the marker `[options]` (+7 lines).

Verified: live in Chrome (markers report `gmpClickable=true`, click opens the info window with Remove), lint 0 errors, unit ✓, build ✓ against post-#747 main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)