### PR TITLE
fix(ci): never promote a superseded commit to production

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -583,6 +583,27 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+      # Pushes to main do not cancel in-progress runs, so a slower older run can
+      # reach this job after a newer commit has already been promoted. Building
+      # --prod from this run's (older) checkout would then overwrite production
+      # with stale content. Seen 2026-08-14: the run for #813 promoted at 04:37
+      # and silently un-published two blog posts that #814 had shipped at 04:13.
+      - name: Check this commit is still the tip of main
+        id: freshness
+        run: |
+          # ls-remote, not fetch: a --depth fetch would mark this clone shallow
+          # and break the full-history --affected checks later in the job.
+          tip="$(git ls-remote origin refs/heads/main | cut -f1)"
+          if [ -z "$tip" ]; then
+            echo "::error::Could not resolve the tip of main; refusing to guess whether this deploy is current."
+            exit 1
+          fi
+          if [ "$tip" != "${{ github.sha }}" ]; then
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::main has advanced to ${tip} since this run started (${{ github.sha }}); skipping production promotion so the newer commit's deploy stands."
+          else
+            echo "stale=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Detect deploy-relevant changes
         id: deploy_preflight
         run: |
@@ -682,7 +703,7 @@ jobs:
           echo "website=$website_changed" >> "$GITHUB_OUTPUT"
           echo "cockpit=$cockpit_changed" >> "$GITHUB_OUTPUT"
       - name: Cache Playwright browsers
-        if: steps.affected.outputs.website == 'true'
+        if: steps.freshness.outputs.stale != 'true' && steps.affected.outputs.website == 'true'
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cache/ms-playwright
@@ -690,10 +711,10 @@ jobs:
           restore-keys: |
             playwright-${{ runner.os }}-
       - name: Install Playwright browsers
-        if: steps.affected.outputs.website == 'true'
+        if: steps.freshness.outputs.stale != 'true' && steps.affected.outputs.website == 'true'
         run: npx playwright install --with-deps chromium
       - name: Prepare website Vercel project
-        if: steps.affected.outputs.website == 'true'
+        if: steps.freshness.outputs.stale != 'true' && steps.affected.outputs.website == 'true'
         run: |
           mkdir -p .vercel
           cat > .vercel/project.json <<EOF
@@ -702,19 +723,19 @@ jobs:
           npx vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
           rm -rf .vercel/output
       - name: Build and deploy website to Vercel (production)
-        if: steps.affected.outputs.website == 'true'
+        if: steps.freshness.outputs.stale != 'true' && steps.affected.outputs.website == 'true'
         id: deploy_website
         run: |
           npx vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
           url=$(npx vercel deploy --prebuilt --archive=tgz --prod --yes --token=${{ secrets.VERCEL_TOKEN }} | tail -n 1)
           echo "deployment_url=$url" >> "$GITHUB_OUTPUT"
       - name: Verify deployed website
-        if: steps.affected.outputs.website == 'true'
+        if: steps.freshness.outputs.stale != 'true' && steps.affected.outputs.website == 'true'
         run: npx nx e2e website --skip-nx-cache
         env:
           BASE_URL: https://threadplane.ai
       - name: Prepare cockpit Vercel project
-        if: steps.affected.outputs.cockpit == 'true'
+        if: steps.freshness.outputs.stale != 'true' && steps.affected.outputs.cockpit == 'true'
         run: |
           mkdir -p .vercel
           cat > .vercel/project.json <<EOF
@@ -723,22 +744,22 @@ jobs:
           npx vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
           rm -rf .vercel/output
       - name: Build and deploy cockpit to Vercel (production)
