### PR TITLE
Refresh AG-UI install and agent surface docs

### DIFF
--- a/apps/website/content/docs/ag-ui/api/api-docs.json
+++ b/apps/website/content/docs/ag-ui/api/api-docs.json
@@ -405,7 +405,7 @@
   {
     "name": "AgUiAgent",
     "kind": "interface",
-    "description": "The neutral Agent contract, widened with the AG-UI adapter's optional\n`customEvents` signal (the chat composition feature-detects it to enable\nlive a2ui streaming) and the optional `clientTools` capability.\nMirrors langgraph's LangGraphAgent extension.",
+    "description": "The neutral Agent contract, widened with the AG-UI adapter's\n`customEvents` signal (the chat composition feature-detects it to enable\nlive a2ui streaming), the browser client-tools capability, and concrete\nACTIVITY-backed `subagents`.\nMirrors langgraph's LangGraphAgent extension where the protocol surfaces\noverlap.",
     "properties": [
       {
         "name": "clientTools",
@@ -620,7 +620,7 @@
       "description": ""
     },
     "examples": [
-      "```ts\nTestBed.configureTestingModule({\n  providers: [provideFakeAgent({ responses: ['Hello from the fake agent'] })],\n});\n```"
+      "```ts\nTestBed.configureTestingModule({\n  providers: [provideFakeAgent({ tokens: ['Hello from the fake agent'] })],\n});\n```"
     ]
   },
   {
@@ -646,6 +646,8 @@
       "type": "AgUiAgent<>",
       "description": ""
     },
-    "examples": []
+    "examples": [
+      "```ts\nimport { HttpAgent } from '@ag-ui/client';\nimport { toAgent } from '@threadplane/ag-ui';\n\nconst agent = toAgent(new HttpAgent({ url: '/api/agent' }));\n```"
+    ]
   }
 ]

--- a/apps/website/content/docs/ag-ui/api/inject-agent.mdx
+++ b/apps/website/content/docs/ag-ui/api/inject-agent.mdx
@@ -65,19 +65,22 @@ These fields are stable across runtime adapters and are what chat components con
 
 ## AG-UI-specific surface
 
-The AG-UI adapter extends the neutral `Agent` contract with one additional signal:
+The AG-UI adapter extends the neutral `Agent` contract with AG-UI-specific protocol surfaces:
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `customEvents()` | `CustomStreamEvent[]` | Custom events emitted by the backend during a run. Accumulates per run; resets on each new `submit()`. |
+| `clientTools` | `ClientToolsCapability` | Browser client-tool catalog, pending calls, and result resolution used by `<chat [clientTools]>`. |
+| `subagents()` | `Map<string, Subagent>` | `ACTIVITY_*` entries with `activityType: 'subagent'`, projected to the neutral subagent contract and keyed by `messageId`. |
 
-`injectAgent()` returns the `AgUiAgent` type — the neutral `Agent` contract plus `customEvents` — so the signal is reachable directly, no cast required:
+`injectAgent()` returns the `AgUiAgent` type — the neutral `Agent` contract plus these AG-UI-specific fields — so they are reachable directly, no cast required:
 
 ```ts
 import { injectAgent } from '@threadplane/ag-ui';
 
 const chat = injectAgent();
-chat.customEvents(); // Signal<CustomStreamEvent[]>
+chat.customEvents(); // CustomStreamEvent[]
+chat.subagents(); // Map<string, Subagent>
 ```
 
 The chat a2ui bridge reads `customEvents` to light up live generative-UI streaming when your backend emits `a2ui-partial` events. The consuming side is documented in chat's [A2UI overview](/docs/chat/a2ui/overview). See the [Custom Events guide](/docs/ag-ui/guides/custom-events) for backend wiring details.

--- a/apps/website/content/docs/ag-ui/api/to-agent.mdx
+++ b/apps/website/content/docs/ag-ui/api/to-agent.mdx
@@ -24,11 +24,13 @@ const agent = toAgent(source, { telemetry: myTelemetrySink });
 
 ## AgUiAgent
 
-`toAgent()` returns an `AgUiAgent`, which extends the neutral `Agent` contract with one additional signal:
+`toAgent()` returns an `AgUiAgent`, which extends the neutral `Agent` contract with AG-UI-specific protocol surfaces:
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `customEvents()` | `Signal<CustomStreamEvent[]>` | Custom events accumulated during a run. Resets at the start of each new run. |
+| `clientTools` | `ClientToolsCapability` | Browser client-tool catalog, pending calls, and result resolution. The chat composition uses this when you pass `<chat [clientTools]>`. |
+| `subagents()` | `Signal<Map<string, Subagent>>` | `ACTIVITY_*` events with `activityType: 'subagent'`, projected to the neutral subagent contract and keyed by `messageId`. |
 
 The standard `Agent` signals (`messages`, `status`, `isLoading`, `error`, `toolCalls`, `state`, `interrupt`) and actions (`submit`, `stop`, `regenerate`) are all present.
 

