### PR TITLE
Fix homepage license copy and docs search matching

### DIFF
--- a/apps/website/e2e/docs.spec.ts
+++ b/apps/website/e2e/docs.spec.ts
@@ -120,4 +120,16 @@ test.describe('Docs search', () => {
     // The modal mounts somewhere — assert by visible input role with placeholder text.
     await expect(page.locator('input[placeholder*="Search"], input[type="search"]').first()).toBeVisible({ timeout: 3000 });
   });
+
+  test('matches docs pages when query omits small connector words', async ({ page, browserName }) => {
+    await page.goto('/docs/langgraph/getting-started/introduction');
+    const modifier = browserName === 'webkit' ? 'Meta' : 'Control';
+    await page.keyboard.press(`${modifier}+KeyK`);
+
+    const searchInput = page.locator('input[placeholder*="Search"], input[type="search"]').first();
+    await searchInput.fill('choosing adapter');
+
+    await expect(page.getByRole('button', { name: /Choosing an adapter/i })).toBeVisible();
+    await expect(page.getByText('No results found')).toHaveCount(0);
+  });
 });

--- a/apps/website/e2e/website.spec.ts
+++ b/apps/website/e2e/website.spec.ts
@@ -21,6 +21,17 @@ test('landing page renders feature blocks (Stream/Render/Ship)', async ({ page }
   await expect(page.locator('#ship-heading')).toBeVisible();
 });
 
