### PR TITLE
fix(langgraph): retain client tool results across failed runs

### DIFF
--- a/apps/website/content/docs/chat/guides/client-tools.mdx
+++ b/apps/website/content/docs/chat/guides/client-tools.mdx
@@ -126,7 +126,7 @@ const clientTools = tools({
 Follow-up is decided **per tool-call group**, not per tool. If the model calls three tools in one turn and any one of them wants a follow-up, the whole group continues in a single run once every result has settled. Only when *every* tool in the group is terminal does the turn end.
 
 <Callout type="warning" title="Your transport must support durable writes">
-  A terminal group has no follow-up run to carry its results, so the adapter writes them to the server directly. On `@threadplane/langgraph` that uses the transport's `updateState`. If a **custom transport does not implement `updateState`**, `flush()` rejects when terminal results are staged. The results stay buffered and an ordinary next message can still carry them, but a reload first loses them and leaves the server thread with an unanswered tool call. If you supply your own transport and use terminal tools, implement `updateState`.
+  A terminal group has no follow-up run to carry its results, so the adapter writes them to the server directly. On `@threadplane/langgraph` that uses the transport's `updateState`. If a **custom transport does not implement `updateState`**, `flush()` rejects when terminal results are staged. The results stay buffered and an ordinary next message can still carry them, but a browser page reload first loses that in-memory fallback and leaves the server thread with an unanswered tool call. If you supply your own transport and use terminal tools, implement `updateState`.
 </Callout>
 
 ## Re-running tools safely with `idempotent`

--- a/apps/website/content/docs/chat/guides/writing-an-adapter.mdx
+++ b/apps/website/content/docs/chat/guides/writing-an-adapter.mdx
@@ -291,18 +291,19 @@ Violate it and the thread carries an assistant message with `tool_calls` and no 
 `resolve()` alone cannot uphold this, because some groups never continue — every tool in them is terminal (`followUp: false`), the user pressed stop, or a continuation limit tripped. That is what `settle` + `flush` are for.
 
 <Callout type="warning" title="flush() is where durability actually happens">
-  If your `settle()` only records locally, you **must** implement `flush()` to write those results to the server. `@threadplane/ag-ui` gets this for free — its `settle()` calls `addMessage()`, which places the message in the outgoing list, so `flush()` is a no-op. `@threadplane/langgraph` buffers instead, so its `flush()` writes the whole batch in one `threads.updateState` call. Omitting `flush()` when your `settle()` is not already durable silently drops results.
+  If your `settle()` only records locally, you **must** implement `flush()` to write those results to the server. `@threadplane/ag-ui` retains each stable result in its source-owned, in-memory outgoing list across adapter retries — not across a browser page reload — so `flush()` is a no-op. `@threadplane/langgraph` keeps results in an in-memory staging buffer, creates a snapshot for each handoff, and writes terminal groups in one `threads.updateState` call. Omitting `flush()` when your `settle()` is not already durable silently drops results.
 </Callout>
 
 ### Implementation rules
 
-Three rules, each learned from a real defect:
+Four rules keep settlement, persistence, and recovery aligned:
 
-1. **Take ownership of the batch when the write starts, not when it finishes.** Remove the buffered entries up front and re-stage them only if the write fails. Leaving them in place across the `await` lets a concurrent `resolve()` re-send what you are already writing (two tool messages for one call) and lets your completion handler remove the wrong entries.
-2. **Coalesce concurrent flushes by chaining, not short-circuiting.** Returning an in-flight promise to a second caller resolves *their* `flush()` without ever writing *their* batch.
-3. **Discard staged results on a thread switch.** A tool message only makes sense against the thread whose assistant message produced its `tool_call_id`. Note that a thread id captured at settle time may already be the *new* thread if your `setThreadId` is synchronous — key the check on something that survives the switch.
+1. **Give every result message a stable ID derived from its tool-call ID.** Replay and overlap are idempotent only when the receiving store uses ID-aware upsert or merge semantics. LangGraph's `add_messages` reducer does; a stable ID alone does not deduplicate an append-only sink.
+2. **Snapshot without forgetting, and acknowledge only after that exact handoff reports success.** Failure, interruption, abort, pause, or supersession leaves the result staged for retry or an ordinary later submit. Overlapping operations may carry the same stable ID only when the receiving path provides the ID-aware merge described above.
+3. **Chain concurrent flushes instead of short-circuiting them.** Results settled after one snapshot need their own write; returning only the older in-flight promise can report success without persisting the newer batch.
+4. **Discard staged results and retry associations on a thread switch.** Advance the staging generation as part of the reset so acknowledgments from old in-flight work become no-ops on the new thread.
 
-Adapters without a durable write path can fall back to attaching staged results to the next outbound run. That is correct in the normal path but loses them across a reload, so document the limitation.
+Adapters without a durable write path can fall back to attaching staged results to the next outbound run. The results stay buffered and an ordinary next message can still carry them, but a browser page reload first loses that in-memory fallback and leaves the server thread with an unanswered tool call.
 
 ## Publishing Your Adapter
 

--- a/docs/superpowers/specs/2026-08-09-langgraph-submit-result-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-09-langgraph-submit-result-recovery-design.md
@@ -1,0 +1,297 @@
+---
+status: approved
+owner: brian
+scope: libs/langgraph
+---
+
+# LangGraph Client-Tool Submit Recovery (Design)
+
+## 1. Goal
+
+Prevent settled client-tool results from being lost when a LangGraph run fails, is interrupted, is aborted, or is superseded after those results have been attached to a run payload.
+
+The adapter must make result replay safe, retain results until a handoff succeeds, and preserve the existing public `Agent` and `ClientToolsCapability` contracts.
+
+## 2. Problem
+
+The LangGraph adapter currently keeps settled client-tool results in a local buffer until either:
+
+- `flush()` writes them directly into thread state,
+- `resolve()` starts a continuation with them, or
+- an ordinary `submit()` prepends them to its payload as a fallback.
+
+The ordinary-submit path calls `drainToolMessages()` before `manager.submit()`. That permanently removes the results before the run outcome is known.
+
+This has two consequences:
+
+1. A failed run leaves no staged result for a later ordinary submit.
+2. The bridge usually reports transport failures through status and error signals rather than rejecting its promise, so a simple promise `catch` around `manager.submit()` cannot restore the batch.
+
+`retry()` can resend the bridge's last payload, but that only protects the explicit retry path. A later new submission cannot recover the drained result.
+
+The buffered wire message also has no stable message `id`. Replaying it after an ambiguous failure could therefore append a second ToolMessage for the same `tool_call_id`.
+
+## 3. Invariants
+
+1. A settled client-tool result remains recoverable until a server handoff succeeds.
+2. Replaying the same result is idempotent at the graph-state reducer.
+3. A result is acknowledged only when the operation that carried it succeeds.
+4. A failed, interrupted, aborted, or superseded operation leaves its result available for retry or a later submission.
+5. A successful retry acknowledges only the result batch present in the retried payload; results settled afterward remain staged.
+6. No result survives a thread switch or lands on a thread other than the one that produced its tool call.
+7. Public `submit()`, `retry()`, `resolve()`, `settle()`, and `flush()` signatures do not change.
+8. Retry and reload acknowledgment is always associated with the exact payload the bridge will resubmit, never with a queued or newer batch.
+
+## 4. Adapter Alignment
+
+The AG-UI adapter records each settled result in its source-owned message list with a stable ID derived from the tool-call ID. Its continuation and retry paths reuse that list, so a failed run does not destroy the result.
+
+The LangGraph adapter cannot use the same storage mechanism because server thread state is authoritative and outbound messages are incremental state updates. It can preserve the same semantics by:
+
+- assigning each buffered ToolMessage a deterministic message ID,
+- snapshotting staged results for an operation without forgetting them,
+- acknowledging the snapshot only after success, and
+- replaying an unacknowledged snapshot when recovery is needed.
+
+LangGraph's required `add_messages` reducer updates an existing message when the same message ID is written again. Stable identity therefore makes an ambiguous replay safe without requiring the optional server-side client-tool execution guard. That guard remains defense-in-depth for deployments that enable it.
+
+## 5. Scope
+
+### In scope
+
+- Stable IDs on LangGraph client-tool result messages.
+- Snapshot-and-ack ownership for staged result batches.
+- Outcome-aware ordinary submit, client-tool continuation, flush, and retry handoffs.
+- Thread-generation protection for late completions.
+- Regression coverage for failure, retry, replay, concurrency, and thread switching.
+- Updating internal comments and adapter guidance affected by the ownership change.
+
+### Out of scope
+
+- Public API changes.
+- Exactly-once execution of browser-side effects.
+- Requiring or automatically installing a server-side execution store.
+- Changing AG-UI behavior.
+- Changing graph schemas that do not use `add_messages`; the adapter already relies on that reducer for incremental message updates.
+- Persistence across a browser reload when a custom transport provides no `updateState()` implementation.
+
+## 6. Design
+
+### 6.1 Stable result identity
+
+`BufferedToolMessage` gains a required `id` field. The ID is deterministic for the tool call, for example:
+
+```ts
+id: `client-tool-result-${toolCallId}`
+```
+
+The same tool call always produces the same ToolMessage ID for settle, flush, continuation, submit fallback, and retry. Thread state is already scoped by thread ID, so the same tool-call ID on another thread does not collide.
+
+### 6.2 Staged batch snapshots
+
+Replace destructive read semantics with an internal batch abstraction:
+
+```ts
+interface StagedToolMessageBatch {
+  readonly generation: number;
+  readonly messages: readonly BufferedToolMessage[];
+  acknowledge(): void;
+}
+```
+
+Creating a batch:
+
+1. Removes entries proven stale for the current thread.
+2. Captures the current buffer generation.
+3. Copies the currently staged messages without deleting them.
+4. Returns an `acknowledge()` closure that removes only the captured message IDs and only when the generation still matches.
+
+New results settled after the snapshot are not part of the batch and cannot be removed by its acknowledgment.
+
+Because messages remain staged until acknowledgment, overlapping operations may carry the same stable message. This is safe under `add_messages` and prevents a newer submission from missing a result owned by an older in-flight operation.
+
+### 6.3 Flush
+
+`flush()` snapshots the current batch, writes it through `persistFn`, and acknowledges it only after the write resolves.
+
+- A missing persistence function still rejects for a non-empty batch.
+- A rejected write leaves the snapshot staged; no explicit re-staging is needed.
+- Concurrent flushes remain chained so a later caller's newly settled results receive their own write.
+- A late successful or failed write after a thread switch cannot acknowledge or revive the old thread's results because its generation is stale.
+
+### 6.4 Run outcomes
+
+`StreamManagerBridge.submit()` returns the bridge's existing `CompleteOutcome` internally. `resubmitLast()` returns a dedicated internal result:
+
+```ts
+type ResubmitOutcome = CompleteOutcome | 'not-started';
+```
+
+`'not-started'` means the bridge has no non-null payload to resubmit. It is not success and must never acknowledge a staged batch.
+
+The public adapter methods continue to resolve `Promise<void>`: they await the internal outcome, perform result acknowledgment, and return no value.
+
+Outcome handling:
+
+| Outcome | Staged result action |
+|---|---|
+| `success` | acknowledge the batch carried by that payload |
+| `error` | retain |
+| `interrupted` | retain |
+| `aborted` | retain |
+| `paused` | retain |
+
+The adapter distinguishes the bridge branch actually taken, not merely the presence of an enqueue option:
+
+```ts
+const createsQueuedRun =
+  request.options?.multitaskStrategy === 'enqueue' && isLoading();
+```
+
+This predicate is evaluated immediately before `manager.submit()` and mirrors the bridge's synchronous branch condition.
+
+- When `createsQueuedRun` is true, successful queue creation counts as a successful handoff because the queued run owns the complete payload. Queue-creation errors retain the batch and continue to reject as they do today. The queued operation does not replace the bridge's retryable `lastPayload`, so it does not replace or clear the capability's retryable batch association.
+- When `createsQueuedRun` is false, the bridge starts an immediate stream and replaces `lastPayload` even if the options contain `multitaskStrategy: 'enqueue'`. The capability must replace or clear its retryable batch association in step with that immediate-stream payload.
+
+### 6.5 Ordinary submit
+
+For a non-null payload, the adapter:
+
+1. Snapshots the current staged batch.
+2. Prepends the batch messages to the outgoing payload.
+3. When `createsQueuedRun` is false, records that batch as the one carried by the bridge's latest retryable payload.
+4. Awaits the bridge outcome.
+5. Acknowledges the batch only on `success`.
+
+When `createsQueuedRun` is true, the submission treats its batch as an independent operation: successful queue creation acknowledges it, while failure retains it without changing the previous retryable batch association.
+
+Null or undefined payloads do not snapshot or carry staged messages. On the immediate-stream branch they clear the capability's retryable batch association in step with the bridge setting its last payload to null, so a later retry cannot acknowledge an older batch that is no longer present on the wire. On the queued branch they leave the prior association unchanged because queue creation does not mutate the bridge's `lastPayload`.
+
+### 6.6 Client-tool continuation
+
+`resolve()` settles the result, snapshots all staged results for the active thread, and starts one continuation with that batch.
+
+The continuation acknowledges its batch only on `success`. All other outcomes retain it for recovery. The method remains fire-and-forget at the public capability boundary.
+
+### 6.7 Retry
+
+The capability tracks the exact staged batch associated with the bridge's latest non-null, non-enqueue run payload. Ordinary submit and client-tool continuation both update this association when they replace the bridge's last payload.
+
+`retry()` and `reload()` use one shared internal resubmit helper:
+
+1. Reuses the bridge's existing last payload, preserving current retry behavior.
+2. Awaits the internal outcome.
+3. Does nothing to staged state for `'not-started'`.
+4. Acknowledges the recorded batch only on `success`.
+
+Results settled after the failed attempt are not part of the recorded batch and remain staged. A later ordinary submit may carry both the retained failed batch and newer staged results.
+
+`retry()` continues to return `Promise<void>` and awaits the helper. `reload()` remains a public `void` method and starts the same helper in the background.
+
+### 6.8 Thread switching
+
+The existing thread-switch clear remains authoritative:
+
+- clear all staged messages,
+- retire outgoing tool-call IDs,
+- increment the buffer generation.
+- clear the capability's retryable batch association, and
+- clear the bridge's `lastPayload` and `lastOptions`.
+
+Every late batch acknowledgment becomes a no-op after the generation changes. Late handlers continue to be rejected by the retired-tool-call guard. A retry or reload issued on the new thread returns `'not-started'` until that thread has submitted its own retryable payload.
+
+## 7. Data Flow
+
+### Failed run followed by a new submit
+
+```text
+settle result
+  -> staged with stable message ID
+  -> submit snapshots and sends it
+  -> run fails
+  -> snapshot remains staged
+  -> later submit sends the same stable message ID
+  -> run succeeds
+  -> snapshot acknowledged and removed
+```
+
+### Ambiguous mid-stream failure followed by retry
+
+```text
+submit sends stable result message
+  -> server may already have applied it
+  -> stream is interrupted
+  -> result remains staged
+  -> retry sends the same message ID
+  -> add_messages updates/reuses the existing logical message
+  -> retry succeeds
+  -> snapshot acknowledged
+```
+
+### Thread switch during an in-flight operation
+
+```text
+operation snapshots generation N
+  -> switchThread clears results and advances to N+1
+  -> old operation completes
+  -> generation mismatch prevents acknowledgment or restoration
+  -> retry/reload has no old payload or batch to resend
+```
+
+## 8. Testing
+
+### Client-tools unit tests
+
+- Settled ToolMessages receive deterministic IDs.
+- A failed flush leaves its snapshot staged.
+- A successful flush acknowledges only its snapshot.
+- A result settled during an in-flight flush remains staged for the chained flush.
+- Multiple snapshots of the same result use the same ID.
+- A stale-generation acknowledgment after thread switch is a no-op.
+
+### Agent integration tests
+
+- A pre-stream submit failure retains the result for the next ordinary submit.
+- A mid-stream failure retains the result with the same message ID.
+- A successful ordinary submit removes the result so an unrelated later submit does not resend it.
+- A successful retry acknowledges the failed run's result batch.
+- A successful retry does not acknowledge a newer result that was absent from the retried payload.
+- A successful reload acknowledges the failed run's result batch through the same helper.
+- Retry and reload after a thread switch do not resubmit or acknowledge the old thread's batch.
+- A null immediate-stream submission clears the prior retryable batch association and yields `'not-started'` on retry.
+- A null queued submission leaves the prior retryable batch association unchanged.
+- A failed client-tool continuation retains its result.
+- A successful client-tool continuation acknowledges its result.
+- A null submit does not snapshot or acknowledge staged results.
+- A thread switch discards staged and in-flight snapshots.
+- An enqueue-option submission while idle follows the immediate-stream rules and replaces the retryable batch association.
+- An enqueue-option submission while loading acknowledges on successful queue creation and retains on queue-creation failure without replacing the prior retryable batch association.
+
+### Bridge tests
+
+- `submit()` returns each existing terminal outcome without changing status/error behavior.
+- `resubmitLast()` returns the retried attempt's outcome or `'not-started'` when no non-null payload exists.
+- Superseded and user-aborted attempts return their existing non-success outcomes.
+- Successful queue creation reports success; queue creation failures still reject.
+- Thread switching clears the retained payload and options.
+
+## 9. Verification
+
+Run the smallest surface first, then the complete project checks:
+
+```text
+npx nx test langgraph --skip-nx-cache
+npx nx lint langgraph --skip-nx-cache
+npx nx build langgraph --skip-nx-cache
+npx nx build website --skip-nx-cache
+```
+
+Also run `git diff --check` and review the complete branch diff against `origin/main` before committing implementation work.
+
+## 10. Compatibility
+
+- No public types or method signatures change.
+- Existing successful submit, resolve, flush, and retry behavior remains unchanged.
+- Custom transports without `updateState()` retain their documented next-run fallback.
+- Stable message IDs improve replay behavior for both Python and JavaScript LangGraph graphs using `add_messages`.
+- The optional durable execution guard remains compatible and can still filter duplicate result delivery by `tool_call_id`.

--- a/libs/langgraph/src/lib/agent.fn.spec.ts
+++ b/libs/langgraph/src/lib/agent.fn.spec.ts
@@ -320,7 +320,8 @@ describe('agent', () => {
     transport.close();
     await submitted;
     await new Promise(r => setTimeout(r, 10));
-    ref.reload();
+    const reloaded = ref.reload();
+    expect(reloaded).toBeUndefined();
     expect(ref.isLoading()).toBe(true);
     await ref.stop();
   });
@@ -1302,7 +1303,7 @@ describe('computeMessageCheckpoints', () => {
 // ── Client-tool staging wiring ───────────────────────────────────────────────
 // The capability is unit-tested in client-tools.spec.ts; these cover the
 // agent.fn.ts seam: which persist function is supplied, the null-payload
-// drain guard, and discarding staged results on a thread switch.
+// staging guard, and discarding staged results on a thread switch.
 
 describe('agent — client tool staging', () => {
   beforeEach(() => TestBed.configureTestingModule({}));
@@ -1329,8 +1330,143 @@ describe('agent — client tool staging', () => {
     return ref.clientTools as {
       setCatalog(specs: unknown[]): void;
       settle(id: string, result: { ok: true; value: unknown }): void;
+      resolve(id: string, result: { ok: true; value: unknown }): void;
       flush(): Promise<void>;
-      drainToolMessages(): Array<{ tool_call_id: string }>;
+      snapshotToolMessages(): {
+        messages: ReadonlyArray<{ id: string; tool_call_id: string }>;
+      };
+    };
+  }
+
+  type StreamScript = (signal: AbortSignal) => AsyncIterable<StreamEvent>;
+
+  class ScriptedAgentTransport implements AgentTransport {
+    readonly calls: Array<{
+      payload: unknown;
+      options: Parameters<AgentTransport['stream']>[4];
+    }> = [];
+    readonly queuedCalls: Array<{
+      payload: unknown;
+      options: Parameters<NonNullable<AgentTransport['createQueuedRun']>>[4];
+    }> = [];
+    readonly joinedCalls: Array<{
+      threadId: string;
+      runId: string;
+      lastEventId: string | undefined;
+    }> = [];
+
+    constructor(
+      private readonly scripts: readonly StreamScript[],
+      private readonly queueError?: Error,
+    ) {}
+
+    stream(
+      _assistantId: string,
+      _threadId: string | null,
+      payload: unknown,
+      signal: AbortSignal,
+      options?: Parameters<AgentTransport['stream']>[4],
+    ): AsyncIterable<StreamEvent> {
+      const script = this.scripts[this.calls.length];
+      this.calls.push({ payload, options });
+      if (!script) throw new Error('No stream script configured for this invocation.');
+      return script(signal);
+    }
+
+    async createQueuedRun(
+      _assistantId: string,
+      threadId: string,
+      payload: unknown,
+      _signal: AbortSignal,
+      options?: Parameters<NonNullable<AgentTransport['createQueuedRun']>>[4],
+    ) {
+      this.queuedCalls.push({ payload, options });
+      if (this.queueError) throw this.queueError;
+      return {
+        id: `queued-${this.queuedCalls.length}`,
+        threadId,
+        values: payload,
+        options,
+        createdAt: new Date(0),
+      };
+    }
+
+    async *joinStream(
+      threadId: string,
+      runId: string,
+      lastEventId: string | undefined,
+    ): AsyncIterable<StreamEvent> {
+      this.joinedCalls.push({ threadId, runId, lastEventId });
+      yield { type: 'values', values: { queued: true } };
+    }
+  }
+
+  function successfulStream(): StreamScript {
+    return () => (async function* () {
+      yield { type: 'values', values: { done: true } };
+    })();
+  }
+
+  function preStreamFailure(message: string): StreamScript {
+    return () => (async function* () {
+      yield* [];
+      throw new Error(message);
+    })();
+  }
+
+  function midStreamFailure(message: string): StreamScript {
+    return () => (async function* () {
+      yield {
+        type: 'messages',
+        messages: [{ id: 'ai-interrupted', type: 'ai', content: 'partial' }],
+      };
+      throw new Error(message);
+    })();
+  }
+
+  function deferred(): { promise: Promise<void>; resolve(): void } {
+    let resolve!: () => void;
+    const promise = new Promise<void>((done) => { resolve = done; });
+    return { promise, resolve };
+  }
+
+  function controlledSuccess(
+    release: Promise<void>,
+    onStarted: () => void,
+    onCompleted: () => void = () => undefined,
+  ): StreamScript {
+    return () => (async function* () {
+      onStarted();
+      await release;
+      yield { type: 'values', values: { done: true } };
+      onCompleted();
+    })();
+  }
+
+  function controlledFailure(
+    release: Promise<void>,
+    onStarted: () => void,
+    message: string,
+  ): StreamScript {
+    return () => (async function* () {
+      onStarted();
+      await release;
+      yield* [];
+      throw new Error(message);
+    })();
+  }
+
+  function messagesFrom(payload: unknown): Array<Record<string, unknown>> {
+    return (payload as { messages: Array<Record<string, unknown>> }).messages;
+  }
+
+  function stagedToolMessage(id: string, content: string): Record<string, unknown> {
+    return {
+      id: `client-tool-result-${id}`,
+      type: 'tool',
+      role: 'tool',
+      tool_call_id: id,
+      content,
     };
   }
 
@@ -1349,11 +1485,17 @@ describe('agent — client tool staging', () => {
     expect(updateCalls).toHaveLength(1);
     expect(updateCalls[0]?.threadId).toBe('t-1');
     expect(updateCalls[0]?.values?.['messages']).toEqual([
-      { type: 'tool', role: 'tool', tool_call_id: 'tc-1', content: 'sunny' },
+      {
+        id: 'client-tool-result-tc-1',
+        type: 'tool',
+        role: 'tool',
+        tool_call_id: 'tc-1',
+        content: 'sunny',
+      },
     ]);
     // A durable write must not issue a run.
     expect(transport.streams).toHaveLength(0);
-    expect(cap.drainToolMessages()).toEqual([]);
+    expect(cap.snapshotToolMessages().messages).toEqual([]);
   });
 
   it('flush() keeps the buffer when there is no thread to write to', async () => {
@@ -1371,12 +1513,654 @@ describe('agent — client tool staging', () => {
     await cap.flush();
 
     expect(updateCalls).toHaveLength(0);
-    expect(cap.drainToolMessages().map((m) => m.tool_call_id)).toEqual(['tc-1']);
+    expect(cap.snapshotToolMessages().messages).toEqual([
+      stagedToolMessage('tc-1', 'sunny'),
+    ]);
   });
 
-  it('submit drains staged tool messages ahead of the payload messages', async () => {
-    // No updateState on the transport → flush() cannot persist, so the staged
-    // result must ride along with the next ordinary submit instead.
+  it('submit acknowledges its deterministic staged batch only after terminal success', async () => {
+    const release = deferred();
+    let streamStarted = false;
+    const transport = new ScriptedAgentTransport([
+      controlledSuccess(release.promise, () => { streamStarted = true; }),
+      successfulStream(),
+    ]);
+    const ref = withInjectionContext(() =>
+      agent({ apiUrl: '', assistantId: 'a', threadId: 't-1', transport, throttle: false })
+    );
+    const cap = staging(ref);
+    cap.setCatalog([SPEC]);
+
+    cap.settle('tc-1', { ok: true, value: 'sunny' });
+    const submitted = ref.submit({ message: 'and tomorrow?' });
+
+    try {
+      await vi.waitFor(() => expect(streamStarted).toBe(true), { timeout: 1000 });
+      expect(cap.snapshotToolMessages().messages).toEqual([
+        stagedToolMessage('tc-1', 'sunny'),
+      ]);
+      expect(messagesFrom(transport.calls[0]?.payload)[0]).toEqual(
+        stagedToolMessage('tc-1', 'sunny'),
+      );
+    } finally {
+      release.resolve();
+    }
+
+    await expect(submitted).resolves.toBeUndefined();
+    expect(cap.snapshotToolMessages().messages).toEqual([]);
+
+    await ref.submit({ message: 'unrelated' });
+    expect(messagesFrom(transport.calls[1]?.payload)).toEqual([
+      expect.objectContaining({ type: 'human', content: 'unrelated' }),
+    ]);
+  });
+
+  it('replays the same staged result after a pre-stream failure and acknowledges it on success', async () => {
+    const transport = new ScriptedAgentTransport([
+      preStreamFailure('connect failed'),
+      successfulStream(),
+      successfulStream(),
+    ]);
+    const ref = withInjectionContext(() =>
+      agent({ apiUrl: '', assistantId: 'a', threadId: 't-1', transport, throttle: false })
+    );
+    const cap = staging(ref);
+    cap.setCatalog([SPEC]);
+    cap.settle('tc-1', { ok: true, value: 'sunny' });
+
+    await expect(ref.submit({ message: 'first' })).resolves.toBeUndefined();
+
+    expect(ref.status()).toBe('error');
+    expect(ref.error()).toBeInstanceOf(AgentError);
+    expect(cap.snapshotToolMessages().messages).toEqual([
+      stagedToolMessage('tc-1', 'sunny'),
+    ]);
+
+    await expect(ref.submit({ message: 'second' })).resolves.toBeUndefined();
+
+    expect(messagesFrom(transport.calls[0]?.payload)[0]).toEqual(
+      stagedToolMessage('tc-1', 'sunny'),
+    );
+    expect(messagesFrom(transport.calls[1]?.payload)[0]).toEqual(
+      stagedToolMessage('tc-1', 'sunny'),
+    );
+    expect(cap.snapshotToolMessages().messages).toEqual([]);
+
+    await ref.submit({ message: 'third' });
+    expect(messagesFrom(transport.calls[2]?.payload)).toEqual([
+      expect.objectContaining({ type: 'human', content: 'third' }),
+    ]);
+  });
+
+  it('replays the identical staged result after a mid-stream failure', async () => {
+    const transport = new ScriptedAgentTransport([
+      midStreamFailure('stream interrupted'),
+      successfulStream(),
+    ]);
+    const ref = withInjectionContext(() =>
+      agent({ apiUrl: '', assistantId: 'a', threadId: 't-1', transport, throttle: false })
+    );
+    const cap = staging(ref);
+    cap.setCatalog([SPEC]);
+    cap.settle('tc-1', { ok: true, value: 'sunny' });
+
+    await ref.submit({ message: 'first' });
+
+    expect(ref.status()).toBe('error');
+    expect(ref.messages().find((message) => message.id === 'ai-interrupted')?.content).toBe('partial');
+    expect(cap.snapshotToolMessages().messages).toEqual([
+      stagedToolMessage('tc-1', 'sunny'),
+    ]);
+
+    await ref.submit({ message: 'second' });
+
+    expect(messagesFrom(transport.calls[0]?.payload)[0]).toEqual(
+      stagedToolMessage('tc-1', 'sunny'),
+    );
+    expect(messagesFrom(transport.calls[1]?.payload)[0]).toEqual(
+      stagedToolMessage('tc-1', 'sunny'),
+    );
+    expect(cap.snapshotToolMessages().messages).toEqual([]);
+  });
+
+  it('retry acknowledges the failed run batch after a successful resubmission', async () => {
+    const transport = new ScriptedAgentTransport([
+      preStreamFailure('connect failed'),
+      successfulStream(),
+    ]);
+    const ref = withInjectionContext(() =>
+      agent({ apiUrl: '', assistantId: 'a', threadId: 't-1', transport, throttle: false })
+    );
+    const cap = staging(ref);
+    cap.setCatalog([SPEC]);
+    cap.settle('tc-1', { ok: true, value: 'sunny' });
+    await ref.submit({ message: 'first' });
+
+    await expect(ref.retry()).resolves.toBeUndefined();
+
+    expect(transport.calls[1]?.payload).toEqual(transport.calls[0]?.payload);
+    expect(messagesFrom(transport.calls[1]?.payload)[0]).toEqual(
+      stagedToolMessage('tc-1', 'sunny'),
+    );
+    expect(cap.snapshotToolMessages().messages).toEqual([]);
+  });
+
+  it('retry acknowledges only the failed payload batch when a newer result settles', async () => {
+    const transport = new ScriptedAgentTransport([
+      preStreamFailure('connect failed'),
+      successfulStream(),
+    ]);
+    const ref = withInjectionContext(() =>
+      agent({ apiUrl: '', assistantId: 'a', threadId: 't-1', transport, throttle: false })
+    );
+    const cap = staging(ref);
+    cap.setCatalog([SPEC]);
+    cap.settle('tc-1', { ok: true, value: 'sunny' });
+    await ref.submit({ message: 'first' });
+    cap.settle('tc-2', { ok: true, value: 'rainy' });
+
+    await ref.retry();
+
+    expect(messagesFrom(transport.calls[1]?.payload)[0]).toEqual(
+      stagedToolMessage('tc-1', 'sunny'),
+    );
+    expect(messagesFrom(transport.calls[1]?.payload).some((message) =>
+      message['id'] === 'client-tool-result-tc-2'
+    )).toBe(false);
+    expect(cap.snapshotToolMessages().messages).toEqual([
+      stagedToolMessage('tc-2', 'rainy'),
+    ]);
+  });
+
+  it('an immediate null submit retains staging and clears the failed result batch from retry', async () => {
+    const transport = new ScriptedAgentTransport([
+      preStreamFailure('connect failed'),
+      successfulStream(),
+    ]);
+    const ref = withInjectionContext(() =>
+      agent({ apiUrl: '', assistantId: 'a', threadId: 't-1', transport, throttle: false })
+    );
+    const cap = staging(ref);
+    cap.setCatalog([SPEC]);
+    cap.settle('tc-1', { ok: true, value: 'sunny' });
+
+    await ref.submit({ message: 'first' });
+    await ref.submit(null);
+
+    expect(transport.calls).toHaveLength(2);
+    expect(transport.calls[1]?.payload).toBeNull();
+    expect(cap.snapshotToolMessages().messages).toEqual([
+      stagedToolMessage('tc-1', 'sunny'),
+    ]);
+
+    await ref.retry();
+
+    expect(transport.calls).toHaveLength(2);
+    expect(cap.snapshotToolMessages().messages).toEqual([
+      stagedToolMessage('tc-1', 'sunny'),
+    ]);
+  });
+
+  it('treats enqueue options as an immediate retryable run while idle', async () => {
+    const transport = new ScriptedAgentTransport([
+      preStreamFailure('idle enqueue failed'),
+      successfulStream(),
+    ]);
+    const ref = withInjectionContext(() =>
+      agent({ apiUrl: '', assistantId: 'a', threadId: 't-1', transport, throttle: false })
+    );
+    const cap = staging(ref);
+    cap.setCatalog([SPEC]);
+    cap.settle('tc-1', { ok: true, value: 'sunny' });
+
+    await ref.submit(
+      { message: 'run now' },
+      { multitaskStrategy: 'enqueue' },
+    );
+
+    expect(transport.calls).toHaveLength(1);
+    expect(transport.queuedCalls).toHaveLength(0);
+    expect(transport.calls[0]?.options).toMatchObject({
+      multitaskStrategy: 'enqueue',
+    });
+    expect(cap.snapshotToolMessages().messages).toEqual([
+      stagedToolMessage('tc-1', 'sunny'),
+    ]);
+
+    await ref.retry();
+
+    expect(transport.calls).toHaveLength(2);
+    expect(transport.calls[1]?.payload).toEqual(transport.calls[0]?.payload);
+    expect(cap.snapshotToolMessages().messages).toEqual([]);
+  });
+
+  it('clears the failed result batch association when regenerate submits null', async () => {
+    const failedTranscript: StreamScript = () => (async function* () {
+      yield {
+        type: 'messages',
+        messages: [
+          { id: 'user-before-regenerate', type: 'human', content: 'first' },
+          { id: 'ai-before-regenerate', type: 'ai', content: 'partial' },
+        ],
+      };
+      throw new Error('initial run failed');
+    })();
+    const transport = new ScriptedAgentTransport([
+      failedTranscript,
+      successfulStream(),
+    ]);
+    const releaseUpdate = deferred();
+    let updateStarted = false;
+    const updateCalls: Array<{
+      threadId: string;
+      values: Record<string, unknown>;
+      options?: { asNode?: string };
+    }> = [];
+    (transport as AgentTransport).updateState = async (
+      threadId,
+      values,
+      _signal,
+      options,
+    ) => {
+      updateCalls.push({ threadId, values, options });
+      updateStarted = true;
+      await releaseUpdate.promise;
+    };
+    const ref = withInjectionContext(() =>
+      agent({ apiUrl: '', assistantId: 'a', threadId: 't-1', transport, throttle: false })
+    );
+    const cap = staging(ref);
+    cap.setCatalog([SPEC]);
+    cap.settle('tc-1', { ok: true, value: 'sunny' });
+
+    await ref.submit({ message: 'first' });
+    const assistantIndex = ref.messages().findIndex(message => message.id === 'ai-before-regenerate');
+    expect(assistantIndex).toBeGreaterThan(-1);
+
+    const regenerated = ref.regenerate(assistantIndex);
+
+    try {
+      await vi.waitFor(() => expect(updateStarted).toBe(true), { timeout: 1000 });
+      expect(updateCalls).toEqual([{
+        threadId: 't-1',
+        values: {
+          messages: [{
+            type: 'remove',
+            role: 'remove',
+            id: 'ai-before-regenerate',
+            content: '',
+          }],
+        },
+        options: { asNode: '__start__' },
+      }]);
+      expect(transport.calls).toHaveLength(1);
+    } finally {
+      releaseUpdate.resolve();
+      await regenerated;
+    }
+
+    expect(transport.calls).toHaveLength(2);
+    expect(transport.calls[1]?.payload).toBeNull();
+    expect(cap.snapshotToolMessages().messages).toEqual([
+      stagedToolMessage('tc-1', 'sunny'),
+    ]);
+
+    await ref.retry();
+
+    expect(transport.calls).toHaveLength(2);
+    expect(cap.snapshotToolMessages().messages).toEqual([
+      stagedToolMessage('tc-1', 'sunny'),
+    ]);
+  });
+
+  it('makes the second of two immediate ordinary submissions the exact retry batch', async () => {
+    const releaseFirst = deferred();
+    let firstStarted = false;
+    const transport = new ScriptedAgentTransport([
+      controlledSuccess(releaseFirst.promise, () => { firstStarted = true; }),
+      preStreamFailure('second submit failed'),
+      successfulStream(),
+    ]);
+    const ref = withInjectionContext(() =>
+      agent({ apiUrl: '', assistantId: 'a', threadId: 't-1', transport, throttle: false })
+    );
+    const cap = staging(ref);
+    cap.setCatalog([SPEC]);
+
+    cap.settle('tc-1', { ok: true, value: 'sunny' });
+    const first = ref.submit({ message: 'first' });
+    cap.settle('tc-2', { ok: true, value: 'rainy' });
+    const second = ref.submit({ message: 'second' });
+
+    try {
+      await expect(second).resolves.toBeUndefined();
+      await vi.waitFor(() => expect(firstStarted).toBe(true), { timeout: 1000 });
+      expect(ref.status()).toBe('error');
+      expect(messagesFrom(transport.calls[0]?.payload)[0]).toEqual(
+        stagedToolMessage('tc-1', 'sunny'),
+      );
+      expect(messagesFrom(transport.calls[1]?.payload).slice(0, 2)).toEqual([
+        stagedToolMessage('tc-1', 'sunny'),
+        stagedToolMessage('tc-2', 'rainy'),
+      ]);
+    } finally {
+      releaseFirst.resolve();
+      await first;
+    }
+
+    cap.settle('tc-3', { ok: true, value: 'windy' });
+    await expect(ref.retry()).resolves.toBeUndefined();
+
+    expect(transport.calls[2]?.payload).toEqual(transport.calls[1]?.payload);
+    expect(messagesFrom(transport.calls[2]?.payload).slice(0, 2)).toEqual([
+      stagedToolMessage('tc-1', 'sunny'),
+      stagedToolMessage('tc-2', 'rainy'),
+    ]);
+    expect(messagesFrom(transport.calls[2]?.payload).some((message) =>
+      message['id'] === 'client-tool-result-tc-3'
+    )).toBe(false);
+    expect(cap.snapshotToolMessages().messages).toEqual([
+      stagedToolMessage('tc-3', 'windy'),
+    ]);
+  });
+
+  it('acknowledges a successful loading enqueue without replacing the active retry batch', async () => {
+    const releaseActive = deferred();
+    let activeStarted = false;
+    const transport = new ScriptedAgentTransport([
+      controlledFailure(
+        releaseActive.promise,
+        () => { activeStarted = true; },
+        'active submit failed',
+      ),
+      successfulStream(),
+    ]);
+    const ref = withInjectionContext(() =>
+      agent({ apiUrl: '', assistantId: 'a', threadId: 't-1', transport, throttle: false })
+    );
+    const cap = staging(ref);
+    cap.setCatalog([SPEC]);
+
+    cap.settle('tc-1', { ok: true, value: 'sunny' });
+    const active = ref.submit({ message: 'active' });
+
+    try {
+      await vi.waitFor(() => expect(activeStarted).toBe(true), { timeout: 1000 });
+      expect(ref.isLoading()).toBe(true);
+      cap.settle('tc-2', { ok: true, value: 'rainy' });
+
+      await ref.submit(
+        { message: 'queued' },
+        { multitaskStrategy: 'enqueue' },
+      );
+
+      expect(transport.calls).toHaveLength(1);
+      expect(transport.queuedCalls).toHaveLength(1);
+      expect(ref.queue()).toMatchObject({
+        size: 1,
+        entries: [{ id: 'queued-1', threadId: 't-1' }],
+      });
+      expect(messagesFrom(transport.queuedCalls[0]?.payload).slice(0, 2)).toEqual([
+        stagedToolMessage('tc-1', 'sunny'),
+        stagedToolMessage('tc-2', 'rainy'),
+      ]);
+      expect(cap.snapshotToolMessages().messages).toEqual([]);
+
+      cap.settle('tc-3', { ok: true, value: 'windy' });
+    } finally {
+      releaseActive.resolve();
+      await active;
+    }
+
+    expect(ref.status()).toBe('error');
+    await ref.retry();
+
+    expect(transport.calls).toHaveLength(2);
+    expect(transport.calls[1]?.payload).toEqual(transport.calls[0]?.payload);
+    expect(messagesFrom(transport.calls[1]?.payload)[0]).toEqual(
+      stagedToolMessage('tc-1', 'sunny'),
+    );
+    expect(messagesFrom(transport.calls[1]?.payload).some((message) =>
+      message['id'] === 'client-tool-result-tc-2'
+        || message['id'] === 'client-tool-result-tc-3'
+    )).toBe(false);
+    expect(cap.snapshotToolMessages().messages).toEqual([
+      stagedToolMessage('tc-3', 'windy'),
+    ]);
+    expect(ref.queue().size).toBe(0);
+    expect(transport.joinedCalls).toEqual([{
+      threadId: 't-1',
+      runId: 'queued-1',
+      lastEventId: undefined,
+    }]);
+  });
+
+  it('does not replace the active retry batch when a loading enqueue is rejected', async () => {
+    const releaseActive = deferred();
+    let activeStarted = false;
+    const transport = new ScriptedAgentTransport(
+      [
+        controlledFailure(
+          releaseActive.promise,
+          () => { activeStarted = true; },
+          'active submit failed',
+        ),
+        successfulStream(),
+      ],
+      new Error('queue creation failed'),
+    );
+    const ref = withInjectionContext(() =>
+      agent({ apiUrl: '', assistantId: 'a', threadId: 't-1', transport, throttle: false })
+    );
+    const cap = staging(ref);
+    cap.setCatalog([SPEC]);
+
+    cap.settle('tc-1', { ok: true, value: 'sunny' });
+    const active = ref.submit({ message: 'active' });
+
+    try {
+      await vi.waitFor(() => expect(activeStarted).toBe(true), { timeout: 1000 });
+      expect(ref.isLoading()).toBe(true);
+      cap.settle('tc-2', { ok: true, value: 'rainy' });
+      await expect(ref.submit(
+        { message: 'queued' },
+        { multitaskStrategy: 'enqueue' },
+      )).rejects.toThrow('queue creation failed');
+      expect(transport.calls).toHaveLength(1);
+      expect(transport.queuedCalls).toHaveLength(1);
+      expect(transport.queuedCalls[0]?.options).toMatchObject({
+        multitaskStrategy: 'enqueue',
+      });
+      expect(messagesFrom(transport.queuedCalls[0]?.payload).slice(0, 2)).toEqual([
+        stagedToolMessage('tc-1', 'sunny'),
+        stagedToolMessage('tc-2', 'rainy'),
+      ]);
+      expect(cap.snapshotToolMessages().messages).toEqual([
+        stagedToolMessage('tc-1', 'sunny'),
+        stagedToolMessage('tc-2', 'rainy'),
+      ]);
+    } finally {
+      releaseActive.resolve();
+      await active;
+    }
+    expect(ref.status()).toBe('error');
+
+    cap.settle('tc-3', { ok: true, value: 'windy' });
+    await expect(ref.retry()).resolves.toBeUndefined();
+
+    expect(transport.calls[1]?.payload).toEqual(transport.calls[0]?.payload);
+    expect(messagesFrom(transport.calls[1]?.payload)[0]).toEqual(
+      stagedToolMessage('tc-1', 'sunny'),
+    );
+    expect(messagesFrom(transport.calls[1]?.payload).some((message) =>
+      message['id'] === 'client-tool-result-tc-2'
+        || message['id'] === 'client-tool-result-tc-3'
+    )).toBe(false);
+    expect(cap.snapshotToolMessages().messages).toEqual([
+      stagedToolMessage('tc-2', 'rainy'),
+      stagedToolMessage('tc-3', 'windy'),
+    ]);
+  });
+
+  it('keeps the active retry batch when a loading enqueue carries null', async () => {
+    const releaseActive = deferred();
+    let activeStarted = false;
+    const transport = new ScriptedAgentTransport([
+      controlledFailure(
+        releaseActive.promise,
+        () => { activeStarted = true; },
+        'active submit failed',
+      ),
+      successfulStream(),
+    ]);
+    const ref = withInjectionContext(() =>
+      agent({ apiUrl: '', assistantId: 'a', threadId: 't-1', transport, throttle: false })
+    );
+    const cap = staging(ref);
+    cap.setCatalog([SPEC]);
+
+    cap.settle('tc-1', { ok: true, value: 'sunny' });
+    const active = ref.submit({ message: 'active' });
+
+    try {
+      await vi.waitFor(() => expect(activeStarted).toBe(true), { timeout: 1000 });
+      expect(ref.isLoading()).toBe(true);
+
+      await ref.submit(null, { multitaskStrategy: 'enqueue' });
+
+      expect(transport.calls).toHaveLength(1);
+      expect(transport.queuedCalls).toHaveLength(1);
+      expect(transport.queuedCalls[0]?.payload).toBeNull();
+      expect(ref.queue()).toMatchObject({
+        size: 1,
+        entries: [{ id: 'queued-1', threadId: 't-1' }],
+      });
+      expect(cap.snapshotToolMessages().messages).toEqual([
+        stagedToolMessage('tc-1', 'sunny'),
+      ]);
+
+      cap.settle('tc-2', { ok: true, value: 'rainy' });
+    } finally {
+      releaseActive.resolve();
+      await active;
+    }
+
+    await ref.retry();
+
+    expect(transport.calls).toHaveLength(2);
+    expect(transport.calls[1]?.payload).toEqual(transport.calls[0]?.payload);
+    expect(cap.snapshotToolMessages().messages).toEqual([
+      stagedToolMessage('tc-2', 'rainy'),
+    ]);
+    expect(ref.queue().size).toBe(0);
+    expect(transport.joinedCalls).toEqual([{
+      threadId: 't-1',
+      runId: 'queued-1',
+      lastEventId: undefined,
+    }]);
+  });
+
+  it('reload starts a retry and acknowledges only its captured batch', async () => {
+    const release = deferred();
+    let retryStarted = false;
+    let retryCompleted = false;
+    const transport = new ScriptedAgentTransport([
+      preStreamFailure('connect failed'),
+      controlledSuccess(
+        release.promise,
+        () => { retryStarted = true; },
+        () => { retryCompleted = true; },
+      ),
+    ]);
+    const ref = withInjectionContext(() =>
+      agent({ apiUrl: '', assistantId: 'a', threadId: 't-1', transport, throttle: false })
+    );
+    const cap = staging(ref);
+    cap.setCatalog([SPEC]);
+    cap.settle('tc-1', { ok: true, value: 'sunny' });
+    await ref.submit({ message: 'first' });
+    cap.settle('tc-2', { ok: true, value: 'rainy' });
+
+    const reloaded = ref.reload();
+
+    try {
+      expect(reloaded).toBeUndefined();
+      await vi.waitFor(() => expect(retryStarted).toBe(true), { timeout: 1000 });
+      expect(messagesFrom(transport.calls[1]?.payload)[0]).toEqual(
+        stagedToolMessage('tc-1', 'sunny'),
+      );
+    } finally {
+      release.resolve();
+    }
+    await vi.waitFor(() => expect(retryCompleted).toBe(true), { timeout: 1000 });
+    await vi.waitFor(() => {
+      expect(cap.snapshotToolMessages().messages).toEqual([
+        stagedToolMessage('tc-2', 'rainy'),
+      ]);
+    }, { timeout: 1000 });
+  });
+
+  it('keeps a failed resolve continuation batch for a later ordinary submit', async () => {
+    const transport = new ScriptedAgentTransport([
+      preStreamFailure('continuation failed'),
+      successfulStream(),
+    ]);
+    const ref = withInjectionContext(() =>
+      agent({ apiUrl: '', assistantId: 'a', threadId: 't-1', transport, throttle: false })
+    );
+    const cap = staging(ref);
+    cap.setCatalog([SPEC]);
+
+    const resolved = cap.resolve('tc-1', { ok: true, value: 'sunny' });
+
+    expect(resolved).toBeUndefined();
+    await vi.waitFor(() => expect(ref.status()).toBe('error'), { timeout: 1000 });
+    expect(messagesFrom(transport.calls[0]?.payload)[0]).toEqual(
+      stagedToolMessage('tc-1', 'sunny'),
+    );
+    expect(cap.snapshotToolMessages().messages).toEqual([
+      stagedToolMessage('tc-1', 'sunny'),
+    ]);
+
+    await ref.submit({ message: 'recover' });
+
+    expect(messagesFrom(transport.calls[1]?.payload)[0]).toEqual(
+      stagedToolMessage('tc-1', 'sunny'),
+    );
+    expect(cap.snapshotToolMessages().messages).toEqual([]);
+  });
+
+  it('acknowledges the exact resolve continuation batch only after success', async () => {
+    const release = deferred();
+    let streamStarted = false;
+    const transport = new ScriptedAgentTransport([
+      controlledSuccess(release.promise, () => { streamStarted = true; }),
+    ]);
+    const ref = withInjectionContext(() =>
+      agent({ apiUrl: '', assistantId: 'a', threadId: 't-1', transport, throttle: false })
+    );
+    const cap = staging(ref);
+    cap.setCatalog([SPEC]);
+
+    const resolved = cap.resolve('tc-1', { ok: true, value: 'sunny' });
+
+    try {
+      expect(resolved).toBeUndefined();
+      await vi.waitFor(() => expect(streamStarted).toBe(true), { timeout: 1000 });
+      expect(messagesFrom(transport.calls[0]?.payload)[0]).toEqual(
+        stagedToolMessage('tc-1', 'sunny'),
+      );
+      expect(cap.snapshotToolMessages().messages).toEqual([
+        stagedToolMessage('tc-1', 'sunny'),
+      ]);
+    } finally {
+      release.resolve();
+    }
+    await vi.waitFor(() => expect(ref.status()).toBe('idle'), { timeout: 1000 });
+    expect(cap.snapshotToolMessages().messages).toEqual([]);
+  });
+
+  it('submit(null) does not acknowledge staged tool messages', async () => {
     const transport = new MockAgentTransport();
     const ref = withInjectionContext(() =>
       agent({ apiUrl: '', assistantId: 'a', threadId: 't-1', transport, throttle: false })
@@ -1385,33 +2169,20 @@ describe('agent — client tool staging', () => {
     cap.setCatalog([SPEC]);
 
     cap.settle('tc-1', { ok: true, value: 'sunny' });
-    await expect(cap.flush()).rejects.toThrow(
-      'Custom LangGraph transports using terminal client tools must implement updateState().',
-    );
-    ref.submit({ message: 'and tomorrow?' });
+    const submitted = ref.submit(null);
 
-    const payload = transport.streams[0]?.payload as { messages: Array<Record<string, unknown>> };
-    expect(payload.messages[0]).toMatchObject({ type: 'tool', tool_call_id: 'tc-1' });
-    expect(payload.messages[1]).toMatchObject({ type: 'human' });
-    // Drained exactly once — a second submit must not re-send it.
-    expect(cap.drainToolMessages()).toEqual([]);
-  });
-
-  it('submit(null) does not drain staged tool messages', async () => {
-    const transport = new MockAgentTransport();
-    const ref = withInjectionContext(() =>
-      agent({ apiUrl: '', assistantId: 'a', threadId: 't-1', transport, throttle: false })
-    );
-    const cap = staging(ref);
-    cap.setCatalog([SPEC]);
-
-    cap.settle('tc-1', { ok: true, value: 'sunny' });
-    ref.submit(null);
-
-    // A null payload signals a no-input resume and cannot carry messages;
-    // draining into it would discard the result silently.
-    expect(transport.streams[0]?.payload).toBeNull();
-    expect(cap.drainToolMessages().map((m) => m.tool_call_id)).toEqual(['tc-1']);
+    try {
+      // A null payload signals a no-input resume and cannot carry messages;
+      // acknowledging here would discard the result silently.
+      expect(transport.streams[0]?.payload).toBeNull();
+      expect(cap.snapshotToolMessages().messages).toEqual([
+        stagedToolMessage('tc-1', 'sunny'),
+      ]);
+    } finally {
+      await ref.stop();
+      transport.close();
+      await submitted;
+    }
   });
 
   it('switchThread discards staged tool messages', () => {
@@ -1427,7 +2198,77 @@ describe('agent — client tool staging', () => {
 
     // Carrying it over would prepend a ToolMessage whose tool_call_id matches
     // no AIMessage on t-2 — turning one broken thread into two.
-    expect(cap.drainToolMessages()).toEqual([]);
+    expect(cap.snapshotToolMessages().messages).toEqual([]);
+  });
+
+  it('clears staged ownership and retry payloads when switching threads', async () => {
+    const transport = new ScriptedAgentTransport([
+      preStreamFailure('old thread failed'),
+    ]);
+    const ref = withInjectionContext(() =>
+      agent({ apiUrl: '', assistantId: 'a', threadId: 't-1', transport, throttle: false })
+    );
+    const cap = staging(ref);
+    cap.setCatalog([SPEC]);
+    cap.settle('tc-old', { ok: true, value: 'old result' });
+    await ref.submit({ message: 'old thread run' });
+
+    expect(transport.calls).toHaveLength(1);
+    expect(cap.snapshotToolMessages().messages).toEqual([
+      stagedToolMessage('tc-old', 'old result'),
+    ]);
+
+    ref.switchThread('t-2');
+
+    expect(cap.snapshotToolMessages().messages).toEqual([]);
+    cap.settle('tc-new', { ok: true, value: 'new result' });
+
+    await ref.retry();
+    const reloaded = ref.reload();
+
+    expect(reloaded).toBeUndefined();
+    // A stale resubmit would invoke transport.stream synchronously before the
+    // fire-and-forget helper reaches its first await, so no timing flush is
+    // needed to prove reload did not start a new-thread stream.
+    expect(transport.calls).toHaveLength(1);
+    expect(cap.snapshotToolMessages().messages).toEqual([
+      stagedToolMessage('tc-new', 'new result'),
+    ]);
+  });
+
+  it('keeps a new-thread result when an old-thread stream completes after the switch', async () => {
+    const releaseOld = deferred();
+    let oldStarted = false;
+    const transport = new ScriptedAgentTransport([
+      controlledSuccess(releaseOld.promise, () => { oldStarted = true; }),
+    ]);
+    const ref = withInjectionContext(() =>
+      agent({ apiUrl: '', assistantId: 'a', threadId: 't-1', transport, throttle: false })
+    );
+    const cap = staging(ref);
+    cap.setCatalog([SPEC]);
+    cap.settle('tc-old', { ok: true, value: 'old result' });
+    const oldRun = ref.submit({ message: 'old thread run' });
+
+    try {
+      await vi.waitFor(() => expect(oldStarted).toBe(true), { timeout: 1000 });
+      ref.switchThread('t-2');
+      cap.settle('tc-new', { ok: true, value: 'new result' });
+      expect(cap.snapshotToolMessages().messages).toEqual([
+        stagedToolMessage('tc-new', 'new result'),
+      ]);
+    } finally {
+      releaseOld.resolve();
+      await oldRun;
+    }
+
+    // The bridge classifies the switched-away stream as interrupted even
+    // though its script later closes successfully. Generation-level stale
+    // acknowledge behavior is covered directly in client-tools.spec.ts; this
+    // seam proves the transition cannot disturb staging on the new thread.
+    expect(cap.snapshotToolMessages().messages).toEqual([
+      stagedToolMessage('tc-new', 'new result'),
+    ]);
   });
 });
 
@@ -1446,7 +2287,7 @@ describe('agent — client tool results settled after a thread switch', () => {
       setCatalog(specs: unknown[]): void;
       settle(id: string, result: { ok: true; value: unknown }): void;
       flush(): Promise<void>;
-      drainToolMessages(): Array<{ tool_call_id: string }>;
+      snapshotToolMessages(): { messages: ReadonlyArray<{ tool_call_id: string }> };
     };
   }
 
@@ -1484,10 +2325,10 @@ describe('agent — client tool results settled after a thread switch', () => {
 
     // Writing here would give t-2 a ToolMessage matching no AIMessage → 400.
     expect(updateCalls).toHaveLength(0);
-    expect(cap.drainToolMessages()).toEqual([]);
+    expect(cap.snapshotToolMessages().messages).toEqual([]);
   });
 
-  it('does not drain a result settled after a thread switch into the new thread submit', async () => {
+  it('does not carry a result settled after a thread switch into the new thread submit', async () => {
     const transport = new MockAgentTransport();
     const { ref, cap } = await agentWithPendingToolCall(transport);
     const streamsBefore = transport.streams.length;
@@ -1501,6 +2342,6 @@ describe('agent — client tool results settled after a thread switch', () => {
     };
     expect(payload.messages).toHaveLength(1);
     expect(payload.messages[0]).toMatchObject({ type: 'human' });
-    expect(cap.drainToolMessages()).toEqual([]);
+    expect(cap.snapshotToolMessages().messages).toEqual([]);
   });
 });

--- a/libs/langgraph/src/lib/agent.fn.ts
+++ b/libs/langgraph/src/lib/agent.fn.ts
@@ -72,7 +72,7 @@ import {
   mergeClientTools,
   mergeStagedToolMessages,
 } from './client-tools';
-import type { ClientToolResultPatch } from './client-tools';
+import type { ClientToolResultPatch, StagedToolMessageBatch } from './client-tools';
 
 /**
  * Walk LangGraph history (newest-first) and pair each AIMessage id with
@@ -198,6 +198,7 @@ export function agent<
   // seam lives here. A holder keeps the binding itself a `const` while its
   // member is filled in later.
   const clientToolStaging: { clear?: () => void } = {};
+  let retryableToolMessageBatch: StagedToolMessageBatch | undefined;
 
   function resetDerivedThreadState(): void {
     status$.next(ResourceStatus.Idle);
@@ -437,11 +438,15 @@ export function agent<
   // updateState() silently no-ops when the transport has no updateState, so
   // only supply a persist function when the effective transport supports it —
   // an omitted transport means the bridge builds a FetchStreamTransport, which
-  // does. When persistFn is undefined, a non-empty flush() rejects and keeps the
-  // buffer staged; the submit wrapper below can still drain it into the next run.
+  // does. When persistFn is undefined, a non-empty flush() rejects while the
+  // results stay staged; an ordinary non-null submit remains their in-memory
+  // fallback path.
   const canPersistToolMessages = !transport || typeof transport.updateState === 'function';
   const clientToolsCap = createClientToolsCapability(
-    (payload, opts) => manager.submit(payload, opts),
+    (payload, opts, batch) => {
+      retryableToolMessageBatch = batch;
+      return manager.submit(payload, opts);
+    },
     {
       toolCalls: toolCallsNeutral,
       isLoading,
@@ -464,7 +469,16 @@ export function agent<
     // can never land on a thread the user has since moved to.
     () => manager.currentThreadId,
   );
-  clientToolStaging.clear = () => clientToolsCap.clearStagedToolMessages();
+  clientToolStaging.clear = () => {
+    retryableToolMessageBatch = undefined;
+    clientToolsCap.clearStagedToolMessages();
+  };
+
+  async function resubmitWithToolRecovery(): Promise<void> {
+    const batch = retryableToolMessageBatch;
+    const outcome = await manager.resubmitLast();
+    if (outcome === 'success') batch?.acknowledge();
+  }
 
   return {
     // ── Runtime-neutral surface (AgentWithHistory) ────────────────────────
@@ -479,7 +493,7 @@ export function agent<
     events$,
     history:            historyNeutral,
     messageCheckpoints: messageCheckpointsSig,
-    submit: (input: AgentSubmitInput | null | undefined, opts?: AgentSubmitOptions & LangGraphSubmitOptions) => {
+    submit: async (input: AgentSubmitInput | null | undefined, opts?: AgentSubmitOptions & LangGraphSubmitOptions) => {
       // Lifecycle: first submit with no existing threadId → thread create.
       if (lcThreadCreatedAt() === null && lastThreadId == null) {
         lcThreadCreatedAt.set(Date.now());
@@ -493,25 +507,33 @@ export function agent<
       // backend middleware can merge them into the model's tool list. Null
       // payloads (regenerate re-runs, command resumes) are left unchanged.
       //
-      // Drain any results settled but not yet made durable (flush unavailable
-      // or a prior flush failed) so they ride along with this run. A null
-      // payload cannot carry them, so leave the buffer alone in that case
-      // rather than silently discarding the staged results.
-      const staged = request.payload === null || request.payload === undefined
-        ? []
-        : clientToolsCap.drainToolMessages();
+      // Snapshot results settled but not yet durable (flush unavailable or a
+      // prior flush failed) so they ride along without being forgotten. The
+      // exact snapshot is acknowledged only when this operation succeeds;
+      // overlaps may safely carry the same deterministic message IDs. A null
+      // payload cannot carry results, so it leaves staging unchanged.
+      const batch = request.payload === null || request.payload === undefined
+        ? undefined
+        : clientToolsCap.snapshotToolMessages();
+      const staged = batch?.messages ?? [];
       const withStaged = staged.length > 0
         ? mergeStagedToolMessages(request.payload, staged)
         : request.payload;
       const payload = mergeClientTools(withStaged, clientToolsCap.catalog());
-      return manager.submit(payload, request.options);
+      const createsQueuedRun =
+        request.options?.multitaskStrategy === 'enqueue' && isLoading();
+      if (!createsQueuedRun) {
+        retryableToolMessageBatch = batch;
+      }
+      const outcome = await manager.submit(payload, request.options);
+      if (outcome === 'success') batch?.acknowledge();
     },
     stop: () => manager.stop(),
 
     retry: async () => {
       if (isLoading()) return;          // no-op while a run is in flight
       error$.next(undefined);           // clear the error before re-running
-      await manager.resubmitLast();
+      await resubmitWithToolRecovery();
     },
 
     clientTools: clientToolsCap,
@@ -579,6 +601,7 @@ export function agent<
       // at `__start__`, this resumes at the entry node and produces a fresh
       // assistant message — the trailing user message becomes the active
       // prompt without being re-appended.
+      retryableToolMessageBatch = undefined;
       await manager.submit(null, undefined);
     },
 
@@ -592,7 +615,9 @@ export function agent<
     // ── Other LangGraph-specific fields ──────────────────────────────────
     value:           value as Signal<T>,
     hasValue:        hasValueSig,
-    reload:          () => manager.resubmitLast(),
+    reload:          () => {
+      void resubmitWithToolRecovery();
+    },
     toolProgress:    toolProgSig,
     queue:           queueSig,
     activeSubagents,

--- a/libs/langgraph/src/lib/client-tools.spec.ts
+++ b/libs/langgraph/src/lib/client-tools.spec.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 import { describe, it, expect, vi } from 'vitest';
 import { signal } from '@angular/core';
-import type { ToolCall } from '@threadplane/chat';
+import type { CompleteOutcome, ToolCall } from '@threadplane/chat';
 import {
   createClientToolsCapability,
   mergeClientTools,
@@ -10,6 +10,7 @@ import {
 import type {
   ClientToolsStore,
   PersistToolMessagesFn,
+  StagedToolMessageBatch,
   SubmitFn,
 } from './client-tools';
 
@@ -39,13 +40,16 @@ function makeStore(overrides?: {
   };
 }
 
-/** Build a submit spy that resolves immediately. */
-function makeSubmitFn(): SubmitFn & { calls: Array<{ payload: unknown }> } {
-  const calls: Array<{ payload: unknown }> = [];
-  const fn = vi.fn(async (payload: unknown) => {
-    calls.push({ payload });
-  }) as unknown as SubmitFn & { calls: Array<{ payload: unknown }> };
-  (fn as unknown as { calls: Array<{ payload: unknown }> }).calls = calls;
+/** Build a submit spy that records the continuation batch and succeeds by default. */
+function makeSubmitFn(
+  outcome: CompleteOutcome = 'success',
+): SubmitFn & { calls: Array<{ payload: unknown; batch?: StagedToolMessageBatch }> } {
+  const calls: Array<{ payload: unknown; batch?: StagedToolMessageBatch }> = [];
+  const fn = vi.fn(async (payload: unknown, _opts: unknown, batch?: StagedToolMessageBatch) => {
+    calls.push({ payload, batch });
+    return outcome;
+  }) as unknown as SubmitFn & { calls: Array<{ payload: unknown; batch?: StagedToolMessageBatch }> };
+  (fn as unknown as { calls: Array<{ payload: unknown; batch?: StagedToolMessageBatch }> }).calls = calls;
   return fn;
 }
 
@@ -393,208 +397,322 @@ describe('createClientToolsCapability', () => {
   });
 });
 
-// ─── flush — durable write without continuing the run ────────────────────────
+// ─── staged client-tool messages ────────────────────────────────────────────
 
-describe('flush', () => {
+describe('staged client-tool messages', () => {
   const spec = { name: 'get_weather', description: 'w', parameters: {} };
 
-  function setup(persist?: (m: readonly unknown[]) => Promise<void>) {
-    const submitFn = vi.fn(async () => undefined);
+  function setup(
+    persist?: PersistToolMessagesFn,
+    currentThreadIdFn?: () => string | null,
+    submitFn: SubmitFn = makeSubmitFn(),
+  ) {
     const store = {
       toolCalls: signal([] as readonly ToolCall[]),
       isLoading: signal(false),
       applyClientResult: () => undefined,
     };
-    const cap = createClientToolsCapability(
-      submitFn as unknown as SubmitFn,
-      store,
-      persist as unknown as PersistToolMessagesFn | undefined,
-    );
+    const cap = createClientToolsCapability(submitFn, store, persist, currentThreadIdFn);
     cap.setCatalog([spec]);
     return { cap, submitFn };
   }
 
-  it('writes all buffered messages in a single persist call', async () => {
-    const persist = vi.fn(async () => undefined);
-    const { cap, submitFn } = setup(persist);
-
+  it('gives every settled ToolMessage a stable deterministic id', () => {
+    const { cap } = setup();
     cap.settle?.('t1', { ok: true, value: 'a' });
-    cap.settle?.('t2', { ok: true, value: 'b' });
-    await cap.flush?.();
-
-    expect(persist).toHaveBeenCalledTimes(1);
-    expect((persist as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0]).toEqual([
-      { type: 'tool', role: 'tool', tool_call_id: 't1', content: 'a' },
-      { type: 'tool', role: 'tool', tool_call_id: 't2', content: 'b' },
+    expect(cap.snapshotToolMessages().messages).toEqual([
+      { id: 'client-tool-result-t1', type: 'tool', role: 'tool', tool_call_id: 't1', content: 'a' },
     ]);
-    expect(submitFn).not.toHaveBeenCalled();
   });
 
-  it('makes no call when the buffer is empty', async () => {
-    const persist = vi.fn(async () => undefined);
-    const { cap } = setup(persist);
-    await cap.flush?.();
-    expect(persist).not.toHaveBeenCalled();
+  it('returns repeated snapshots without draining', () => {
+    const { cap } = setup();
+    cap.settle?.('t1', { ok: true, value: 'a' });
+    expect(cap.snapshotToolMessages().messages).toEqual(cap.snapshotToolMessages().messages);
   });
 
-  it('resolves without persistence when the buffer is empty', async () => {
-    const { cap } = setup(undefined);
+  it('acknowledges only the entries captured by its snapshot', () => {
+    const { cap } = setup();
+    cap.settle?.('t1', { ok: true, value: 'a' });
+    const batch = cap.snapshotToolMessages();
+    cap.settle?.('t2', { ok: true, value: 'b' });
+    batch.acknowledge();
+    expect(cap.snapshotToolMessages().messages).toEqual([
+      { id: 'client-tool-result-t2', type: 'tool', role: 'tool', tool_call_id: 't2', content: 'b' },
+    ]);
+  });
 
+  it('does not remove a later same-id settlement when acknowledging an older snapshot', () => {
+    const { cap } = setup();
+    cap.settle?.('t1', { ok: true, value: 'first' });
+    const batch = cap.snapshotToolMessages();
+    cap.settle?.('t1', { ok: true, value: 'second' });
+    batch.acknowledge();
+    expect(cap.snapshotToolMessages().messages).toEqual([
+      { id: 'client-tool-result-t1', type: 'tool', role: 'tool', tool_call_id: 't1', content: 'second' },
+    ]);
+  });
+
+  it('makes a pre-switch acknowledgment a no-op for newly settled messages', () => {
+    let threadId: string | null = 'thread-a';
+    const { cap } = setup(undefined, () => threadId);
+    cap.settle?.('t1', { ok: true, value: 'old' });
+    const batch = cap.snapshotToolMessages();
+    cap.clearStagedToolMessages();
+    threadId = 'thread-b';
+    cap.settle?.('t2', { ok: true, value: 'new' });
+    batch.acknowledge();
+    expect(cap.snapshotToolMessages().messages).toEqual([
+      { id: 'client-tool-result-t2', type: 'tool', role: 'tool', tool_call_id: 't2', content: 'new' },
+    ]);
+  });
+
+  it('clears staged messages on a thread switch', () => {
+    const { cap } = setup();
+    cap.settle?.('t1', { ok: true, value: 'old' });
+    cap.clearStagedToolMessages();
+    expect(cap.snapshotToolMessages().messages).toEqual([]);
+  });
+
+  it('drops only stale entries when taking a snapshot for the current thread', () => {
+    let threadId: string | null = 'thread-a';
+    const { cap } = setup(undefined, () => threadId);
+    cap.settle?.('old', { ok: true, value: 'old' });
+    threadId = 'thread-b';
+    cap.settle?.('new', { ok: true, value: 'new' });
+    expect(cap.snapshotToolMessages().messages.map((message) => message.tool_call_id)).toEqual(['new']);
+  });
+
+  it('flushes an empty snapshot without persistence', async () => {
+    const { cap } = setup();
     await expect(cap.flush?.()).resolves.toBeUndefined();
   });
 
-  it('keeps the buffer when persist fails so a later drain retries', async () => {
-    const persist = vi.fn(async () => { throw new Error('boom'); });
+  it('does not persist an empty snapshot when persistence is available', async () => {
+    const persist = vi.fn(async () => undefined);
     const { cap } = setup(persist);
-
-    cap.settle?.('t1', { ok: true, value: 'a' });
-    await cap.flush?.();
-
-    expect(cap.drainToolMessages()).toEqual([
-      { type: 'tool', role: 'tool', tool_call_id: 't1', content: 'a' },
-    ]);
+    await expect(cap.flush?.()).resolves.toBeUndefined();
+    expect(persist).not.toHaveBeenCalled();
   });
 
-  it('rejects and keeps the buffer when staged results have no persistence function', async () => {
-    const { cap } = setup(undefined);
+  it('rejects a non-empty flush without persistence and retains its messages', async () => {
+    const { cap } = setup();
     cap.settle?.('t1', { ok: true, value: 'a' });
-    cap.settle?.('t2', { ok: true, value: 'b' });
-
     await expect(cap.flush?.()).rejects.toThrow(
       'Custom LangGraph transports using terminal client tools must implement updateState().',
     );
-    expect(cap.drainToolMessages()).toEqual([
-      { type: 'tool', role: 'tool', tool_call_id: 't1', content: 'a' },
-      { type: 'tool', role: 'tool', tool_call_id: 't2', content: 'b' },
-    ]);
+    expect(cap.snapshotToolMessages().messages).toHaveLength(1);
   });
 
-  it('empties the buffer after a successful flush', async () => {
-    const persist = vi.fn(async () => undefined);
+  it('retains messages after a failed flush', async () => {
+    const persist = vi.fn(async () => { throw new Error('boom'); });
     const { cap } = setup(persist);
-
     cap.settle?.('t1', { ok: true, value: 'a' });
     await cap.flush?.();
-
-    // The central invariant: a successful write must NOT leave the result
-    // staged, or the next submit would re-send it and the thread would carry
-    // two ToolMessages for one tool_call_id.
-    expect(cap.drainToolMessages()).toEqual([]);
-  });
-
-  it('drainToolMessages returns the buffer and then empties it', async () => {
-    const { cap } = setup(undefined);
-    cap.settle?.('t1', { ok: true, value: 'a' });
-    // Assert the FIRST drain returns the message: without this the test would
-    // pass against a drainToolMessages that always returns [].
-    expect(cap.drainToolMessages()).toEqual([
-      { type: 'tool', role: 'tool', tool_call_id: 't1', content: 'a' },
+    expect(cap.snapshotToolMessages().messages).toEqual([
+      { id: 'client-tool-result-t1', type: 'tool', role: 'tool', tool_call_id: 't1', content: 'a' },
     ]);
-    expect(cap.drainToolMessages()).toEqual([]);
   });
 
-  // ── concurrency: the buffer has three mutators ──────────────────────────────
-  // flush() takes ownership of its batch at snapshot time. resolve() and
-  // drainToolMessages() clear the buffer unconditionally and know nothing about
-  // an in-flight write, so anything left in the buffer across the await is
-  // fair game for them.
-
-  it('does not drop or duplicate results when resolve and settle interleave with an in-flight flush', async () => {
-    let releasePersist!: () => void;
-    const persist = vi.fn(
-      () => new Promise<void>((resolve) => { releasePersist = resolve; }),
-    );
+  it('persists every already-buffered message in one successful flush', async () => {
+    const persist = vi.fn(async () => undefined);
     const { cap, submitFn } = setup(persist);
-
     cap.settle?.('t1', { ok: true, value: 'a' });
-    const flushed = cap.flush?.();          // batch = [t1]; write in flight
+    cap.settle?.('t2', { ok: true, value: 'b' });
+    await cap.flush?.();
+    expect(persist).toHaveBeenCalledTimes(1);
+    expect(persist.mock.calls[0][0]).toEqual([
+      { id: 'client-tool-result-t1', type: 'tool', role: 'tool', tool_call_id: 't1', content: 'a' },
+      { id: 'client-tool-result-t2', type: 'tool', role: 'tool', tool_call_id: 't2', content: 'b' },
+    ]);
+    expect(submitFn).not.toHaveBeenCalled();
+    expect(cap.snapshotToolMessages().messages).toEqual([]);
+  });
 
-    cap.resolve('t2', { ok: true, value: 'b' });   // submits, then clears buffer
-    cap.settle?.('t3', { ok: true, value: 'c' }); // buffer = [t3]
-
+  it('acknowledges only its successful flush snapshot', async () => {
+    let releasePersist!: () => void;
+    const persist = vi.fn(() => new Promise<void>((resolve) => { releasePersist = resolve; }));
+    const { cap } = setup(persist);
+    cap.settle?.('t1', { ok: true, value: 'a' });
+    const flushed = cap.flush?.();
+    cap.settle?.('t2', { ok: true, value: 'b' });
     releasePersist();
     await flushed;
-
-    // t1 is being written by the flush, so resolve() must not re-send it.
-    const payload = (submitFn as unknown as ReturnType<typeof vi.fn>)
-      .mock.calls[0][0] as { messages: Array<{ tool_call_id: string }> };
-    expect(payload.messages.map((m) => m.tool_call_id)).toEqual(['t2']);
-
-    // t3 was never persisted nor submitted — it must survive for the next drain.
-    expect(cap.drainToolMessages().map((m) => m.tool_call_id)).toEqual(['t3']);
+    expect(cap.snapshotToolMessages().messages.map((message) => message.tool_call_id)).toEqual(['t2']);
   });
 
-  it('persists a batch staged while an earlier flush is still in flight', async () => {
-    // The abort path in startClientToolExecutor flushes once PER settled call,
-    // so two adjacent flushes are routine. The second must not be swallowed by
-    // the in-flight guard — its batch was staged after the first took its
-    // snapshot, so returning the first promise would leave it unwritten.
-    const releases: Array<() => void> = [];
-    const persist = vi.fn(
-      () => new Promise<void>((resolve) => { releases.push(resolve); }),
-    );
+  it('chains flushes so a later settlement is persisted', async () => {
+    let persistCall = 0;
+    let releaseFirst!: () => void;
+    const persist = vi.fn(() => {
+      persistCall += 1;
+      if (persistCall === 1) {
+        return new Promise<void>((resolve) => { releaseFirst = resolve; });
+      }
+      return Promise.resolve();
+    });
     const { cap } = setup(persist);
-
     cap.settle?.('t1', { ok: true, value: 'a' });
     const first = cap.flush?.();
     cap.settle?.('t2', { ok: true, value: 'b' });
     const second = cap.flush?.();
-
-    releases[0]();
-    for (let i = 0; i < 50 && releases.length < 2; i++) await Promise.resolve();
-    releases[1]?.();
-    await Promise.all([first, second]);
-
-    const persisted = (persist as unknown as ReturnType<typeof vi.fn>).mock.calls
-      .flatMap((call) => (call[0] as Array<{ tool_call_id: string }>)
-        .map((m) => m.tool_call_id));
-    expect(persisted).toEqual(['t1', 't2']);
-    expect(cap.drainToolMessages()).toEqual([]);
+    expect(persist).toHaveBeenCalledTimes(1);
+    expect(releaseFirst).toBeTypeOf('function');
+    releaseFirst();
+    await expect(Promise.all([first, second])).resolves.toEqual([undefined, undefined]);
+    expect(persist).toHaveBeenCalledTimes(2);
+    expect(persist.mock.calls[0][0]).toEqual([
+      { id: 'client-tool-result-t1', type: 'tool', role: 'tool', tool_call_id: 't1', content: 'a' },
+    ]);
+    expect(persist.mock.calls[1][0]).toEqual([
+      { id: 'client-tool-result-t2', type: 'tool', role: 'tool', tool_call_id: 't2', content: 'b' },
+    ]);
   });
 
-  it('coalesces overlapping flush calls into a single persist call', async () => {
-    let releasePersist!: () => void;
-    const persist = vi.fn(
-      () => new Promise<void>((resolve) => { releasePersist = resolve; }),
-    );
+  it('serializes every overlapping flush behind one queue tail', async () => {
+    const releaseGates = Array.from({ length: 4 }, () => {
+      let resolve!: () => void;
+      const promise = new Promise<void>((done) => { resolve = done; });
+      return { promise, resolve };
+    });
+    const persistedIds: string[][] = [];
+    let activePersists = 0;
+    let maxActivePersists = 0;
+    const persist = vi.fn(async (messages: readonly { tool_call_id: string }[]) => {
+      const callIndex = persistedIds.length;
+      persistedIds.push(messages.map((message) => message.tool_call_id));
+      activePersists += 1;
+      maxActivePersists = Math.max(maxActivePersists, activePersists);
+      await releaseGates[callIndex].promise;
+      activePersists -= 1;
+    });
     const { cap } = setup(persist);
+    const flushes: Array<Promise<void> | undefined> = [];
 
+    try {
+      cap.settle?.('t1', { ok: true, value: 'a' });
+      flushes.push(cap.flush?.(), cap.flush?.(), cap.flush?.());
+      await vi.waitFor(
+        () => expect(persist.mock.calls.length).toBeGreaterThanOrEqual(1),
+        { timeout: 1000 },
+      );
+
+      cap.settle?.('t2', { ok: true, value: 'b' });
+      releaseGates[0].resolve();
+      await vi.waitFor(
+        () => expect(persist.mock.calls.length).toBeGreaterThanOrEqual(2),
+        { timeout: 1000 },
+      );
+
+      cap.settle?.('t3', { ok: true, value: 'c' });
+      flushes.push(cap.flush?.());
+      releaseGates[1].resolve();
+      await vi.waitFor(
+        () => expect(persist.mock.calls.length).toBeGreaterThanOrEqual(3),
+        { timeout: 1000 },
+      );
+      await Promise.resolve();
+
+      cap.settle?.('t4', { ok: true, value: 'd' });
+      releaseGates[2].resolve();
+      await vi.waitFor(
+        () => expect(persist.mock.calls.length).toBeGreaterThanOrEqual(4),
+        { timeout: 1000 },
+      );
+      releaseGates[3].resolve();
+      await Promise.all(flushes);
+
+      expect(maxActivePersists).toBe(1);
+      expect(persistedIds).toEqual([['t1'], ['t2'], ['t3'], ['t4']]);
+    } finally {
+      for (const gate of releaseGates) gate.resolve();
+      await Promise.allSettled(flushes);
+    }
+  });
+
+  it('coalesces overlapping flushes for the same snapshot', async () => {
+    let releasePersist!: () => void;
+    const persist = vi.fn(() => new Promise<void>((resolve) => { releasePersist = resolve; }));
+    const { cap } = setup(persist);
     cap.settle?.('t1', { ok: true, value: 'a' });
-    const first  = cap.flush?.();
+    const first = cap.flush?.();
     const second = cap.flush?.();
-
     releasePersist();
     await Promise.all([first, second]);
-
     expect(persist).toHaveBeenCalledTimes(1);
   });
 
-  // ── clearStagedToolMessages — thread switches must not leak ─────────────────
-
-  it('clearStagedToolMessages discards the buffer', () => {
-    const { cap } = setup(undefined);
+  it('allows overlapping flush and resolve to carry the same stable message id', async () => {
+    let releasePersist!: () => void;
+    const persist = vi.fn(() => new Promise<void>((resolve) => { releasePersist = resolve; }));
+    const submitFn = makeSubmitFn();
+    const { cap } = setup(persist, undefined, submitFn);
     cap.settle?.('t1', { ok: true, value: 'a' });
-    cap.clearStagedToolMessages();
-    expect(cap.drainToolMessages()).toEqual([]);
+    const flushed = cap.flush?.();
+    cap.resolve('t2', { ok: true, value: 'b' });
+    releasePersist();
+    await flushed;
+    await Promise.resolve();
+    const persisted = persist.mock.calls[0][0] as Array<{ id: string }>;
+    const continued = ((submitFn as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0] as {
+      messages: Array<{ id: string }>;
+    }).messages;
+    expect(persisted[0].id).toBe('client-tool-result-t1');
+    expect(continued.map((message) => message.id)).toEqual([
+      'client-tool-result-t1',
+      'client-tool-result-t2',
+    ]);
   });
 
-  it('does not re-stage a failed batch that was cleared while in flight', async () => {
-    let rejectPersist!: (err: Error) => void;
+  it('does not retain a failed flush from a cleared generation', async () => {
+    let rejectPersist!: (error: Error) => void;
     const persist = vi.fn(
       () => new Promise<void>((_resolve, reject) => { rejectPersist = reject; }),
     );
     const { cap } = setup(persist);
-
-    cap.settle?.('t1', { ok: true, value: 'a' });
+    cap.settle?.('t1', { ok: true, value: 'old' });
     const flushed = cap.flush?.();
-    // Thread switched away while the write was in flight.
     cap.clearStagedToolMessages();
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     rejectPersist(new Error('boom'));
     await flushed;
+    warning.mockRestore();
+    expect(cap.snapshotToolMessages().messages).toEqual([]);
+  });
 
-    // Re-staging here would prepend the old thread's ToolMessage onto the NEW
-    // thread's next payload, where its tool_call_id matches no AIMessage.
-    expect(cap.drainToolMessages()).toEqual([]);
+  it('acknowledges the exact resolve batch after a successful outcome', async () => {
+    const submitFn = makeSubmitFn();
+    const { cap } = setup(undefined, undefined, submitFn);
+    cap.settle?.('t1', { ok: true, value: 'a' });
+    cap.resolve('t2', { ok: true, value: 'b' });
+    await Promise.resolve();
+    const payload = (submitFn as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0] as {
+      messages: readonly unknown[];
+    };
+    const batch = (submitFn as unknown as ReturnType<typeof vi.fn>).mock.calls[0][2] as StagedToolMessageBatch;
+    expect(batch.messages).toBe(payload.messages);
+    expect(cap.snapshotToolMessages().messages).toEqual([]);
+  });
+
+  it.each<CompleteOutcome>(['error', 'interrupted', 'aborted', 'paused'])(
+    'retains the resolve batch after a %s outcome',
+    async (outcome) => {
+      const { cap } = setup(undefined, undefined, makeSubmitFn(outcome));
+      cap.resolve('t1', { ok: true, value: 'a' });
+      await Promise.resolve();
+      expect(cap.snapshotToolMessages().messages).toHaveLength(1);
+    },
+  );
+
+  it('keeps a settlement made after a successful resolve acknowledgment', async () => {
+    let resolveSubmit!: (outcome: CompleteOutcome) => void;
+    const submitFn = vi.fn(() => new Promise<CompleteOutcome>((resolve) => { resolveSubmit = resolve; })) as SubmitFn;
+    const { cap } = setup(undefined, undefined, submitFn);
+    cap.resolve('t1', { ok: true, value: 'a' });
+    cap.settle?.('t2', { ok: true, value: 'b' });
+    resolveSubmit('success');
+    await Promise.resolve();
+    expect(cap.snapshotToolMessages().messages.map((message) => message.tool_call_id)).toEqual(['t2']);
   });
 });
 
@@ -602,14 +720,14 @@ describe('flush', () => {
 
 describe('mergeStagedToolMessages', () => {
   const staged = [
-    { type: 'tool', role: 'tool', tool_call_id: 't1', content: 'a' },
+    { id: 'client-tool-result-t1', type: 'tool', role: 'tool', tool_call_id: 't1', content: 'a' },
   ] as const;
 
   it('prepends staged messages ahead of the payload messages', () => {
     const out = mergeStagedToolMessages({ messages: [{ type: 'human', content: 'hi' }] }, staged);
     expect(out).toEqual({
       messages: [
-        { type: 'tool', role: 'tool', tool_call_id: 't1', content: 'a' },
+        { id: 'client-tool-result-t1', type: 'tool', role: 'tool', tool_call_id: 't1', content: 'a' },
         { type: 'human', content: 'hi' },
       ],
     });

--- a/libs/langgraph/src/lib/client-tools.ts
+++ b/libs/langgraph/src/lib/client-tools.ts
@@ -3,6 +3,7 @@ import { computed, signal } from '@angular/core';
 import type { Signal } from '@angular/core';
 import {
   selectPendingClientToolCalls,
+  type CompleteOutcome,
   type ClientToolsCapability,
   type ClientToolResult,
   type ClientToolSpec,
@@ -43,7 +44,11 @@ export interface ClientToolsStore {
  * Accepts a payload (input) and optional LangGraph submit options.
  * Corresponds to StreamManagerBridge.submit.
  */
-export type SubmitFn = (payload: unknown, opts?: LangGraphSubmitOptions) => Promise<void>;
+export type SubmitFn = (
+  payload: unknown,
+  opts?: LangGraphSubmitOptions,
+  batch?: StagedToolMessageBatch,
+) => Promise<CompleteOutcome>;
 
 /** Serialize a tool result value to a string for the ToolMessage content. */
 function safeStringify(v: unknown): string {
@@ -72,12 +77,34 @@ export function mergeClientTools(
   return { ...(payload as Record<string, unknown>), client_tools: catalog };
 }
 
-/** Wire shape for a settled client-tool result awaiting durability. */
+/**
+ * Wire shape for a settled client-tool result awaiting durability. `id` is
+ * deterministic for the tool-call ID so overlapping handoffs and retries
+ * update the same logical ToolMessage.
+ */
 export interface BufferedToolMessage {
+  readonly id: string;
   readonly type: 'tool';
   readonly role: 'tool';
   readonly tool_call_id: string;
   readonly content: string;
+}
+
+/**
+ * Non-destructive snapshot of staged messages. Callers acknowledge only after
+ * the exact handoff succeeds; acknowledgment removes only captured entries and
+ * becomes a no-op after a thread-reset generation change.
+ */
+export interface StagedToolMessageBatch {
+  readonly generation: number;
+  readonly messages: readonly BufferedToolMessage[];
+  acknowledge(): void;
+}
+
+export interface LangGraphClientToolsCapability extends ClientToolsCapability {
+  readonly catalog: Signal<readonly ClientToolSpec[]>;
+  snapshotToolMessages(): StagedToolMessageBatch;
+  clearStagedToolMessages(): void;
 }
 
 /** Writes settled tool messages into server thread state without starting a run. */
@@ -130,23 +157,25 @@ export function mergeStagedToolMessages(
  *    The backend ends the run without emitting a ToolMessage result for
  *    client tools, so `result` stays undefined on those entries.
  *  - settle(id, result): marks the call as resolved, writes the local result,
- *    and buffers a ToolMessage without issuing a run.
- *  - flush(): makes the whole buffer durable in ONE persistFn call without
+ *    and stages a ToolMessage with a deterministic ID without issuing a run.
+ *  - flush(): snapshots the whole staged group into ONE persistFn call without
  *    starting a run — the settlement path for tool groups that never continue.
- *    The batch leaves the buffer at snapshot time and is re-staged only if the
- *    write fails. When persistFn is absent, a non-empty flush rejects without
- *    taking ownership of the buffer, retaining it for explicit recovery through
- *    the later-submit drainToolMessages() fallback. A concurrent resolve()/drain
- *    can never re-send an in-flight batch.
- *  - clearStagedToolMessages(): discards the buffer on a thread switch.
+ *    Successful persistence acknowledges the captured entries; failed writes
+ *    retain them. When persistFn is absent, a non-empty flush rejects without
+ *    changing the staged results. Flushes are chained so entries settled after
+ *    one snapshot receive their own write. Concurrent persistence,
+ *    continuation, and ordinary submits may safely carry the same stable IDs.
+ *  - clearStagedToolMessages(): discards staged results on a thread switch and
+ *    advances the generation so late acknowledgments cannot affect new state.
  *  - resolve(id, result): settles the result, then issues a NEW run on the SAME
- *    thread by calling submitFn with the full buffered ToolMessage group:
+ *    thread by calling submitFn with a non-destructive ToolMessage snapshot:
  *      input: {
  *        messages: [{ type: 'tool', role: 'tool', tool_call_id: id, content }],
  *        client_tools: catalog(),
  *      }
- *    The `add_messages` reducer on the Python side appends the ToolMessage
- *    to thread state. Including `client_tools` ensures the model sees the
+ *    The snapshot remains staged unless that continuation reports success.
+ *    LangGraph's `add_messages` reducer reuses each stable message ID on safe
+ *    overlap or replay. Including `client_tools` ensures the model sees the
  *    full tool catalog on the continuation run.
  *
  * Catalog shipping: the catalog is NOT injected by this factory's
@@ -161,17 +190,13 @@ export function createClientToolsCapability(
   store: ClientToolsStore,
   persistFn?: PersistToolMessagesFn,
   currentThreadIdFn?: CurrentThreadIdFn,
-): ClientToolsCapability & {
-  catalog: Signal<readonly ClientToolSpec[]>;
-  drainToolMessages(): BufferedToolMessage[];
-  clearStagedToolMessages(): void;
-} {
+): LangGraphClientToolsCapability {
   const catalog = signal<readonly ClientToolSpec[]>([]);
   const resolvedIds = signal<ReadonlySet<string>>(new Set());
   const toolMessageBuffer: StagedToolMessage[] = [];
   let flushInFlight: Promise<void> | undefined;
-  // Bumped whenever the buffer is discarded, so an in-flight flush can tell
-  // whether its batch still belongs to the current thread.
+  // Bumped whenever a thread reset discards staged state. Every snapshot keeps
+  // its generation, making acknowledgments from the prior thread no-ops.
   let bufferGeneration = 0;
   // Tool calls belonging to threads we have left. A handler still running when
   // the user switches threads settles AFTER the switch, by which point both the
@@ -235,23 +260,32 @@ export function createClientToolsCapability(
     // shape used in buildSubmitUpdate (agent.fn.ts line 732).
     toolMessageBuffer.push({
       threadId: currentThreadIdFn?.() ?? null,
-      message: { type: 'tool', role: 'tool', tool_call_id: id, content },
+      message: {
+        id: `client-tool-result-${id}`,
+        type: 'tool',
+        role: 'tool',
+        tool_call_id: id,
+        content,
+      },
     });
   }
 
   /**
-   * Remove every staged entry, returning only those still valid for the thread
-   * a write would land on right now. An entry is stale when it was stamped with
-   * a different thread — dropped rather than misdelivered.
+   * Returns a non-destructive snapshot of entries still valid for the thread a
+   * write would land on right now. Captured entries remain staged, so
+   * overlapping operations may carry the same deterministic message IDs.
+   * Acknowledgment removes only the exact captured entries while the snapshot
+   * generation is current. An entry stamped for another thread is dropped
+   * rather than misdelivered.
    *
    * A null on either side means "thread not tracked yet" (no threadId option
    * and no run has reported one); those are kept, since there is no evidence of
    * a switch and dropping them would lose results on untracked transports.
    */
-  function takeStagedForCurrentThread(): StagedToolMessage[] {
+  function snapshotToolMessages(): StagedToolMessageBatch {
     const current = currentThreadIdFn?.() ?? null;
-    const taken = toolMessageBuffer.splice(0, toolMessageBuffer.length);
-    return taken.filter((entry) => {
+    for (let index = toolMessageBuffer.length - 1; index >= 0; index -= 1) {
+      const entry = toolMessageBuffer[index];
       const stale =
         entry.threadId !== null && current !== null && entry.threadId !== current;
       if (stale) {
@@ -259,20 +293,36 @@ export function createClientToolsCapability(
           `Discarding a client tool result staged for thread ${entry.threadId}; ` +
             `the active thread is now ${current}.`,
         );
+        toolMessageBuffer.splice(index, 1);
       }
-      return !stale;
-    });
+    }
+
+    const generation = bufferGeneration;
+    const entries = [...toolMessageBuffer];
+    const messages = entries.map(({ message }) => ({ ...message }));
+    let acknowledged = false;
+
+    return {
+      generation,
+      messages,
+      acknowledge(): void {
+        if (acknowledged || generation !== bufferGeneration) return;
+        acknowledged = true;
+        for (const entry of entries) {
+          const index = toolMessageBuffer.indexOf(entry);
+          if (index !== -1) toolMessageBuffer.splice(index, 1);
+        }
+      },
+    };
   }
 
   /**
-   * Persist one batch. Takes ownership of the buffer at snapshot time:
-   * resolve() and drainToolMessages() clear the buffer unconditionally and know
-   * nothing about an in-flight write, so anything left staged across the await
-   * could be re-sent (a duplicate ToolMessage for one tool_call_id) or removed
-   * by the wrong index (dropping a result that was never persisted).
+   * Persist one snapshot. Only that snapshot is acknowledged after persistence
+   * succeeds; failure leaves its exact entries staged for retry or submit.
    */
   function runFlush(): Promise<void> {
-    if (toolMessageBuffer.length === 0) return Promise.resolve();
+    const batch = snapshotToolMessages();
+    if (batch.messages.length === 0) return Promise.resolve();
     if (!persistFn) {
       return Promise.reject(
         new Error(
@@ -281,37 +331,19 @@ export function createClientToolsCapability(
         ),
       );
     }
-    const staged = takeStagedForCurrentThread();
-    if (staged.length === 0) return Promise.resolve();
-
-    const generation = bufferGeneration;
-    const batch = staged.map((entry) => entry.message);
-    const inFlight = persistFn(batch)
+    return persistFn(batch.messages)
+      .then(() => {
+        batch.acknowledge();
+      })
       .catch((err: unknown) => {
-        // Re-stage at the FRONT so ordering is preserved for the next drain —
-        // unless the buffer was cleared meanwhile (thread switch), in which
-        // case these results belong to a thread we have left.
-        if (generation === bufferGeneration) {
-          toolMessageBuffer.unshift(...staged);
-        }
         console.warn(
-          `Client tool flush failed; ${batch.length} result(s) remain staged for the next run.`,
+          `Client tool flush failed; ${batch.messages.length} result(s) remain staged for the next run.`,
           err,
         );
-      })
-      .finally(() => {
-        // Only clear if no later flush has already claimed the slot.
-        if (flushInFlight === inFlight) flushInFlight = undefined;
       });
-    flushInFlight = inFlight;
-    return inFlight;
   }
 
-  const capability: ClientToolsCapability & {
-    catalog: Signal<readonly ClientToolSpec[]>;
-    drainToolMessages(): BufferedToolMessage[];
-    clearStagedToolMessages(): void;
-  } = {
+  const capability: LangGraphClientToolsCapability = {
     catalog,
 
     setCatalog(specs: readonly ClientToolSpec[]): void {
@@ -324,9 +356,8 @@ export function createClientToolsCapability(
       settleResult(id, result);
     },
 
-    /** Remove and return every buffered tool message valid for this thread. */
-    drainToolMessages(): BufferedToolMessage[] {
-      return takeStagedForCurrentThread().map((entry) => entry.message);
+    snapshotToolMessages(): StagedToolMessageBatch {
+      return snapshotToolMessages();
     },
 
     /**
@@ -340,37 +371,45 @@ export function createClientToolsCapability(
       // agent.fn.ts calls this ahead of manager.switchThread for that reason.
       for (const toolCall of store.toolCalls()) retiredToolCallIds.add(toolCall.id);
       toolMessageBuffer.length = 0;
-      // Invalidate any in-flight flush so its failure path cannot re-stage the
-      // old thread's messages into the new thread's buffer.
+      // Invalidate every outstanding snapshot acknowledgment from the old thread.
       bufferGeneration += 1;
     },
 
     flush(): Promise<void> {
-      if (flushInFlight) {
-        // Chain rather than short-circuit. The caller's batch may have been
-        // staged AFTER the in-flight write took its snapshot, so returning that
-        // promise would resolve without ever persisting it — which is exactly
-        // what happens when an abort fires one flush per settled call. The
-        // chain terminates because runFlush() returns immediately once the
-        // buffer is empty.
-        const chained = flushInFlight.then(() => runFlush());
-        flushInFlight = chained;
-        return chained;
-      }
-      return runFlush();
+      // Only this method owns the queue tail. Results settled after an active
+      // snapshot need their own write, and every caller must remain behind all
+      // callers already queued. The chain terminates when a fresh snapshot is
+      // empty.
+      const queued = flushInFlight
+        ? flushInFlight.then(() => runFlush(), () => runFlush())
+        : runFlush();
+      flushInFlight = queued;
+
+      const clearTail = (): void => {
+        if (flushInFlight === queued) flushInFlight = undefined;
+      };
+      // Both handlers return normally, so this bookkeeping branch cannot
+      // create an unhandled rejection when the caller observes `queued`.
+      void queued.then(clearTail, clearTail);
+      return queued;
     },
 
     resolve(id: string, result: ClientToolResult): void {
       settleResult(id, result);
-      // Issue a new run on the same thread. LangGraph's add_messages reducer
-      // appends the ToolMessages to the thread state. `client_tools` is
-      // included so the model sees the full tool catalog on the continuation.
+      // Issue a new run with a non-destructive snapshot. The exact batch is
+      // acknowledged only when that continuation succeeds; failures retain it
+      // for retry. Stable IDs make overlap with flush or submit safe under
+      // LangGraph's add_messages reducer. `client_tools` keeps the full catalog
+      // visible to the continuation.
+      const batch = snapshotToolMessages();
       const toolPayload = {
-        messages: takeStagedForCurrentThread().map((entry) => entry.message),
+        messages: batch.messages,
         client_tools: catalog(),
       };
 
-      void submitFn(toolPayload);
+      void submitFn(toolPayload, undefined, batch).then((outcome) => {
+        if (outcome === 'success') batch.acknowledge();
+      });
     },
   };
 

--- a/libs/langgraph/src/lib/internals/stream-manager.bridge.spec.ts
+++ b/libs/langgraph/src/lib/internals/stream-manager.bridge.spec.ts
@@ -121,7 +121,7 @@ describe('createStreamManagerBridge', () => {
 
       transport.emit([{ type: 'values', values: { answer: 'hello' } }]);
       transport.close();
-      await submitted;
+      expect(await submitted).toBe('success');
 
       expect(bridge.getMessageDelivery('ai-1')).toEqual({
         generation: streaming.generation,
@@ -556,7 +556,9 @@ describe('createStreamManagerBridge', () => {
         destroy$: destroy$.asObservable(),
       });
 
-      await bridge.submit({});
+      const submitted = bridge.submit({});
+
+      expect(await submitted).toBe('paused');
 
       expect(bridge.getMessageDelivery('ai-values-interrupt')).toMatchObject({
         phase: 'complete',
@@ -583,7 +585,7 @@ describe('createStreamManagerBridge', () => {
         messageMetadata: { langgraph_node: 'model' },
       }, { type: 'error', error: new Error('rejected') }]);
       transport.close();
-      await submitted;
+      expect(await submitted).toBe('error');
 
       expect(bridge.getMessageDelivery('ai-error')).toEqual({
         generation: expect.any(String),
@@ -611,7 +613,7 @@ describe('createStreamManagerBridge', () => {
         messageMetadata: { langgraph_node: 'model' },
       }]);
       transport.close();
-      await submitted;
+      expect(await submitted).toBe('interrupted');
 
       expect(bridge.getMessageDelivery('ai-interrupted')).toEqual({
         generation: expect.any(String),
@@ -727,7 +729,7 @@ describe('createStreamManagerBridge', () => {
         destroy$: destroy$.asObservable(),
       });
 
-      void bridge.submit({});
+      const submitted = bridge.submit({});
       transport.emit([{
         type: 'messages',
         messages: [{ id: 'ai-aborted', type: 'ai', content: 'partial' }],
@@ -735,6 +737,9 @@ describe('createStreamManagerBridge', () => {
       }]);
       await new Promise(resolve => setTimeout(resolve, 0));
       await bridge.stop();
+      transport.close();
+
+      expect(await submitted).toBe('aborted');
 
       expect(bridge.getMessageDelivery('ai-aborted')).toEqual({
         generation: expect.any(String),
@@ -815,9 +820,9 @@ describe('createStreamManagerBridge', () => {
         destroy$: destroy$.asObservable(),
       });
 
-      await bridge.submit({ retry: true });
+      expect(await bridge.submit({ retry: true })).toBe('error');
       const first = bridge.getMessageDelivery('ai-retry');
-      await bridge.resubmitLast();
+      expect(await bridge.resubmitLast()).toBe('success');
       const second = bridge.getMessageDelivery('ai-retry');
 
       expect(first).toMatchObject({ phase: 'complete', outcome: 'error' });
@@ -1307,6 +1312,219 @@ describe('createStreamManagerBridge', () => {
         destroy$.next();
       },
     );
+  });
+
+  describe('submit outcomes and retry state', () => {
+    it('returns not-started without a retained non-null payload', async () => {
+      let streamCalls = 0;
+      const transport: AgentTransport = {
+        async *stream() {
+          streamCalls += 1;
+          yield { type: 'values', values: { unexpected: true } };
+        },
+      };
+      const subjects = makeSubjects();
+      const destroy$ = new Subject<void>();
+      const bridge = createStreamManagerBridge({
+        options: { apiUrl: '', assistantId: 'test', transport },
+        subjects,
+        threadId$: of('thread-1'),
+        destroy$: destroy$.asObservable(),
+      });
+
+      expect(await bridge.resubmitLast()).toBe('not-started');
+      expect(streamCalls).toBe(0);
+      destroy$.next();
+    });
+
+    it('clears retry state for immediate null and undefined submissions', async () => {
+      const streamPayloads: unknown[] = [];
+      const transport: AgentTransport = {
+        async *stream(_assistantId, _threadId, payload) {
+          streamPayloads.push(payload);
+          yield { type: 'values', values: { completed: streamPayloads.length } };
+        },
+      };
+      const subjects = makeSubjects();
+      const destroy$ = new Subject<void>();
+      const bridge = createStreamManagerBridge({
+        options: { apiUrl: '', assistantId: 'test', transport },
+        subjects,
+        threadId$: of('thread-1'),
+        destroy$: destroy$.asObservable(),
+      });
+
+      const beforeNull = { run: 'before-null' };
+      expect(await bridge.submit(beforeNull)).toBe('success');
+      expect(await bridge.submit(null)).toBe('success');
+      expect(await bridge.resubmitLast()).toBe('not-started');
+
+      const beforeUndefined = { run: 'before-undefined' };
+      expect(await bridge.submit(beforeUndefined)).toBe('success');
+      expect(await bridge.submit(undefined)).toBe('success');
+      expect(await bridge.resubmitLast()).toBe('not-started');
+      expect(streamPayloads).toEqual([beforeNull, null, beforeUndefined, undefined]);
+      destroy$.next();
+    });
+
+    it('uses stream while idle for enqueue options and returns the stream outcome', async () => {
+      let streamCalls = 0;
+      const transport: AgentTransport = {
+        async *stream() {
+          streamCalls += 1;
+          yield { type: 'error', error: new Error('stream failed') };
+        },
+        async createQueuedRun() {
+          throw new Error('enqueue should not run while idle');
+        },
+      };
+      const subjects = makeSubjects();
+      const destroy$ = new Subject<void>();
+      const bridge = createStreamManagerBridge({
+        options: { apiUrl: '', assistantId: 'test', transport },
+        subjects,
+        threadId$: of('thread-1'),
+        destroy$: destroy$.asObservable(),
+      });
+
+      expect(await bridge.submit({ run: 'idle' }, { multitaskStrategy: 'enqueue' })).toBe('error');
+      expect(streamCalls).toBe(1);
+      expect(subjects.queue$.value.size).toBe(0);
+      destroy$.next();
+    });
+
+    it('returns success for a queued active run without replacing the active retry input', async () => {
+      const calls: Array<{ payload: unknown; options: unknown }> = [];
+      let releaseActive!: () => void;
+      const activeGate = new Promise<void>(resolve => { releaseActive = resolve; });
+      const activePayload = { run: 'active' };
+      const activeOptions = { context: { source: 'active' } };
+      const transport: AgentTransport = {
+        async *stream(_assistantId, _threadId, payload, signal, options) {
+          calls.push({ payload, options });
+          if (calls.length === 1) {
+            const aborted = new Promise<void>(resolve => {
+              if (signal.aborted) resolve();
+              else signal.addEventListener('abort', () => resolve(), { once: true });
+            });
+            await Promise.race([activeGate, aborted]);
+            return;
+          }
+          yield { type: 'values', values: { retried: true } };
+        },
+        async createQueuedRun(_assistantId, threadId, values, _signal, options) {
+          return { id: 'queued-1', threadId, values, options, createdAt: new Date() };
+        },
+      };
+      const subjects = makeSubjects();
+      const destroy$ = new Subject<void>();
+      const bridge = createStreamManagerBridge({
+        options: { apiUrl: '', assistantId: 'test', transport },
+        subjects,
+        threadId$: of('thread-1'),
+        destroy$: destroy$.asObservable(),
+      });
+
+      const active = bridge.submit(activePayload, activeOptions);
+      const queuedOutcome = await bridge.submit(
+        { run: 'queued' },
+        { multitaskStrategy: 'enqueue' },
+      );
+      const resubmitOutcome = await bridge.resubmitLast();
+      releaseActive();
+      const activeOutcome = await active;
+
+      expect(queuedOutcome).toBe('success');
+      expect(resubmitOutcome).toBe('success');
+      expect(activeOutcome).toBe('interrupted');
+      expect(calls).toEqual([
+        { payload: activePayload, options: activeOptions },
+        { payload: activePayload, options: activeOptions },
+      ]);
+      destroy$.next();
+    });
+
+    it('keeps the active retry input when queue creation fails', async () => {
+      const calls: Array<{ payload: unknown; options: unknown }> = [];
+      let releaseActive!: () => void;
+      const activeGate = new Promise<void>(resolve => { releaseActive = resolve; });
+      const activePayload = { run: 'active' };
+      const activeOptions = { context: { source: 'active' } };
+      const transport: AgentTransport = {
+        async *stream(_assistantId, _threadId, payload, signal, options) {
+          calls.push({ payload, options });
+          if (calls.length === 1) {
+            const aborted = new Promise<void>(resolve => {
+              if (signal.aborted) resolve();
+              else signal.addEventListener('abort', () => resolve(), { once: true });
+            });
+            await Promise.race([activeGate, aborted]);
+            return;
+          }
+          yield { type: 'values', values: { retried: true } };
+        },
+        async createQueuedRun() {
+          throw new Error('queue creation failed');
+        },
+      };
+      const subjects = makeSubjects();
+      const destroy$ = new Subject<void>();
+      const bridge = createStreamManagerBridge({
+        options: { apiUrl: '', assistantId: 'test', transport },
+        subjects,
+        threadId$: of('thread-1'),
+        destroy$: destroy$.asObservable(),
+      });
+
+      const active = bridge.submit(activePayload, activeOptions);
+      const queueResult = await bridge.submit(
+        { run: 'queued' },
+        { multitaskStrategy: 'enqueue' },
+      ).then(
+        value => ({ status: 'fulfilled' as const, value }),
+        error => ({ status: 'rejected' as const, error }),
+      );
+      const resubmitOutcome = await bridge.resubmitLast();
+      releaseActive();
+      const activeOutcome = await active;
+
+      expect(queueResult).toMatchObject({
+        status: 'rejected',
+        error: new Error('queue creation failed'),
+      });
+      expect(resubmitOutcome).toBe('success');
+      expect(activeOutcome).toBe('interrupted');
+      expect(calls).toEqual([
+        { payload: activePayload, options: activeOptions },
+        { payload: activePayload, options: activeOptions },
+      ]);
+      destroy$.next();
+    });
+
+    it('clears retry state when switching threads', async () => {
+      let streamCalls = 0;
+      const transport: AgentTransport = {
+        async *stream() {
+          streamCalls += 1;
+          yield { type: 'values', values: { completed: true } };
+        },
+      };
+      const subjects = makeSubjects();
+      const destroy$ = new Subject<void>();
+      const bridge = createStreamManagerBridge({
+        options: { apiUrl: '', assistantId: 'test', transport },
+        subjects,
+        threadId$: of('thread-1'),
+        destroy$: destroy$.asObservable(),
+      });
+
+      expect(await bridge.submit({ run: 'thread-1' })).toBe('success');
+      bridge.switchThread('thread-2');
+
+      expect(await bridge.resubmitLast()).toBe('not-started');
+      expect(streamCalls).toBe(1);
+      destroy$.next();
+    });
   });
 
   it('sets status to Loading when submit is called', async () => {
@@ -1830,7 +2048,7 @@ describe('createStreamManagerBridge', () => {
     expect(subjects.status$.value).toBe(ResourceStatus.Loading);
 
     releaseReplacement();
-    await replacement;
+    expect(await replacement).toBe('success');
     await initial;
     expect(joinedRuns).toEqual(['queued-1', 'queued-2']);
     destroy$.next();
@@ -2268,7 +2486,7 @@ describe('createStreamManagerBridge', () => {
       const newStreaming = bridge.getMessageDelivery('new-ai');
 
       releaseOld();
-      await first;
+      expect(await first).toBe('interrupted');
 
       expect(subjects.messages$.value).toEqual([
         expect.objectContaining({ id: 'new-ai', content: 'new' }),

--- a/libs/langgraph/src/lib/internals/stream-manager.bridge.ts
+++ b/libs/langgraph/src/lib/internals/stream-manager.bridge.ts
@@ -90,12 +90,14 @@ export interface StreamManagerBridgeOptions<T, ResolvedBag extends BagTemplate =
   destroy$:  Observable<void>;
 }
 
+type ResubmitOutcome = CompleteOutcome | 'not-started';
+
 export interface StreamManagerBridge {
-  submit:                (values: unknown, opts?: LangGraphSubmitOptions) => Promise<void>;
+  submit:                (values: unknown, opts?: LangGraphSubmitOptions) => Promise<CompleteOutcome>;
   stop:                  () => Promise<void>;
   switchThread:          (id: string | null) => void;
   joinStream:            (runId: string, lastEventId?: string) => Promise<void>;
-  resubmitLast:          () => Promise<void>;
+  resubmitLast:          () => Promise<ResubmitOutcome>;
   getReasoningDurationMs:(id: string) => number | undefined;
   getMessageDelivery:    (id: string) => MessageDelivery;
   getSubagentMessageDelivery: (toolCallId: string, message: BaseMessage) => MessageDelivery;
@@ -358,6 +360,8 @@ export function createStreamManagerBridge<T, ResolvedBag extends BagTemplate = B
     if (resetState) {
       invalidateQueueDrain();
       abortController?.abort();
+      lastPayload = null;
+      lastOptions = undefined;
     }
     currentThreadId = id;
     if (resetState) {
@@ -622,7 +626,7 @@ export function createStreamManagerBridge<T, ResolvedBag extends BagTemplate = B
     payload: unknown,
     opts?: LangGraphSubmitOptions,
     requestType = 'submit',
-  ): Promise<void> {
+  ): Promise<CompleteOutcome> {
     invalidateQueueDrain();
     abortController?.abort();
     const controller = new AbortController();
@@ -640,7 +644,7 @@ export function createStreamManagerBridge<T, ResolvedBag extends BagTemplate = B
     subjects.toolProgress$.next([]);
     toolProgressMap.clear();
     canonicalMessageIds.clear();
-    lastPayload = payload;
+    lastPayload = payload ?? null;
     lastOptions = opts;
 
     // Tracks whether at least one stream event has been processed this run.
@@ -681,9 +685,9 @@ export function createStreamManagerBridge<T, ResolvedBag extends BagTemplate = B
         processEvent(event);
       }
 
-      if (!isCurrentExecution(controller, attempt)) return;
+      if (!isCurrentExecution(controller, attempt)) return finishOutcome(attempt);
       const outcome = await finalizeClosedAttempt(controller, attempt);
-      if (outcome === null) return;
+      if (outcome === null) return finishOutcome(attempt);
 
       if (!controller.signal.aborted) {
         if (outcome !== 'error') {
@@ -695,9 +699,10 @@ export function createStreamManagerBridge<T, ResolvedBag extends BagTemplate = B
           durationMs: Date.now() - startedAt,
         });
       }
+      return outcome;
     } catch (err) {
-      if (!isCurrentExecution(controller, attempt)) return;
-      if (attempt.terminalOutcome) return;
+      if (!isCurrentExecution(controller, attempt)) return finishOutcome(attempt);
+      if (attempt.terminalOutcome) return attempt.terminalOutcome;
       if (isAbortError(err) && userAbortedControllers.has(controller)) {
         finalizeAttempt(attempt, 'aborted');
         // User explicitly called stop() — treat as graceful idle, not an error.
@@ -727,6 +732,7 @@ export function createStreamManagerBridge<T, ResolvedBag extends BagTemplate = B
           errorClass: agentRuntimeTelemetryErrorClass(err),
         });
       }
+      return finishOutcome(attempt);
     } finally {
       if (abortController === controller) abortController = null;
     }
@@ -1061,9 +1067,9 @@ export function createStreamManagerBridge<T, ResolvedBag extends BagTemplate = B
     submit: async (payload, opts) => {
       if (opts?.multitaskStrategy === 'enqueue' && subjects.status$.value === ResourceStatus.Loading) {
         await enqueueRun(payload, opts);
-        return;
+        return 'success';
       }
-      await runStream(payload, opts);
+      return runStream(payload, opts);
     },
 
     stop: async () => {
@@ -1146,9 +1152,8 @@ export function createStreamManagerBridge<T, ResolvedBag extends BagTemplate = B
     },
 
     resubmitLast: async () => {
-      if (lastPayload !== null) {
-        await runStream(lastPayload, lastOptions, 'resubmit');
-      }
+      if (lastPayload === null) return 'not-started';
+      return runStream(lastPayload, lastOptions, 'resubmit');
     },
 
     getReasoningDurationMs: (id: string): number | undefined => {


### PR DESCRIPTION
## Summary

- Retain staged client tool results until the exact submit or state update succeeds.
- Preserve deterministic message IDs and exact batch ownership across retries, queued runs, overlapping flushes, and thread switches.
- Document the LangGraph ownership rules and their relationship to the in-repo AG-UI adapter.

## Why

Failed or interrupted runs could consume staged tool results before the server had durably accepted them. Retries could then omit those results or associate them with the wrong run. Flush chaining also needed a single queue tail so multiple overlapping callers could never persist concurrently.

## Validation

- `npx nx test langgraph --skip-nx-cache`
- `npx nx lint langgraph --skip-nx-cache`
- `npx nx run langgraph:type-tests --skip-nx-cache`
- `npx nx build langgraph --skip-nx-cache`
- `npx nx build website --skip-nx-cache`
- `git diff --check`