--- a/apps/website/content/docs/ag-ui/concepts/architecture.mdx
+++ b/apps/website/content/docs/ag-ui/concepts/architecture.mdx
@@ -88,7 +88,9 @@ Every AG-UI event is passed through the reducer. The reducer updates Angular sig
 - `toolCalls` for tool call starts, arguments, results, and completion.
 - `state` for AG-UI state snapshots and JSON Patch deltas.
 - `interrupt` cleared on `RUN_STARTED` and set by the `CUSTOM` `on_interrupt` event.
-- `events$` for custom events.
+- `events$` for runtime-neutral custom-event side effects.
+- `customEvents` for accumulated non-`on_interrupt` `CUSTOM` events used by live a2ui and app-specific reactive UI.
+- `subagents` for `ACTIVITY_*` events with `activityType: 'subagent'`.
 
 When the user submits input, the adapter builds a user message, appends it locally, adds it to the AG-UI source with `source.addMessage()`, then calls `source.runAgent()`.
 
@@ -105,6 +107,12 @@ events — matching the LangGraph adapter. Without it, a2ui still renders from
 the final tool-call surface; with it, surfaces build up live.
 
 The consuming side — how the chat composition turns these events into rendered surfaces — lives in chat's [A2UI overview](/docs/chat/a2ui/overview).
+
+## Browser client tools
+
+`AgUiAgent.clientTools` is the browser-tool bridge consumed by `<chat [clientTools]>`. The chat composition registers the browser catalog on the agent; the adapter threads that catalog into every `source.runAgent({ tools })` call, exposes unresolved browser-owned tool calls through `clientTools.pending()`, and sends the browser result back as a tool message before continuing the run.
+
+See chat's [Client Tools guide](/docs/chat/guides/client-tools) for declaring `action()`, `view()`, and `ask()` tools. With AG-UI, the backend must bind the supplied AG-UI tool specs and finish the turn without emitting `TOOL_CALL_RESULT` for browser-owned tools so the client can resolve them.
 
 ## Provider choices
 
@@ -188,9 +196,10 @@ The AG-UI adapter currently covers:
 - Tool calls from `TOOL_CALL_*`.
 - Shared state from `STATE_SNAPSHOT` and `STATE_DELTA`.
 - Message replacement from `MESSAGES_SNAPSHOT`.
-- Custom events from `CUSTOM`.
+- Custom events from non-`on_interrupt` `CUSTOM` events, surfaced through both `events$` and `customEvents`.
 - Interrupts from `CUSTOM` events named `on_interrupt`.
-- Subagent/activity progress from `ACTIVITY_SNAPSHOT` and `ACTIVITY_DELTA`.
+- Browser client tools via `AgUiAgent.clientTools`.
+- Subagent progress from `ACTIVITY_SNAPSHOT` and `ACTIVITY_DELTA` events whose `activityType` is `subagent`.
 - Citations stored under `state.citations`.
 
 These features are intentionally out of scope for the AG-UI adapter today:

--- a/apps/website/content/docs/ag-ui/getting-started/installation.mdx
+++ b/apps/website/content/docs/ag-ui/getting-started/installation.mdx
@@ -9,10 +9,11 @@
 ## Install packages
 
 ```bash
-npm install @threadplane/chat @threadplane/ag-ui @ag-ui/client @ag-ui/core
+npm install @threadplane/chat @threadplane/ag-ui @ag-ui/client @ag-ui/core marked
 ```
 
 `@threadplane/chat` provides the chat UI primitives. `@threadplane/ag-ui` provides the adapter that wires an AG-UI backend into the `Agent` contract those primitives consume.
+`marked` is the required markdown parser peer used by `@threadplane/chat` when assistant messages render through `<chat>`.
 
 ## Peer Dependencies
 

