### PR TITLE
Bump partial markdown parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@angular/platform-browser": "~21.1.0",
         "@angular/router": "~21.1.0",
         "@cacheplane/partial-json": "^0.1.1",
-        "@cacheplane/partial-markdown": "^0.5.5",
+        "@cacheplane/partial-markdown": "^0.5.6",
         "@langchain/core": "^1.1.33",
         "@langchain/langgraph-sdk": "^1.7.4",
         "@neondatabase/serverless": "^0.10.0",
@@ -7272,9 +7272,9 @@
       "license": "MIT"
     },
     "node_modules/@cacheplane/partial-markdown": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@cacheplane/partial-markdown/-/partial-markdown-0.5.5.tgz",
-      "integrity": "sha512-jvnM5ARXpozRFl8hvu8+wv3tP6hBYC9Np94Glo4vYEHYjTDUKfx7pW3RY6eTlAHxbin8v7mCWMKDuIVWs12VOA==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@cacheplane/partial-markdown/-/partial-markdown-0.5.6.tgz",
+      "integrity": "sha512-1hMw5QHjvyqSJebt0y2S3Y36GVsTe4H+FQB1AiJmr1e7mWl57HAcJsyZDSBsEu1AqlITMQiY7LkCEJsg0ej75Q==",
       "license": "MIT",
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "@angular/platform-browser": "~21.1.0",
     "@angular/router": "~21.1.0",
     "@cacheplane/partial-json": "^0.1.1",
-    "@cacheplane/partial-markdown": "^0.5.5",
+    "@cacheplane/partial-markdown": "^0.5.6",
     "@langchain/core": "^1.1.33",
     "@langchain/langgraph-sdk": "^1.7.4",
     "@neondatabase/serverless": "^0.10.0",


### PR DESCRIPTION
## Summary
- Bump `@cacheplane/partial-markdown` from `^0.5.5` to `^0.5.6`.
- Update the lockfile to resolve the published `0.5.6` tarball.

## Why
`0.5.6` contains the upstream streaming parser fix that suppresses partial closing code-fence markers while a fenced code block is still streaming.

## Verification
- `npm ls @cacheplane/partial-markdown --depth=0`
- Direct parser smoke for streamed closing backticks
- `npx nx run licensing:prebuild`
- `npx nx test chat --runInBand`
