### PR TITLE
fix(cockpit-langgraph): make the subgraphs example demonstrate real nesting

### DIFF
--- a/cockpit/langgraph/subgraphs/angular/e2e/fixtures/subgraphs.json
+++ b/cockpit/langgraph/subgraphs/angular/e2e/fixtures/subgraphs.json
@@ -1,11 +1,39 @@
 {
   "fixtures": [
     {
-      "match": {
-        "userMessage": "Hello"
-      },
+      "match": { "responseFormat": "json_schema", "userMessage": "LangGraph checkpointing" },
       "response": {
-        "content": "Hello \u2014 nice to meet you. What would you like help with today?\n\nTell me the specific question or topic and any preferences (depth: quick summary vs deep dive, date range, types of sources, format: bullet list, tutorial, pros/cons, citations). Example: \u201cCompare CRISPR vs base editors for somatic therapy, include clinical trials since 2020 and cite sources.\u201d\n\nOnce you reply I\u2019ll prepare and run a focused research query and return the findings."
+        "content": {
+          "needs_research": true,
+          "topic": "LangGraph checkpointing: what a checkpointer persists and when"
+        }
+      }
+    },
+    {
+      "match": { "responseFormat": "json_schema", "userMessage": "what can you do" },
+      "response": {
+        "content": {
+          "needs_research": false,
+          "topic": ""
+        }
+      }
+    },
+    {
+      "match": { "systemMessage": "Research Subgraph", "userMessage": "LangGraph checkpointing" },
+      "response": {
+        "content": "- A checkpointer writes one state snapshot per super-step.\n- Snapshots are keyed by thread_id, so each conversation replays independently.\n- Interrupts resume from the snapshot taken immediately before the pause.\n- InMemorySaver is for development; Postgres and SQLite savers persist across restarts."
+      }
+    },
+    {
+      "match": { "systemMessage": "Orchestrator Agent", "userMessage": "LangGraph checkpointing" },
+      "response": {
+        "content": "Checkpointing saves your graph's state as it runs, so a conversation can pause and pick up exactly where it left off. Each thread gets its own history, and durable savers keep it around across restarts."
+      }
+    },
+    {
+      "match": { "systemMessage": "Orchestrator Agent", "userMessage": "what can you do" },
+      "response": {
+        "content": "Hi! I answer questions, and when one needs a factual deep dive I hand the topic to a research subgraph before replying. Ask me something specific and you'll see it happen."
       }
     }
   ]

--- a/cockpit/langgraph/subgraphs/angular/e2e/manual/subgraphs.manual.ts
+++ b/cockpit/langgraph/subgraphs/angular/e2e/manual/subgraphs.manual.ts
@@ -1,21 +1,45 @@
+// SPDX-License-Identifier: MIT
+//
+// Manual (live-LLM) counterpart to subgraphs.spec.ts. Run against a real
+// OpenAI key with the example served on its cockpit port — the routing
+// decision is a genuine model call here, so assertions check the branch that
+// actually ran rather than baking in a fixture's answer.
 import { expect, test } from '@playwright/test';
 
-test.describe('LangGraph Subgraphs Example', () => {
+test.describe('LangGraph Subgraphs Example (live)', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('http://localhost:4305');
     await page.waitForSelector('app-subgraphs', { state: 'attached' });
   });
 
-  test('renders the chat interface with subagent sidebar', async ({ page }) => {
-    await expect(page.locator('chat')).toBeVisible();
-    await expect(page.locator('textarea[name="messageText"]')).toBeVisible();
-    await expect(page.locator('text=No active subagents')).toBeVisible();
+  test('a research question routes into the child graph', async ({ page }) => {
+    await page.fill('textarea[name="messageText"]', 'How does LangGraph checkpointing work?');
+    await page.click('button[type="submit"]');
+
+    const panel = page.getByTestId('subgraph-panel');
+    await expect(panel.getByTestId('route')).toContainText('Nested', { timeout: 60_000 });
+    await expect(panel.getByTestId('research-topic')).not.toBeEmpty({ timeout: 60_000 });
+    await expect(panel.getByTestId('research-brief')).not.toBeEmpty({ timeout: 60_000 });
+
+    const assistant = page
+      .locator('chat-message[data-role="assistant"][data-streaming="false"]')
+      .last();
+    await expect(assistant).toBeAttached({ timeout: 60_000 });
+    await expect(assistant.locator('.chat-md')).not.toBeEmpty();
   });
 
-  test('sends a message and receives a response', async ({ page }) => {
-    await page.fill('textarea[name="messageText"]', 'hello');
+  test('a greeting skips the child graph', async ({ page }) => {
+    await page.fill('textarea[name="messageText"]', 'hi there');
     await page.click('button[type="submit"]');
-    await expect(page.locator('.chat-md').first()).toBeVisible({ timeout: 30000 });
-    await expect(page.locator('.chat-md').first()).not.toBeEmpty({ timeout: 30000 });
+
+    const assistant = page
+      .locator('chat-message[data-role="assistant"][data-streaming="false"]')
+      .last();
+    await expect(assistant).toBeAttached({ timeout: 60_000 });
+    await expect(assistant.locator('.chat-md')).not.toBeEmpty();
+
+    const panel = page.getByTestId('subgraph-panel');
+    await expect(panel.getByTestId('route')).toContainText('Direct');
+    await expect(panel.getByTestId('research-brief')).toHaveCount(0);
   });
 });

--- a/cockpit/langgraph/subgraphs/angular/e2e/subgraphs.spec.ts
+++ b/cockpit/langgraph/subgraphs/angular/e2e/subgraphs.spec.ts
@@ -1,10 +1,58 @@
 // SPDX-License-Identifier: MIT
 import { test, expect } from '@playwright/test';
-import { submitAndWaitForResponse } from '@threadplane-internal/e2e-harness';
 
-test('subgraphs: hello prompt produces assistant turn', async ({ page }) => {
-  const bubble = await submitAndWaitForResponse(page, 'Hello');
-  // Smoke: backend booted, aimock replayed fixture, assistant bubble
-  // finalized (data-streaming="false") and is present in the DOM.
-  await expect(bubble).toBeVisible();
+// Distinctive line from the research subgraph's brief. It exists only in the
+// child graph's `research_brief` output, never in the parent's answer — which
+// is what makes it usable as a probe for the state boundary.
+const BRIEF_MARKER = 'one state snapshot per super-step';
+
+test.describe('cockpit subgraphs: conditional nesting', () => {
+  test('a research question routes into the child graph and shows its brief', async ({ page }) => {
+    await page.goto('/');
+    await page.getByText('Ask something that needs research').click();
+
+    const finalAssistant = page
+      .locator('chat-message[data-role="assistant"][data-streaming="false"]')
+      .last();
+    await expect(finalAssistant).toBeAttached({ timeout: 30_000 });
+
+    const panel = page.getByTestId('subgraph-panel');
+    await expect(panel.getByTestId('route')).toContainText('Nested');
+    await expect(panel.getByTestId('research-topic')).toContainText('checkpointer persists');
+    await expect(panel.getByTestId('research-brief')).toContainText(BRIEF_MARKER);
+    await expect(finalAssistant).toContainText('Checkpointing saves');
+  });
+
+  test("the child's brief never reaches the transcript", async ({ page }) => {
+    await page.goto('/');
+    await page.getByText('Ask something that needs research').click();
+
+    // Sidebar has it (proves the assertion below is not vacuous — the brief
+    // was produced and delivered, it just went somewhere the transcript isn't).
+    await expect(page.getByTestId('research-brief')).toContainText(BRIEF_MARKER, {
+      timeout: 30_000,
+    });
+    await expect(
+      page.locator('chat-message[data-role="assistant"][data-streaming="false"]').last(),
+    ).toBeAttached({ timeout: 30_000 });
+
+    // Scan every rendered message, not just the last one.
+    await expect(page.locator('chat-message').filter({ hasText: BRIEF_MARKER })).toHaveCount(0);
+    await expect(page.locator('chat-message')).toHaveCount(2); // the ask + the parent's answer
+  });
+
+  test('a greeting skips the child graph and still answers', async ({ page }) => {
+    await page.goto('/');
+    await page.getByText('Ask something that does not').click();
+
+    const finalAssistant = page
+      .locator('chat-message[data-role="assistant"][data-streaming="false"]')
+      .last();
+    await expect(finalAssistant).toBeAttached({ timeout: 30_000 });
+    await expect(finalAssistant).toContainText('I answer questions');
+
+    const panel = page.getByTestId('subgraph-panel');
+    await expect(panel.getByTestId('route')).toContainText('Direct');
+    await expect(panel.getByTestId('research-brief')).toHaveCount(0);
+  });
 });

--- a/cockpit/langgraph/subgraphs/angular/prompts/subgraphs.md
+++ b/cockpit/langgraph/subgraphs/angular/prompts/subgraphs.md
@@ -1,5 +1,20 @@
 # LangGraph Subgraphs (Angular)
 
-This capability demonstrates composing LangGraph subgraphs — independent graphs invoked as nodes inside a parent graph — using the `@threadplane/chat` Angular component library. The `<chat-subagent-card>` renders a live status card for each active subgraph invocation, letting the user see which specialised agent is running and what it has produced.
+This capability demonstrates LangGraph subgraph composition — a compiled child
+graph added to a parent graph as a plain node — rendered with the
+`@threadplane/chat` Angular component library.
 
-Key components used: `<chat>`, `<chat-subagent-card>`. Cards appear in the message feed as the parent graph delegates work to subgraphs; each card shows the subgraph name, its streamed output, and a completion badge when the subgraph finishes.
+The parent orchestrator routes conditionally: requests that need a factual
+deep dive enter the `research` child graph first, everything else answers
+directly. The child graph's state has no `messages` key, so it exchanges only
+`research_topic` and `research_brief` with the parent and never touches the
+transcript.
+
+The sidebar reads the parent graph's own state through `agent.value()` to show
+which branch ran and what the child returned. It deliberately does **not** use
+`agent.subagents()`: that signal is populated only by delegation *tool calls*
+(`subagentToolNames` + `subagent_type`), not by plain subgraph nodes. For that
+pattern see the Chat Subagents capability.
+
+Key components used: `<chat>`. `provideAgent({ transcriptNodeNames: ['answer'] })`
+keeps the router's and the subgraph's tokens out of the chat transcript.

--- a/cockpit/langgraph/subgraphs/angular/src/app/agent-ref.ts
+++ b/cockpit/langgraph/subgraphs/angular/src/app/agent-ref.ts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+import { createAgentRef } from '@threadplane/chat';
+
+/**
+ * Parent graph state for the subgraphs cockpit.
+ *
+ * `research_topic` and `research_brief` are the two keys the parent shares
+ * with the compiled child graph — writing a topic is what routes execution
+ * into the subgraph, and the brief is what comes back out. The child's own
+ * state has no `messages` key, which is why nothing it produces reaches the
+ * transcript.
+ */
+export interface SubgraphsState {
+  messages: unknown[];
+  research_topic: string;
+  research_brief: string;
+}
+
+/**
+ * Typed DI handle for the subgraphs agent.
+ * Wire with `provideAgent(SUBGRAPHS_AGENT, { ... })` and inject with
+ * `injectAgent(SUBGRAPHS_AGENT)` to get `LangGraphAgent<SubgraphsState>`.
+ */
+export const SUBGRAPHS_AGENT = createAgentRef<SubgraphsState>('subgraphs');

--- a/cockpit/langgraph/subgraphs/angular/src/app/app.config.ts
+++ b/cockpit/langgraph/subgraphs/angular/src/app/app.config.ts
@@ -3,12 +3,25 @@ import { ApplicationConfig } from '@angular/core';
 import { provideAgent } from '@threadplane/langgraph';
 import { provideChat } from '@threadplane/chat';
 import { environment } from '../environments/environment';
+import { SUBGRAPHS_AGENT } from './agent-ref';
 
 export const appConfig: ApplicationConfig = {
   providers: [
-    provideAgent({
+    provideAgent(SUBGRAPHS_AGENT, {
       apiUrl: environment.langGraphApiUrl,
       assistantId: environment.streamingAssistantId,
+      // Only the parent's `answer` node writes the user-facing turn.
+      //
+      // This is load-bearing, and its failure mode is mid-stream rather than
+      // final-state. LangGraph emits the child's tokens under a
+      // `research:<uuid>` namespace, and that namespace is NOT a subagent
+      // namespace (`tools:`), so the bridge merges those tokens into the
+      // transcript as they arrive. Verified against a live model: without
+      // this option the message list transiently grows to 3 — the child's
+      // internal brief renders as its own chat bubble — before the parent's
+      // authoritative `values` event collapses it back to 2. Because the end
+      // state self-corrects, a final-state e2e assertion cannot catch it.
+      transcriptNodeNames: ['answer'],
     }),
     provideChat({}),
   ],

--- a/cockpit/langgraph/subgraphs/angular/src/app/subgraphs.component.ts
+++ b/cockpit/langgraph/subgraphs/angular/src/app/subgraphs.component.ts
@@ -1,52 +1,76 @@
 // SPDX-License-Identifier: MIT
-import { Component, computed } from '@angular/core';
-import { ChatComponent } from '@threadplane/chat';
+import { Component, ChangeDetectionStrategy, computed } from '@angular/core';
+import { ChatComponent, ChatWelcomeSuggestionComponent } from '@threadplane/chat';
 import { injectAgent } from '@threadplane/langgraph';
 import { ExampleChatLayoutComponent } from '@threadplane/example-layouts';
+import { SUBGRAPHS_AGENT } from './agent-ref';
+
+const WELCOME_SUGGESTIONS = [
+  // Labels asserted by e2e (subgraphs.spec.ts page.getByText) — do not change
+  // without updating the spec and the aimock fixtures together.
+  {
+    label: 'Ask something that needs research',
+    value: 'How does LangGraph checkpointing work?',
+    description: 'Orchestrator routes into the research subgraph, then answers from its brief.',
+  },
+  {
+    label: 'Ask something that does not',
+    value: 'Hi there — what can you do?',
+    description: 'Orchestrator skips the subgraph entirely and answers directly.',
+  },
+] as const;
 
 /**
- * SubgraphsComponent demonstrates nested agent delegation with `injectAgent()`.
+ * Subgraph composition cockpit example.
  *
- * This example shows how a parent orchestrator delegates tasks to child subgraphs.
- * The sidebar tracks active subagents in real time using `stream.subagents()`,
- * a Signal<Map<string, SubagentStreamRef>> of running child graph executions.
+ * The LangGraph backend is a parent graph with a compiled child graph added as
+ * a plain node. The parent's `orchestrate` node classifies each turn and a
+ * conditional edge decides whether execution enters the child at all.
  *
- * Key integration points:
- * - `stream.subagents()` returns a Map<string, SubagentStreamRef> of active subagents
- * - Each entry has a unique tool call ID (key) and a `status()` signal
- * - `subagentEntries` is a `computed()` signal derived from the map for template iteration
+ * **Why this sidebar reads `agent.value()` and not `agent.subagents()`.**
+ * `subagents()` is populated by the SubagentTracker, which keys on delegation
+ * *tool calls* — a tool whose name is listed in `subagentToolNames` and whose
+ * args carry a `subagent_type`, producing `tools:<id>` namespaced stream
+ * events. A plain subgraph node emits a `research:<uuid>` namespace instead
+ * and never appears in that map. See the Chat Subagents capability for the
+ * tool-call path; this capability shows the composition primitive underneath
+ * it, so child activity is read straight off the parent's own graph state.
+ *
+ * `research_topic` and `research_brief` are the only two keys the parent
+ * shares with the child. The brief is rendered here, in the sidebar, and
+ * nowhere else — `transcriptNodeNames: ['answer']` in `app.config.ts` keeps
+ * everything except the parent's final turn out of the chat transcript.
  */
 @Component({
   selector: 'app-subgraphs',
   standalone: true,
-  imports: [ChatComponent, ExampleChatLayoutComponent],
+  imports: [ChatComponent, ChatWelcomeSuggestionComponent, ExampleChatLayoutComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styles: `
     :host {
-      --st-done: #2ea567;
-      --st-active: #e0a850;
-      --st-error: #e0645a;
+      --st-nested: #2ea567;
+      --st-direct: #e0a850;
     }
     .panel {
       padding: 1rem;
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
     }
     .cap {
-      margin-bottom: 1rem;
       font-size: 10px;
       font-weight: 700;
       text-transform: uppercase;
       letter-spacing: 0.12em;
       color: var(--ds-text-muted);
+      margin: 0;
     }
-    .empty {
-      font-size: 13px;
-      font-style: italic;
-      color: var(--ds-text-muted);
-    }
-    .row {
+    .route {
       display: flex;
       align-items: center;
       gap: 0.5rem;
-      padding: 6px 0;
+      font-size: 13px;
+      color: var(--ds-text-primary);
     }
     .dot {
       width: 8px;
@@ -55,66 +79,113 @@ import { ExampleChatLayoutComponent } from '@threadplane/example-layouts';
       flex-shrink: 0;
       background: var(--ds-text-muted);
     }
-    .dot--complete { background: var(--st-done); }
-    .dot--error { background: var(--st-error); }
-    .dot--running { background: var(--st-active); }
-    .id {
-      font-family: var(--ds-font-mono);
-      font-size: 11px;
-      color: var(--ds-text-primary);
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      min-width: 0;
-    }
-    .count {
-      margin-left: auto;
-      font-size: 11px;
+    .dot--nested { background: var(--st-nested); }
+    .dot--direct { background: var(--st-direct); }
+    .hint {
+      font-size: 12px;
+      font-style: italic;
       color: var(--ds-text-muted);
-      flex-shrink: 0;
+      margin: 0;
+    }
+    .field {
+      display: flex;
+      flex-direction: column;
+      gap: 0.35rem;
+    }
+    .topic {
+      font-family: var(--ds-font-mono);
+      font-size: 12px;
+      color: var(--ds-text-primary);
+      word-break: break-word;
+    }
+    .brief {
+      font-size: 12px;
+      line-height: 1.5;
+      color: var(--ds-text-primary);
+      white-space: pre-wrap;
+      word-break: break-word;
+      margin: 0;
     }
   `,
   template: `
     <example-chat-layout>
-      <chat main [agent]="agent" class="flex-1 min-w-0" />
-      <div sidebar class="panel">
-        <h3 class="cap">Subagents</h3>
-        @if (subagentEntries().length === 0) {
-          <p class="empty">No subagents active</p>
-        }
-        @for (entry of subagentEntries(); track entry.id) {
-          <div class="row">
-            <span class="dot"
-                  [class.dot--complete]="entry.status === 'complete'"
-                  [class.dot--error]="entry.status === 'error'"
-                  [class.dot--running]="entry.status !== 'complete' && entry.status !== 'error'"></span>
-            <span class="id">{{ entry.id }}</span>
-            <span class="count">{{ entry.msgCount }} msgs</span>
+      <chat main [agent]="agent" class="flex-1 min-w-0">
+        <div chatWelcomeSuggestions>
+          @for (s of suggestions; track s.value) {
+            <chat-welcome-suggestion
+              [label]="s.label"
+              [value]="s.value"
+              [description]="s.description"
+              (selected)="send($event)"
+            />
+          }
+        </div>
+      </chat>
+
+      <div sidebar class="panel" data-testid="subgraph-panel">
+        <div class="field">
+          <h3 class="cap">Route</h3>
+          @if (delegated()) {
+            <p class="route" data-testid="route">
+              <span class="dot dot--nested"></span>Nested — research subgraph ran
+            </p>
+          } @else {
+            <p class="route" data-testid="route">
+              <span class="dot dot--direct"></span>Direct — subgraph skipped
+            </p>
+          }
+        </div>
+
+        @if (delegated()) {
+          <div class="field">
+            <h3 class="cap">Topic sent to child</h3>
+            <code class="topic" data-testid="research-topic">{{ topic() }}</code>
           </div>
+
+          <div class="field">
+            <h3 class="cap">Brief returned by child</h3>
+            @if (brief()) {
+              <p class="brief" data-testid="research-brief">{{ brief() }}</p>
+            } @else {
+              <p class="hint">Running…</p>
+            }
+          </div>
+          <p class="hint">
+            The child graph's state has no <code>messages</code> key, so this brief
+            never entered the transcript.
+          </p>
+        } @else {
+          <p class="hint">
+            The orchestrator answered without entering the child graph. Ask a
+            factual question to route through it.
+          </p>
         }
       </div>
     </example-chat-layout>
   `,
 })
 export class SubgraphsComponent {
-  /**
-   * The streaming resource that tracks subgraph (child agent) activity.
-   *
-   * `stream.subagents()` is a Signal<Map<string, SubagentStreamRef>> that updates
-   * as the parent orchestrator dispatches work to child subgraphs.
-   */
-  protected readonly agent = injectAgent();
+  protected readonly suggestions = WELCOME_SUGGESTIONS;
 
   /**
-   * Derived signal: converts the subagents Map to an array for template iteration.
-   * Using `computed()` ensures the template re-renders whenever the Map changes.
+   * Typed agent — `agent.value()` is `Signal<SubgraphsState>`, the parent
+   * graph's live state as LangGraph streams `values` events.
    */
-  protected readonly subagentEntries = computed(() => {
-    const map = this.agent.subagents()!
-    return Array.from(map.entries()).map(([id, ref]) => ({
-      id,
-      status: ref.status(),
-      msgCount: ref.messages().length,
-    }));
-  });
+  protected readonly agent = injectAgent(SUBGRAPHS_AGENT);
+
+  /** The topic the parent handed to the child graph this turn, if any. */
+  protected readonly topic = computed(() => this.agent.value()?.research_topic ?? '');
+
+  /** The brief the child graph handed back. */
+  protected readonly brief = computed(() => this.agent.value()?.research_brief ?? '');
+
+  /**
+   * A non-empty topic is exactly what the parent's conditional edge routes on,
+   * so it doubles as the UI's "did we nest?" signal.
+   */
+  protected readonly delegated = computed(() => this.topic().length > 0);
+
+  protected send(text: string): void {
+    void this.agent.submit({ message: text });
+  }
 }

--- a/cockpit/langgraph/subgraphs/angular/src/index.ts
+++ b/cockpit/langgraph/subgraphs/angular/src/index.ts
@@ -28,6 +28,6 @@ export const langgraphSubgraphsAngularModule: CockpitCapabilityModule = {
     'cockpit/langgraph/subgraphs/angular/prompts/subgraphs.md',
   ],
   codeAssetPaths: [
-    'cockpit/langgraph/subgraphs/angular/src/app.component.ts',
+    'cockpit/langgraph/subgraphs/angular/src/app/subgraphs.component.ts',
   ],
 };

--- a/cockpit/langgraph/subgraphs/python/docs/guide.md
+++ b/cockpit/langgraph/subgraphs/python/docs/guide.md
@@ -1,131 +1,184 @@
-# Nested Agent Delegation with Subgraphs and Angular
+# Nested Graph Composition with Subgraphs and Angular
 
 <Summary>
-Build a chat interface that visualizes nested agent delegation using `provideAgent()` and
-`injectAgent()` from `@threadplane/langgraph`. A parent orchestrator dispatches research tasks to a child
-subgraph, and the sidebar tracks each subagent's status in real time using `stream.subagents()`.
+Build a chat interface over a LangGraph parent graph that composes a compiled child
+graph as a node, using `provideAgent()` and `injectAgent()` from `@threadplane/langgraph`.
+The parent orchestrator decides per turn whether to enter the child graph, and the sidebar
+reads the parent's own state through `agent.value()` to show which branch ran and what the
+child returned.
 </Summary>
 
 <Prompt>
-Add a subgraph-powered orchestrator to this Angular component using `provideAgent()` and `injectAgent()` from `@threadplane/langgraph`. Use `stream.subagents()` to track active child subgraph executions, and derive a `subagentEntries` signal with `computed()` for template iteration. Bind `stream.messages()` beside the `<chat>` component from `@threadplane/chat`.
+Add a parent/child LangGraph composition to this Angular app using `provideAgent()` and `injectAgent()` from `@threadplane/langgraph`. The parent should route conditionally into a compiled child graph whose state has no `messages` key, and the component should read `agent.value()` for the shared `research_topic` / `research_brief` keys. Set `transcriptNodeNames` so only the parent's answer node reaches the chat transcript.
 </Prompt>
 
-<Steps>
-<Step title="Configure the provider">
+<Warning>
+A plain subgraph node is **not** a tracked subagent. `agent.subagents()` is populated only
+by delegation *tool calls* whose name matches `subagentToolNames` and whose args carry a
+`subagent_type` — that path emits `tools:<id>` namespaced events. A subgraph added as a
+plain node emits a `research:<uuid>` namespace and never appears in that map. For the
+tool-call pattern, see [Chat Subagents](/chat/core-capabilities/subagents/overview/python).
+</Warning>
 
-Set up `provideAgent()` in your app config with the LangGraph API URL:
+<Steps>
+<Step title="Define the typed state and configure the provider">
+
+The parent state carries the transcript plus the keys it shares with the child:
+
+```typescript
+// agent-ref.ts
+import { createAgentRef } from '@threadplane/chat';
+
+export interface SubgraphsState {
+  messages: unknown[];
+  research_topic: string;
+  research_brief: string;
+}
+
+export const SUBGRAPHS_AGENT = createAgentRef<SubgraphsState>('subgraphs');
+```
 
 ```typescript
 // app.config.ts
 import { ApplicationConfig } from '@angular/core';
 import { provideAgent } from '@threadplane/langgraph';
+import { SUBGRAPHS_AGENT } from './agent-ref';
 
 export const appConfig: ApplicationConfig = {
   providers: [
-    provideAgent({
+    provideAgent(SUBGRAPHS_AGENT, {
       apiUrl: 'https://your-deployment.langgraph.app',
       assistantId: 'subgraphs',
+      transcriptNodeNames: ['answer'],
     }),
   ],
 };
 ```
 
-</Step>
-<Step title="Create the streaming resource">
+`transcriptNodeNames` whitelists the graph nodes whose message tokens belong in the chat
+transcript. It matters more than it looks: a child subgraph's `research:<uuid>` namespace is
+not a subagent (`tools:`) namespace, so without this option the child's tokens merge into the
+transcript as they stream and its internal brief briefly renders as its own chat bubble. The
+parent's final `values` event corrects the message list afterwards, so the symptom is a
+mid-stream flash rather than a wrong end state.
 
-In your component, call `injectAgent()` to retrieve the configured subgraphs agent:
+</Step>
+<Step title="Read the shared state in your component">
+
+`injectAgent(SUBGRAPHS_AGENT)` gives you `LangGraphAgent<SubgraphsState>`, so
+`agent.value()` is typed:
 
 ```typescript
 // subgraphs.component.ts
 import { Component, computed } from '@angular/core';
 import { injectAgent } from '@threadplane/langgraph';
+import { SUBGRAPHS_AGENT } from './agent-ref';
 
 export class SubgraphsComponent {
-  protected readonly stream = injectAgent();
+  protected readonly agent = injectAgent(SUBGRAPHS_AGENT);
 
-  subagentEntries = computed(() => Array.from(this.stream.subagents().entries()));
+  protected readonly topic = computed(() => this.agent.value()?.research_topic ?? '');
+  protected readonly brief = computed(() => this.agent.value()?.research_brief ?? '');
+
+  /** A non-empty topic is what the parent's conditional edge routes on. */
+  protected readonly delegated = computed(() => this.topic().length > 0);
 }
 ```
 
-`stream.subagents()` is a `Signal<Map<string, SubagentStreamRef>>`. Each entry holds a run ID and a `status()` signal that updates as the child subgraph runs.
+`agent.value()` is a `Signal<SubgraphsState>` fed by LangGraph's `values` stream mode. It
+updates as the parent graph advances, so the sidebar reflects the branch that actually ran.
 
 </Step>
-<Step title="Build the template with subagent sidebar">
+<Step title="Build the template">
 
-Use `<chat>` from `@threadplane/chat` and render a sibling sidebar:
+Use `<chat>` from `@threadplane/chat` and render a sibling sidebar off the same signals:
 
 ```html
-<chat [agent]="stream" />
+<chat [agent]="agent" />
 
 <aside>
-    <h3>Subagents</h3>
-    @for (entry of subagentEntries(); track entry[0]) {
-      <div>{{ entry[0].substring(0, 8) }}: {{ entry[1].status() }}</div>
-    }
-    @empty {
-      <p>No active subagents</p>
-    }
+  <h3>Route</h3>
+  @if (delegated()) {
+    <p>Nested — research subgraph ran</p>
+    <code>{{ topic() }}</code>
+    <p>{{ brief() }}</p>
+  } @else {
+    <p>Direct — subgraph skipped</p>
+  }
 </aside>
 ```
 
-The `@empty` block renders when no subagents are active. Each entry shows a truncated run ID and the current status (`'pending'`, `'running'`, `'complete'`, or `'error'`).
-
 <Tip>
-Use `computed()` to derive `subagentEntries` from the Map. This ensures Angular's change detection picks up updates when subagents are added or their status changes.
+The brief renders here and nowhere else. Because the child's state has no `messages` key,
+its output never enters the transcript — the parent decides what, if anything, to say
+about it.
 </Tip>
 
 </Step>
-<Step title="The LangGraph backend with parent-child subgraphs">
+<Step title="The LangGraph backend">
 
-The backend uses a parent orchestrator that delegates to a compiled child subgraph:
+The parent adds the *compiled* child graph as a node and routes into it conditionally:
 
 ```python
 # graph.py
-from langgraph.graph import StateGraph, MessagesState, END
-from langchain_openai import ChatOpenAI
+from typing import Annotated, TypedDict
+from langgraph.graph import StateGraph, START, END
+from langgraph.graph.message import add_messages
 
-llm = ChatOpenAI(model="gpt-5-mini", streaming=True)
+class ResearchState(TypedDict):          # child — no `messages` key
+    research_topic: str
+    research_brief: str
 
-# Child: research subgraph
-async def research_node(state: MessagesState) -> dict:
-    response = await llm.ainvoke(state["messages"])
-    return {"messages": [response]}
+class OrchestratorState(TypedDict):      # parent — transcript + shared keys
+    messages: Annotated[list, add_messages]
+    research_topic: str
+    research_brief: str
 
-research_graph = StateGraph(MessagesState)
+research_graph = StateGraph(ResearchState)
 research_graph.add_node("research", research_node)
-research_graph.set_entry_point("research")
+research_graph.add_edge(START, "research")
 research_graph.add_edge("research", END)
 
-# Parent: orchestrator
-async def orchestrate_node(state: MessagesState) -> dict:
-    response = await llm.ainvoke(state["messages"])
-    return {"messages": [response]}
+def route_after_orchestrate(state: OrchestratorState) -> str:
+    return "research" if state.get("research_topic") else "answer"
 
-parent_graph = StateGraph(MessagesState)
+parent_graph = StateGraph(OrchestratorState)
 parent_graph.add_node("orchestrate", orchestrate_node)
-parent_graph.add_node("research", research_graph.compile())
-parent_graph.add_edge("orchestrate", "research")
-parent_graph.add_edge("research", END)
+parent_graph.add_node("research", research_graph.compile())   # subgraph AS a node
+parent_graph.add_node("answer", answer_node)
+parent_graph.add_edge(START, "orchestrate")
+parent_graph.add_conditional_edges(
+    "orchestrate", route_after_orchestrate, {"research": "research", "answer": "answer"}
+)
+parent_graph.add_edge("research", "answer")
+parent_graph.add_edge("answer", END)
 graph = parent_graph.compile()
 ```
 
-The child subgraph is compiled and passed as a node to the parent graph. LangGraph streams subgraph events separately, which `angular` captures and exposes through `stream.subagents()`.
+LangGraph wires a subgraph node through the keys the two state schemas **share**. Here that
+is `research_topic` and `research_brief`: the child receives a topic, returns a brief, and
+can neither read nor append to the parent's `messages`. The child runs as its own graph with
+its own step sequence, and its stream events arrive under a `research:<uuid>` namespace
+rather than flattened into the parent's.
 
 <Tip>
-Child subgraphs can have their own state, checkpointers, and tools. This pattern is ideal for multi-agent systems where specialized agents handle distinct concerns.
+Child subgraphs can have their own state, checkpointers, and tools. Reach for this pattern
+when you want a reusable unit of graph logic with a narrow, explicit interface to its caller.
 </Tip>
 
 </Step>
 </Steps>
 
 <Tip>
-The `<chat>` component handles message rendering, input, loading states, and error display. Focus your component on subagent tracking logic.
+The `<chat>` component handles message rendering, input, loading states, and error display.
+Focus your component on reading the shared state keys.
 </Tip>
 
 <Warning>
-Never expose your LangSmith API key in client-side code. Use server-side environment variables or a proxy.
+Never expose your LangSmith API key in client-side code. Use server-side environment
+variables or a proxy.
 </Warning>
 
 <Related>
-- [Chat Subagents](/chat/core-capabilities/subagents/overview/python) — Learn how ChatSubagentsComponent visualizes nested agent delegation
+- [Chat Subagents](/chat/core-capabilities/subagents/overview/python) — tool-call delegation, the pattern that does populate `subagents()`
 </Related>

--- a/cockpit/langgraph/subgraphs/python/prompts/subgraphs.md
+++ b/cockpit/langgraph/subgraphs/python/prompts/subgraphs.md
@@ -1,10 +1,14 @@
 # Orchestrator Agent
 
-You are an orchestrator that delegates research tasks to a specialized research subgraph.
+You write the user-facing answer for a parent graph that composes a research
+subgraph as a node.
 
-When a user asks a question, briefly acknowledge the request and prepare a focused
-research query. The research subgraph will then perform the in-depth investigation
-and return its findings.
+When an internal brief from the research subgraph is present, treat it as your
+source material: fold it into a direct, conversational answer. Do not mention
+the brief, the subgraph, or your own routing — the user asked a question, not
+for a status report.
 
-You are demonstrating LangGraph's subgraph feature, where a parent graph
-coordinates child subgraphs that run as nested agents.
+When no brief is present the parent answered directly, without entering the
+child graph. Reply briefly and naturally.
+
+Keep answers to a few sentences unless the question clearly needs more.

--- a/cockpit/langgraph/subgraphs/python/src/graph.py
+++ b/cockpit/langgraph/subgraphs/python/src/graph.py
@@ -1,61 +1,174 @@
 """
-LangGraph Subgraphs Graph
+LangGraph Subgraphs Graph — nested execution with a state boundary
 
-Demonstrates nested agent delegation using subgraphs. A parent orchestrator
-delegates research tasks to a specialized child subgraph. The parent graph
-controls the overall flow while the research subgraph handles deep-dive
-information gathering independently.
+Demonstrates LangGraph's composition primitive: a *compiled child graph added
+to a parent graph as a plain node*. Three things make this a real subgraph
+demo rather than a straight-line chain:
+
+1. **A conditional route.** The `orchestrate` node classifies the request and
+   the parent decides whether to enter the child graph at all. A greeting
+   answers directly; a factual question routes through `research` first.
+
+2. **A state boundary.** The parent state carries `messages`; the child state
+   (`ResearchState`) does not. LangGraph wires a subgraph node through the
+   keys the two schemas *share* — here `research_topic` and `research_brief` —
+   so the child receives a topic and returns a brief, and can neither read the
+   chat transcript nor append to it.
+
+3. **Nested execution.** The child runs as its own graph with its own step
+   sequence, and LangGraph emits its stream events under a namespace
+   (`research:<uuid>`) rather than flattening them into the parent's.
+
+**A plain subgraph node is not a tracked "subagent".** `agent.subagents()` in
+`@threadplane/langgraph` is populated only by delegation *tool calls* whose
+name matches `subagentToolNames` and whose args carry a `subagent_type` — that
+path emits `tools:<id>` namespaces, and it is demonstrated in
+`cockpit/chat/subagents`. This example therefore surfaces child activity by
+reading the parent graph's own state through `agent.value()`.
 """
 
 from pathlib import Path
-from langgraph.graph import StateGraph, MessagesState, END
+from typing import Annotated, TypedDict
+
+from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_openai import ChatOpenAI
-from langchain_core.messages import SystemMessage
+from langgraph.graph import END, START, StateGraph
+from langgraph.graph.message import add_messages
+from pydantic import BaseModel, Field
 
 PROMPTS_DIR = Path(__file__).parent.parent / "prompts"
 
+# Gate phrase for the router's structured-output call. Kept distinct from the
+# other two system prompts so e2e fixture replay can tell the calls apart.
+ROUTER_PROMPT = (
+    "Delegation Router.\n"
+    "Decide whether answering the latest user turn requires a factual "
+    "deep dive that should be handed to the research subgraph.\n"
+    "Greetings, small talk, and questions about your own capabilities do "
+    "NOT require research. Questions about facts, comparisons, or how a "
+    "technology works DO.\n"
+    "When research is required, restate the request as one focused topic "
+    "line for the subgraph."
+)
+
+RESEARCH_PROMPT = (
+    "Research Subgraph.\n"
+    "You are a focused researcher running as a child graph. You are given a "
+    "topic and nothing else — you cannot see the chat transcript, so never "
+    "address the user or ask questions. Return 3-5 terse factual bullets. "
+    "Your output is an internal brief the parent orchestrator will use to "
+    "write the user-facing answer."
+)
+
+
+class DelegationDecision(BaseModel):
+    """Structured routing decision produced by the `orchestrate` node."""
+
+    needs_research: bool = Field(
+        description="True when answering requires a factual deep dive that the research subgraph should handle."
+    )
+    topic: str = Field(
+        default="",
+        description="One focused topic line for the subgraph. Empty string when needs_research is false.",
+    )
+
+
+class ResearchState(TypedDict):
+    """Child graph state — deliberately has no `messages` key.
+
+    The only keys here are the ones shared with the parent, which is exactly
+    the contract LangGraph uses to pass state into and out of a subgraph node.
+    """
+
+    research_topic: str
+    research_brief: str
+
+
+class OrchestratorState(TypedDict):
+    """Parent graph state — the transcript plus the shared subgraph channel."""
+
+    messages: Annotated[list, add_messages]
+    research_topic: str
+    research_brief: str
+
 
 def build_subgraphs_graph():
-    """
-    Constructs a parent graph that delegates to a child research subgraph.
-
-    The parent orchestrator decides when to delegate to the research subgraph.
-    The research subgraph runs independently and returns its results to the parent.
-    """
+    """Constructs a parent graph that conditionally enters a child subgraph."""
     llm = ChatOpenAI(model="gpt-5-mini", streaming=True)
+    router = ChatOpenAI(model="gpt-5-mini").with_structured_output(DelegationDecision)
+    researcher = ChatOpenAI(model="gpt-5-mini")
 
     # ── Child: research subgraph ──────────────────────────────────────────────
 
-    async def research_node(state: MessagesState) -> dict:
-        """Specialized research agent — performs deep-dive information gathering."""
-        messages = state["messages"]
-        response = await llm.ainvoke(messages)
-        return {"messages": [response]}
+    async def research_node(state: ResearchState) -> dict:
+        """Turn a topic into an internal brief. No transcript access."""
+        response = await researcher.ainvoke(
+            [
+                SystemMessage(content=RESEARCH_PROMPT),
+                HumanMessage(content=f"Topic: {state['research_topic']}"),
+            ]
+        )
+        text = response.content
+        if isinstance(text, list):  # multi-part content
+            text = "".join(part.get("text", "") for part in text if isinstance(part, dict))
+        return {"research_brief": str(text).strip()}
 
-    research_graph = StateGraph(MessagesState)
+    research_graph = StateGraph(ResearchState)
     research_graph.add_node("research", research_node)
-    research_graph.set_entry_point("research")
+    research_graph.add_edge(START, "research")
     research_graph.add_edge("research", END)
     compiled_research = research_graph.compile()
 
     # ── Parent: orchestrator graph ────────────────────────────────────────────
 
-    async def orchestrate_node(state: MessagesState) -> dict:
+    async def orchestrate_node(state: OrchestratorState) -> dict:
+        """Classify the request. Writing a topic is what triggers delegation.
+
+        Both shared keys are reset every turn so a topic left over from an
+        earlier turn in the same thread can't re-trigger the subgraph.
         """
-        Orchestrator node — reviews the request and prepares context
-        before delegating to the research subgraph.
+        decision = await router.ainvoke(
+            [SystemMessage(content=ROUTER_PROMPT), *state["messages"]]
+        )
+        topic = decision.topic.strip() if decision.needs_research else ""
+        return {"research_topic": topic, "research_brief": ""}
+
+    def route_after_orchestrate(state: OrchestratorState) -> str:
+        """The parent's decision: enter the child graph, or skip it."""
+        return "research" if state.get("research_topic") else "answer"
+
+    async def answer_node(state: OrchestratorState) -> dict:
+        """The only node that writes to the transcript.
+
+        `transcriptNodeNames: ['answer']` on the Angular side mirrors this:
+        the router's and the subgraph's tokens never reach the chat UI.
         """
         system_prompt = (PROMPTS_DIR / "subgraphs.md").read_text()
-        messages = [SystemMessage(content=system_prompt)] + state["messages"]
-        response = await llm.ainvoke(messages)
+        brief = state.get("research_brief") or ""
+        context = (
+            [SystemMessage(content=f"Internal brief returned by the research subgraph:\n{brief}")]
+            if brief
+            else []
+        )
+        response = await llm.ainvoke(
+            [SystemMessage(content=system_prompt), *context, *state["messages"]]
+        )
         return {"messages": [response]}
 
-    parent_graph = StateGraph(MessagesState)
+    parent_graph = StateGraph(OrchestratorState)
     parent_graph.add_node("orchestrate", orchestrate_node)
+    # The compiled child graph IS the node — no wrapper function. This is what
+    # makes it a subgraph rather than an inline helper call.
     parent_graph.add_node("research", compiled_research)
-    parent_graph.set_entry_point("orchestrate")
-    parent_graph.add_edge("orchestrate", "research")
-    parent_graph.add_edge("research", END)
+    parent_graph.add_node("answer", answer_node)
+    parent_graph.add_edge(START, "orchestrate")
+    parent_graph.add_conditional_edges(
+        "orchestrate",
+        route_after_orchestrate,
+        {"research": "research", "answer": "answer"},
+    )
+    parent_graph.add_edge("research", "answer")
+    parent_graph.add_edge("answer", END)
     return parent_graph.compile()
 
 

--- a/cockpit/langgraph/subgraphs/python/src/index.ts
+++ b/cockpit/langgraph/subgraphs/python/src/index.ts
@@ -30,6 +30,7 @@ export const langgraphSubgraphsPythonModule: CockpitCapabilityModule = {
   docsPath: '/docs/langgraph/core-capabilities/subgraphs/overview/python',
   promptAssetPaths: ['cockpit/langgraph/subgraphs/python/prompts/subgraphs.md'],
   codeAssetPaths: [
+    'cockpit/langgraph/subgraphs/angular/src/app/agent-ref.ts',
     'cockpit/langgraph/subgraphs/angular/src/app/subgraphs.component.ts',
   ],
   backendAssetPaths: [


### PR DESCRIPTION
## The problem

`cockpit/langgraph/subgraphs` advertised subagent delegation it could never perform.

**The sidebar could never populate.** `app.config.ts` set no `subagentToolNames`, and the graph added a compiled subgraph as a plain node — which emits a `research:<uuid>` namespace, not `tools:<id>`. `SubagentTracker` only registers delegation *tool calls* (`libs/langgraph/src/lib/internals/subagent-tracker.ts:78-112,265-269`), so `agent.subagents()` was permanently empty and the sidebar always rendered "No active subagents". The manual e2e asserted exactly that empty state and never asserted it populated.

**No delegation happened.** The docstring claimed "the parent orchestrator decides when to delegate," but the edges were unconditional (`orchestrate → research → END`). Both graphs were bare `MessagesState`, so the child inherited and appended to the parent's messages.

## The decision: honest nesting, not tool-call delegation

- `cockpit/chat/subagents` **already** demonstrates the tool-call path end to end (`task` tool + `subagent_type` + `ToolNode` loop + sidebar). Converting this example would have made it a near-duplicate and deleted the repo's only demo of LangGraph's actual composition primitive.
- The website docs already state the correct rule — `docs/langgraph/guides/subgraphs.mdx:114`: *"Plain subgraph nodes do not appear in this map."* The example was contradicting published docs; it now agrees with them.
- The example is filed under topic `subgraphs`, not `subagents`.

So: keep the plain subgraph-as-node pattern, but make it teach something real.

## Changes

**Backend** (`python/src/graph.py`)
- `orchestrate` makes a structured routing decision; a conditional edge enters the child graph or skips to `answer`. The parent actually decides.
- A real state boundary: the child's `ResearchState` has **no** `messages` key. LangGraph wires the subgraph node through the keys the two schemas share (`research_topic`, `research_brief`), so the child gets a topic, returns a brief, and can neither read nor append to the transcript.
- `answer` is the sole transcript-writing node.

**Frontend**
- Sidebar reads the parent's own state through a typed `agent.value()` instead of the map that can never fill — and the component doc says plainly why `subagents()` is the wrong signal here, pointing at Chat Subagents for the tool-call path.
- `transcriptNodeNames: ['answer']`.

**Docs** — `python/docs/guide.md` rewritten (the false `stream.subagents()` claim at :112 is gone; a `<Warning>` now states the subgraph-vs-subagent distinction up front). Both `prompts/subgraphs.md` corrected; the Angular one no longer claims a `<chat-subagent-card>` per subgraph invocation.

Drive-by: `angular/src/index.ts` `codeAssetPaths` pointed at a nonexistent `src/app.component.ts`.

## Tests

Three e2e specs replace the single smoke test. No test asserts an empty state as its only assertion:
1. Research branch routes into the child and the sidebar shows the topic **and** the returned brief.
2. The child's brief never reaches the transcript — paired with a positive sidebar assertion on the same marker, so it cannot pass vacuously, plus an exact message count.
3. Greeting skips the child and still answers.

The manual live-LLM spec now asserts the branch that ran, not an empty sidebar.

## Verification

- `nx e2e cockpit-langgraph-subgraphs-angular` — **3/3 green**.
- `nx build --configuration=production` — green.
- **Live model in Chrome**, both branches driven by hand. Research path: sidebar flips to "Nested", real topic populates, brief streams in, transcript stays at `[user, assistant]` with the brief absent from the live DOM. Direct path: sidebar stays "Direct", answer arrives.
- **Wire-level check** of the raw run stream confirmed the namespaces: 64 top-level `messages` events from `orchestrate`, 767 under `messages|research:<uuid>` from the child, 633 from `answer`.
- **Mutation-tested `transcriptNodeNames`.** Removing it does *not* fail the aimock e2e — fixture replay is atomic, so the leak is invisible there. Against a live model it is clearly load-bearing: message count transiently reaches **3** (the child's internal brief rendering as its own chat bubble) before the parent's `values` event collapses it back to 2. With the option, the count never exceeds 2 at any sampled point. The end state self-corrects, which is why no final-state assertion can catch it — recorded in a comment at the call site rather than claimed as test coverage.

## Note on guide.md:112

Checked for the separate in-flight correction mentioned in the task: no open PRs, and the only related branch (`blove/langgraph-subgraphs-post`) touches website content only. Nothing had landed, so this PR corrects the claim as part of the guide rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)