### PR TITLE
feat(website): link Brian's X and LinkedIn profiles from the Person node

### DIFF
--- a/apps/website/next-env.d.ts
+++ b/apps/website/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./../../dist/apps/website/.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/website/src/lib/blog-authors.ts
+++ b/apps/website/src/lib/blog-authors.ts
@@ -9,7 +9,12 @@ export interface Author {
    * with docs and code in this repository.
    */
   knowsAbout?: readonly string[];
+  /**
+   * Profile handles, not URLs. Each is opt-in: `sameAs` is an identity claim, so
+   * a handle the record does not name must never be synthesized from another.
+   */
   twitter?: string;
+  linkedin?: string;
   github?: string;
   avatar?: string;
 }
@@ -21,6 +26,8 @@ export const blogAuthors: Record<string, Author> = {
     bio: 'Agentic software architect building developer tooling for fullstack AI-powered web applications.',
     knowsAbout: ['Angular', 'TypeScript', 'LangGraph', 'AG-UI', 'Generative UI', 'Agent user interfaces'],
     github: 'blove',
+    twitter: 'blovedev',
+    linkedin: 'blove',
   },
 };
 

--- a/apps/website/src/lib/structured-data.spec.ts
+++ b/apps/website/src/lib/structured-data.spec.ts
@@ -233,6 +233,7 @@ describe('aboutPageJsonLd', () => {
     expect(person['name']).toBe(AUTHOR.name);
     expect(person['jobTitle']).toBe(AUTHOR.role);
     expect(person['description']).toBe(AUTHOR.bio);
+    // The fixture names only a GitHub handle, so only that profile may appear.
     expect(person['sameAs']).toEqual(['https://github.com/blove']);
     expect(person['url']).toBe('https://threadplane.ai/about');
   });
@@ -251,12 +252,24 @@ describe('aboutPageJsonLd', () => {
     expect((person['worksFor'] as JsonLdNode)['@id']).toBe(ORGANIZATION_ID);
   });
 
-  it('resolves the real site author to a real GitHub profile', () => {
+  it('omits a profile the author record does not name', () => {
+    // Each handle is opt-in per field: an author with only a GitHub handle must
+    // not acquire an invented X or LinkedIn URL.
+    const graph = aboutPageJsonLd({ name: 'Anon', github: 'anon' })['@graph'] as JsonLdNode[];
+    const person = graph.find((node) => node['@type'] === 'Person') as JsonLdNode;
+    expect(person['sameAs']).toEqual(['https://github.com/anon']);
+  });
+
+  it('resolves the real site author to real profiles', () => {
     // The page passes `blogAuthors['brian']`; `sameAs` is an identity claim, so
-    // this pins the profile the repo actually knows rather than the fixture's.
+    // this pins the profiles the repo actually knows rather than the fixture's.
     const graph = aboutPageJsonLd(blogAuthors['brian'])['@graph'] as JsonLdNode[];
     const person = graph.find((node) => node['@type'] === 'Person') as JsonLdNode;
-    expect(person['sameAs']).toEqual(['https://github.com/blove']);
+    expect(person['sameAs']).toEqual([
+      'https://github.com/blove',
+      'https://x.com/blovedev',
+      'https://www.linkedin.com/in/blove',
+    ]);
   });
 
   it('serializes to JSON', () => {

--- a/apps/website/src/lib/structured-data.ts
+++ b/apps/website/src/lib/structured-data.ts
@@ -127,6 +127,19 @@ export const PERSON_ID = `${getCanonicalUrl(ABOUT_PATH)}#person`;
  * Every field is derived from the caller's {@link Author} record; nothing about
  * the person is stated here.
  */
+/**
+ * The external profiles an author record actually names, as absolute URLs.
+ *
+ * Order is stable so the emitted JSON-LD does not churn between builds.
+ */
+function personProfiles(author: Author): string[] {
+  return [
+    author.github && `https://github.com/${author.github}`,
+    author.twitter && `https://x.com/${author.twitter}`,
+    author.linkedin && `https://www.linkedin.com/in/${author.linkedin}`,
+  ].filter((url): url is string => Boolean(url));
+}
+
 export function aboutPageJsonLd(author: Author) {
   const url = getCanonicalUrl(ABOUT_PATH);
   const person: JsonLdNode = {
@@ -137,8 +150,9 @@ export function aboutPageJsonLd(author: Author) {
     ...(author.role ? { jobTitle: author.role } : {}),
     ...(author.bio ? { description: author.bio } : {}),
     // Only profiles the repo actually knows about; `sameAs` is an identity
-    // claim, so a guessed profile is a false one.
-    ...(author.github ? { sameAs: [`https://github.com/${author.github}`] } : {}),
+    // claim, so a guessed profile is a false one. Each handle is a separate
+    // opt-in field — one is never derived from another.
+    ...(personProfiles(author).length ? { sameAs: personProfiles(author) } : {}),
     ...(author.knowsAbout?.length ? { knowsAbout: [...author.knowsAbout] } : {}),
     worksFor: { '@id': ORGANIZATION_ID },
   };


### PR DESCRIPTION
Follow-up to #828. `sameAs` is how a `Person` node resolves to a real-world identity, and answer engines rely on it for entity disambiguation — which is most of why `/about` carries a Person node. It listed only GitHub, so the two strongest disambiguating signals were absent.

## What changed

Adds the profiles Brian already links publicly from [brianflove.com](https://brianflove.com), verified against that page's **raw HTML** rather than a fetched summary — an earlier summarization pass in this work invented a `brianlove.dev` domain that appears nowhere in the real markup, so the URLs were re-checked directly.

```json
"sameAs": [
  "https://github.com/blove",
  "https://x.com/blovedev",
  "https://www.linkedin.com/in/blove"
]
```

LinkedIn answers `999` to automated requests; that's its anti-bot response, not a dead link. X and GitHub both return 200.

## The invariant is preserved

The existing code comment is explicit that `sameAs` is an identity claim and a guessed profile is a false one. That still holds: each handle is its own opt-in field on the author record, so one is never derived from another. An author naming only a GitHub handle does not acquire an invented X URL — there's a test for precisely that:

```ts
it('omits a profile the author record does not name', () => {
  const person = /* author: { name: 'Anon', github: 'anon' } */;
  expect(person['sameAs']).toEqual(['https://github.com/anon']);
});
```

`personProfiles()` emits a stable order so the JSON-LD doesn't churn between builds.

`twitter` was already declared on the `Author` interface and read by nothing; populating it now feeds only `sameAs`.

## Verification

- `npx vitest run --config vite.config.mts` from `apps/website`: **314 passed**, 5 failed — the same pre-existing failures in `thanks/page.spec.tsx`, `PostCard.spec.tsx`, `Differentiator.spec.tsx`, untouched here (313 before; 1 added test accounts for the delta)
- `nx lint website`: **0 errors**, 29 warnings (unchanged)
- `nx build website --configuration=production`: succeeds, and the built `/about` emits all three URLs in order

🤖 Generated with [Claude Code](https://claude.com/claude-code)