--- a/apps/website/content/docs/ag-ui/getting-started/quickstart.mdx
+++ b/apps/website/content/docs/ag-ui/getting-started/quickstart.mdx
@@ -14,7 +14,7 @@ Want to see the finished result before you build? Open the live [AG-UI demo](htt
 <Step title="Install the packages">
 
 ```bash
-npm install @threadplane/chat @threadplane/ag-ui @ag-ui/client @ag-ui/core
+npm install @threadplane/chat @threadplane/ag-ui @ag-ui/client @ag-ui/core marked
 ```
 
 </Step>

--- a/apps/website/src/app/docs/page.tsx
+++ b/apps/website/src/app/docs/page.tsx
@@ -38,7 +38,7 @@ const BACKENDS: Backend[] = [
   {
     title: 'AG-UI',
     blurb: 'For CrewAI, Mastra, Pydantic AI, Strands, and more.',
-    install: 'npm i @threadplane/chat @threadplane/ag-ui @ag-ui/client @ag-ui/core',
+    install: 'npm i @threadplane/chat @threadplane/ag-ui @ag-ui/client @ag-ui/core marked',
     href: '/docs/ag-ui/getting-started/quickstart',
     logoSrc: '/logos/runtimes/copilotkit.svg',
     attribution: 'AG-UI · CopilotKit',

--- a/apps/website/src/app/llms.txt/route.ts
+++ b/apps/website/src/app/llms.txt/route.ts
@@ -36,7 +36,7 @@ function buildLlmsTxt(): string {
     '# LangGraph backend with browser client tools:',
     'npm install @threadplane/chat @threadplane/langgraph @langchain/core @langchain/langgraph-sdk @threadplane/middleware marked',
     '# AG-UI backend:',
-    'npm install @threadplane/chat @threadplane/ag-ui @ag-ui/client @ag-ui/core',
+    'npm install @threadplane/chat @threadplane/ag-ui @ag-ui/client @ag-ui/core marked',
     '',
     '## Key API (symmetric across adapters)',
     '- provideAgent(config) — wires the adapter into Angular DI. Same name across @threadplane/langgraph and @threadplane/ag-ui.',

--- a/libs/ag-ui/README.md
+++ b/libs/ag-ui/README.md
@@ -32,10 +32,12 @@ Part of [Threadplane](https://github.com/cacheplane/angular-agent-framework).
 ## Install
 
 ```bash
-npm install @threadplane/ag-ui @threadplane/chat @ag-ui/client @ag-ui/core
+npm install @threadplane/ag-ui @threadplane/chat @ag-ui/client @ag-ui/core marked
 ```
 
 **Peer dependencies:** `@threadplane/chat: *`, `@angular/core: ^20.0.0 || ^21.0.0`, `@ag-ui/client: *`, `@ag-ui/core: *`, `rxjs: ~7.8.0`
+
+`marked` is the required markdown parser peer used by `@threadplane/chat` when you render assistant messages through `<chat>`.
 
 ---
 
@@ -83,6 +85,9 @@ Both `@threadplane/langgraph` and `@threadplane/ag-ui` expose `provideAgent`/`in
 | `toolCalls()` | In-progress and completed tool calls |
 | `error()` | Last run error, if any |
 | `state()` | Raw AG-UI state snapshot |
+| `customEvents()` | Non-`on_interrupt` `CUSTOM` events for live a2ui and app-specific side effects |
+| `subagents()` | `ACTIVITY_*` entries with `activityType: 'subagent'`, projected to the neutral subagent contract |
+| `clientTools` | Browser client-tool catalog, pending calls, and result resolution used by `<chat [clientTools]>` |
 
 Which capabilities populate depends on the events the AG-UI backend emits. `submit()`, `stop()`, and `regenerate()` are supported.
 

--- a/libs/ag-ui/src/lib/testing/provide-fake-agent.ts
+++ b/libs/ag-ui/src/lib/testing/provide-fake-agent.ts
@@ -15,7 +15,7 @@ import { FakeAgent } from './fake-agent';
  * @example
  * ```ts
  * TestBed.configureTestingModule({
- *   providers: [provideFakeAgent({ responses: ['Hello from the fake agent'] })],
+ *   providers: [provideFakeAgent({ tokens: ['Hello from the fake agent'] })],
  * });
  * ```
  */

--- a/libs/ag-ui/src/lib/to-agent.ts
+++ b/libs/ag-ui/src/lib/to-agent.ts
@@ -49,10 +49,12 @@ function agentRuntimeTelemetryErrorClass(error: unknown): string {
 }
 
 /**
- * The neutral Agent contract, widened with the AG-UI adapter's optional
+ * The neutral Agent contract, widened with the AG-UI adapter's
  * `customEvents` signal (the chat composition feature-detects it to enable
- * live a2ui streaming) and the optional `clientTools` capability.
- * Mirrors langgraph's LangGraphAgent extension.
+ * live a2ui streaming), the browser client-tools capability, and concrete
+ * ACTIVITY-backed `subagents`.
+ * Mirrors langgraph's LangGraphAgent extension where the protocol surfaces
+ * overlap.
  */
 export interface AgUiAgent<TState = Record<string, unknown>> extends Agent<TState> {
   customEvents: Signal<CustomStreamEvent[]>;
@@ -76,6 +78,14 @@ export interface AgUiAgent<TState = Record<string, unknown>> extends Agent<TStat
  * of toAgent() should treat the returned object's lifecycle as tied to the
  * agent instance they constructed. The subscriber registered via
  * source.subscribe() will fire for the lifetime of source.
+ *
+ * @example
+ * ```ts
+ * import { HttpAgent } from '@ag-ui/client';
+ * import { toAgent } from '@threadplane/ag-ui';
+ *
+ * const agent = toAgent(new HttpAgent({ url: '/api/agent' }));
+ * ```
  */
 export function toAgent(source: AbstractAgent, options: ToAgentOptions = {}): AgUiAgent {
   const store: ReducerStore = {


### PR DESCRIPTION
## Summary
- add the required `marked` install peer to AG-UI docs, docs landing, README, and `/llms.txt` snippets
- document the current `AgUiAgent` surface: `customEvents`, browser `clientTools`, and ACTIVITY-backed `subagents`
- update stale generated API examples from `responses` to `tokens` and add a `toAgent` source example

## Verification
- `npm run generate-api-docs`
- `npx nx run-many -t lint,test,type-tests,build -p ag-ui`
- `npx nx run-many -t lint,build -p website`
- `npx nx build website`
- `npx nx e2e website --skip-nx-cache`
- `git diff --check`