### PR TITLE
fix(cockpit-render): eliminate [object Object] flash for mid-stream value bindings

### DIFF
--- a/cockpit/render/computed-functions/angular/src/app/computed-functions.component.ts
+++ b/cockpit/render/computed-functions/angular/src/app/computed-functions.component.ts
@@ -35,10 +35,10 @@ import { toDisplayText } from '../../../../shared/to-display-text';
     }
   `,
   template: `
-    @if (label() || value()) {
+    @if (displayValue()) {
       <div class="row">
         <span class="row__label">{{ label() }}:</span>
-        <span class="row__value">{{ value() }}</span>
+        <span class="row__value">{{ displayValue() }}</span>
       </div>
     } @else if (loading()) {
       <div class="sr-skeleton" style="height: 11px; width: 100%; margin: 3px 0;"></div>
@@ -49,6 +49,9 @@ import { toDisplayText } from '../../../../shared/to-display-text';
 class DemoValueComponent {
   readonly label = input('');
   readonly value = input<unknown>('');
+  // Coerce through toDisplayText so an unresolved binding object mid-stream
+  // (e.g. a partial `$computed` value) renders as the skeleton, not `[object Object]`.
+  readonly displayValue = computed(() => toDisplayText(this.value()));
   readonly childKeys = input<string[]>([]);
   readonly spec = input<Spec | null>(null);
   readonly bindings = input<Record<string, string>>({});

--- a/cockpit/render/state-management/angular/src/app/state-management.component.ts
+++ b/cockpit/render/state-management/angular/src/app/state-management.component.ts
@@ -83,10 +83,10 @@ class DemoHeadingComponent {
     }
   `,
   template: `
-    @if (label() || value()) {
+    @if (displayValue()) {
       <div class="row">
         <span class="row__label">{{ label() }}:</span>
-        <span class="row__value">{{ value() }}</span>
+        <span class="row__value">{{ displayValue() }}</span>
       </div>
     } @else if (loading()) {
       <div class="sr-skeleton" style="height: 11px; width: 100%; margin: 3px 0;"></div>
@@ -97,6 +97,7 @@ class DemoHeadingComponent {
 class DemoLabelComponent {
   readonly label = input('');
   readonly value = input('');
+  readonly displayValue = computed(() => toDisplayText(this.value()));
   readonly childKeys = input<string[]>([]);
   readonly spec = input<Spec | null>(null);
   readonly bindings = input<Record<string, string>>({});


### PR DESCRIPTION
## Summary

Follow-up to #771. The computed-functions example briefly flashed `[object Object]` **during streaming** — between the skeleton and the resolved value.

**Root cause (confirmed via Chrome MCP):** `demo-value` (and `demo-label`) rendered their `value` input directly with `{{ value() }}`. While a `$computed` binding streams in, the render library passes an *unresolved object* (e.g. a partial `{ "$computed": … }` materializes to `{}`) to the component. At char position ~330 of the "Text Transforms" spec, `value()` was `typeof "object"` and the row rendered `UPPERCASE: [object Object]` until the binding finished streaming and resolved to `HELLO WORLD`.

**Fix:** route the value through the existing tested `toDisplayText()` helper via a `displayValue` computed, and guard the row on it. An unresolved object → `''` → the row stays hidden until the value resolves, so no `[object Object]` ever shows.

## Verification (Chrome MCP)
- At the transient position (pos 330, `"value": { "$compu…`): `value()` is an object, but now renders nothing — **no `[object Object]`** (was `UPPERCASE: [object Object]`).
- At completion: "UPPERCASE: **HELLO WORLD**", "REVERSED: **gnimaerts**".
- state-management `demo-label` (also fixed for consistency) still renders "NAME: Alice / AGE: 30 / THEME: dark".
- Both examples build (production).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
