### PR TITLE
[codex] Fix AG-UI production Maps key baking

### DIFF
--- a/examples/ag-ui/angular/project.json
+++ b/examples/ag-ui/angular/project.json
@@ -53,7 +53,13 @@
               "maximumError": "16kb"
             }
           ],
-          "outputHashing": "all"
+          "outputHashing": "all",
+          "fileReplacements": [
+            {
+              "replace": "examples/ag-ui/angular/src/environments/generated-keys.ts",
+              "with": "examples/ag-ui/angular/src/environments/generated-keys.local.ts"
+            }
+          ]
         },
         "development": {
           "optimization": false,


### PR DESCRIPTION
## Summary
- Add the generated Maps key file replacement to the AG-UI Angular production build.
- This makes the `inject-env` output participate in production bundles, not only development bundles.

## Root cause
The deploy workflow set `GOOGLE_MAPS_API_KEY` and ran `inject-env`, but the Angular production configuration did not replace the committed `generated-keys.ts` stub with `generated-keys.local.ts`. As a result, production deployed a keyless bundle even when the secret was available.

## Validation
- Before the fix: dummy-key production build ran `inject-env` with key length 29, but the output bundle still had key length 0.
- After the fix: `GOOGLE_MAPS_API_KEY=DUMMY_MAPS_KEY_FOR_BUILD_TEST GOOGLE_MAPS_MAP_ID=DUMMY_MAP_ID_FOR_BUILD_TEST npx nx build examples-ag-ui-angular --configuration=production --skip-nx-cache`, then checked output bundle key length 29 and Map ID set.
- `npx nx lint examples-ag-ui-angular` (0 errors; existing warnings remain).