-        if: steps.affected.outputs.cockpit == 'true'
+        if: steps.freshness.outputs.stale != 'true' && steps.affected.outputs.cockpit == 'true'
         id: deploy_cockpit
         run: |
           npx vercel build --prod --local-config vercel.cockpit.json --token=${{ secrets.VERCEL_TOKEN }}
           url=$(npx vercel deploy --prebuilt --archive=tgz --prod --yes --token=${{ secrets.VERCEL_TOKEN }} | tail -n 1)
           echo "deployment_url=$url" >> "$GITHUB_OUTPUT"
       - name: Verify deployed cockpit
-        if: steps.affected.outputs.cockpit == 'true'
+        if: steps.freshness.outputs.stale != 'true' && steps.affected.outputs.cockpit == 'true'
         run: |
           npx tsx apps/cockpit/scripts/deploy-smoke.ts --url https://cockpit.threadplane.ai --retries 20 --retry-delay-ms 5000
 
       - name: Build and assemble Angular examples
-        if: steps.examples_changed.outputs.changed == 'true'
+        if: steps.freshness.outputs.stale != 'true' && steps.examples_changed.outputs.changed == 'true'
         run: npx tsx scripts/assemble-examples.ts
       - name: Deploy Angular examples to Vercel (production)
-        if: steps.examples_changed.outputs.changed == 'true'
+        if: steps.freshness.outputs.stale != 'true' && steps.examples_changed.outputs.changed == 'true'
         working-directory: deploy/examples
         run: |
           mkdir -p .vercel
@@ -770,8 +791,28 @@ jobs:
         with:
           node-version: 22
           cache: npm
+      # Same staleness guard as the deploy job: a slower older run must not
+      # promote its (older) build over a newer commit's demo deployment.
+      - name: Check this commit is still the tip of main
+        id: freshness
+        run: |
+          # ls-remote, not fetch: a --depth fetch would mark this clone shallow
+          # and break the full-history --affected checks later in the job.
+          tip="$(git ls-remote origin refs/heads/main | cut -f1)"
+          if [ -z "$tip" ]; then
+            echo "::error::Could not resolve the tip of main; refusing to guess whether this deploy is current."
+            exit 1
+          fi
+          if [ "$tip" != "${{ github.sha }}" ]; then
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::main has advanced to ${tip} since this run started (${{ github.sha }}); skipping the canonical demo promotion."
+          else
+            echo "stale=false" >> "$GITHUB_OUTPUT"
+          fi
       - run: npm ci
+        if: steps.freshness.outputs.stale != 'true'
       - name: Build and assemble canonical demo
+        if: steps.freshness.outputs.stale != 'true'
         env:
           # Baked into the SPA bundle by inject-env at build time (assemble-demo.ts
           # runs `nx build examples-chat-angular`, whose build target dependsOn
@@ -782,6 +823,7 @@ jobs:
           GOOGLE_MAPS_MAP_ID: 86d464ea7d5306034fe2a254
         run: npx tsx scripts/assemble-demo.ts
       - name: Deploy canonical demo to Vercel (production)
+        if: steps.freshness.outputs.stale != 'true'
         working-directory: deploy/demo
         run: |
           mkdir -p .vercel
@@ -791,6 +833,7 @@ jobs:
           npx vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
           npx vercel deploy --prebuilt --prod --yes --token=${{ secrets.VERCEL_TOKEN }}
       - name: Verify canonical demo build stamp
+        if: steps.freshness.outputs.stale != 'true'
         env:
           DEMO_URL: https://demo.threadplane.ai
           EXPECTED_SHA: ${{ github.sha }}
@@ -849,6 +892,23 @@ jobs:
             echo "::error::examples/ag-ui — e2e finished with ${{ needs.examples-ag-ui-e2e.result }}; refusing to deploy the ag-ui demo."
             exit 1
           fi
