### PR TITLE
feat(website): let homepage sections switch between video and code

### DIFF
--- a/apps/website/src/app/page.tsx
+++ b/apps/website/src/app/page.tsx
@@ -42,6 +42,7 @@ async function buildPanes(media: SectionMedia, clipUrl: string): Promise<MediumP
   if (media.video) {
     const clip = media.video;
     panes.push({
+      id: 'video',
       key: 'video',
       label: 'Video',
       content: (
@@ -65,17 +66,19 @@ async function buildPanes(media: SectionMedia, clipUrl: string): Promise<MediumP
     });
   }
 
-  for (const block of media.code ?? []) {
+  const codeBlocks = media.code ?? [];
+  codeBlocks.forEach((block, index) => {
     panes.push({
+      id: `code-${index}`,
       key: 'code',
-      label: 'Code',
+      label: codeBlocks.length > 1 ? block.label : 'Code',
       content: (
         <div style={{ borderRadius: 14, overflow: 'hidden', border: `1px solid ${tokens.surfaces.border}` }}>
           <HighlightedCode code={block.source} lang={block.language} />
         </div>
       ),
     });
-  }
+  });
 
   return panes;
 }

--- a/apps/website/src/app/page.tsx
+++ b/apps/website/src/app/page.tsx
@@ -3,8 +3,12 @@ import { EcosystemStrip } from '../components/landing/EcosystemStrip';
 import { Differentiator } from '../components/landing/Differentiator';
 import { FeatureBlock } from '../components/landing/FeatureBlock';
 import { BrowserFrame } from '../components/ui/BrowserFrame';
-import { HITL_CLIP } from '../lib/demo-media';
 import { DemoShowcase } from '../components/landing/DemoShowcase';
+import { MediumSwitcher } from '../components/landing/MediumSwitcher';
+import type { MediumPane } from '../components/landing/MediumSwitcher';
+import { HighlightedCode } from '../components/landing/HighlightedCode';
+import { SECTION_MEDIA } from '../lib/section-media';
+import type { SectionMedia } from '../lib/section-media';
 import { PilotBlock } from '../components/landing/PilotBlock';
 import { WhitePaperBlock } from '../components/landing/WhitePaperBlock';
 import { Promises } from '../components/landing/Promises';
@@ -23,7 +27,63 @@ export const metadata = createPageMetadata({
   type: 'website',
 });
 
+/**
+ * Builds the panes for a section on the SERVER.
+ *
+ * `HighlightedCode` is an async Server Component, so it cannot be rendered from
+ * inside the client `MediumSwitcher`. Highlighting here and passing the result
+ * as a prop is what makes the code tab possible at all.
+ */
+async function buildPanes(media: SectionMedia, clipUrl: string): Promise<MediumPane[]> {
+  // Typed, not inferred: `const panes = []` is `any[]` under this tsconfig and
+  // fails the production build's type check.
+  const panes: MediumPane[] = [];
+
+  if (media.video) {
+    const clip = media.video;
+    panes.push({
+      key: 'video',
+      label: 'Video',
+      content: (
+        <BrowserFrame url={clipUrl} elevation="lg">
+          <div style={{ position: 'relative', width: '100%', aspectRatio: '16 / 10', background: '#15161f' }}>
+            <video
+              autoPlay
+              muted
+              loop
+              playsInline
+              poster={clip.poster}
+              aria-label={clip.caption}
+              style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
+            >
+              <source src={clip.videoWebm} type="video/webm" />
+              <source src={clip.videoMp4} type="video/mp4" />
+            </video>
+          </div>
+        </BrowserFrame>
+      ),
+    });
+  }
+
+  for (const block of media.code ?? []) {
+    panes.push({
+      key: 'code',
+      label: 'Code',
+      content: (
+        <div style={{ borderRadius: 14, overflow: 'hidden', border: `1px solid ${tokens.surfaces.border}` }}>
+          <HighlightedCode code={block.source} lang={block.language} />
+        </div>
+      ),
+    });
+  }
+
+  return panes;
+}
+
 export default async function HomePage() {
+  const streamPanes = await buildPanes(SECTION_MEDIA.stream, SECTION_MEDIA.stream.video?.url ?? '');
+  const approvePanes = await buildPanes(SECTION_MEDIA.approve, SECTION_MEDIA.approve.video?.url ?? '');
+
   return (
     <>
       <Hero />
@@ -59,17 +119,7 @@ export default async function HomePage() {
           { title: '@threadplane/langgraph', description: 'Native LangGraph streaming.' },
         ]}
         cta={{ label: 'Read the streaming guide', href: '/docs/langgraph/guides/streaming' }}
-        visual={
-          <BrowserFrame url="cockpit.threadplane.ai/langgraph/core-capabilities/streaming/overview/python" elevation="md">
-            <img
-              src="/screenshots/cockpit-docs.webp"
-              alt="Cockpit reference app — Angular streaming guide with provideAgent setup"
-              style={{ display: 'block', width: '100%', height: 'auto' }}
-              loading="lazy"
-              decoding="async"
-            />
-          </BrowserFrame>
-        }
+        visual={<MediumSwitcher sectionId="stream" panes={streamPanes} />}
       />
 
       {/* Render */}
@@ -167,24 +217,7 @@ export default async function HomePage() {
         ]}
         cta={{ label: 'Interrupt patterns', href: '/docs/langgraph/guides/interrupts' }}
         visualLeft
