### PR TITLE
chore(release): bump publishable packages to 0.0.55

### DIFF
--- a/libs/a2ui/package.json
+++ b/libs/a2ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/a2ui",
-  "version": "0.0.54",
+  "version": "0.0.55",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/ag-ui/package.json
+++ b/libs/ag-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/ag-ui",
-  "version": "0.0.54",
+  "version": "0.0.55",
   "description": "AG-UI protocol adapter for @threadplane/chat — works with any AG-UI-compatible backend.",
   "keywords": ["angular", "ag-ui", "agent", "adapter", "threadplane"],
   "peerDependencies": {

--- a/libs/chat/package.json
+++ b/libs/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/chat",
-  "version": "0.0.54",
+  "version": "0.0.55",
   "exports": {
     "./chat.css": "./chat.css",
     "./themes/default-dark.css": "./themes/default-dark.css",

--- a/libs/langgraph/package.json
+++ b/libs/langgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/langgraph",
-  "version": "0.0.54",
+  "version": "0.0.55",
   "description": "LangGraph adapter for @threadplane/chat — Angular bindings for LangGraph Platform.",
   "keywords": ["angular", "langgraph", "langchain", "agent", "adapter", "threadplane"],
   "peerDependencies": {

--- a/libs/licensing/package.json
+++ b/libs/licensing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/licensing",
-  "version": "0.0.54",
+  "version": "0.0.55",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/render/package.json
+++ b/libs/render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/render",
-  "version": "0.0.54",
+  "version": "0.0.55",
   "peerDependencies": {
     "@angular/core": "^20.0.0 || ^21.0.0",
     "@angular/common": "^20.0.0 || ^21.0.0",

--- a/libs/telemetry/package.json
+++ b/libs/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/telemetry",
-  "version": "0.0.54",
+  "version": "0.0.55",
   "license": "MIT",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Atomic bump of the 7 publishable `@threadplane/*` packages `0.0.54 → 0.0.55` (chat, langgraph, ag-ui, render, a2ui, licensing, telemetry). Middleware is versioned/published separately (unchanged).

Since 0.0.54, main landed:
- **#751** — `fix(langgraph): stop streamed chunks being dropped by prefix-based dedupe` (the streaming-accumulation bug that dropped bare-pipe deltas and intermittently corrupted streamed tables mid-render). This is the reason to cut the release — npm consumers currently have the bug.
- #755, #756 docs.

Pre-validated locally: `verify-release-versions.mjs --tag v0.0.55` passes (atomic), and a fresh `nx run-many -t lint,test,build` over all 7 publishable projects (`--skip-nx-cache`, the exact set `publish.yml` gates on) is green.

On merge, tag `v0.0.55` on the squashed commit → triggers `publish.yml` (OIDC trusted publishing + provenance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)