### PR TITLE
fix(examples-chat): unblock canonical demo prod deploy (bundle budget + Maps key)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -809,6 +809,14 @@ jobs:
           cache: npm
       - run: npm ci
       - name: Build and assemble canonical demo
+        env:
+          # Baked into the SPA bundle by inject-env at build time (assemble-demo.ts
+          # runs `nx build examples-chat-angular`, whose build target dependsOn
+          # inject-env). Without the key the App-mode map toggle is disabled in
+          # prod. The key ships in the public bundle (normal for Maps JS) — restrict
+          # it by HTTP referrer in the Google Cloud console. The Map ID is not a secret.
+          GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
+          GOOGLE_MAPS_MAP_ID: 86d464ea7d5306034fe2a254
         run: npx tsx scripts/assemble-demo.ts
       - name: Deploy canonical demo to Vercel (production)
         working-directory: deploy/demo

--- a/examples/chat/angular/project.json
+++ b/examples/chat/angular/project.json
@@ -50,8 +50,8 @@
           "budgets": [
             {
               "type": "initial",
-              "maximumWarning": "500kb",
-              "maximumError": "1.5mb"
+              "maximumWarning": "1.6mb",
+              "maximumError": "1.75mb"
             },
             {
               "type": "anyComponentStyle",
@@ -74,8 +74,8 @@
           "budgets": [
             {
               "type": "initial",
-              "maximumWarning": "500kb",
-              "maximumError": "1.5mb"
+              "maximumWarning": "1.6mb",
+              "maximumError": "1.75mb"
             },
             {
               "type": "anyComponentStyle",


### PR DESCRIPTION
## Why
The App-mode itinerary cockpit (#772) merged, but the **`Canonical demo → Vercel`** job **failed on main** — so the new frontend never deployed (prod still serves the pre-#772 build).

Two issues, both fixed here:

1. **Prod bundle budget exceeded.** `@angular/google-maps` + `@angular/cdk/drag-drop` + the map/itinerary surface pushed the production initial bundle ~80 kB over the 1.5 MB budget. Only the *production* config enforces budgets, so every dev build + e2e passed while `assemble-demo.ts` (`nx build … --configuration=production`) failed. → Raised the initial budget to **1.75 MB** (warn 1.6 MB), matching the feature's real weight. (Same class as the earlier cockpit budget bump.)

2. **Maps key not wired into the canonical deploy.** The `Build and assemble canonical demo` step passed no `GOOGLE_MAPS_*` env, so `inject-env` baked a keyless bundle → App-mode toggle disabled in prod. → Added `GOOGLE_MAPS_API_KEY` + `GOOGLE_MAPS_MAP_ID` (mirroring the ag-ui deploy step; same secret + map id).

## Verified
- `nx build examples-chat-angular --configuration=production` → **generation complete** (1.58 MB < 1.75 MB).
- ci.yml parses as valid YAML.

Backend already deployed on the #772 merge (`Deploy LangGraph` succeeded). Once this lands, the canonical demo redeploys with App mode + the map key enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)