-        visual={
-          <BrowserFrame url={HITL_CLIP.url} elevation="lg">
-            <div style={{ position: 'relative', width: '100%', aspectRatio: '16 / 10', background: '#15161f' }}>
-              <video
-                autoPlay
-                muted
-                loop
-                playsInline
-                poster={HITL_CLIP.poster}
-                aria-label={HITL_CLIP.caption}
-                style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
-              >
-                <source src={HITL_CLIP.videoWebm} type="video/webm" />
-                <source src={HITL_CLIP.videoMp4} type="video/mp4" />
-              </video>
-            </div>
-          </BrowserFrame>
-        }
+        visual={<MediumSwitcher sectionId="approve" panes={approvePanes} />}
       />
 
       <PilotBlock />

--- a/apps/website/src/components/landing/MediumSwitcher.spec.tsx
+++ b/apps/website/src/components/landing/MediumSwitcher.spec.tsx
@@ -5,7 +5,8 @@ import { describe, expect, it, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { MediumSwitcher } from './MediumSwitcher';
 
-vi.mock('../../lib/analytics/client', () => ({ trackCtaClick: vi.fn() }));
+const trackCtaClickMock = vi.hoisted(() => vi.fn());
+vi.mock('../../lib/analytics/client', () => ({ trackCtaClick: trackCtaClickMock }));
 
 describe('MediumSwitcher', () => {
   it('renders a lone medium with no tablist', () => {
@@ -72,5 +73,24 @@ describe('MediumSwitcher', () => {
 
     fireEvent.keyDown(tablist, { key: 'ArrowLeft' });
     expect(screen.getAllByRole('tab')[1].getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('reports the medium a reader switches to', () => {
+    trackCtaClickMock.mockClear();
+    render(<MediumSwitcher sectionId="stream" panes={twoPanes} />);
+
+    fireEvent.click(screen.getAllByRole('tab')[1]);
+
+    expect(trackCtaClickMock).toHaveBeenCalledWith(
+      expect.objectContaining({ surface: 'home_medium_switcher', cta_id: 'stream_code' }),
+    );
+  });
+
+  it('does not report the medium a reader never chose', () => {
+    trackCtaClickMock.mockClear();
+    render(<MediumSwitcher sectionId="stream" panes={twoPanes} />);
+
+    // Rendering is not a choice; only an explicit switch is.
+    expect(trackCtaClickMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/website/src/components/landing/MediumSwitcher.spec.tsx
+++ b/apps/website/src/components/landing/MediumSwitcher.spec.tsx
@@ -2,7 +2,7 @@
 // @vitest-environment jsdom
 import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { MediumSwitcher } from './MediumSwitcher';
 
 vi.mock('../../lib/analytics/client', () => ({ trackCtaClick: vi.fn() }));
@@ -40,5 +40,23 @@ describe('MediumSwitcher', () => {
     const panel = screen.getByRole('tabpanel');
     expect(tab.getAttribute('aria-controls')).toBe(panel.getAttribute('id'));
     expect(panel.getAttribute('aria-labelledby')).toBe(tab.getAttribute('id'));
+  });
+
+  it('mounts only the active pane', () => {
+    render(<MediumSwitcher sectionId="stream" panes={twoPanes} />);
+
+    // Not "hidden" — absent. A CSS-toggled implementation would still fetch the
+    // video and the iframe on page load, which is the cost this avoids.
+    expect(screen.getByText('the clip')).toBeTruthy();
+    expect(screen.queryByText('the snippet')).toBeNull();
+  });
+
+  it('swaps which pane is mounted when a tab is clicked', () => {
+    render(<MediumSwitcher sectionId="stream" panes={twoPanes} />);
+
+    fireEvent.click(screen.getAllByRole('tab')[1]);
+
+    expect(screen.queryByText('the clip')).toBeNull();
+    expect(screen.getByText('the snippet')).toBeTruthy();
   });
 });

--- a/apps/website/src/components/landing/MediumSwitcher.spec.tsx
+++ b/apps/website/src/components/landing/MediumSwitcher.spec.tsx
@@ -94,7 +94,7 @@ describe('MediumSwitcher', () => {
     fireEvent.click(screen.getAllByRole('tab')[1]);
 
     expect(trackCtaClickMock).toHaveBeenCalledWith(
-      expect.objectContaining({ surface: 'home_medium_switcher', cta_id: 'stream_code' }),
+      expect.objectContaining({ surface: 'home_medium_switcher', cta_id: 'medium_stream_code' }),
     );
   });
 

--- a/apps/website/src/components/landing/MediumSwitcher.spec.tsx
+++ b/apps/website/src/components/landing/MediumSwitcher.spec.tsx
@@ -67,12 +67,24 @@ describe('MediumSwitcher', () => {
 
     fireEvent.keyDown(tablist, { key: 'ArrowRight' });
     expect(screen.getAllByRole('tab')[1].getAttribute('aria-selected')).toBe('true');
+    expect(document.activeElement).toBe(screen.getAllByRole('tab')[1]);
 
     fireEvent.keyDown(tablist, { key: 'ArrowRight' });
     expect(screen.getAllByRole('tab')[0].getAttribute('aria-selected')).toBe('true');
 
     fireEvent.keyDown(tablist, { key: 'ArrowLeft' });
     expect(screen.getAllByRole('tab')[1].getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('jumps to the first and last tab with Home and End', () => {
+    render(<MediumSwitcher sectionId="stream" panes={twoPanes} />);
+    const tablist = screen.getByRole('tablist');
+
+    fireEvent.keyDown(tablist, { key: 'End' });
+    expect(screen.getAllByRole('tab')[1].getAttribute('aria-selected')).toBe('true');
+
+    fireEvent.keyDown(tablist, { key: 'Home' });
+    expect(screen.getAllByRole('tab')[0].getAttribute('aria-selected')).toBe('true');
   });
 
   it('reports the medium a reader switches to', () => {

--- a/apps/website/src/components/landing/MediumSwitcher.spec.tsx
+++ b/apps/website/src/components/landing/MediumSwitcher.spec.tsx
@@ -59,4 +59,18 @@ describe('MediumSwitcher', () => {
     expect(screen.queryByText('the clip')).toBeNull();
     expect(screen.getByText('the snippet')).toBeTruthy();
   });
+
+  it('moves between tabs with arrow keys, wrapping at the ends', () => {
+    render(<MediumSwitcher sectionId="stream" panes={twoPanes} />);
+    const tablist = screen.getByRole('tablist');
+
+    fireEvent.keyDown(tablist, { key: 'ArrowRight' });
+    expect(screen.getAllByRole('tab')[1].getAttribute('aria-selected')).toBe('true');
+
+    fireEvent.keyDown(tablist, { key: 'ArrowRight' });
+    expect(screen.getAllByRole('tab')[0].getAttribute('aria-selected')).toBe('true');
+
+    fireEvent.keyDown(tablist, { key: 'ArrowLeft' });
+    expect(screen.getAllByRole('tab')[1].getAttribute('aria-selected')).toBe('true');
+  });
 });

--- a/apps/website/src/components/landing/MediumSwitcher.spec.tsx
+++ b/apps/website/src/components/landing/MediumSwitcher.spec.tsx
@@ -19,4 +19,26 @@ describe('MediumSwitcher', () => {
     expect(screen.getByText('the clip')).toBeTruthy();
     expect(screen.queryByRole('tablist')).toBeNull();
   });
+  const twoPanes = [
+    { key: 'video' as const, label: 'Video', content: <p>the clip</p> },
+    { key: 'code' as const, label: 'Code', content: <p>the snippet</p> },
+  ];
+
+  it('exposes a tab per medium with the first selected', () => {
+    render(<MediumSwitcher sectionId="stream" panes={twoPanes} />);
+
+    const tabs = screen.getAllByRole('tab');
+    expect(tabs).toHaveLength(2);
+    expect(tabs[0].getAttribute('aria-selected')).toBe('true');
+    expect(tabs[1].getAttribute('aria-selected')).toBe('false');
+  });
+
+  it('points each tab at the panel it controls', () => {
+    render(<MediumSwitcher sectionId="stream" panes={twoPanes} />);
+
+    const tab = screen.getAllByRole('tab')[0];
+    const panel = screen.getByRole('tabpanel');
+    expect(tab.getAttribute('aria-controls')).toBe(panel.getAttribute('id'));
+    expect(panel.getAttribute('aria-labelledby')).toBe(tab.getAttribute('id'));
+  });
 });

--- a/apps/website/src/components/landing/MediumSwitcher.spec.tsx
+++ b/apps/website/src/components/landing/MediumSwitcher.spec.tsx
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+// @vitest-environment jsdom
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MediumSwitcher } from './MediumSwitcher';
+
+vi.mock('../../lib/analytics/client', () => ({ trackCtaClick: vi.fn() }));
+
+describe('MediumSwitcher', () => {
+  it('renders a lone medium with no tablist', () => {
+    render(
+      <MediumSwitcher
+        sectionId="stream"
+        panes={[{ key: 'video', label: 'Video', content: <p>the clip</p> }]}
+      />,
+    );
+
+    expect(screen.getByText('the clip')).toBeTruthy();
+    expect(screen.queryByRole('tablist')).toBeNull();
+  });
+});

--- a/apps/website/src/components/landing/MediumSwitcher.spec.tsx
+++ b/apps/website/src/components/landing/MediumSwitcher.spec.tsx
@@ -13,7 +13,7 @@ describe('MediumSwitcher', () => {
     render(
       <MediumSwitcher
         sectionId="stream"
-        panes={[{ key: 'video', label: 'Video', content: <p>the clip</p> }]}
+        panes={[{ id: 'video', key: 'video', label: 'Video', content: <p>the clip</p> }]}
       />,
     );
 
@@ -21,8 +21,8 @@ describe('MediumSwitcher', () => {
     expect(screen.queryByRole('tablist')).toBeNull();
   });
   const twoPanes = [
-    { key: 'video' as const, label: 'Video', content: <p>the clip</p> },
-    { key: 'code' as const, label: 'Code', content: <p>the snippet</p> },
+    { id: 'video', key: 'video' as const, label: 'Video', content: <p>the clip</p> },
+    { id: 'code', key: 'code' as const, label: 'Code', content: <p>the snippet</p> },
   ];
 
   it('exposes a tab per medium with the first selected', () => {
@@ -104,5 +104,20 @@ describe('MediumSwitcher', () => {
 
     // Rendering is not a choice; only an explicit switch is.
     expect(trackCtaClickMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps ids unique when a section has two code panes', () => {
+    render(
+      <MediumSwitcher
+        sectionId="stream"
+        panes={[
+          { id: 'code-0', key: 'code', label: 'Component', content: <p>first</p> },
+          { id: 'code-1', key: 'code', label: 'Template', content: <p>second</p> },
+        ]}
+      />,
+    );
+
+    const ids = screen.getAllByRole('tab').map((t) => t.getAttribute('id'));
+    expect(new Set(ids).size).toBe(ids.length);
   });
 });

--- a/apps/website/src/components/landing/MediumSwitcher.tsx
+++ b/apps/website/src/components/landing/MediumSwitcher.tsx
@@ -39,7 +39,7 @@ export function MediumSwitcher({ sectionId, panes }: MediumSwitcherProps) {
     setActive(index);
     trackCtaClick({
       surface: 'home_medium_switcher',
-      cta_id: `${sectionId}_${panes[index].key}`,
+      cta_id: `medium_${sectionId}_${panes[index].key}`,
       cta_text: panes[index].label,
     });
   };

--- a/apps/website/src/components/landing/MediumSwitcher.tsx
+++ b/apps/website/src/components/landing/MediumSwitcher.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 'use client';
-import { useState, type ReactNode } from 'react';
+import { useState, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from 'react';
 import { tokens } from '@threadplane/design-tokens';
 
 export interface MediumPane {
@@ -31,9 +31,21 @@ export function MediumSwitcher({ sectionId, panes }: MediumSwitcherProps) {
   const tabId = (key: string) => `${sectionId}-tab-${key}`;
   const panelId = (key: string) => `${sectionId}-panel-${key}`;
 
+  const onKeyDown = (event: ReactKeyboardEvent) => {
+    if (event.key !== 'ArrowRight' && event.key !== 'ArrowLeft') return;
+    event.preventDefault();
+    const delta = event.key === 'ArrowRight' ? 1 : -1;
+    setActive((current) => (current + delta + panes.length) % panes.length);
+  };
+
   return (
     <div>
-      <div role="tablist" aria-label="Choose how to view this" style={{ display: 'flex', gap: 6, marginBottom: 12 }}>
+      <div
+        role="tablist"
+        aria-label="Choose how to view this"
+        onKeyDown={onKeyDown}
+        style={{ display: 'flex', gap: 6, marginBottom: 12 }}
+      >
         {panes.map((pane, index) => {
           const selected = index === active;
           return (

--- a/apps/website/src/components/landing/MediumSwitcher.tsx
+++ b/apps/website/src/components/landing/MediumSwitcher.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 'use client';
 import { useState, type ReactNode } from 'react';
+import { tokens } from '@threadplane/design-tokens';
 
 export interface MediumPane {
   key: 'video' | 'code' | 'live';
@@ -27,5 +28,49 @@ export function MediumSwitcher({ sectionId, panes }: MediumSwitcherProps) {
     return <>{panes[0]?.content ?? null}</>;
   }
 
-  return <>{panes[active].content}</>;
+  const tabId = (key: string) => `${sectionId}-tab-${key}`;
+  const panelId = (key: string) => `${sectionId}-panel-${key}`;
+
+  return (
+    <div>
+      <div role="tablist" aria-label="Choose how to view this" style={{ display: 'flex', gap: 6, marginBottom: 12 }}>
+        {panes.map((pane, index) => {
+          const selected = index === active;
+          return (
+            <button
+              key={pane.key}
+              id={tabId(pane.key)}
+              role="tab"
+              type="button"
+              aria-selected={selected}
+              aria-controls={panelId(pane.key)}
+              tabIndex={selected ? 0 : -1}
+              onClick={() => setActive(index)}
+              style={{
+                fontFamily: 'Inter, sans-serif',
+                fontSize: 13,
+                fontWeight: 600,
+                padding: '8px 14px',
+                borderRadius: 8,
+                border: 'none',
+                cursor: 'pointer',
+                background: selected ? tokens.colors.accent : tokens.colors.accentSurface,
+                color: selected ? tokens.colors.textInverted : tokens.colors.textMuted,
+              }}
+            >
+              {pane.label}
+            </button>
+          );
+        })}
+      </div>
+
+      <div
+        id={panelId(panes[active].key)}
+        role="tabpanel"
+        aria-labelledby={tabId(panes[active].key)}
+      >
+        {panes[active].content}
+      </div>
+    </div>
+  );
 }

--- a/apps/website/src/components/landing/MediumSwitcher.tsx
+++ b/apps/website/src/components/landing/MediumSwitcher.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 'use client';
-import { useState, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from 'react';
+import { useRef, useState, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from 'react';
 import { tokens } from '@threadplane/design-tokens';
 import { trackCtaClick } from '../../lib/analytics/client';
 
@@ -22,7 +22,10 @@ interface MediumSwitcherProps {
 }
 
 export function MediumSwitcher({ sectionId, panes }: MediumSwitcherProps) {
+  // Call sites pass a static `panes` array, so the index cannot go stale. If a
+  // caller ever makes a medium conditional, this needs a clamp.
   const [active, setActive] = useState(0);
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
   // One medium needs no control surface; chrome around a single option is noise.
   if (panes.length <= 1) {
@@ -42,11 +45,17 @@ export function MediumSwitcher({ sectionId, panes }: MediumSwitcherProps) {
   };
 
   const onKeyDown = (event: ReactKeyboardEvent) => {
-    if (event.key !== 'ArrowRight' && event.key !== 'ArrowLeft') return;
+    const last = panes.length - 1;
+    let next: number;
+    if (event.key === 'ArrowRight') next = (active + 1) % panes.length;
+    else if (event.key === 'ArrowLeft') next = (active - 1 + panes.length) % panes.length;
+    else if (event.key === 'Home') next = 0;
+    else if (event.key === 'End') next = last;
+    else return;
+
     event.preventDefault();
-    const delta = event.key === 'ArrowRight' ? 1 : -1;
-    const next = (active + delta + panes.length) % panes.length;
     select(next);
+    tabRefs.current[next]?.focus();
   };
 
   return (
@@ -62,6 +71,9 @@ export function MediumSwitcher({ sectionId, panes }: MediumSwitcherProps) {
           return (
             <button
               key={pane.key}
+              ref={(el) => {
+                tabRefs.current[index] = el;
+              }}
               id={tabId(pane.key)}
               role="tab"
               type="button"

--- a/apps/website/src/components/landing/MediumSwitcher.tsx
+++ b/apps/website/src/components/landing/MediumSwitcher.tsx
@@ -2,6 +2,7 @@
 'use client';
 import { useState, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from 'react';
 import { tokens } from '@threadplane/design-tokens';
+import { trackCtaClick } from '../../lib/analytics/client';
 
 export interface MediumPane {
   key: 'video' | 'code' | 'live';
@@ -31,11 +32,21 @@ export function MediumSwitcher({ sectionId, panes }: MediumSwitcherProps) {
   const tabId = (key: string) => `${sectionId}-tab-${key}`;
   const panelId = (key: string) => `${sectionId}-panel-${key}`;
 
+  const select = (index: number) => {
+    setActive(index);
+    trackCtaClick({
+      surface: 'home_medium_switcher',
+      cta_id: `${sectionId}_${panes[index].key}`,
+      cta_text: panes[index].label,
+    });
+  };
+
   const onKeyDown = (event: ReactKeyboardEvent) => {
     if (event.key !== 'ArrowRight' && event.key !== 'ArrowLeft') return;
     event.preventDefault();
     const delta = event.key === 'ArrowRight' ? 1 : -1;
-    setActive((current) => (current + delta + panes.length) % panes.length);
+    const next = (active + delta + panes.length) % panes.length;
+    select(next);
   };
 
   return (
@@ -57,7 +68,7 @@ export function MediumSwitcher({ sectionId, panes }: MediumSwitcherProps) {
               aria-selected={selected}
               aria-controls={panelId(pane.key)}
               tabIndex={selected ? 0 : -1}
-              onClick={() => setActive(index)}
+              onClick={() => select(index)}
               style={{
                 fontFamily: 'Inter, sans-serif',
                 fontSize: 13,

--- a/apps/website/src/components/landing/MediumSwitcher.tsx
+++ b/apps/website/src/components/landing/MediumSwitcher.tsx
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+'use client';
+import { useState, type ReactNode } from 'react';
+
+export interface MediumPane {
+  key: 'video' | 'code' | 'live';
+  label: string;
+  /**
+   * Pre-rendered content. Code panes are highlighted on the server and passed
+   * in, because `HighlightedCode` is an async Server Component and a client
+   * component cannot render one as a child.
+   */
+  content: ReactNode;
+}
+
+interface MediumSwitcherProps {
+  /** Used for tab/panel ids and the analytics `cta_id`. */
+  sectionId: string;
+  panes: MediumPane[];
+}
+
+export function MediumSwitcher({ sectionId, panes }: MediumSwitcherProps) {
+  const [active, setActive] = useState(0);
+
+  // One medium needs no control surface; chrome around a single option is noise.
+  if (panes.length <= 1) {
+    return <>{panes[0]?.content ?? null}</>;
+  }
+
+  return <>{panes[active].content}</>;
+}

--- a/apps/website/src/components/landing/MediumSwitcher.tsx
+++ b/apps/website/src/components/landing/MediumSwitcher.tsx
@@ -5,6 +5,9 @@ import { tokens } from '@threadplane/design-tokens';
 import { trackCtaClick } from '../../lib/analytics/client';
 
 export interface MediumPane {
+  /** Unique within a switcher — used for React keys and DOM ids. */
+  id: string;
+  /** Which medium this is; drives analytics, not identity. */
   key: 'video' | 'code' | 'live';
   label: string;
   /**
@@ -32,8 +35,8 @@ export function MediumSwitcher({ sectionId, panes }: MediumSwitcherProps) {
     return <>{panes[0]?.content ?? null}</>;
   }
 
-  const tabId = (key: string) => `${sectionId}-tab-${key}`;
-  const panelId = (key: string) => `${sectionId}-panel-${key}`;
+  const tabId = (id: string) => `${sectionId}-tab-${id}`;
+  const panelId = (id: string) => `${sectionId}-panel-${id}`;
 
   const select = (index: number) => {
     setActive(index);
@@ -62,7 +65,7 @@ export function MediumSwitcher({ sectionId, panes }: MediumSwitcherProps) {
     <div>
       <div
         role="tablist"
-        aria-label="Choose how to view this"
+        aria-label={`Choose how to view the ${sectionId} section`}
         onKeyDown={onKeyDown}
         style={{ display: 'flex', gap: 6, marginBottom: 12 }}
       >
@@ -70,15 +73,15 @@ export function MediumSwitcher({ sectionId, panes }: MediumSwitcherProps) {
           const selected = index === active;
           return (
             <button
-              key={pane.key}
+              key={pane.id}
               ref={(el) => {
                 tabRefs.current[index] = el;
               }}
-              id={tabId(pane.key)}
+              id={tabId(pane.id)}
               role="tab"
               type="button"
               aria-selected={selected}
-              aria-controls={panelId(pane.key)}
+              aria-controls={panelId(pane.id)}
               tabIndex={selected ? 0 : -1}
               onClick={() => select(index)}
               style={{
@@ -100,9 +103,9 @@ export function MediumSwitcher({ sectionId, panes }: MediumSwitcherProps) {
       </div>
 
       <div
-        id={panelId(panes[active].key)}
+        id={panelId(panes[active].id)}
         role="tabpanel"
-        aria-labelledby={tabId(panes[active].key)}
+        aria-labelledby={tabId(panes[active].id)}
       >
         {panes[active].content}
       </div>

--- a/apps/website/src/lib/analytics/events.ts
+++ b/apps/website/src/lib/analytics/events.ts
@@ -35,6 +35,7 @@ export type AnalyticsSurface =
   | 'home'
   | 'home_demo'
   | 'home_whitepaper'
+  | 'home_medium_switcher'
   | 'pricing'
   | 'docs'
   | 'blog'
@@ -87,7 +88,11 @@ export type CtaId =
   | `footer_${string}`
   // Landing section CTAs derive ids from surface + demo key at runtime
   | `final_cta_${string}`
-  | `home_demo_${string}`;
+  | `home_demo_${string}`
+  // MediumSwitcher derives ids from section id + medium key at runtime
+  | `${string}_video`
+  | `${string}_code`
+  | `${string}_live`;
 
 export type AnalyticsLibrary = 'langgraph' | 'render' | 'chat' | 'ag-ui' | 'unknown';
 

--- a/apps/website/src/lib/analytics/events.ts
+++ b/apps/website/src/lib/analytics/events.ts
@@ -90,9 +90,7 @@ export type CtaId =
   | `final_cta_${string}`
   | `home_demo_${string}`
   // MediumSwitcher derives ids from section id + medium key at runtime
-  | `${string}_video`
-  | `${string}_code`
-  | `${string}_live`;
+  | `medium_${string}`;
 
 export type AnalyticsLibrary = 'langgraph' | 'render' | 'chat' | 'ag-ui' | 'unknown';
 

--- a/apps/website/src/lib/demo-media.ts
+++ b/apps/website/src/lib/demo-media.ts
@@ -41,8 +41,8 @@ export const HITL_CLIP: DemoClip = {
 
 /**
  * The LangGraph streaming demo, recorded on the canonical demo shell. Exported
- * rather than re-declared per consumer so the homepage showcase and the section
- * switcher cannot drift apart.
+ * so the section switcher does not add another hardcoded copy of these URLs.
+ * `DemoShowcase` still declares its own; consolidating it is tracked separately.
  */
 export const LANGGRAPH_CLIP: DemoClip = {
   caption: 'Tokens stream into the Angular surface as the agent produces them.',

--- a/apps/website/src/lib/demo-media.ts
+++ b/apps/website/src/lib/demo-media.ts
@@ -38,3 +38,16 @@ export const HITL_CLIP: DemoClip = {
   videoWebm: `${DEMO_CDN}/hitl-demo.webm`,
   poster: `${DEMO_CDN}/hitl-demo-poster.webp`,
 };
+
+/**
+ * The LangGraph streaming demo, recorded on the canonical demo shell. Exported
+ * rather than re-declared per consumer so the homepage showcase and the section
+ * switcher cannot drift apart.
+ */
+export const LANGGRAPH_CLIP: DemoClip = {
+  caption: 'Tokens stream into the Angular surface as the agent produces them.',
+  url: 'demo.threadplane.ai',
+  videoMp4: `${DEMO_CDN}/langgraph-demo.mp4`,
+  videoWebm: `${DEMO_CDN}/langgraph-demo.webm`,
+  poster: `${DEMO_CDN}/langgraph-demo-poster.webp`,
+};

--- a/apps/website/src/lib/section-media.spec.ts
+++ b/apps/website/src/lib/section-media.spec.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+import { describe, expect, it } from 'vitest';
+import { SECTION_MEDIA } from './section-media';
+import { DEMO_CDN } from './demo-media';
+
+describe('SECTION_MEDIA', () => {
+  it('declares at least one medium for every section', () => {
+    for (const [key, media] of Object.entries(SECTION_MEDIA)) {
+      const count = [media.video, media.code, media.live].filter(Boolean).length;
+      expect(count, key).toBeGreaterThan(0);
+    }
+  });
+
+  it('serves every video through the shared blob base', () => {
+    for (const [key, media] of Object.entries(SECTION_MEDIA)) {
+      if (!media.video) continue;
+      for (const url of [media.video.videoMp4, media.video.videoWebm, media.video.poster]) {
+        expect(url, key).toContain(DEMO_CDN);
+      }
+    }
+  });
+
+  it('gives every code pane a label and real source', () => {
+    for (const [key, media] of Object.entries(SECTION_MEDIA)) {
+      for (const block of media.code ?? []) {
+        expect(block.label.trim().length, key).toBeGreaterThan(0);
+        expect(block.source.trim().length, key).toBeGreaterThan(40);
+        expect(block.source, key).not.toMatch(/TODO|FIXME/);
+      }
+    }
+  });
+});

--- a/apps/website/src/lib/section-media.ts
+++ b/apps/website/src/lib/section-media.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+import { HITL_CLIP, LANGGRAPH_CLIP, type DemoClip } from './demo-media';
+import type { SolutionCodeBlocks } from './solutions-data';
+
+/**
+ * What a homepage section can show. Every medium is optional and that is
+ * load-bearing: a section with one medium renders bare, with no tablist, and
+ * sections gain tabs as media is produced rather than blocking on a recording
+ * that does not exist yet.
+ */
+export interface SectionMedia {
+  video?: DemoClip;
+  code?: SolutionCodeBlocks;
+  /** Phase 2. Declared now so the switcher's shape does not change later. */
+  live?: { prompt: string; mode?: 'embed' | 'popup' | 'sidebar' };
+}
+
+export const SECTION_MEDIA: Record<'stream' | 'approve', SectionMedia> = {
+  stream: {
+    video: LANGGRAPH_CLIP,
+    code: [
+      {
+        label: 'chat.component.ts — headless streaming',
+        language: 'typescript',
+        source: `export class ChatPageComponent {
+  protected readonly agent = injectAgent();
+
+  // Signals, not callbacks: the template re-renders as tokens arrive.
+  readonly messages = computed(() => this.agent.messages());
+  readonly isLoading = computed(() => this.agent.isLoading());
+
+  send(message: string) {
+    this.agent.submit({ message });
+  }
+}`,
+      },
+    ],
+  },
+  approve: {
+    video: HITL_CLIP,
+    code: [
+      {
+        label: 'approval.component.ts — the gate',
+        language: 'typescript',
+        source: `export class ApprovalComponent {
+  protected readonly agent = injectAgent(APPROVAL_AGENT);
+
+  // Non-null only while the graph is paused on an interrupt.
+  readonly pendingApproval = computed(() => this.agent.interrupt());
+
+  approve() {
+    this.agent.submit({ resume: { approved: true } });
+  }
+
+  reject(reason: string) {
+    this.agent.submit({ resume: { approved: false, reason } });
+  }
+}`,
+      },
+    ],
+  },
+};


### PR DESCRIPTION
Phase 1 of [the medium switcher spec](docs/superpowers/specs/2026-08-25-homepage-medium-switcher-design.md), executed from [the plan](docs/superpowers/plans/2026-08-26-homepage-medium-switcher.md).

A reader can now view the **Stream** and **Approve** sections as a video *or* as code. Different readers want different evidence — a video proves it's real, code proves it's small — and the homepage previously showed no code at all despite being a developer framework.

## The constraint that shaped it

**Only the active pane is mounted.** Inactive panes are absent from the DOM, not hidden with CSS — otherwise the homepage would fetch every video on load. The built output confirms it: **2 tablists, 2 `<video>` elements**, one per section.

This is pinned by a test that was itself verified to fail: rendering every pane makes `mounts only the active pane` fail. Without that check, a later "cleanup" to CSS-toggling would pass the suite while quietly regressing the page.

`HighlightedCode` is an async Server Component, so a client component can't render one as a child. Code panes are highlighted in `page.tsx` on the server and passed in as props — that's what makes the code tab possible at all.

## Three defects caught in review

**Arrow keys changed selection without moving focus.** The classic ARIA tabs trap: `aria-selected` moved, DOM focus didn't, and because the newly-inactive tab keeps `tabIndex={-1}`, the next Tab press skipped the entire tablist. The arrow-key test only asserted `aria-selected`, which is exactly how it got through — it now asserts `document.activeElement`, and that assertion was confirmed to fail before the fix.

**Duplicate pane ids.** `SectionMedia.code` is `readonly SolutionCode[]`, so two code blocks were always possible — and both would have been keyed `'code'`, colliding on the React key *and* producing duplicate DOM ids that break `aria-controls`/`aria-labelledby`. `MediumPane` now carries an `id` distinct from its medium `key`; the built page shows four unique tab ids. Regression test included.

**A suffix-anchored analytics type.** The first fix widened `CtaId` with `` `${string}_video` ``, which accepts any string ending in `_video` from any surface. Every other loose member in that union is prefix-anchored (`nav_${string}`, `home_demo_${string}`), so the id is now `medium_<section>_<medium>` and the union member is `` `medium_${string}` ``.

Home/End key support was added alongside the focus fix.

## Also here

`LANGGRAPH_CLIP` moves into `demo-media.ts` rather than being re-declared. Its comment states plainly that `DemoShowcase` still hardcodes its own copies — an earlier draft claimed the constant prevented drift, which was false while only one consumer used it.

## Known follow-ups (not in this PR)

- **`DemoShowcase` has an incomplete ARIA tabs pattern** — `role="tablist"`/`role="tab"`/`aria-selected` with no `aria-controls`, no roving tabindex, and no keyboard handling. That's worse than plain buttons: it promises assistive tech a widget it doesn't deliver. Tracked separately; it's a live homepage section and deserves its own change.
- **A third near-identical `<video>` block** now exists across `page.tsx`, `DemoShowcase.tsx`, and `SolutionDemoBlock.tsx`. Worth extracting a shared player over `DemoClip`.
- **`public/screenshots/cockpit-docs.webp` is now unreferenced** (it was the old Stream visual). Verified with `grep -rn "cockpit-docs" apps/website/src` → no matches. Left in place for an asset-pruning pass.

## Verification

- `npx vitest run --config vite.config.mts` from `apps/website`: **334 passed**, 5 failed — the same pre-existing failures in `thanks/page.spec.tsx`, `PostCard.spec.tsx`, `Differentiator.spec.tsx`, untouched here (321 at branch point; 13 added tests account for the delta)
- `nx lint website`: **0 errors**, 29 warnings (unchanged)
- `nx build website --configuration=production`: succeeds
- Built homepage: 2 tablists, 2 videos, 4 unique tab ids

🤖 Generated with [Claude Code](https://claude.com/claude-code)