+      # Same staleness guard as the other production promotions.
+      - name: Check this commit is still the tip of main
+        id: freshness
+        run: |
+          # ls-remote, not fetch: a --depth fetch would mark this clone shallow
+          # and break the full-history --affected checks later in the job.
+          tip="$(git ls-remote origin refs/heads/main | cut -f1)"
+          if [ -z "$tip" ]; then
+            echo "::error::Could not resolve the tip of main; refusing to guess whether this deploy is current."
+            exit 1
+          fi
+          if [ "$tip" != "${{ github.sha }}" ]; then
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::main has advanced to ${tip} since this run started (${{ github.sha }}); skipping the ag-ui demo promotion."
+          else
+            echo "stale=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Check if ag-ui demo changed
         id: ag_ui_changed
         run: |
@@ -870,19 +930,19 @@ jobs:
             echo "::notice::No ag-ui demo files changed; skipping ag-ui demo deploy."
           fi
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        if: steps.ag_ui_changed.outputs.changed == 'true'
+        if: steps.freshness.outputs.stale != 'true' && steps.ag_ui_changed.outputs.changed == 'true'
         with:
           node-version: 22
           cache: npm
       - name: Install uv
-        if: steps.ag_ui_changed.outputs.changed == 'true'
+        if: steps.freshness.outputs.stale != 'true' && steps.ag_ui_changed.outputs.changed == 'true'
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with:
           python-version: '3.12'
-      - if: steps.ag_ui_changed.outputs.changed == 'true'
+      - if: steps.freshness.outputs.stale != 'true' && steps.ag_ui_changed.outputs.changed == 'true'
         run: npm ci
       - name: Build and assemble ag-ui demo
-        if: steps.ag_ui_changed.outputs.changed == 'true'
+        if: steps.freshness.outputs.stale != 'true' && steps.ag_ui_changed.outputs.changed == 'true'
         env:
           # Baked into the SPA bundle by inject-env at build time. Without the
           # key the App-mode map toggle is disabled in prod. The key ships in
@@ -892,7 +952,7 @@ jobs:
           GOOGLE_MAPS_MAP_ID: 86d464ea7d5306034fe2a254
         run: npx tsx scripts/assemble-ag-ui-demo.ts
       - name: Deploy ag-ui demo SPA to Vercel (production)
-        if: steps.ag_ui_changed.outputs.changed == 'true'
+        if: steps.freshness.outputs.stale != 'true' && steps.ag_ui_changed.outputs.changed == 'true'
         run: |
           mkdir -p deploy/ag-ui-demo/.vercel
           cat > deploy/ag-ui-demo/.vercel/project.json <<EOF
@@ -902,7 +962,7 @@ jobs:
           npx vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
           npx vercel deploy --prebuilt --prod --yes --token=${{ secrets.VERCEL_TOKEN }}
       - name: Deploy ag-ui backend to Railway
-        if: steps.ag_ui_changed.outputs.changed == 'true'
+        if: steps.freshness.outputs.stale != 'true' && steps.ag_ui_changed.outputs.changed == 'true'
         working-directory: examples/ag-ui/python
         env:
           RAILWAY_TOKEN: ${{ secrets.AG_UI_DEMO_RAILWAY_TOKEN }}

--- a/scripts/ci-workflow.spec.mjs
+++ b/scripts/ci-workflow.spec.mjs
@@ -15,6 +15,14 @@ describe('CI workflow', () => {
     );
   }
 
