### PR TITLE
feat(a2ui): client-side functions (Phase 2 of the v0.9 migration)

### DIFF
--- a/apps/website/content/docs/a2ui/api/api-docs.json
+++ b/apps/website/content/docs/a2ui/api/api-docs.json
@@ -724,6 +724,35 @@
     "examples": []
   },
   {
+    "name": "A2uiFunctionContext",
+    "kind": "interface",
+    "description": "Execution context handed to every function implementation.",
+    "properties": [
+      {
+        "name": "locale",
+        "type": "string",
+        "description": "BCP 47 locale for Intl-based formatting; host default when undefined.",
+        "optional": true
+      }
+    ],
+    "methods": [
+      {
+        "name": "resolveArg",
+        "signature": "resolveArg(value: unknown): unknown",
+        "description": "Resolve a (possibly dynamic) argument value — bare literal, `{ path }`\nbinding, or nested `{ call }` — against the current data model/scope.",
+        "params": [
+          {
+            "name": "value",
+            "type": "unknown",
+            "description": "",
+            "optional": false
+          }
+        ]
+      }
+    ],
+    "examples": []
+  },
+  {
     "name": "A2uiIcon",
     "kind": "interface",
     "description": "",
@@ -1466,6 +1495,20 @@
     "examples": []
   },
   {
+    "name": "A2uiFunctionImpl",
+    "kind": "type",
+    "description": "",
+    "signature": "(args: Record<string, unknown>, ctx: A2uiFunctionContext) => unknown",
+    "examples": []
+  },
+  {
+    "name": "A2uiFunctionRegistry",
+    "kind": "type",
+    "description": "",
+    "signature": "ReadonlyMap<string, A2uiFunctionImpl>",
+    "examples": []
+  },
+  {
     "name": "A2uiMessage",
     "kind": "type",
     "description": "",
@@ -1527,6 +1570,27 @@
     "description": "Wire version stamped on every A2UI v0.9-family envelope.",
     "signature": "\"v0.9\"",
     "examples": []
+  },
+  {
+    "name": "createA2uiFunctionRegistry",
+    "kind": "function",
+    "description": "Creates an A2UI client-side function registry containing the standard\nbasic-catalog functions (`formatString`, `formatNumber`, `formatCurrency`,\n`formatDate`, `pluralize`, `and`, `or`, `not`), optionally extended or\noverridden with custom implementations.",
+    "signature": "createA2uiFunctionRegistry(overrides: Record<string, A2uiFunctionImpl>): A2uiFunctionRegistry",
+    "params": [
+      {
+        "name": "overrides",
+        "type": "Record<string, A2uiFunctionImpl>",
+        "description": "",
+        "optional": true
+      }
+    ],
+    "returns": {
+      "type": "A2uiFunctionRegistry",
+      "description": ""
+    },
+    "examples": [
+      "```ts\nconst registry = createA2uiFunctionRegistry();\nresolveDynamic({ call: 'formatCurrency', args: { value: 42, currency: 'USD' } }, {}, undefined, registry);\n```"
+    ]
   },
   {
     "name": "createA2uiMessageParser",
@@ -1637,8 +1701,8 @@
   {
     "name": "resolveDynamic",
     "kind": "function",
-    "description": "Resolves an A2UI v0.9 dynamic value against a client data model.\n\nBare literals (strings, numbers, booleans) pass through unchanged, `{ path }`\nreferences read from the model by JSON-pointer path, arrays resolve\nelement-wise, and client-side function calls (`{ call }`) resolve to\n`undefined` until function execution ships. Unrecognized plain objects pass\nthrough unchanged.",
-    "signature": "resolveDynamic(value: unknown, model: Record<string, unknown>, scope: A2uiScope): unknown",
+    "description": "Resolves an A2UI v0.9 dynamic value against a client data model.\n\nBare literals (strings, numbers, booleans) pass through unchanged, `{ path }`\nreferences read from the model by JSON-pointer path, arrays resolve\nelement-wise, and client-side function calls (`{ call }`) execute through the\nprovided function registry — argument values resolve recursively, so args may\nthemselves be bindings or nested calls. Without a registry (or for unknown\nfunction names) calls resolve to `undefined`. Unrecognized plain objects pass\nthrough unchanged.",
+    "signature": "resolveDynamic(value: unknown, model: Record<string, unknown>, scope: A2uiScope, registry: A2uiFunctionRegistry): unknown",
     "params": [
       {
         "name": "value",
@@ -1657,6 +1721,12 @@
         "type": "A2uiScope",
         "description": "",
         "optional": true
+      },
+      {
+        "name": "registry",
+        "type": "A2uiFunctionRegistry",
+        "description": "",
+        "optional": true
       }
     ],
     "returns": {
@@ -1664,7 +1734,7 @@
       "description": ""
     },
     "examples": [
-      "```ts\nconst model = { customer: { name: 'Ada' } };\nresolveDynamic({ path: '/customer/name' }, model); // 'Ada'\nresolveDynamic('Checkout', model); // 'Checkout'\n```"
+      "```ts\nconst model = { customer: { name: 'Ada' } };\nresolveDynamic({ path: '/customer/name' }, model); // 'Ada'\nresolveDynamic('Checkout', model); // 'Checkout'\nresolveDynamic(\n  { call: 'formatString', args: { value: 'Hi ${/customer/name}' } },\n  model, undefined, createA2uiFunctionRegistry(),\n); // 'Hi Ada'\n```"
     ]
   },
   {

--- a/apps/website/content/docs/a2ui/getting-started/introduction.mdx
+++ b/apps/website/content/docs/a2ui/getting-started/introduction.mdx
@@ -63,7 +63,7 @@ The parser and resolver are deliberately conservative:
 - unknown envelope keys are ignored (forward compatibility with future protocol versions);
 - missing data-model paths resolve to `undefined`;
 - unrecognized dynamic-value shapes pass through unchanged;
-- `{ call: ... }` function-call values resolve to `undefined` until client-side function execution ships.
+- `{ call: ... }` function-call values execute through the standard function registry when one is passed to `resolveDynamic`; without a registry (or for unknown names) they resolve to `undefined`.
 
 This makes the protocol layer suitable for streaming, but it is not a full schema validator. If you accept untrusted agent output, validate the payload at your boundary before wiring it to privileged handlers.
 

--- a/apps/website/content/docs/a2ui/getting-started/quickstart.mdx
+++ b/apps/website/content/docs/a2ui/getting-started/quickstart.mdx
@@ -103,7 +103,7 @@ resolveDynamic('Search flights', model);         // "Search flights"
 resolveDynamic({ path: '/missing' }, model);     // undefined
 ```
 
-A bare literal (string, number, boolean) passes through unchanged. A `{ path }` reads from the model by JSON pointer. A missing path resolves to `undefined` rather than throwing — same conservative posture as the parser. A `{ call }` function-call value resolves to `undefined` until client-side function execution ships.
+A bare literal (string, number, boolean) passes through unchanged. A `{ path }` reads from the model by JSON pointer. A missing path resolves to `undefined` rather than throwing — same conservative posture as the parser. A `{ call }` function-call value executes through a function registry (`createA2uiFunctionRegistry()`) when one is supplied; without one it resolves to `undefined`.
 
 ## Conclusion
 

--- a/apps/website/content/docs/a2ui/guides/data-model.mdx
+++ b/apps/website/content/docs/a2ui/guides/data-model.mdx
@@ -94,7 +94,7 @@ Nesting is just JSON: `value: { name: 'Ada', address: { city: 'London' } }` writ
 
 1. `null` / `undefined` pass through as-is.
 2. Arrays are mapped recursively — each element resolved in turn.
-3. A `{ call }` function-call value resolves to `undefined` (client-side function execution ships in an upcoming release). Checked before path refs so a call's `args` never masquerade as a binding.
+3. A `{ call }` function-call value executes through the function registry passed to `resolveDynamic` (standard set: `formatString`, `formatNumber`, `formatCurrency`, `formatDate`, `pluralize`, `and`, `or`, `not`); args resolve recursively, so they may be bindings or nested calls. Without a registry, or for unknown names, the value resolves to `undefined`. Checked before path refs so a call's `args` never masquerade as a binding.
 4. A `{ path }` reference reads from the model.
 5. Anything else — a bare string, number, boolean, or plain object — passes through unchanged. Bare values *are* the v0.9 literal form; there are no wrapper objects.
 

--- a/apps/website/content/docs/a2ui/guides/message-protocol.mdx
+++ b/apps/website/content/docs/a2ui/guides/message-protocol.mdx
@@ -54,7 +54,7 @@ A reference is `{"path":"/origin"}` — a JSON pointer into the surface's data m
 {"text":{"path":"/headline"}}
 ```
 
-A function call is `{"call":"formatDate","args":{...}}` — a typed invocation of a client-side catalog function (`formatString`, `formatCurrency`, `required`, ...). Function calls are part of the wire format today; `resolveDynamic` resolves them to `undefined` until function execution ships in an upcoming release.
+A function call is `{"call":"formatDate","args":{...}}` — a typed invocation of a client-side catalog function (`formatString`, `formatCurrency`, `required`, ...). Function calls execute client-side: pass `createA2uiFunctionRegistry()` as the fourth argument to `resolveDynamic` and the standard formatting/logic functions run with recursively-resolved args. Unknown names resolve to `undefined` (with a one-time console warning).
 
 ## What are the four envelopes?
 

--- a/apps/website/content/docs/a2ui/reference/parser-resolver-guards.mdx
+++ b/apps/website/content/docs/a2ui/reference/parser-resolver-guards.mdx
@@ -46,7 +46,7 @@ resolveDynamic(2, model); // 2
 |-------------|--------|
 | bare literal (string, number, boolean) | returned as-is |
 | `{ path }` | the value at that model path |
-| `{ call }` | `undefined` — client-side function execution ships in an upcoming release |
+| `{ call }` | executes via the `A2uiFunctionRegistry` passed as the fourth argument (`createA2uiFunctionRegistry()` provides the standard set); `undefined` without a registry or for unknown names |
 | arrays | recursively resolved array values |
 | `null` or `undefined` | returned as-is |
 | unrecognized plain objects | returned as-is |

--- a/apps/website/content/docs/a2ui/reference/schema.mdx
+++ b/apps/website/content/docs/a2ui/reference/schema.mdx
@@ -34,7 +34,7 @@ type DynamicBoolean = boolean | A2uiPathRef | A2uiFunctionCall;
 type DynamicStringList = string[] | A2uiPathRef | A2uiFunctionCall;
 ```
 
-Absolute paths start with `/` and are resolved from the model root. Relative paths are resolved from an optional `A2uiScope` (used inside children templates). Function calls are typed on the wire today; execution ships in an upcoming release, so `resolveDynamic` returns `undefined` for them.
+Absolute paths start with `/` and are resolved from the model root. Relative paths are resolved from an optional `A2uiScope` (used inside children templates). Function calls execute through an `A2uiFunctionRegistry` (see `createA2uiFunctionRegistry`); `resolveDynamic` returns `undefined` for them only when no registry is supplied or the name is unknown.
 
 ## Children
 

--- a/apps/website/content/docs/chat/a2ui/catalog.mdx
+++ b/apps/website/content/docs/chat/a2ui/catalog.mdx
@@ -431,7 +431,7 @@ Renders an HTML5 `<audio>` element with native controls.
 
 ## Client-Side Functions
 
-The v0.9 basic catalog defines typed client-side functions that can appear in `{ "call": ... }` dynamic values and `checks` rules: validation (`required`, `regex`, `length`, `numeric`, `email`), formatting (`formatString`, `formatNumber`, `formatCurrency`, `formatDate`, `pluralize`), logic (`and`, `or`, `not`), and `openUrl`. Function values are part of the wire format today, but **execution ships in an upcoming release** — `resolveDynamic` currently returns `undefined` for them. The exception is `openUrl` used as a local action, which the surface component's built-in `a2ui:localAction` fallback already handles.
+The v0.9 basic catalog defines typed client-side functions that can appear in `{ "call": ... }` dynamic values and `checks` rules: validation (`required`, `regex`, `length`, `numeric`, `email`), formatting (`formatString`, `formatNumber`, `formatCurrency`, `formatDate`, `pluralize`), logic (`and`, `or`, `not`), and `openUrl`. The formatting and logic functions (`formatString` with `${...}` interpolation, `formatNumber`, `formatCurrency`, `formatDate`, `pluralize`, `and`, `or`, `not`) **execute client-side** via `createA2uiFunctionRegistry()`, which `surfaceToSpec` applies to every dynamic value. `openUrl` runs as a local action through the surface component's built-in `a2ui:localAction` fallback (new tab, `noopener`). The validation functions (`required`, `regex`, `length`, `numeric`, `email`) are typed on the wire but not yet enforced — validation `checks` ship in an upcoming release.
 
 ## Component Summary
 

--- a/apps/website/content/docs/chat/a2ui/overview.mdx
+++ b/apps/website/content/docs/chat/a2ui/overview.mdx
@@ -188,7 +188,7 @@ The surface-to-spec conversion turns this into a render `click` binding that cal
 
 `label` is a Threadplane extension, derived from the Button's child Text; transcripts use it to label the user bubble. If the surface has `sendDataModel: true`, the emitted message also includes `metadata.a2uiClientDataModel` with the current surface data model snapshot.
 
-The other action form, `{ "functionCall": { "call": ..., "args": ... } }`, executes a client-side function locally instead of round-tripping to the agent; function execution ships in an upcoming release.
+The other action form, `{ "functionCall": { "call": ..., "args": ... } }`, executes a client-side function locally instead of round-tripping to the agent — wired to the surface component's `a2ui:localAction` handler, with `openUrl` (new tab, `noopener`) built in.
 
 Catalog components receive resolved props as Angular inputs from the render engine. Bind `(action)` when you want agent-bound events, and bind `(events)` when you want the lower-level render stream.
 

--- a/apps/website/content/docs/chat/a2ui/surface-component.mdx
+++ b/apps/website/content/docs/chat/a2ui/surface-component.mdx
@@ -47,11 +47,11 @@ Before the spec is emitted, each component prop is evaluated against the surface
 
 - A bare literal value — passed through as-is
 - A path reference `{ path: '/some/pointer' }` — kept as a live json-render state binding against `dataModel` (so user input writes back through the render state store)
-- A function call `{ call: ... }` — omitted until client-side function execution ships
+- A function call `{ call: ... }` — executed through the standard function registry (formatString/formatters/logic); unknown functions omit the prop
 
 **3. Map actions to `on` bindings**
 
-The internal conversion maps each component's A2UI `event` action into a render-spec `on` binding on the corresponding element. Actions map to the `a2ui:event` handler, which builds an `A2uiActionMessage` (with the event's `context` resolved against the data model) for the `(action)` output. `functionCall` actions execute client-side and are not wired until function execution ships.
+The internal conversion maps each component's A2UI `event` action into a render-spec `on` binding on the corresponding element. Actions map to the `a2ui:event` handler, which builds an `A2uiActionMessage` (with the event's `context` resolved against the data model) for the `(action)` output. `functionCall` actions map to the built-in `a2ui:localAction` handler — consumer handlers take priority, and `openUrl` opens in a new tab with `noopener` as the built-in fallback.
 
 **4. Expand template children**
 

--- a/docs/superpowers/plans/2026-08-17-a2ui-v09-phase2-functions.md
+++ b/docs/superpowers/plans/2026-08-17-a2ui-v09-phase2-functions.md
@@ -1,0 +1,46 @@
+# A2UI v0.9 Phase 2 — Client-Side Functions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement A2UI v0.9 client-side function execution — `{call, args}` dynamic values resolve through a function registry (formatString/formatNumber/formatCurrency/formatDate/pluralize/and/or/not), and `action.functionCall` buttons execute locally (`openUrl`).
+
+**Architecture:** A pure-TS function registry in `libs/a2ui` (`functions.ts`); `resolveDynamic` gains an optional registry parameter and invokes functions with recursively-resolved args; `surface-to-spec` passes a default registry and wires `functionCall` actions to the existing `a2ui:localAction` handler in `<a2ui-surface>`. Additive, non-breaking. Base: main after PR #817. Authoritative arg shapes: `scratchpad/basic-catalog.json` `functions` map (already verified).
+
+**Tech Stack:** Pure TS + `Intl` (NumberFormat/PluralRules); vitest; no new deps.
+
+---
+
+### Task 1: `libs/a2ui/src/lib/functions.ts` — registry + standard functions
+
+**Files:** Create `libs/a2ui/src/lib/functions.ts`, `functions.spec.ts`. Modify `libs/a2ui/src/index.ts`.
+
+- [ ] Failing spec covering, per official schemas: `formatNumber` (decimals, grouping), `formatCurrency` (currency code, decimals), `formatDate` (TR35 subset: yy yyyy M MM MMM MMMM d dd E EEEE h hh H HH m mm s ss a; ISO-string and epoch input), `pluralize` (Intl.PluralRules categories, `other` fallback), `and`/`or` (values array, min 2)/`not`, `formatString` interpolation: `${/abs/path}`, `${relative}` (scope), nested calls with named args `${formatDate(value:${/d}, format:'yyyy-MM-dd')}`, quoted string args, `\${` escape, unknown function → `undefined` result for the whole value + one-time console.warn.
+- [ ] Implement `A2uiFunctionContext { resolveArg(v: unknown): unknown; locale?: string }`, `A2uiFunctionImpl`, `A2uiFunctionRegistry = ReadonlyMap<string, A2uiFunctionImpl>`, `createA2uiFunctionRegistry(overrides?: Record<string, A2uiFunctionImpl>)`. formatString gets a small recursive expression parser (path | 'quoted' | number | ident(args)); keep it linear (no backtracking regexes — CodeQL).
+- [ ] Export from `index.ts`. Green + commit.
+
+### Task 2: `resolveDynamic` registry integration
+
+**Files:** Modify `libs/a2ui/src/lib/resolve.ts`, `resolve.spec.ts`.
+
+- [ ] Failing spec: `resolveDynamic({call:'formatCurrency',args:{value:{path:'/price'},currency:'USD'}}, {price: 42}, undefined, registry)` → formatted string; `{call}` without registry (or unknown name) → `undefined`; args containing `{path}`/nested `{call}` resolve against the model/scope.
+- [ ] Implement optional 4th param `registry?: A2uiFunctionRegistry`; on `isFunctionCall`, look up impl and invoke with `ctx.resolveArg = (v) => resolveDynamic(v, model, scope, registry)`; missing impl → `undefined` (+ one-time warn per name). Green + commit.
+
+### Task 3: renderer wiring
+
+**Files:** Modify `libs/chat/src/lib/a2ui/surface-to-spec.ts`, `surface-to-spec.spec.ts`, `libs/chat/src/lib/a2ui/surface.component.ts` (openUrl noopener), specs.
+
+- [ ] Failing spec: a Text `text: {call:'formatString', args:{value:'Total: ${/total}'}}` resolves in the spec props; `action: {functionCall:{call:'openUrl',args:{url}}}` produces `on.click = { action: 'a2ui:localAction', params: { call, args } }`; unknown-function props resolve to `undefined` (prop omitted-equivalent).
+- [ ] Implement: module-level `DEFAULT_A2UI_FUNCTIONS = createA2uiFunctionRegistry()`; pass to every `resolveDynamic` call; delete the Phase-1 `isFunctionCall → skip` branches; `resolveAction` handles `functionCall`. In `surface.component.ts`, the existing `a2ui:localAction` openUrl builtin gains `'noopener'` window features. Green + commit.
+
+### Task 4: prompts + docs
+
+**Files:** Modify `examples/chat/python/src/schemas/a2ui_v09.py` + byte-identical ag-ui twin; `apps/website/content/docs/a2ui/reference/parser-resolver-guards.mdx`, `apps/website/content/docs/chat/a2ui/catalog.mdx` (functions section), `libs/a2ui/README.md`; `npm run generate-api-docs`.
+
+- [ ] Schema prompt: functions section advertising the 8 value functions + `functionCall` actions with `openUrl`; examples use named-arg interpolation exactly per spec. Verify twins byte-identical; pytest suites still green.
+- [ ] Docs updated from "typed, execution ships later" to shipped semantics. Commit.
+
+### Task 5: verification + PR
+
+- [ ] `npx nx run-many -t lint test build -p a2ui chat`; both example pytest suites; `npx nx affected -t lint test build`.
+- [ ] Live Chrome smoke: serve examples/chat with real key, prompt for a surface using a formatted value (e.g. "show a card with today's date formatted"), verify function output renders.
+- [ ] PR `feat(a2ui): client-side functions (Phase 2)`; merge on green.

--- a/examples/ag-ui/python/src/schemas/a2ui_v09.py
+++ b/examples/ag-ui/python/src/schemas/a2ui_v09.py
@@ -39,10 +39,30 @@ object keyed by the type name):
 ### Dynamic values
 
 Properties documented as Dynamic (DynamicString / DynamicNumber /
-DynamicBoolean / DynamicStringList) accept either:
+DynamicBoolean / DynamicStringList) accept any of:
 - a bare literal ("Hello", 5, true, ["a", "b"]) — no wrapper objects, OR
 - a data-model binding {"path": "/some/pointer"} (JSON Pointer into the
-  surface's data model).
+  surface's data model), OR
+- a client-side function call {"call": "<fn>", "args": {...}} using one of
+  the catalog functions below. Function args are themselves Dynamic values.
+
+### Client-side functions
+
+Value functions (usable wherever a Dynamic value is accepted):
+- formatString: {"call": "formatString", "args": {"value": "Hi ${/user/name}"}}
+  — interpolates ${...} expressions: JSON-pointer paths (${/abs} or
+  ${relative} inside templates) and nested calls with NAMED args, e.g.
+  ${formatDate(value:${/date}, format:'yyyy-MM-dd')}. Escape a literal with \${.
+- formatNumber: args {value, decimals?, grouping?}
+- formatCurrency: args {value, currency (ISO 4217), decimals?, grouping?}
+- formatDate: args {value (ISO 8601 or epoch ms), format (TR35 pattern, e.g.
+  'yyyy-MM-dd', 'EEEE, MMMM d', 'h:mm a')}
+- pluralize: args {value, one?, other, zero?, two?, few?, many?} — 'other' is
+  the required fallback
+- and / or: args {values: [DynamicBoolean, DynamicBoolean, ...]} ; not: args {value}
+
+Action function (only inside {"functionCall": ...} actions): openUrl with
+args {url} — opens the URL in a new tab.
 
 ### Children
 

--- a/examples/chat/python/src/schemas/a2ui_v09.py
+++ b/examples/chat/python/src/schemas/a2ui_v09.py
@@ -39,10 +39,30 @@ object keyed by the type name):
 ### Dynamic values
 
 Properties documented as Dynamic (DynamicString / DynamicNumber /
-DynamicBoolean / DynamicStringList) accept either:
+DynamicBoolean / DynamicStringList) accept any of:
 - a bare literal ("Hello", 5, true, ["a", "b"]) — no wrapper objects, OR
 - a data-model binding {"path": "/some/pointer"} (JSON Pointer into the
-  surface's data model).
+  surface's data model), OR
+- a client-side function call {"call": "<fn>", "args": {...}} using one of
+  the catalog functions below. Function args are themselves Dynamic values.
+
+### Client-side functions
+
+Value functions (usable wherever a Dynamic value is accepted):
+- formatString: {"call": "formatString", "args": {"value": "Hi ${/user/name}"}}
+  — interpolates ${...} expressions: JSON-pointer paths (${/abs} or
+  ${relative} inside templates) and nested calls with NAMED args, e.g.
+  ${formatDate(value:${/date}, format:'yyyy-MM-dd')}. Escape a literal with \${.
+- formatNumber: args {value, decimals?, grouping?}
+- formatCurrency: args {value, currency (ISO 4217), decimals?, grouping?}
+- formatDate: args {value (ISO 8601 or epoch ms), format (TR35 pattern, e.g.
+  'yyyy-MM-dd', 'EEEE, MMMM d', 'h:mm a')}
+- pluralize: args {value, one?, other, zero?, two?, few?, many?} — 'other' is
+  the required fallback
+- and / or: args {values: [DynamicBoolean, DynamicBoolean, ...]} ; not: args {value}
+
+Action function (only inside {"functionCall": ...} actions): openUrl with
+args {url} — opens the URL in a new tab.
 
 ### Children
 

--- a/libs/a2ui/README.md
+++ b/libs/a2ui/README.md
@@ -101,7 +101,7 @@ const messages = parser.push(chunk); // A2uiMessage[]
 
 - Bare literals (string, number, boolean, string arrays, plain objects) — pass through unchanged.
 - `{ path: string }` — looked up in `model` via JSON pointer. If an `A2uiScope` is provided, relative paths resolve against `scope.basePath` (used inside `children` templates).
-- `{ call: string, args? }` — client-side function calls; typed today, executed in an upcoming release (currently resolve to `undefined`).
+- `{ call: string, args? }` — client-side function calls, executed through the registry passed as the fourth argument (`createA2uiFunctionRegistry()` provides the standard set: `formatString` with `${...}` interpolation, `formatNumber`, `formatCurrency`, `formatDate`, `pluralize`, `and`, `or`, `not`). Args resolve recursively. Without a registry, or for unknown names, calls resolve to `undefined`.
 
 Type guards:
 

--- a/libs/a2ui/src/index.ts
+++ b/libs/a2ui/src/index.ts
@@ -18,4 +18,6 @@ export { createA2uiMessageParser } from './lib/parser.js';
 export type { A2uiMessageParser } from './lib/parser.js';
 export { resolveDynamic } from './lib/resolve.js';
 export type { A2uiScope } from './lib/resolve.js';
+export { createA2uiFunctionRegistry } from './lib/functions.js';
+export type { A2uiFunctionRegistry, A2uiFunctionImpl, A2uiFunctionContext } from './lib/functions.js';
 export { isPathRef, isFunctionCall } from './lib/guards.js';

--- a/libs/a2ui/src/lib/functions.spec.ts
+++ b/libs/a2ui/src/lib/functions.spec.ts
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: MIT
+import { describe, expect, test, vi, afterEach } from 'vitest';
+import { createA2uiFunctionRegistry } from './functions';
+import { resolveDynamic } from './resolve';
+
+const registry = createA2uiFunctionRegistry();
+const model = {
+  price: 1234.5,
+  count: 3,
+  name: 'Ada',
+  date: '2026-08-17T14:30:00',
+  flags: { a: true, b: false },
+};
+
+function run(call: string, args: Record<string, unknown>, m: Record<string, unknown> = model): unknown {
+  return resolveDynamic({ call, args }, m, undefined, registry);
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('formatNumber', () => {
+  test('formats with decimals and grouping', () => {
+    expect(run('formatNumber', { value: { path: '/price' }, decimals: 2, grouping: true }))
+      .toBe(new Intl.NumberFormat(undefined, {
+        minimumFractionDigits: 2, maximumFractionDigits: 2, useGrouping: true,
+      }).format(1234.5));
+  });
+
+  test('grouping off', () => {
+    expect(run('formatNumber', { value: 1234.5, decimals: 0, grouping: false }))
+      .toBe(new Intl.NumberFormat(undefined, {
+        minimumFractionDigits: 0, maximumFractionDigits: 0, useGrouping: false,
+      }).format(1234.5));
+  });
+
+  test('non-numeric value resolves to undefined', () => {
+    expect(run('formatNumber', { value: 'nope' })).toBeUndefined();
+  });
+});
+
+describe('formatCurrency', () => {
+  test('formats with ISO currency code', () => {
+    expect(run('formatCurrency', { value: { path: '/price' }, currency: 'USD' }))
+      .toBe(new Intl.NumberFormat(undefined, { style: 'currency', currency: 'USD' }).format(1234.5));
+  });
+
+  test('honors decimals', () => {
+    expect(run('formatCurrency', { value: 10, currency: 'EUR', decimals: 0 }))
+      .toBe(new Intl.NumberFormat(undefined, {
+        style: 'currency', currency: 'EUR',
+        minimumFractionDigits: 0, maximumFractionDigits: 0,
+      }).format(10));
+  });
+});
+
+describe('formatDate', () => {
+  test('formats ISO string with TR35 pattern', () => {
+    const out = run('formatDate', { value: '2026-08-17T00:00:00', format: 'yyyy-MM-dd' });
+    expect(out).toBe('2026-08-17');
+  });
+
+  test('month and weekday names', () => {
+    const out = run('formatDate', { value: '2026-08-17T00:00:00', format: 'EEEE, MMMM d, yyyy' });
+    expect(out).toBe('Monday, August 17, 2026');
+  });
+
+  test('12h time with meridiem', () => {
+    const out = run('formatDate', { value: '2026-08-17T14:05:09', format: 'h:mm a' });
+    expect(out).toBe('2:05 PM');
+  });
+
+  test('two-digit year and short month', () => {
+    expect(run('formatDate', { value: '2026-01-05T00:00:00', format: 'MMM d, yy' })).toBe('Jan 5, 26');
+  });
+
+  test('epoch millis input', () => {
+    const d = new Date(2026, 0, 2, 0, 0, 0);
+    expect(run('formatDate', { value: d.getTime(), format: 'yyyy' })).toBe('2026');
+  });
+
+  test('unparseable date resolves to undefined', () => {
+    expect(run('formatDate', { value: 'not a date', format: 'yyyy' })).toBeUndefined();
+  });
+});
+
+describe('pluralize', () => {
+  test('one vs other', () => {
+    expect(run('pluralize', { value: 1, one: 'item', other: 'items' })).toBe('item');
+    expect(run('pluralize', { value: { path: '/count' }, one: 'item', other: 'items' })).toBe('items');
+  });
+
+  test('zero category argument wins when provided', () => {
+    expect(run('pluralize', { value: 0, zero: 'nothing', one: 'item', other: 'items' })).toBe('nothing');
+  });
+
+  test('falls back to other', () => {
+    expect(run('pluralize', { value: 5, other: 'things' })).toBe('things');
+  });
+});
+
+describe('logic', () => {
+  test('and', () => {
+    expect(run('and', { values: [true, { path: '/flags/a' }] })).toBe(true);
+    expect(run('and', { values: [true, { path: '/flags/b' }] })).toBe(false);
+  });
+
+  test('or', () => {
+    expect(run('or', { values: [{ path: '/flags/b' }, false] })).toBe(false);
+    expect(run('or', { values: [{ path: '/flags/b' }, true] })).toBe(true);
+  });
+
+  test('not', () => {
+    expect(run('not', { value: { path: '/flags/b' } })).toBe(true);
+  });
+});
+
+describe('formatString interpolation', () => {
+  test('absolute path expression', () => {
+    expect(run('formatString', { value: 'Hello ${/name}!' })).toBe('Hello Ada!');
+  });
+
+  test('relative path resolves against scope', () => {
+    const out = resolveDynamic(
+      { call: 'formatString', args: { value: 'Hi ${name}' } },
+      { items: [{ name: 'Bo' }] },
+      { basePath: '/items/0', item: undefined },
+      registry,
+    );
+    expect(out).toBe('Hi Bo');
+  });
+
+  test('nested function call with named args', () => {
+    const out = run('formatString', {
+      value: "Due ${formatDate(value:${/date}, format:'yyyy-MM-dd')}",
+    });
+    expect(out).toBe('Due 2026-08-17');
+  });
+
+  test('multiple expressions and literal text', () => {
+    expect(run('formatString', { value: '${/name} has ${/count} items' })).toBe('Ada has 3 items');
+  });
+
+  test('escaped \\${ stays literal', () => {
+    expect(run('formatString', { value: 'literal \\${/name}' })).toBe('literal ${/name}');
+  });
+
+  test('unresolvable path interpolates empty', () => {
+    expect(run('formatString', { value: 'x=${/missing}!' })).toBe('x=!');
+  });
+
+  test('quoted string and number args in nested calls', () => {
+    const out = run('formatString', {
+      value: "${pluralize(value:${/count}, one:'thing', other:'things')}",
+    });
+    expect(out).toBe('things');
+  });
+});
+
+describe('registry behavior', () => {
+  test('unknown function resolves to undefined and warns once per name', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    expect(run('mysteryFn', { x: 1 })).toBeUndefined();
+    expect(run('mysteryFn', { x: 2 })).toBeUndefined();
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  test('overrides extend the standard set', () => {
+    const custom = createA2uiFunctionRegistry({
+      shout: (args, ctx) => String(ctx.resolveArg(args['value'])).toUpperCase(),
+    });
+    expect(resolveDynamic({ call: 'shout', args: { value: { path: '/name' } } }, model, undefined, custom))
+      .toBe('ADA');
+  });
+
+  test('function args recurse through nested calls', () => {
+    expect(run('not', { value: { call: 'and', args: { values: [true, true] } } })).toBe(false);
+  });
+});

--- a/libs/a2ui/src/lib/functions.ts
+++ b/libs/a2ui/src/lib/functions.ts
@@ -1,0 +1,368 @@
+// SPDX-License-Identifier: MIT
+// A2UI v0.9 client-side functions (basic catalog `functions` map).
+// Arg shapes follow the official catalog schema at
+// https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json.
+
+/** Execution context handed to every function implementation. */
+export interface A2uiFunctionContext {
+  /** Resolve a (possibly dynamic) argument value — bare literal, `{ path }`
+   * binding, or nested `{ call }` — against the current data model/scope. */
+  resolveArg(value: unknown): unknown;
+  /** BCP 47 locale for Intl-based formatting; host default when undefined. */
+  locale?: string;
+}
+
+export type A2uiFunctionImpl = (
+  args: Record<string, unknown>,
+  ctx: A2uiFunctionContext,
+) => unknown;
+
+export type A2uiFunctionRegistry = ReadonlyMap<string, A2uiFunctionImpl>;
+
+function toNumber(v: unknown): number | undefined {
+  if (typeof v === 'number' && Number.isFinite(v)) return v;
+  if (typeof v === 'string' && v.trim() !== '') {
+    const n = Number(v);
+    if (Number.isFinite(n)) return n;
+  }
+  return undefined;
+}
+
+function toDate(v: unknown): Date | undefined {
+  if (v instanceof Date) return Number.isNaN(v.getTime()) ? undefined : v;
+  if (typeof v === 'number' && Number.isFinite(v)) return new Date(v);
+  if (typeof v === 'string') {
+    const d = new Date(v);
+    return Number.isNaN(d.getTime()) ? undefined : d;
+  }
+  return undefined;
+}
+
+// --- formatDate: Unicode TR35 pattern subset ---
+
+const DATE_TOKENS = [
+  'yyyy', 'yy', 'MMMM', 'MMM', 'MM', 'M', 'dd', 'd', 'EEEE', 'E',
+  'HH', 'H', 'hh', 'h', 'mm', 'm', 'ss', 's', 'a',
+] as const;
+
+function dateToken(token: string, d: Date, locale?: string): string {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  switch (token) {
+    case 'yyyy': return String(d.getFullYear());
+    case 'yy': return pad(d.getFullYear() % 100);
+    case 'MMMM': return new Intl.DateTimeFormat(locale ?? 'en-US', { month: 'long' }).format(d);
+    case 'MMM': return new Intl.DateTimeFormat(locale ?? 'en-US', { month: 'short' }).format(d);
+    case 'MM': return pad(d.getMonth() + 1);
+    case 'M': return String(d.getMonth() + 1);
+    case 'dd': return pad(d.getDate());
+    case 'd': return String(d.getDate());
+    case 'EEEE': return new Intl.DateTimeFormat(locale ?? 'en-US', { weekday: 'long' }).format(d);
+    case 'E': return new Intl.DateTimeFormat(locale ?? 'en-US', { weekday: 'short' }).format(d);
+    case 'HH': return pad(d.getHours());
+    case 'H': return String(d.getHours());
+    case 'hh': return pad(((d.getHours() + 11) % 12) + 1);
+    case 'h': return String(((d.getHours() + 11) % 12) + 1);
+    case 'mm': return pad(d.getMinutes());
+    case 'm': return String(d.getMinutes());
+    case 'ss': return pad(d.getSeconds());
+    case 's': return String(d.getSeconds());
+    case 'a': return d.getHours() < 12 ? 'AM' : 'PM';
+    default: return token;
+  }
+}
+
+function formatDatePattern(d: Date, pattern: string, locale?: string): string {
+  let out = '';
+  let i = 0;
+  while (i < pattern.length) {
+    const token = DATE_TOKENS.find((t) => pattern.startsWith(t, i));
+    if (token) {
+      out += dateToken(token, d, locale);
+      i += token.length;
+    } else {
+      out += pattern[i];
+      i += 1;
+    }
+  }
+  return out;
+}
+
+// --- formatString: `${expression}` interpolation ---
+// Expressions: JSON-pointer paths (absolute `/a/b` or relative `a/b`),
+// nested named-arg function calls `fn(name:value, ...)`, quoted strings,
+// numbers, booleans. `\${` escapes a literal `${`. The scanner is a
+// single-pass state machine — no backtracking regexes (CodeQL ReDoS).
+
+interface ExprEnv {
+  ctx: A2uiFunctionContext;
+  registry: A2uiFunctionRegistry;
+  resolvePath(path: string): unknown;
+}
+
+/** Find the `}` closing the `${` that starts at `start` (index of `$`),
+ * honoring nested `${...}` and single-quoted strings. Returns -1 if
+ * unterminated. */
+function findClosingBrace(s: string, start: number): number {
+  let depth = 0;
+  let i = start;
+  let inQuote = false;
+  while (i < s.length) {
+    const c = s[i];
+    if (inQuote) {
+      if (c === "'") inQuote = false;
+      i += 1;
+      continue;
+    }
+    if (c === "'") { inQuote = true; i += 1; continue; }
+    if (c === '$' && s[i + 1] === '{') { depth += 1; i += 2; continue; }
+    if (c === '}') {
+      depth -= 1;
+      if (depth === 0) return i;
+    }
+    i += 1;
+  }
+  return -1;
+}
+
+/** Split a call's argument list on top-level commas (nesting + quote aware). */
+function splitArgs(s: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let inQuote = false;
+  let cur = '';
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (inQuote) {
+      cur += c;
+      if (c === "'") inQuote = false;
+      continue;
+    }
+    if (c === "'") { inQuote = true; cur += c; continue; }
+    if (c === '(' || c === '{') depth += 1;
+    else if (c === ')' || c === '}') depth -= 1;
+    else if (c === ',' && depth === 0) {
+      parts.push(cur);
+      cur = '';
+      continue;
+    }
+    cur += c;
+  }
+  if (cur.trim().length > 0) parts.push(cur);
+  return parts;
+}
+
+const CALL_HEAD = /^([A-Za-z_][A-Za-z0-9_]*)\(/;
+
+/** Evaluate one expression (the text inside `${...}`). */
+function evalExpr(raw: string, env: ExprEnv): unknown {
+  const s = raw.trim();
+  if (s.length === 0) return undefined;
+  // Quoted string
+  if (s.startsWith("'") && s.endsWith("'") && s.length >= 2) {
+    return s.slice(1, -1);
+  }
+  if (s === 'true') return true;
+  if (s === 'false') return false;
+  const asNumber = toNumber(s);
+  if (asNumber !== undefined && /^-?[\d.]+$/.test(s)) return asNumber;
+  // Nested `${...}` wrapper
+  if (s.startsWith('${') && s.endsWith('}')) {
+    return evalExpr(s.slice(2, -1), env);
+  }
+  // Function call with named args
+  const head = CALL_HEAD.exec(s);
+  if (head && s.endsWith(')')) {
+    const name = head[1];
+    const argsText = s.slice(head[0].length, -1);
+    const args: Record<string, unknown> = {};
+    for (const part of splitArgs(argsText)) {
+      const colon = topLevelColonIndex(part);
+      if (colon === -1) continue;
+      const key = part.slice(0, colon).trim();
+      const valueText = part.slice(colon + 1).trim();
+      if (key) args[key] = evalExpr(valueText, env);
+    }
+    const impl = env.registry.get(name);
+    if (!impl) {
+      warnUnknownFunction(name);
+      return undefined;
+    }
+    // Args are already evaluated to plain values here.
+    return impl(args, { ...env.ctx, resolveArg: (v) => v });
+  }
+  // JSON-pointer path (absolute or relative)
+  return env.resolvePath(s);
+}
+
+/** Index of the first top-level `:` (outside quotes/parens/braces). */
+function topLevelColonIndex(s: string): number {
+  let depth = 0;
+  let inQuote = false;
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (inQuote) {
+      if (c === "'") inQuote = false;
+      continue;
+    }
+    if (c === "'") inQuote = true;
+    else if (c === '(' || c === '{') depth += 1;
+    else if (c === ')' || c === '}') depth -= 1;
+    else if (c === ':' && depth === 0) return i;
+  }
+  return -1;
+}
+
+function interpolate(template: string, env: ExprEnv): string {
+  let out = '';
+  let i = 0;
+  while (i < template.length) {
+    if (template[i] === '\\' && template.startsWith('${', i + 1)) {
+      out += '${';
+      i += 3;
+      continue;
+    }
+    if (template[i] === '$' && template[i + 1] === '{') {
+      const close = findClosingBrace(template, i);
+      if (close === -1) {
+        out += template.slice(i);
+        break;
+      }
+      const value = evalExpr(template.slice(i + 2, close), env);
+      out += value == null ? '' : String(value);
+      i = close + 1;
+      continue;
+    }
+    out += template[i];
+    i += 1;
+  }
+  return out;
+}
+
+// --- Standard function implementations ---
+
+const warnedFunctions = new Set<string>();
+function warnUnknownFunction(name: string): void {
+  if (warnedFunctions.has(name)) return;
+  warnedFunctions.add(name);
+  console.warn(`[a2ui] unknown client-side function "${name}" — resolving to undefined`);
+}
+
+function numberFormatOptions(
+  args: Record<string, unknown>,
+  ctx: A2uiFunctionContext,
+  extra?: Intl.NumberFormatOptions,
+): Intl.NumberFormatOptions {
+  const options: Intl.NumberFormatOptions = { ...extra };
+  const decimals = toNumber(ctx.resolveArg(args['decimals']));
+  if (decimals !== undefined) {
+    options.minimumFractionDigits = decimals;
+    options.maximumFractionDigits = decimals;
+  }
+  const grouping = ctx.resolveArg(args['grouping']);
+  if (typeof grouping === 'boolean') options.useGrouping = grouping;
+  return options;
+}
+
+const STANDARD_FUNCTIONS: Record<string, A2uiFunctionImpl> = {
+  formatString(args, ctx) {
+    const template = ctx.resolveArg(args['value']);
+    if (typeof template !== 'string') return undefined;
+    const env: ExprEnv = {
+      ctx,
+      registry: currentRegistry ?? new Map(),
+      resolvePath: (p) => ctx.resolveArg({ path: p }),
+    };
+    return interpolate(template, env);
+  },
+  formatNumber(args, ctx) {
+    const value = toNumber(ctx.resolveArg(args['value']));
+    if (value === undefined) return undefined;
+    return new Intl.NumberFormat(ctx.locale, numberFormatOptions(args, ctx)).format(value);
+  },
+  formatCurrency(args, ctx) {
+    const value = toNumber(ctx.resolveArg(args['value']));
+    const currency = ctx.resolveArg(args['currency']);
+    if (value === undefined || typeof currency !== 'string' || currency.length === 0) return undefined;
+    try {
+      return new Intl.NumberFormat(
+        ctx.locale,
+        numberFormatOptions(args, ctx, { style: 'currency', currency }),
+      ).format(value);
+    } catch {
+      return undefined;
+    }
+  },
+  formatDate(args, ctx) {
+    const date = toDate(ctx.resolveArg(args['value']));
+    const format = ctx.resolveArg(args['format']);
+    if (!date || typeof format !== 'string') return undefined;
+    return formatDatePattern(date, format, ctx.locale);
+  },
+  pluralize(args, ctx) {
+    const value = toNumber(ctx.resolveArg(args['value']));
+    if (value === undefined) return undefined;
+    const category = new Intl.PluralRules(ctx.locale).select(value);
+    const explicitZero = value === 0 && args['zero'] !== undefined ? 'zero' : undefined;
+    const pick = explicitZero ?? category;
+    const chosen = args[pick] !== undefined ? args[pick] : args['other'];
+    const resolved = ctx.resolveArg(chosen);
+    return resolved === undefined ? undefined : String(resolved);
+  },
+  and(args, ctx) {
+    const values = args['values'];
+    if (!Array.isArray(values)) return undefined;
+    return values.every((v) => ctx.resolveArg(v) === true);
+  },
+  or(args, ctx) {
+    const values = args['values'];
+    if (!Array.isArray(values)) return undefined;
+    return values.some((v) => ctx.resolveArg(v) === true);
+  },
+  not(args, ctx) {
+    return ctx.resolveArg(args['value']) !== true;
+  },
+};
+
+// formatString needs the registry that owns it to evaluate nested calls;
+// tracked per-invocation via resolveDynamic's wiring (see resolve.ts),
+// with a module fallback for direct registry use.
+let currentRegistry: A2uiFunctionRegistry | null = null;
+
+/** @internal Used by resolveDynamic to make nested `${fn(...)}` calls inside
+ * formatString dispatch through the same registry. */
+export function withActiveRegistry<T>(registry: A2uiFunctionRegistry, fn: () => T): T {
+  const prev = currentRegistry;
+  currentRegistry = registry;
+  try {
+    return fn();
+  } finally {
+    currentRegistry = prev;
+  }
+}
+
+/** @internal One-time warning helper shared with resolveDynamic. */
+export function warnUnknownA2uiFunction(name: string): void {
+  warnUnknownFunction(name);
+}
+
+/**
+ * Creates an A2UI client-side function registry containing the standard
+ * basic-catalog functions (`formatString`, `formatNumber`, `formatCurrency`,
+ * `formatDate`, `pluralize`, `and`, `or`, `not`), optionally extended or
+ * overridden with custom implementations.
+ *
+ * @example
+ * ```ts
+ * const registry = createA2uiFunctionRegistry();
+ * resolveDynamic({ call: 'formatCurrency', args: { value: 42, currency: 'USD' } }, {}, undefined, registry);
+ * ```
+ */
+export function createA2uiFunctionRegistry(
+  overrides?: Record<string, A2uiFunctionImpl>,
+): A2uiFunctionRegistry {
+  const map = new Map<string, A2uiFunctionImpl>(Object.entries(STANDARD_FUNCTIONS));
+  if (overrides) {
+    for (const [name, impl] of Object.entries(overrides)) map.set(name, impl);
+  }
+  return map;
+}

--- a/libs/a2ui/src/lib/resolve.ts
+++ b/libs/a2ui/src/lib/resolve.ts
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: MIT
 import { getByPointer } from './pointer.js';
 import { isFunctionCall, isPathRef } from './guards.js';
+import {
+  withActiveRegistry, warnUnknownA2uiFunction,
+  type A2uiFunctionRegistry,
+} from './functions.js';
 
 export interface A2uiScope {
   basePath: string;
@@ -23,8 +27,10 @@ function resolvePathRef(
  *
  * Bare literals (strings, numbers, booleans) pass through unchanged, `{ path }`
  * references read from the model by JSON-pointer path, arrays resolve
- * element-wise, and client-side function calls (`{ call }`) resolve to
- * `undefined` until function execution ships. Unrecognized plain objects pass
+ * element-wise, and client-side function calls (`{ call }`) execute through the
+ * provided function registry — argument values resolve recursively, so args may
+ * themselves be bindings or nested calls. Without a registry (or for unknown
+ * function names) calls resolve to `undefined`. Unrecognized plain objects pass
  * through unchanged.
  *
  * @example
@@ -32,20 +38,37 @@ function resolvePathRef(
  * const model = { customer: { name: 'Ada' } };
  * resolveDynamic({ path: '/customer/name' }, model); // 'Ada'
  * resolveDynamic('Checkout', model); // 'Checkout'
+ * resolveDynamic(
+ *   { call: 'formatString', args: { value: 'Hi ${/customer/name}' } },
+ *   model, undefined, createA2uiFunctionRegistry(),
+ * ); // 'Hi Ada'
  * ```
  */
 export function resolveDynamic(
   value: unknown,
   model: Record<string, unknown>,
   scope?: A2uiScope,
+  registry?: A2uiFunctionRegistry,
 ): unknown {
   if (value == null) return value;
-  if (Array.isArray(value)) return value.map(item => resolveDynamic(item, model, scope));
+  if (Array.isArray(value)) return value.map(item => resolveDynamic(item, model, scope, registry));
 
-  // Client-side function call — execution ships in a later phase. Checked
-  // before path refs so `{ call, args: { path: ... } }`-style args never
-  // masquerade as bindings.
-  if (isFunctionCall(value)) return undefined;
+  // Client-side function call. Checked before path refs so
+  // `{ call, args: { path: ... } }`-style args never masquerade as bindings.
+  if (isFunctionCall(value)) {
+    if (!registry) return undefined;
+    const impl = registry.get(value.call);
+    if (!impl) {
+      warnUnknownA2uiFunction(value.call);
+      return undefined;
+    }
+    const args = (value.args ?? {}) as Record<string, unknown>;
+    return withActiveRegistry(registry, () =>
+      impl(args, {
+        resolveArg: (v) => resolveDynamic(v, model, scope, registry),
+      }),
+    );
+  }
 
   // Path reference
   if (isPathRef(value)) return resolvePathRef(value, model, scope);

--- a/libs/chat/src/lib/a2ui/surface-to-spec.spec.ts
+++ b/libs/chat/src/lib/a2ui/surface-to-spec.spec.ts
@@ -37,9 +37,28 @@ describe('surfaceToSpec (v0.9)', () => {
     expect(spec.state).toEqual({ greeting: 'Hello World' });
   });
 
-  it('omits function-call props until Phase 2 ships execution', () => {
+  it('resolves function-call props through the standard registry', () => {
+    const surface = makeSurface(
+      [c({ id: 'root', component: 'Text', text: { call: 'formatString', args: { value: 'Total: ${/total}' } } })],
+      { total: 42 },
+    );
+    const spec = surfaceToSpec(surface)!;
+    expect(spec.elements['root'].props['text']).toBe('Total: 42');
+  });
+
+  it('resolves formatCurrency props against the data model', () => {
+    const surface = makeSurface(
+      [c({ id: 'root', component: 'Text', text: { call: 'formatCurrency', args: { value: { path: '/price' }, currency: 'USD' } } })],
+      { price: 10 },
+    );
+    const spec = surfaceToSpec(surface)!;
+    expect(spec.elements['root'].props['text'])
+      .toBe(new Intl.NumberFormat(undefined, { style: 'currency', currency: 'USD' }).format(10));
+  });
+
+  it('omits props whose function call is unknown', () => {
     const surface = makeSurface([
-      c({ id: 'root', component: 'Text', text: { call: 'formatString', args: { value: 'x' } } }),
+      c({ id: 'root', component: 'Text', text: { call: 'mysteryFn', args: {} } }),
     ]);
     const spec = surfaceToSpec(surface)!;
     expect('text' in spec.elements['root'].props).toBe(false);
@@ -164,14 +183,17 @@ describe('surfaceToSpec (v0.9)', () => {
     expect(params['context']).toEqual({ email: 'alice@example.com' });
   });
 
-  it('functionCall actions emit no on binding (Phase 2)', () => {
+  it('functionCall actions wire to the local-action handler', () => {
     const surface = makeSurface([
       c({ id: 'root', component: 'Button', child: 'lbl',
         action: { functionCall: { call: 'openUrl', args: { url: 'https://x' } } } }),
       c({ id: 'lbl', component: 'Text', text: 'Open' }),
     ]);
     const spec = surfaceToSpec(surface)!;
-    expect(spec.elements['root'].on).toBeUndefined();
+    expect(spec.elements['root'].on!['click']).toEqual({
+      action: 'a2ui:localAction',
+      params: { call: 'openUrl', args: { url: 'https://x' } },
+    });
   });
 
   it('passes through elements without actions unchanged', () => {

--- a/libs/chat/src/lib/a2ui/surface-to-spec.ts
+++ b/libs/chat/src/lib/a2ui/surface-to-spec.ts
@@ -3,7 +3,13 @@ import type { Spec, UIElement } from '@json-render/core';
 import type {
   A2uiSurface, A2uiAction, A2uiChildren,
 } from '@threadplane/a2ui';
-import { resolveDynamic, getByPointer, isPathRef, isFunctionCall } from '@threadplane/a2ui';
+import {
+  resolveDynamic, getByPointer, isPathRef, isFunctionCall,
+  createA2uiFunctionRegistry,
+} from '@threadplane/a2ui';
+
+/** Shared standard-function registry (formatString, formatters, logic). */
+const A2UI_FUNCTIONS = createA2uiFunctionRegistry();
 
 /** Keys that are protocol structure (base fields + child/action wiring),
  * not renderable props. */
@@ -21,7 +27,20 @@ function resolveAction(
 ): RenderedAction | undefined {
   if (!action || typeof action !== 'object') return undefined;
   if (!('event' in action)) {
-    // functionCall actions execute client-side (Phase 2); nothing to wire yet.
+    // Local client-side function action — routed to the surface component's
+    // built-in `a2ui:localAction` handler (openUrl et al.).
+    if ('functionCall' in action && action.functionCall
+        && typeof action.functionCall.call === 'string') {
+      return {
+        click: {
+          action: 'a2ui:localAction',
+          params: {
+            call: action.functionCall.call,
+            args: action.functionCall.args ?? {},
+          },
+        },
+      } as RenderedAction;
+    }
     return undefined;
   }
   const event = action.event;
@@ -29,7 +48,7 @@ function resolveAction(
   const resolvedContext: Record<string, unknown> = {};
   if (event.context && typeof event.context === 'object') {
     for (const [key, value] of Object.entries(event.context)) {
-      resolvedContext[key] = resolveDynamic(value, surface.dataModel);
+      resolvedContext[key] = resolveDynamic(value, surface.dataModel, undefined, A2UI_FUNCTIONS);
     }
   }
   return {
@@ -89,10 +108,10 @@ export function surfaceToSpec(surface: A2uiSurface): Spec | null {
         bindings[key] = path;
         resolvedProps[key] = { $bindState: path };
       } else if (isFunctionCall(value)) {
-        // Client-side function values ship in Phase 2 — omit until then.
-        continue;
+        const resolved = resolveDynamic(value, surface.dataModel, undefined, A2UI_FUNCTIONS);
+        if (resolved !== undefined) resolvedProps[key] = resolved;
       } else {
-        resolvedProps[key] = resolveDynamic(value, surface.dataModel);
+        resolvedProps[key] = resolveDynamic(value, surface.dataModel, undefined, A2UI_FUNCTIONS);
       }
     }
     if (Object.keys(bindings).length > 0) {
@@ -116,13 +135,17 @@ export function surfaceToSpec(surface: A2uiSurface): Spec | null {
       children = items.map(t => t.child);
       // Resolve tab titles and pass them as a plain string array for the Tabs component's tab bar.
       resolvedProps['tabTitles'] = items.map(t =>
-        t.title !== undefined ? String(resolveDynamic(t.title, surface.dataModel)) : '',
+        t.title !== undefined
+          ? String(resolveDynamic(t.title, surface.dataModel, undefined, A2UI_FUNCTIONS))
+          : '',
       );
     } else if (type === 'ChoicePicker') {
       // Resolve options[*].label (DynamicString) so the component receives plain strings.
       const opts = (rawProps as { options?: { label?: unknown; value: string }[] }).options ?? [];
       resolvedProps['options'] = opts.map(o => ({
-        label: o.label !== undefined ? String(resolveDynamic(o.label, surface.dataModel)) : '',
+        label: o.label !== undefined
+          ? String(resolveDynamic(o.label, surface.dataModel, undefined, A2UI_FUNCTIONS))
+          : '',
         value: o.value,
       }));
     } else {
@@ -140,7 +163,7 @@ export function surfaceToSpec(surface: A2uiSurface): Spec | null {
               const itemProps: Record<string, unknown> = {};
               for (const [k, v] of Object.entries(tRaw)) {
                 if (RESERVED_PROP_KEYS.has(k)) continue;
-                itemProps[k] = resolveDynamic(v, surface.dataModel, scope);
+                itemProps[k] = resolveDynamic(v, surface.dataModel, scope, A2UI_FUNCTIONS);
               }
               elements[`${t.componentId}__${i}`] = { type: tType, props: itemProps };
             }

--- a/libs/chat/src/lib/a2ui/surface.component.ts
+++ b/libs/chat/src/lib/a2ui/surface.component.ts
@@ -134,7 +134,7 @@ export class A2uiSurfaceComponent {
 
         // Built-in fallback
         if (call === 'openUrl' && typeof globalThis.window !== 'undefined') {
-          globalThis.window.open(String(args['url'] ?? ''), '_blank');
+          globalThis.window.open(String(args['url'] ?? ''), '_blank', 'noopener');
         }
         return undefined;
       },


### PR DESCRIPTION
## Summary

Phase 2 of the A2UI v0.9.1 migration (follows #817): client-side function execution per the official basic-catalog function schemas.

- **`@threadplane/a2ui`**: new `createA2uiFunctionRegistry()` with the standard set — `formatString` (full `${...}` interpolation: absolute/relative JSON-pointer paths, nested named-arg calls like `${formatDate(value:${/d}, format:'yyyy-MM-dd')}`, `\${` escape; single-pass scanner, no backtracking regexes), `formatNumber`, `formatCurrency`, `formatDate` (TR35 pattern subset), `pluralize` (Intl.PluralRules), `and`/`or`/`not`. `resolveDynamic` gains an optional registry parameter; function args resolve recursively (bindings and nested calls); unknown names resolve to `undefined` with a one-time warning. Registry is extensible via overrides.
- **`@threadplane/chat`**: `surfaceToSpec` resolves every dynamic value through the standard registry, and `action.functionCall` now wires to the existing `a2ui:localAction` handler (consumer handlers take priority; built-in `openUrl` opens a new tab with `noopener`).
- **Prompts/docs**: schema prompt (both example apps, byte-identical) advertises the functions; a2ui/chat docs updated from "typed, ships later" to shipped semantics; api-docs regenerated.

Additive and non-breaking. Plan: `docs/superpowers/plans/2026-08-17-a2ui-v09-phase2-functions.md`.

## Verification

- `libs/a2ui` 86 unit tests (26 new for functions), `libs/chat` 1128 — green; both libs build + lint clean
- Python suites: 56 + 23 passed; schema-prompt twins byte-identical
- `nx affected -t lint test build`: green except the pre-existing `cockpit-telemetry:lint` worktree-environment failure (untouched project, posthog-js specifier vs local install)
- **Live Chrome smoke** (real gpt-5-mini): prompted for a receipt card using `formatCurrency` + `formatString`; the surface rendered `$1,234.50` and `Thanks, Ada!` — both values computed client-side by the registry from the LLM's `{call}` emissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)