### PR TITLE
fix(cockpit-render): numeric content bindings + scrubber handle lag

### DIFF
--- a/cockpit/render/computed-functions/angular/src/app/computed-functions.component.ts
+++ b/cockpit/render/computed-functions/angular/src/app/computed-functions.component.ts
@@ -12,6 +12,7 @@ import { StreamingTimelineComponent } from '../../../../shared/streaming-timelin
 import { ExampleSplitLayoutComponent } from '@threadplane/example-layouts';
 import { COMPUTED_FUNCTIONS_SPECS } from './specs';
 import { highlightJson } from '../../../../shared/json-highlight';
+import { toDisplayText } from '../../../../shared/to-display-text';
 
 // --- Inline view components registered in the demo registry ---
 
@@ -73,10 +74,7 @@ class DemoValueComponent {
 })
 class DemoHeadingComponent {
   readonly content = input<unknown>('');
-  readonly displayContent = computed(() => {
-    const c = this.content();
-    return typeof c === 'string' ? c : '';
-  });
+  readonly displayContent = computed(() => toDisplayText(this.content()));
   readonly childKeys = input<string[]>([]);
   readonly spec = input<Spec | null>(null);
   readonly bindings = input<Record<string, string>>({});

--- a/cockpit/render/computed-functions/angular/src/app/specs.ts
+++ b/cockpit/render/computed-functions/angular/src/app/specs.ts
@@ -16,14 +16,14 @@ export const COMPUTED_FUNCTIONS_SPECS: DemoSpec[] = [
           type: 'Value',
           props: {
             label: 'Uppercase',
-            value: { $fn: 'uppercase', args: { value: 'hello world' } },
+            value: { $computed: 'uppercase', args: { value: 'hello world' } },
           },
         },
         reversed: {
           type: 'Value',
           props: {
             label: 'Reversed',
-            value: { $fn: 'reverse', args: { value: 'streaming' } },
+            value: { $computed: 'reverse', args: { value: 'streaming' } },
           },
         },
       },
@@ -43,14 +43,14 @@ export const COMPUTED_FUNCTIONS_SPECS: DemoSpec[] = [
           type: 'Value',
           props: {
             label: 'Formatted Date',
-            value: { $fn: 'formatDate', args: { value: '2024-06-15T12:00:00Z' } },
+            value: { $computed: 'formatDate', args: { value: '2024-06-15T12:00:00Z' } },
           },
         },
         product: {
           type: 'Value',
           props: {
             label: 'Multiply 7 x 6',
-            value: { $fn: 'multiply', args: { a: 7, b: 6 } },
+            value: { $computed: 'multiply', args: { a: 7, b: 6 } },
           },
         },
       },
@@ -70,21 +70,21 @@ export const COMPUTED_FUNCTIONS_SPECS: DemoSpec[] = [
           type: 'Value',
           props: {
             label: 'Multiply 12 x 5',
-            value: { $fn: 'multiply', args: { a: 12, b: 5 } },
+            value: { $computed: 'multiply', args: { a: 12, b: 5 } },
           },
         },
         transform: {
           type: 'Value',
           props: {
             label: 'Uppercase',
-            value: { $fn: 'uppercase', args: { value: 'computed functions' } },
+            value: { $computed: 'uppercase', args: { value: 'computed functions' } },
           },
         },
         format: {
           type: 'Value',
           props: {
             label: 'Date',
-            value: { $fn: 'formatDate', args: { value: '2025-01-01T00:00:00Z' } },
+            value: { $computed: 'formatDate', args: { value: '2025-01-01T00:00:00Z' } },
           },
         },
       },

--- a/cockpit/render/element-rendering/angular/src/app/element-rendering.component.ts
+++ b/cockpit/render/element-rendering/angular/src/app/element-rendering.component.ts
@@ -12,6 +12,7 @@ import { StreamingTimelineComponent } from '../../../../shared/streaming-timelin
 import { ExampleSplitLayoutComponent } from '@threadplane/example-layouts';
 import { ELEMENT_RENDERING_SPECS } from './specs';
 import { highlightJson } from '../../../../shared/json-highlight';
