### PR TITLE
chore: update partial markdown parser

### DIFF
--- a/libs/chat/package.json
+++ b/libs/chat/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@cacheplane/partial-json": ">=0.1.1 <0.3.0",
-    "@cacheplane/partial-markdown": "^0.5.5"
+    "@cacheplane/partial-markdown": "^0.5.7"
   },
   "peerDependencies": {
     "zod": "^3.25.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@angular/platform-browser": "~21.1.0",
         "@angular/router": "~21.1.0",
         "@cacheplane/partial-json": "^0.1.1",
-        "@cacheplane/partial-markdown": "^0.5.6",
+        "@cacheplane/partial-markdown": "^0.5.7",
         "@langchain/core": "^1.1.33",
         "@langchain/langgraph-sdk": "^1.7.4",
         "@neondatabase/serverless": "^0.10.0",
@@ -207,7 +207,7 @@
       "license": "PolyForm-Noncommercial-1.0.0 OR LicenseRef-Threadplane-Commercial",
       "dependencies": {
         "@cacheplane/partial-json": ">=0.1.1 <0.3.0",
-        "@cacheplane/partial-markdown": "^0.5.5"
+        "@cacheplane/partial-markdown": "^0.5.7"
       },
       "peerDependencies": {
         "@angular/common": "^20.0.0 || ^21.0.0",
@@ -7272,9 +7272,9 @@
       "license": "MIT"
     },
     "node_modules/@cacheplane/partial-markdown": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/@cacheplane/partial-markdown/-/partial-markdown-0.5.6.tgz",
-      "integrity": "sha512-1hMw5QHjvyqSJebt0y2S3Y36GVsTe4H+FQB1AiJmr1e7mWl57HAcJsyZDSBsEu1AqlITMQiY7LkCEJsg0ej75Q==",
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@cacheplane/partial-markdown/-/partial-markdown-0.5.7.tgz",
+      "integrity": "sha512-8Gs3bbRuo8vsPjf3U5Ms+awZpzL+80mJ9EVlbygE8EzP2UNB5YuKd2CqFIxIoN1VlGrjjiqfOccJTLl3LyzngQ==",
       "license": "MIT",
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "@angular/platform-browser": "~21.1.0",
     "@angular/router": "~21.1.0",
     "@cacheplane/partial-json": "^0.1.1",
-    "@cacheplane/partial-markdown": "^0.5.6",
+    "@cacheplane/partial-markdown": "^0.5.7",
     "@langchain/core": "^1.1.33",
     "@langchain/langgraph-sdk": "^1.7.4",
     "@neondatabase/serverless": "^0.10.0",


### PR DESCRIPTION
## Summary
- Update `@cacheplane/partial-markdown` to `^0.5.7` in the root app and `@threadplane/chat` package.
- Refresh `package-lock.json` to resolve the published `0.5.7` tarball.

## Test Plan
- `node --input-type=module` parser probe for blockquote/table rendering with installed `@cacheplane/partial-markdown@0.5.7`
- `npx nx test chat`
- `npx nx build chat`
- `npx playwright test markdown-surfaces.spec.ts -g "streaming markdown table" --config examples/chat/angular/e2e/playwright.config.ts`
- Chrome smoke against `http://localhost:4200/embed`: sent `stream a blockquote then a markdown table regression`; verified one blockquote, one table, two body rows, expected headers, no raw pipe paragraphs, and no detached cells
