### PR TITLE
chore(release): bump publishable packages to 0.0.54

### DIFF
--- a/libs/a2ui/package.json
+++ b/libs/a2ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/a2ui",
-  "version": "0.0.53",
+  "version": "0.0.54",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/ag-ui/package.json
+++ b/libs/ag-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/ag-ui",
-  "version": "0.0.53",
+  "version": "0.0.54",
   "description": "AG-UI protocol adapter for @threadplane/chat — works with any AG-UI-compatible backend.",
   "keywords": ["angular", "ag-ui", "agent", "adapter", "threadplane"],
   "peerDependencies": {

--- a/libs/chat/package.json
+++ b/libs/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/chat",
-  "version": "0.0.53",
+  "version": "0.0.54",
   "exports": {
     "./chat.css": "./chat.css",
     "./themes/default-dark.css": "./themes/default-dark.css",

--- a/libs/langgraph/package.json
+++ b/libs/langgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/langgraph",
-  "version": "0.0.53",
+  "version": "0.0.54",
   "description": "LangGraph adapter for @threadplane/chat — Angular bindings for LangGraph Platform.",
   "keywords": ["angular", "langgraph", "langchain", "agent", "adapter", "threadplane"],
   "peerDependencies": {

--- a/libs/licensing/package.json
+++ b/libs/licensing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/licensing",
-  "version": "0.0.53",
+  "version": "0.0.54",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/render/package.json
+++ b/libs/render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/render",
-  "version": "0.0.53",
+  "version": "0.0.54",
   "peerDependencies": {
     "@angular/core": "^20.0.0 || ^21.0.0",
     "@angular/common": "^20.0.0 || ^21.0.0",

--- a/libs/telemetry/package.json
+++ b/libs/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/telemetry",
-  "version": "0.0.53",
+  "version": "0.0.54",
   "license": "MIT",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Release 0.0.54 — all 7 `@threadplane/*` libs

Version bump only (7 files, 7 lines). `verify-release-versions.mjs` green — the `publishable` group is atomic at **0.0.54**.

## What ships (main since v0.0.53)

- **⚠️ BREAKING (styling): `ngaf` → `tplane` internal prefix rename (#741)** — all `--ngaf-chat-*` CSS custom properties are now `--tplane-chat-*`. Consumers overriding theme vars must rename. The npm scope stays `@threadplane`.
- **chat-sidebar flexbox content layout + destroy cleanup (#740)** — the content slot fills beside the panel via flex (no `min-height: 100vh`); the `<html>` edge-claim clears on destroy (fixes the phantom right-edge gap after unmounting an open sidebar).
- **Streaming tables** — no more raw pipes mid-stream (#743); partial-markdown 0.5.0→0.5.3 (#734, #739, #744) for open-line rendering, headers, and body rows.
- Overlay-directive lint cleanup + regenerated api docs (#742).

Per the 0.0.x policy this is a patch bump despite the breaking rename — pin exact versions.

## After merge

1. CI dry-run publish (`publish.yml` workflow_dispatch, `dry-run: true`)
2. On green + owner confirmation: push the `v0.0.54` tag (publishes with provenance) + GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)