+import { toDisplayText } from '../../../../shared/to-display-text';
 
 // --- Inline view components registered in the demo registry ---
 
@@ -30,10 +31,7 @@ import { highlightJson } from '../../../../shared/json-highlight';
 })
 class DemoTextComponent {
   readonly content = input<unknown>('');
-  readonly displayContent = computed(() => {
-    const c = this.content();
-    return typeof c === 'string' ? c : '';
-  });
+  readonly displayContent = computed(() => toDisplayText(this.content()));
   readonly childKeys = input<string[]>([]);
   readonly spec = input<Spec | null>(null);
   readonly bindings = input<Record<string, string>>({});
@@ -59,10 +57,7 @@ class DemoTextComponent {
 })
 class DemoHeadingComponent {
   readonly content = input<unknown>('');
-  readonly displayContent = computed(() => {
-    const c = this.content();
-    return typeof c === 'string' ? c : '';
-  });
+  readonly displayContent = computed(() => toDisplayText(this.content()));
   readonly childKeys = input<string[]>([]);
   readonly spec = input<Spec | null>(null);
   readonly bindings = input<Record<string, string>>({});

--- a/cockpit/render/registry/angular/src/app/registry.component.ts
+++ b/cockpit/render/registry/angular/src/app/registry.component.ts
@@ -12,6 +12,7 @@ import { StreamingTimelineComponent } from '../../../../shared/streaming-timelin
 import { ExampleSplitLayoutComponent } from '@threadplane/example-layouts';
 import { REGISTRY_SPECS } from './specs';
 import { highlightJson } from '../../../../shared/json-highlight';
+import { toDisplayText } from '../../../../shared/to-display-text';
 
 // --- Inline view components registered in the demo registry ---
 
@@ -30,10 +31,7 @@ import { highlightJson } from '../../../../shared/json-highlight';
 })
 class DemoTextComponent {
   readonly content = input<unknown>('');
-  readonly displayContent = computed(() => {
-    const c = this.content();
-    return typeof c === 'string' ? c : '';
-  });
+  readonly displayContent = computed(() => toDisplayText(this.content()));
   readonly childKeys = input<string[]>([]);
   readonly spec = input<Spec | null>(null);
   readonly bindings = input<Record<string, string>>({});
@@ -59,10 +57,7 @@ class DemoTextComponent {
 })
 class DemoHeadingComponent {
   readonly content = input<unknown>('');
-  readonly displayContent = computed(() => {
-    const c = this.content();
-    return typeof c === 'string' ? c : '';
-  });
+  readonly displayContent = computed(() => toDisplayText(this.content()));
   readonly childKeys = input<string[]>([]);
   readonly spec = input<Spec | null>(null);
   readonly bindings = input<Record<string, string>>({});

--- a/cockpit/render/repeat-loops/angular/src/app/repeat-loops.component.ts
+++ b/cockpit/render/repeat-loops/angular/src/app/repeat-loops.component.ts
@@ -12,6 +12,7 @@ import { StreamingTimelineComponent } from '../../../../shared/streaming-timelin
 import { ExampleSplitLayoutComponent } from '@threadplane/example-layouts';
 import { REPEAT_LOOPS_SPECS } from './specs';
 import { highlightJson } from '../../../../shared/json-highlight';
+import { toDisplayText } from '../../../../shared/to-display-text';
 
 // --- Inline view components registered in the demo registry ---
 
@@ -30,10 +31,7 @@ import { highlightJson } from '../../../../shared/json-highlight';
 })
 class DemoTextComponent {
   readonly content = input<unknown>('');
-  readonly displayContent = computed(() => {
-    const c = this.content();
-    return typeof c === 'string' ? c : '';
-  });
+  readonly displayContent = computed(() => toDisplayText(this.content()));
   readonly childKeys = input<string[]>([]);
   readonly spec = input<Spec | null>(null);
   readonly bindings = input<Record<string, string>>({});
@@ -59,10 +57,7 @@ class DemoTextComponent {
 })
 class DemoHeadingComponent {
   readonly content = input<unknown>('');
-  readonly displayContent = computed(() => {
-    const c = this.content();
-    return typeof c === 'string' ? c : '';
-  });
+  readonly displayContent = computed(() => toDisplayText(this.content()));
   readonly childKeys = input<string[]>([]);
   readonly spec = input<Spec | null>(null);
   readonly bindings = input<Record<string, string>>({});

--- a/cockpit/render/shared/streaming-timeline.component.ts
+++ b/cockpit/render/shared/streaming-timeline.component.ts
@@ -60,7 +60,6 @@ import { StreamingSimulator } from './streaming-simulator';
       border: 2px solid var(--tl-green-bright);
       transform: translate(-50%, -50%);
       box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
-      transition: left 0.075s linear;
     }
     .tl__count {
       flex-shrink: 0;

--- a/cockpit/render/shared/to-display-text.spec.ts
+++ b/cockpit/render/shared/to-display-text.spec.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+import { toDisplayText } from './to-display-text';
+
+describe('toDisplayText', () => {
+  it('returns strings unchanged', () => {
+    expect(toDisplayText('Alice')).toBe('Alice');
+    expect(toDisplayText('')).toBe('');
+  });
+
+  it('stringifies numbers (the bug: numeric $state bindings were dropped)', () => {
+    expect(toDisplayText(30)).toBe('30');
+    expect(toDisplayText(42.5)).toBe('42.5');
+  });
+
+  it('preserves zero (falsy but must display)', () => {
+    expect(toDisplayText(0)).toBe('0');
+  });
+
+  it('stringifies booleans', () => {
+    expect(toDisplayText(true)).toBe('true');
+    expect(toDisplayText(false)).toBe('false');
+  });
+
+  it('returns empty string for null / undefined', () => {
+    expect(toDisplayText(null)).toBe('');
+    expect(toDisplayText(undefined)).toBe('');
+  });
+
+  it('returns empty string for objects and arrays (not display text)', () => {
+    expect(toDisplayText({ a: 1 })).toBe('');
+    expect(toDisplayText([1, 2])).toBe('');
+  });
+});

--- a/cockpit/render/shared/to-display-text.ts
+++ b/cockpit/render/shared/to-display-text.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+
+/**
+ * Coerce a resolved element prop (which may be a string, number, boolean, or —
+ * for an unresolved/object binding — something else) into display text.
+ *
+ * Demo view components bind props like `content`/`value` that can resolve to
+ * non-string primitives via `$state`/`$fn` bindings (e.g. a numeric
+ * `/user/age`). Returning `''` only for strings silently dropped those values;
+ * this renders any primitive and treats objects/null as "no text".
+ */
+export function toDisplayText(value: unknown): string {
+  if (value == null) return '';
+  const t = typeof value;
+  if (t === 'string' || t === 'number' || t === 'boolean' || t === 'bigint') {
+    return String(value);
+  }
+  return '';
+}

--- a/cockpit/render/spec-rendering/angular/src/app/spec-rendering.component.ts
+++ b/cockpit/render/spec-rendering/angular/src/app/spec-rendering.component.ts
@@ -12,6 +12,7 @@ import { StreamingTimelineComponent } from '../../../../shared/streaming-timelin
 import { ExampleSplitLayoutComponent } from '@threadplane/example-layouts';
 import { SPEC_RENDERING_SPECS } from './specs';
 import { highlightJson } from '../../../../shared/json-highlight';
+import { toDisplayText } from '../../../../shared/to-display-text';
 
 // --- Inline view components registered in the demo registry ---
 
@@ -30,10 +31,7 @@ import { highlightJson } from '../../../../shared/json-highlight';
 })
 class DemoTextComponent {
   readonly content = input<unknown>('');
-  readonly displayContent = computed(() => {
-    const c = this.content();
-    return typeof c === 'string' ? c : '';
-  });
+  readonly displayContent = computed(() => toDisplayText(this.content()));
   readonly childKeys = input<string[]>([]);
   readonly spec = input<Spec | null>(null);
   readonly bindings = input<Record<string, string>>({});
@@ -59,10 +57,7 @@ class DemoTextComponent {
 })
 class DemoHeadingComponent {
   readonly content = input<unknown>('');
-  readonly displayContent = computed(() => {
-    const c = this.content();
-    return typeof c === 'string' ? c : '';
-  });
+  readonly displayContent = computed(() => toDisplayText(this.content()));
   readonly childKeys = input<string[]>([]);
   readonly spec = input<Spec | null>(null);
   readonly bindings = input<Record<string, string>>({});

--- a/cockpit/render/state-management/angular/src/app/state-management.component.ts
+++ b/cockpit/render/state-management/angular/src/app/state-management.component.ts
@@ -12,6 +12,7 @@ import { StreamingTimelineComponent } from '../../../../shared/streaming-timelin
 import { ExampleSplitLayoutComponent } from '@threadplane/example-layouts';
 import { STATE_MANAGEMENT_SPECS } from './specs';
 import { highlightJson } from '../../../../shared/json-highlight';
+import { toDisplayText } from '../../../../shared/to-display-text';
 
 // --- Inline view components registered in the demo registry ---
 
@@ -30,10 +31,7 @@ import { highlightJson } from '../../../../shared/json-highlight';
 })
 class DemoTextComponent {
   readonly content = input<unknown>('');
-  readonly displayContent = computed(() => {
-    const c = this.content();
-    return typeof c === 'string' ? c : '';
-  });
+  readonly displayContent = computed(() => toDisplayText(this.content()));
   readonly childKeys = input<string[]>([]);
   readonly spec = input<Spec | null>(null);
   readonly bindings = input<Record<string, string>>({});
@@ -59,10 +57,7 @@ class DemoTextComponent {
 })
 class DemoHeadingComponent {
   readonly content = input<unknown>('');
-  readonly displayContent = computed(() => {
-    const c = this.content();
-    return typeof c === 'string' ? c : '';
-  });
+  readonly displayContent = computed(() => toDisplayText(this.content()));
   readonly childKeys = input<string[]>([]);
   readonly spec = input<Spec | null>(null);
   readonly bindings = input<Record<string, string>>({});


### PR DESCRIPTION
## Summary

Three bug fixes in the render examples, found while reviewing the redesigned examples.

### 1. Numeric `$state` bindings rendered blank
Demo `Text`/`Heading` coerced content with `typeof c === 'string' ? c : ''`, dropping non-strings. state-management's **User Profile** bound `/user/age` (`30`, a number) to a `Text` → blank age. **Fix:** shared tested `toDisplayText()` helper (stringifies primitives, `''` for null/objects, preserves `0`), applied across all render example demo components. Verified: renders "User Profile / Alice / **30**".

### 2. Scrubber handle lagged the progress fill
The timeline handle had `transition: left 0.075s linear` while the fill had none, so it trailed during rAF playback and animated on seek/spec-switch. **Fix:** removed the transition — handle snaps each frame, matching the fill. Verified: after seek, handle `left` and fill `width` both 100% (`transitionDuration: 0s`).

### 3. computed-functions rendered `[object Object]`
The specs bound values with `{ $fn: 'uppercase', args: {...} }`, but the render library's computed-function binding key is **`$computed`** (`{ $computed: name, args }`). `$fn` was unrecognized → the raw object rendered as `[object Object]`. **Fix:** renamed `$fn` → `$computed` across the three specs (registered functions + args shape were already correct). Verified: renders "UPPERCASE: HELLO WORLD", "MULTIPLY 7 X 6: 42", "FORMATTED DATE: 6/15/2024".

All three were pre-existing latent bugs (not introduced by the redesign), surfaced by the example content.

## Verification
- ✅ `toDisplayText` unit tests (6) + full `render/shared` suite (22)
- ✅ All 6 render examples build (production)
- ✅ Chrome MCP confirmation of each fix (numeric age, scrubber tracking, `$computed` resolution across all three computed-functions specs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
