### PR TITLE
fix(deploy): restore shared-deployment namespace merge (src/__init__.py collision)

### DIFF
--- a/cockpit/langgraph/client-tools/python/src/__init__.py
+++ b/cockpit/langgraph/client-tools/python/src/__init__.py
@@ -1,1 +1,0 @@
-# SPDX-License-Identifier: MIT

--- a/scripts/generate-shared-deployment-config.ts
+++ b/scripts/generate-shared-deployment-config.ts
@@ -1,4 +1,4 @@
-import { cpSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { dirname, resolve } from 'path';
 import { capabilities } from '../apps/cockpit/scripts/capability-registry';
 
@@ -40,6 +40,19 @@ const stageDependency = (sourceRoot: string, alias: string): string => {
   const sourceDir = resolve(rootDir, sourceRoot);
   const stagedDir = resolve(stagedDependenciesDir, alias);
   cpSync(sourceDir, stagedDir, { recursive: true });
+
+  // Every dep ships a `src/` package and they must all merge as PEP 420
+  // namespace portions on the deployment's sys.path. A single
+  // `src/__init__.py` turns that dep's `src` into a REGULAR package which
+  // wins exclusively, so every other dep's `from src.x import ...` raises
+  // ModuleNotFoundError at startup and the whole revision fails to deploy
+  // (this exact failure shipped in #642 and broke deploys from Aug 7).
+  const initPy = resolve(stagedDir, 'src/__init__.py');
+  if (existsSync(initPy)) {
+    throw new Error(
+      `${sourceRoot}/src/__init__.py breaks the shared deployment's namespace-package merge — delete it (deps' src dirs must be namespace packages)`,
+    );
+  }
 
   const relativePath = `./deps/${alias}`;
   stagedDependencyRoots.set(sourceRoot, relativePath);


### PR DESCRIPTION
Production smoke has been failing with all-graph run timeouts. Root cause (via LangGraph Cloud revision logs): every revision since Aug 7 is DEPLOY_FAILED with `Graph 'c-interrupts' failed to load: ModuleNotFoundError: No module named 'src.aviation_tools'` — repeated failed rollouts today then wedged the run queue on the old revision.

`cockpit/langgraph/client-tools/python/src/__init__.py` (an empty license-header file shipped in #642) turned that dep's `src` into a **regular** package. Per PEP 420 a regular package wins exclusively over all namespace portions, so on the shared deployment's aggregated sys.path every other dep's `from src.x import ...` stopped resolving. Reproduced locally against the staged `deps/` tree; after deleting the file, `src.aviation_tools` + `src.graph` import cleanly across the merged namespace.

- delete the `__init__.py` (nothing imports `src` as a regular package; graph entrypoints load by file path)
- `generate-shared-deployment-config.ts` now throws at manifest-generation time if any staged dep reintroduces a `src/__init__.py`, so this class of breakage fails in CI instead of at LangGraph Cloud startup

Merging this touches the deploy workflow's trigger paths, so `Deploy LangGraph` will roll a fresh revision; production smoke should recover once it's live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)