### PR TITLE
fix: remove unused fake agent delay variable

### DIFF
--- a/libs/ag-ui/src/lib/testing/fake-agent.ts
+++ b/libs/ag-ui/src/lib/testing/fake-agent.ts
@@ -64,7 +64,6 @@ export class FakeAgent extends AbstractAgent {
 
     const tokens = this.tokens;
     const reasoningTokens = this.reasoningTokens;
-    const delayMs = this.delayMs;
     const messageId = `fake-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 
     const sequence: BaseEvent[] = [


### PR DESCRIPTION
Summary:
- Remove a stale unused local from the AG-UI fake agent testing scaffold.
- Fixes the production TypeScript build failure in ag-ui.

Verification:
- Reproduced failure with: npx nx run-many -t build --projects=chat,langgraph,ag-ui,render,a2ui,licensing,telemetry --configuration=production
- npx nx build ag-ui --configuration=production
- npx nx run-many -t build --projects=chat,langgraph,ag-ui,render,a2ui,licensing,telemetry --configuration=production
- git diff --check