+test('landing page license copy distinguishes MIT packages from commercially licensed chat', async ({ page }) => {
+  await page.goto('/');
+  const main = page.locator('main');
+
+  await expect(main).toContainText('Most packages are MIT');
+  await expect(main).toContainText('@threadplane/chat');
+  await expect(main).toContainText('commercially licensed for production use');
+  await expect(main).not.toContainText('MIT today, MIT tomorrow');
+  await expect(main).not.toContainText('MIT · No signup required · App telemetry off by default');
+});
+
 test('pricing page shows plan cards', async ({ page }) => {
   await page.goto('/pricing');
   await expect(page.getByText('Community').first()).toBeVisible();

--- a/apps/website/src/components/docs/DocsSearch.tsx
+++ b/apps/website/src/components/docs/DocsSearch.tsx
@@ -16,6 +16,27 @@ interface SearchablePage {
   libraryTitle: string;
 }
 
+const SEARCH_STOP_WORDS = new Set(['a', 'an', 'and', 'for', 'in', 'of', 'on', 'or', 'the', 'to', 'with']);
+
+function searchTokens(value: string): string[] {
+  return value
+    .toLowerCase()
+    .split(/[^a-z0-9@.-]+/)
+    .filter((token) => token.length > 0 && !SEARCH_STOP_WORDS.has(token));
+}
+
+function searchableText(page: SearchablePage): string {
+  return [page.title, page.description, page.slug, page.section, page.libraryTitle].filter(Boolean).join(' ');
+}
+
+function matchesQuery(page: SearchablePage, query: string): boolean {
+  const queryTokens = searchTokens(query);
+  if (queryTokens.length === 0) return false;
+
+  const pageText = searchableText(page).toLowerCase();
+  return queryTokens.every((token) => pageText.includes(token));
+}
+
 const allSearchablePages: SearchablePage[] = [
   ...specialDocsPages.map((page) => ({
     title: page.title,
@@ -43,13 +64,7 @@ export function DocsSearch({ library }: { library?: LibraryId }) {
   const router = useRouter();
 
   const results = query.length > 0
-    ? allSearchablePages.filter((p) =>
-        p.title.toLowerCase().includes(query.toLowerCase()) ||
-        p.description?.toLowerCase().includes(query.toLowerCase()) ||
-        p.slug?.toLowerCase().includes(query.toLowerCase()) ||
-        p.section?.toLowerCase().includes(query.toLowerCase()) ||
-        p.libraryTitle.toLowerCase().includes(query.toLowerCase())
-      ).slice(0, 8)
+    ? allSearchablePages.filter((p) => matchesQuery(p, query)).slice(0, 8)
     : allSearchablePages.filter((p) => !library || !p.library || p.library === library).slice(0, 6);
 
   const handleKeyDown = useCallback((e: KeyboardEvent) => {

--- a/apps/website/src/components/landing/DemoModal.tsx
+++ b/apps/website/src/components/landing/DemoModal.tsx
@@ -119,7 +119,7 @@ export function DemoModal({ open, onClose, tabs, active, onActive }: DemoModalPr
         </div>
 
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '8px 14px', borderTop: `1px solid ${tokens.surfaces.border}`, background: tokens.surfaces.surface }}>
-          <span style={{ fontFamily: 'Inter, sans-serif', fontSize: 12, color: tokens.colors.textMuted }}>Esc or click outside to close &middot; MIT &middot; no signup</span>
+          <span style={{ fontFamily: 'Inter, sans-serif', fontSize: 12, color: tokens.colors.textMuted }}>Esc or click outside to close &middot; no signup</span>
           <a href={tab.href} target="_blank" rel="noopener noreferrer"
             onClick={() => trackExternalLinkClick(tab.href, { surface: 'home_demo', cta_id: `home_demo_full_${tab.key.replace(/-/g, '_')}`, cta_text: 'Open the full demo' })}
             style={{ fontFamily: 'Inter, sans-serif', fontSize: 12, fontWeight: 600, color: tokens.colors.accent, textDecoration: 'none' }}>Open the full demo &#8599;</a>

--- a/apps/website/src/components/landing/DemoShowcase.tsx
+++ b/apps/website/src/components/landing/DemoShowcase.tsx
@@ -86,7 +86,7 @@ export function DemoShowcase() {
         </Button>
       </div>
       <p style={{ fontFamily: tokens.typography.caption.family, fontSize: tokens.typography.caption.size, color: tokens.colors.textMuted, margin: '14px 0 0' }}>
-        Video loops instantly · click Launch to open the live, interactive demo · MIT · no signup
+        Video loops instantly · click Launch to open the live, interactive demo · no signup
       </p>
       <DemoModal
         open={modalOpen}

--- a/apps/website/src/components/landing/FinalCTA.tsx
+++ b/apps/website/src/components/landing/FinalCTA.tsx
@@ -13,7 +13,7 @@ interface FinalCTAProps {
   primary?: { label: string; href: string; external?: boolean } | null;
   /** Optional secondary CTA. Defaults to "See each feature in action →" → cockpit. */
   secondary?: { label: string; href: string; external?: boolean } | null;
-  /** Optional trailing caption. Defaults to MIT line. Pass null to hide. */
+  /** Optional trailing caption. Defaults to licensing and telemetry line. Pass null to hide. */
   caption?: string | null;
 }
 
@@ -24,7 +24,7 @@ export function FinalCTA({
   subtext = 'Install the framework, read the docs, and have a streaming chat in your app this afternoon.',
   primary = null,
   secondary = DEFAULT_SECONDARY,
-  caption = 'MIT · No signup required · App telemetry off by default',
+  caption = 'Most packages are MIT · @threadplane/chat requires a production license · App telemetry off by default',
 }: FinalCTAProps = {}) {
   return (
     <Section surface="tinted" ariaLabelledBy="final-cta-heading">

--- a/apps/website/src/components/landing/Promises.tsx
+++ b/apps/website/src/components/landing/Promises.tsx
@@ -6,8 +6,8 @@ import { Card } from '../ui/Card';
 
 const PROMISES = [
   {
-    title: 'No closed core',
-    body: 'MIT today, MIT tomorrow. Primitives and compositions both stay in the open repo. Pilot-to-Prod is the only paid thing.',
+    title: 'No runtime lock-in',
+    body: 'MIT adapters and render primitives stay open. @threadplane/chat is free for noncommercial use and commercially licensed for production.',
   },
   {
     title: 'No abandoned majors',


### PR DESCRIPTION
## Summary
- align remaining homepage/demo licensing copy with current package licensing
- make docs search match meaningful query tokens so `choosing adapter` finds `Choosing an adapter`
- add e2e regressions for the licensing copy and docs search behavior

## Test Plan
- `npx nx e2e website --grep "matches docs pages|license copy" --workers=1 --retries=0`
- `npx nx lint website`
- `npx nx build website`
- `npx nx e2e website --workers=1 --retries=0`
