### PR TITLE
Refresh public agent context version

### DIFF
--- a/apps/website/public/AGENTS.md
+++ b/apps/website/public/AGENTS.md
@@ -1,4 +1,4 @@
-# Threadplane v0.0.54
+# Threadplane v0.0.55
 
 Production-ready chat, durable threads, interrupts, subagents, planning, memory, and generative UI for Angular agent apps.
 

--- a/apps/website/public/CLAUDE.md
+++ b/apps/website/public/CLAUDE.md
@@ -1,4 +1,4 @@
-# Threadplane v0.0.54
+# Threadplane v0.0.55
 
 Production-ready chat, durable threads, interrupts, subagents, planning, memory, and generative UI for Angular agent apps.
 


### PR DESCRIPTION
## Summary
- refresh generated public `AGENTS.md` and `CLAUDE.md` from `v0.0.54` to `v0.0.55`
- verify API docs generation produces no package API reference diff

## Test Plan
- `npm run generate-agent-context`
- `npm run generate-api-docs`
- `node` version check for `apps/website/public/AGENTS.md` and `apps/website/public/CLAUDE.md` against `libs/langgraph/package.json`
- `npx nx build website`