+  async function readCanonicalDemoJob() {
+    const workflow = await readWorkflow();
+    return workflow.slice(
+      workflow.indexOf('  demo-deploy:'),
+      workflow.indexOf('  production-smoke:')
+    );
+  }
+
   async function readProductionSmokeJob() {
     const workflow = await readWorkflow();
     return workflow.slice(
@@ -107,6 +115,33 @@ describe('CI workflow', () => {
     assert.match(productionSmokeJob, /BASE_URL:\s*https:\/\/cockpit\.threadplane\.ai/);
     assert.match(productionSmokeJob, /EXAMPLES_URL:\s*https:\/\/examples\.threadplane\.ai/);
     assert.match(productionSmokeJob, /DEMO_URL:\s*https:\/\/demo\.threadplane\.ai/);
+  });
+
+  it('guards every production promotion against a superseded commit', async () => {
+    // Pushes to main do not cancel in-progress runs, so a slower older run can
+    // reach a deploy job after a newer commit shipped. Without this guard it
+    // rebuilds --prod from its older checkout and overwrites production.
+    const workflow = await readWorkflow();
+
+    for (const job of [await readDeployJob(), await readCanonicalDemoJob()]) {
+      assert.match(job, /id:\s*freshness/);
+      assert.match(job, /git ls-remote origin refs\/heads\/main/);
+    }
+
+    // Each `vercel deploy --prod` must sit behind the freshness gate.
+    const promotions = workflow
+      .split(/^      - /m)
+      .filter((step) => /vercel deploy[^\n]*--prod/.test(step));
+
+    assert.ok(promotions.length >= 4, `expected the 4 known promotions, found ${promotions.length}`);
+    for (const step of promotions) {
+      const name = step.split('\n')[0];
+      assert.match(
+        step,
+        /if:[^\n]*steps\.freshness\.outputs\.stale\s*!=\s*'true'/,
+        `production promotion is not guarded by the freshness check: ${name}`
+      );
+    }
   });
 
   it('binds Vercel deploys to the renamed Threadplane projects', async () => {


### PR DESCRIPTION
Implements the deploy-job guard for the production overwrite we hit earlier today.

## What happened

`cancel-in-progress` is `true` only for `pull_request`, so pushes to main serialize instead of cancelling. A slower older run can therefore reach its deploy job long after a newer commit has shipped — and it rebuilds `--prod` from **its own older checkout** and promotes that.

Yesterday's sequence:

| Time | Event |
| :--- | :--- |
| 04:13 | Vercel published `77cb0ef7` (#814) — two blog posts live |
| 04:25–04:37 | CI run for the **older** `4d02844b` (#813) built and promoted |
| 04:37 → | Both posts 404 in production |

They stayed broken until the next merge happened to redeploy them. Nothing failed and CI was green throughout, which is the worrying part.

## The guard

Each promoting job now resolves the current tip of main and skips promotion when it no longer matches `github.sha`, logging a `::warning::` so the skip is visible in the run. Setup and change-detection steps still run; only production-touching steps are gated.

**Covers all five promotions:** website, cockpit, Angular examples, canonical demo, and the ag-ui demo. I'd only found four by reading the file — the fifth was caught by the new spec assertion, which is the argument for having it.

Three implementation details worth review:

- **`git ls-remote`, not `git fetch --depth=1`.** A shallow fetch would mark the deploy job's full clone shallow and break the `nx --affected` history checks that run immediately after. This was the one way to get the guard subtly wrong.
- **Fails loudly if the tip can't be resolved.** An empty result must not read as "stale", or a transient network blip would silently stop deploying altogether.
- **The demo build-stamp verification is gated too**, since it asserts the deployed SHA equals this run's SHA and would fail on a legitimate skip.

## Honest limitation

This narrows the race to the build window (~10 min) rather than closing it. A commit landing mid-build can still be overtaken. Closing it fully means serializing promotions or letting Vercel own the alias — a bigger change I didn't want to bundle into a fix.

I also left `cancel-in-progress` alone. Flipping it for main would stop the queue pile-up but can kill a deploy mid-flight; the guard closes the correctness hole without that tradeoff.

## Checks

- `scripts/ci-workflow.spec.mjs`: 11 → **12 tests, all passing**, including a new assertion that every `vercel deploy --prod` sits behind the gate
- `ci-scope` / `cockpit-matrix` / `cockpit-ports` specs: 31 passing
- YAML parses; `actionlint` reports nothing new (its 7 findings are all pre-existing lines)

The guard only executes on pushes to main, so this PR's own CI won't exercise it — it takes effect on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)