### PR TITLE
feat(website): add 'LangGraph Subgraphs: When to Split a Graph and When Not To' blog post

### DIFF
--- a/apps/website/content/blog/2026-08-27-langgraph-subgraphs-when-to-split.mdx
+++ b/apps/website/content/blog/2026-08-27-langgraph-subgraphs-when-to-split.mdx
@@ -42,6 +42,13 @@ Nothing about `add_node` fenced anything off.
 Isolation is something you design — give the child its own state schema, then map in at the boundary and map the result back out.
 That's a decision you make and maintain, not a property `compile()` hands you.
 
+We ship one graph that does exactly that, and because it's a capability demo built to show the primitive, it's a clean look at the shape.
+Its child state schema has no `messages` key at all.
+Parent and child share exactly two keys, `research_topic` and `research_brief`, so the child is handed a topic and hands back a brief — it can't read the transcript, and it can't append to one.
+
+That boundary is real, and none of it came from `compile()`.
+It came from writing two `TypedDict`s and being deliberate about what they share.
+
 ### What about context windows and error boundaries?
 
 Those are real reasons to split — our own docs lean on them.
@@ -141,7 +148,9 @@ By id — and this is the part I find well-designed: the namespace segment _is_ 
 Marking a child running and routing its messages need no matching at all.
 
 There is also a description-comparison ladder — exact match on the tool call's `description` argument, then substring either direction, then a last-resort fallback to any unmapped subagent still pending or running.
-It only runs for children whose state opens with a human message, and none of the graphs we ship on the LangGraph transport reach it: they invoke the child with an empty message list, so the first message in child state is the AI response.
+It only runs for children whose state opens with a human message, and none of the graphs we ship reach it.
+The ones dispatched through a tool call invoke the child with an empty message list, so the first message in child state is the AI response.
+The one wired in as a plain node doesn't keep a `messages` key in child state at all.
 Treat that path as untested rather than as the mechanism.
 
 The general point survives, though, and it's the one worth carrying to any protocol.

--- a/apps/website/content/blog/2026-08-27-langgraph-subgraphs-when-to-split.mdx
+++ b/apps/website/content/blog/2026-08-27-langgraph-subgraphs-when-to-split.mdx
@@ -17,7 +17,8 @@ This post is about the layer underneath: what a subgraph actually changes at run
 
 Nested execution and namespaced stream events. That's the honest list.
 
-Let's start with the canonical pattern, which is small. Compile a child `StateGraph`, then add the compiled graph as a node in the parent:
+Let's start with the canonical pattern, which is small.
+Compile a child `StateGraph`, then add the compiled graph as a node in the parent:
 
 ```python
 research_builder = StateGraph(MessagesState)
@@ -29,28 +30,42 @@ builder = StateGraph(MessagesState)
 builder.add_node("research", research_subgraph)  # a compiled graph, used as a node
 ```
 
-Two things genuinely change. The child runs as its own graph, with its own nodes and its own step sequence rather than being flattened into the parent's. And LangGraph emits the child's stream events under a namespace, so a consumer can tell parent output from child output.
+Two things change.
+The child runs as its own graph, with its own nodes and its own step sequence rather than being flattened into the parent's.
+And LangGraph emits the child's stream events under a namespace, so a consumer can tell parent output from child output.
 
-Here's the part I think gets assumed and shouldn't: state isolation isn't one of them.
+Here's the part I think gets assumed and shouldn't: state isolation isn't a third.
 
-If parent and child share `MessagesState`, the child appends to the same message list the parent is building. Nothing about `add_node` fenced anything off. Isolation is something you design — give the child its own state schema, then map in at the boundary and map the result back out. That's a decision you make and maintain, not a property `compile()` hands you.
+If parent and child share `MessagesState`, the child appends to the same message list the parent is building.
+Nothing about `add_node` fenced anything off.
+
+Isolation is something you design — give the child its own state schema, then map in at the boundary and map the result back out.
+That's a decision you make and maintain, not a property `compile()` hands you.
 
 ### What about context windows and error boundaries?
 
-Those are real reasons to split, and I don't want to wave them away — our own docs lean on them. The [subgraphs guide](/docs/langgraph/guides/subgraphs) points at per-task context windows and failure containment as reasons to reach for subagents, and the docstring on our own research child's only node calls it "a focused contractor."
+Those are real reasons to split — our own docs lean on them.
+The [subgraphs guide](/docs/langgraph/guides/subgraphs) points at per-task context windows and failure containment as reasons to reach for subagents, and the docstring on our own research child's only node calls it "a focused contractor."
 
-But look at where each of those actually comes from. A narrow context window is a consequence of what you pass into the child's `ainvoke` — you get it by handing over a topic instead of a transcript. An error boundary is a consequence of how the parent handles a failed child call. Reuse across parents is a consequence of the child being a value you can reference twice.
+But look at where each one actually comes from.
+A narrow context window is a consequence of what you pass into the child's `ainvoke` — you get it by handing over a topic instead of a transcript.
+An error boundary is a consequence of how the parent handles a failed child call, and a node-level retry wraps any node, plain function or compiled graph alike.
+Reuse across parents is a consequence of the child being a value you can reference twice.
 
-You can have all three without ever compiling a child graph, and you can compile a child graph and get none of them. The one thing the compile step itself hands you that you can't get another way is the namespace.
+You can have all three without ever compiling a child graph, and you can compile a child graph and get none of them.
 
-So if you're splitting purely to keep state tidy, be honest that you're the one who has to keep it tidy.
+There is one more, and it's worth stating because it looks like a counterexample.
+Wire the child in as a node under a parent that has a checkpointer, and the child's steps get checkpointed under its namespace — which is what lets you interrupt and resume at child granularity.
+Notice that's the namespace again, doing a second job.
 
 ## Why do people really split?
 
 In our own repo, the honest answer is: so the frontend can see the delegation.
 
-That's a claim about four graphs in one codebase, not a law of the framework. But it's a natural experiment rather than a portfolio — nobody wrote these to prove a point about subgraphs, and the reasons got written down at the time.
+That's four graphs in one codebase, not a law of the framework.
+But it's a natural experiment rather than a portfolio — nobody wrote these to prove a point about subgraphs, and the constraint that drove them, a frontend that renders per-child progress, isn't specific to us.
 
+Let's look at what we wrote down at the time.
 Here's the comment sitting above the research subagent in our canonical `examples/chat` graph:
 
 ```python
@@ -61,15 +76,28 @@ Here's the comment sitting above the research subagent in our canonical `example
 # SubagentTracker keys on to populate `agent.subagents()`.
 ```
 
-That's not a state argument. That's a visibility argument.
+That's not a state argument. It's a visibility argument.
 
-The design doc for that feature is even more direct. It lists a plain `@tool` returning a synthesized "subagent" payload as an approach considered, and rejects it for exactly one reason: no subgraph runs, so no `tools:` namespace events are emitted, so the card renders empty.
+The design doc for that feature is blunter still. Here's the alternative it rejected:
 
-Then there's the conversion. Our `cockpit/chat/subagents` demo originally ran its three specialists as a flat in-process helper, and was rewritten to dispatch a real compiled child graph — because the flat version emitted no namespace events, so `subagents()` stayed empty and no card rendered. A working feature was restructured so a UI card would appear.
+```text
+Plain `@tool` returning a synthesized "subagent" payload — Simpler graph
+code but does not exercise the SubagentTracker code path: no `tools:`
+namespace events get emitted because no subgraph runs. The card would
+render empty. Rejected.
+```
 
-One nuance worth naming, since it cuts against the tidy mental model. In both of those graphs the compiled child is invoked from inside a `@tool` body, not wired in as a plain node. That's deliberate: the tool call is what the tracker registers, and our own docs are blunt that [plain subgraph nodes](/docs/langgraph/guides/subgraphs) don't show up in that map at all.
+Then there's the conversion.
+Our `cockpit/chat/subagents` demo originally ran its three specialists as a flat in-process helper, and was rewritten to dispatch a real compiled child graph — because the flat version emitted no namespace events, so `subagents()` stayed empty and no card rendered.
+A working feature was restructured so a UI card would appear.
 
-Which means the thesis is actually sharper for plain `add_node` subgraphs, not weaker. Those still get a namespace, so they're still observable in the raw stream — they just don't get a name, so nothing downstream can attribute them to anything. The subgraph is what makes the events observable; the tool call is what gives them an identity.
+In both of those graphs the compiled child is invoked from inside a `@tool` body, not wired in as a plain node.
+That's deliberate: the tool call is what the tracker registers, and our own docs are blunt that [plain subgraph nodes](/docs/langgraph/guides/subgraphs) don't show up in that map at all.
+
+Which cuts the other way from how it sounds — plain `add_node` subgraphs make the point sharper, not weaker.
+Those still get a namespace, so they're still observable in the raw stream.
+They just don't get a name, so nothing downstream can attribute them to anything.
+The subgraph is what makes the events observable; the tool call is what gives them an identity.
 
 ## What does the frontend see while a child runs?
 
@@ -77,6 +105,7 @@ Namespaced events — and nearly everything interesting downstream follows from 
 
 ### What the wire looks like
 
+Let's take it from the wire inward.
 The event type carries the namespace after a pipe, so the base type is the part before it:
 
 ```text
@@ -84,59 +113,83 @@ messages                 # parent
 messages|tools:call-1    # child run dispatched by tool call "call-1"
 ```
 
-Our transport requests those child streams by default: `streamSubgraphs` defaults to `true`, so it's opt-out, not opt-in. That's the LangGraph JS SDK's own option name, passed straight through — worth knowing if you're coming from the Python API, where the in-process `graph.stream()` equivalent is the `subgraphs=True` kwarg.
+Our transport requests those child streams by default — `streamSubgraphs` is `true` unless you turn it off.
+That's the LangGraph JS SDK's own option name, passed straight through, and worth knowing if you're coming from the Python API, where the in-process `graph.stream()` equivalent is the `subgraphs=True` kwarg.
 
 ### The terminal-event hazard
 
 A child graph terminates before the parent does, and a child's terminal event looks an awful lot like the parent's.
 
-Without a namespace guard, that child terminal marker gets read as "the run finished" and closes out the parent's still-streaming assistant message. We guard it by refusing namespaced events as top-level terminal evidence, and there's a test that feeds a namespaced terminal marker in and asserts the parent message settles with outcome `interrupted` rather than success.
+Without a namespace guard, that child terminal marker gets read as "the run finished" and closes out the parent's still-streaming assistant message.
+We guard it by refusing namespaced events as top-level terminal evidence, and there's a test that feeds a namespaced terminal marker in and asserts the parent message settles with outcome `interrupted` rather than success.
 
 If you ever write a transport against this stream yourself, that's the bug you'll hit, and it will look like truncation rather than a namespace bug.
 
 ### Where child text goes
 
-Into your main transcript, by default. Our `filterSubagentMessages` is off unless you set it, so a child's tokens flow into `messages()` alongside the parent's.
+Into your main transcript, by default.
+Our `filterSubagentMessages` is off unless you set it, so a child's tokens flow into `messages()` alongside the parent's.
 
-That's not really a config detail specific to us. Any consumer reading a namespaced stream has to decide what a child's tokens mean, and "append them like everything else" is the path of least resistance — so unless something opts out, child text lands in the parent transcript and the same content renders twice.
+That isn't a quirk of our config.
+Any consumer reading a namespaced stream has to decide what a child's tokens mean, and "append them like everything else" is the path of least resistance — so unless something opts out, child text lands in the parent transcript and the same content renders twice.
 
-### How a child gets attributed
+### How does a child get attributed?
 
-Structurally, and this is the part I find genuinely well-designed: the namespace segment _is_ the identifier.
+By id — and this is the part I find well-designed: the namespace segment _is_ the identifier.
 
-`tools:<id>` carries the parent tool call id, so the tracker slices the prefix off and looks the id up directly against what it recorded when the tool call came through. Marking a child running and routing its messages need no matching at all.
+`tools:<id>` carries the parent tool call id, so the tracker slices the prefix off and looks the id up directly against what it recorded when the tool call came through.
+Marking a child running and routing its messages need no matching at all.
 
-There is also a description-comparison ladder — exact match on the tool call's `description` argument, then substring either direction, then a last-resort fallback to any unmapped subagent still pending. It only runs for children whose state opens with a human message, and neither graph we ship reaches it: both invoke the child with an empty message list, so the first message in child state is the AI response. Treat that path as untested rather than as the mechanism.
+There is also a description-comparison ladder — exact match on the tool call's `description` argument, then substring either direction, then a last-resort fallback to any unmapped subagent still pending.
+It only runs for children whose state opens with a human message, and neither graph we ship reaches it: both invoke the child with an empty message list, so the first message in child state is the AI response.
+Treat that path as untested rather than as the mechanism.
 
-The general point survives, though, and it's the one worth carrying to any protocol: a consumer mapping child runs onto delegations is doing string matching unless the protocol gives it an id. LangGraph gives it an id. That's why the ladder is vestigial here and would be load-bearing in a fan-out graph with look-alike children.
+The general point survives, though, and it's the one worth carrying to any protocol.
+A consumer mapping child runs onto delegations is doing string matching unless the protocol gives it an id.
+LangGraph gives it an id — which is why the ladder is vestigial here and would be load-bearing in a fan-out graph with look-alike children.
 
-One more limit, stated plainly: only the _first_ `tools:` segment of a namespace is read. A subagent that itself delegates will have its inner events attributed to the outer tool call. Deeper nesting isn't exercised anywhere in this repo, so treat it as untested rather than supported.
+One limit, though: only the _first_ `tools:` segment of a namespace is read.
+A subagent that itself delegates will have its inner events attributed to the outer tool call.
+Nothing in this repo exercises deeper nesting, so don't build on it.
 
 ## When should you not split?
 
 When there's no observable boundary to draw and no genuinely divergent state.
 
-The cleanest evidence I have for that is a control group we didn't set out to build. Our AG-UI demo ships the same three-subagent feature as the LangGraph one — same team, same three roles, same cards in the UI — with no subgraph anywhere. Its module docstring says so outright:
+The cleanest evidence I have is a control group we didn't set out to build.
+Our AG-UI demo ships the same three-subagent feature as the LangGraph one — and it's a LangGraph `StateGraph` too, same framework, same orchestrator-plus-`task`-tool shape, same three roles, same cards in the UI — with no subgraph anywhere.
+Its module docstring says so outright:
 
-```python
+```text
 Mirrors cockpit/chat/subagents' orchestrator + `task` tool + `_run_subagent`
 structure, but each dispatch emits `subagent_activity` CUSTOM events
 ```
 
-One variable changed between the two: whether the transport already carries a first-class delegation event. AG-UI's does, so the specialists stayed a flat `async` helper and progress reaches the frontend as a custom event dispatched from the tool body.
+One variable changed between the two: whether the transport already carries a first-class delegation event.
+AG-UI's does, so the specialists stayed a flat `async` helper and progress reaches the frontend as a custom event dispatched from the tool body.
 
-So the subgraph was never required by the feature. It was required by the transport.
+The subgraph was never required by the feature. It was required by the transport.
 
-Staying flat wasn't free, to be fair. That helper hand-rolls its own per-token streaming to emit progress, the child gets no independent checkpointing, and there's no separate state schema to isolate anything into. What it bought was one fewer graph for a feature that renders identically.
+You could dispatch custom events from the LangGraph graph too — nothing stops you, and `adispatch_custom_event` is a LangChain primitive, not an AG-UI one.
+What namespaces buy is that you don't have to.
+The boundary emits its own identity for free, and a transport that reads it works against any graph rather than any graph that remembered to instrument itself.
 
-That's the test I'd apply. If your transport already has a way to say "a child is working right now," or your UI doesn't render per-child progress at all, then a subgraph is a boundary you now have to defend: an extra state schema, mapping at both edges, and one more place to look when a message goes missing.
+Staying flat wasn't free.
+That helper hand-rolls its own per-token streaming through a callback handler to emit progress, and there's no separate state schema to isolate anything into.
+What it bought was one fewer graph for a feature that renders identically.
 
-And splitting because a region of the graph _feels_ like a separate concern isn't a reason on its own. A node is already a unit. For me, the bar is whether something outside the graph needs to observe the child as a distinct run.
+That's the test I'd apply.
+If your transport already has a way to say "a child is working right now," or your UI doesn't render per-child progress at all, then a subgraph is a boundary you now have to defend: an extra state schema, mapping at both edges, and one more place to look when a message goes missing.
+
+And splitting because a region of the graph _feels_ like a separate concern isn't a reason on its own.
+A node is already a unit.
 
 ## Conclusion
 
-Here's the heuristic. Split when something outside the graph needs to see the child run as its own thing — a card, a progress panel, per-child streaming. Split when the child genuinely needs a different state schema and you're willing to own the mapping at both edges. Don't split for tidiness, and don't assume the split isolated state, because with a shared `MessagesState` it didn't.
+Split when something outside the graph needs to see the child run as its own thing — a card, a progress panel, per-child streaming.
+Split when the child genuinely needs a different state schema and you're willing to own the mapping at both edges.
+Don't split for tidiness, and don't assume the split isolated state, because with a shared `MessagesState` it didn't.
 
 The [architecture matrix](/docs/langgraph/concepts/agent-architecture) covers the tiering question, the [subgraphs guide](/docs/langgraph/guides/subgraphs) has the composition and `subagents()` wiring, and [What injectAgent() Actually Returns](/blog/what-inject-agent-returns) walks the signal surface those child streams land in.
 
-If you've got a graph where the split earned itself for a reason that isn't observability, I'd genuinely like to hear it — that's the case this post doesn't have.
+If you've split a graph for a reason that isn't observability, I'd like to hear it — that's the case I don't have.

--- a/apps/website/content/blog/2026-08-27-langgraph-subgraphs-when-to-split.mdx
+++ b/apps/website/content/blog/2026-08-27-langgraph-subgraphs-when-to-split.mdx
@@ -1,0 +1,93 @@
+---
+title: 'LangGraph Subgraphs: When to Split a Graph and When Not To'
+description: 'When a LangGraph subgraph earns its complexity, how state crosses the boundary, and what your UI sees while a child graph runs.'
+date: 2026-08-27
+tags: [langgraph, subgraphs, agents, streaming, angular]
+author: brian
+featured: false
+draft: false
+---
+
+Most people reach for a LangGraph subgraph expecting a _state_ boundary, and what they actually get is an _observable_ one.
+
+That's the whole post, so let's start there and then earn it.
+
+If your question is "single agent, approval loop, or multi-agent?", that's an architecture question and the [decision matrix](/docs/langgraph/concepts/agent-architecture) already answers it.
+This post is about the layer underneath: what a subgraph actually changes at runtime, why our own graphs got split, and what the frontend sees while a child is running.
+
+## What does a subgraph actually give you?
+
+Nested execution and namespaced stream events. That's the honest list.
+
+Let's start with the canonical pattern, which is small. Compile a child `StateGraph`, then add the compiled graph as a node in the parent:
+
+```python
+research_builder = StateGraph(MessagesState)
+research_builder.add_node("search", search_web)
+research_builder.add_edge(START, "search")
+research_subgraph = research_builder.compile()
+
+builder = StateGraph(MessagesState)
+builder.add_node("research", research_subgraph)  # a compiled graph, used as a node
+```
+
+Two things genuinely change. The child runs as its own graph, with its own nodes and its own step sequence rather than being flattened into the parent's. And LangGraph emits the child's stream events under a namespace, so a consumer can tell parent output from child output.
+
+Here's the part I think gets assumed and shouldn't: state isolation is not one of them.
+
+If parent and child share `MessagesState`, the child appends to the same message list the parent is building. Nothing about `add_node` fenced anything off. Isolation is something you design — give the child its own state schema, then map in at the boundary and map the result back out. That's a decision you make and maintain, not a property `compile()` hands you.
+
+So if you're splitting purely to keep state tidy, be honest that you're the one who has to keep it tidy.
+
+## Why do people really split?
+
+In our own repo, the honest answer is: so the frontend can see the delegation.
+
+Let's look at the evidence, because we wrote it down.
+
+The comment sitting above the research subagent in our canonical `examples/chat` graph says the quiet part out loud — running it as an actual subgraph rather than inline logic is what causes LangGraph to emit stream events under a `tools:<id>` namespace for the child run, which is what our `@threadplane/langgraph` `SubagentTracker` keys on to populate `agent.subagents()`. That's not a state argument. That's a visibility argument.
+
+The design doc for that feature is even more direct. It lists a plain `@tool` returning a synthesized "subagent" payload as an approach considered, and rejects it for exactly one reason: no subgraph runs, so no `tools:` namespace events are emitted, so the card would render empty. Simpler graph code, invisible to the UI, rejected.
+
+Then there's the conversion. Our `cockpit/chat/subagents` demo originally ran its three specialists as a flat in-process helper. It was rewritten to dispatch a real compiled child graph — and the design doc frames the whole change as a demo-wiring gap: the flat version emitted no namespace events, so `subagents()` stayed empty and no card rendered. A working feature was restructured so a UI card would appear.
+
+One nuance worth naming, since it cuts against the tidy mental model. In both of those graphs the compiled child is invoked from inside a `@tool` body, not wired in as a plain node. That's deliberate: the tool call is what the tracker registers, and our own docs are blunt that [plain subgraph nodes](/docs/langgraph/guides/subgraphs) don't show up in that map at all. So "subgraph" and "tracked subagent" aren't the same thing — the subgraph is what makes the events observable, and the tool call is what gives them a name.
+
+## What does the frontend see while a child runs?
+
+Namespaced events — and nearly everything interesting downstream follows from that one fact.
+
+Let's take it from the wire inward. The event type carries the namespace after a pipe, so the base type is the part before it:
+
+```text
+messages                 # parent
+messages|tools:call-1    # child run dispatched by tool call "call-1"
+```
+
+Our transport requests those child streams by default: `streamSubgraphs` defaults to `true`, so it's opt-out, not opt-in. Small naming trap if you're coming from the raw SDK docs — the option on our config is `streamSubgraphs`, not `subgraphs: true`.
+
+Now the hazard. A child graph terminates before the parent does, and a child's terminal event looks an awful lot like the parent's. Without a namespace guard, that child terminal marker gets read as "the run finished" and closes out the parent's still-streaming assistant message. We guard it by refusing namespaced events as top-level terminal evidence, and there's a test that feeds a namespaced terminal marker in and asserts the parent message settles as `interrupted` rather than complete. If you ever write a transport against this stream yourself, that's the bug you'll hit, and it will look like truncation rather than a namespace bug.
+
+Child text also lands in your main transcript by default. `filterSubagentMessages` is optional and off unless you set it, so a child's tokens flow into `messages()` alongside the parent's. Turning it on is usually what you want once you're rendering the child separately, otherwise the same content shows up twice.
+
+Attribution, meanwhile, is a heuristic and I'd rather you know that than discover it. The tracker maps a child namespace onto a parent tool call by comparing the child's first human message against the tool call's `description` argument: exact match first, then substring in either direction, then — if nothing matched — a last-resort fallback to any unmapped subagent that's still pending or running. That fallback is doing real work in practice, since a delegation tool doesn't have to take a `description` argument at all. It's good enough for the demos we ship. It is not structural, and a graph that fans out several look-alike children would be leaning on it hard.
+
+One more limit, stated plainly: only the _first_ `tools:` segment of a namespace is read. A subagent that itself delegates will have its inner events attributed to the outer tool call. Deeper nesting isn't exercised anywhere in this repo, so treat it as untested rather than supported.
+
+## When should you not split?
+
+When there's no observable boundary to draw and no genuinely divergent state.
+
+Let's use the cleanest control group we have. Our AG-UI demo ships the same three-subagent feature as the LangGraph one — same roles, same cards in the UI — with no subgraph anywhere. The specialists are a flat `async` helper, and progress reaches the frontend through a custom `subagent_activity` event dispatched from the tool body.
+
+Nothing was compromised by staying flat. The AG-UI transport already carries a first-class delegation event, so there was no structural workaround to perform. Same feature, same UI, one fewer graph.
+
+That's the test I'd apply. If your transport already has a way to say "a child is working right now," or your UI doesn't render per-child progress at all, then a subgraph is a boundary you now have to defend: an extra state schema, mapping at both edges, and one more place to look when a message goes missing.
+
+And splitting because a region of the graph _feels_ like a separate concern isn't a reason on its own. A node is already a unit. For me, the bar is whether something outside the graph needs to observe the child as a distinct run.
+
+## Conclusion
+
+Here's the heuristic. Split when something outside the graph needs to see the child run as its own thing — a card, a progress panel, per-child streaming. Split when the child genuinely needs a different state schema and you're willing to own the mapping at both edges. Don't split for tidiness, and don't assume the split isolated state, because with a shared `MessagesState` it didn't.
+
+The [architecture matrix](/docs/langgraph/concepts/agent-architecture) covers the tiering question, the [subgraphs guide](/docs/langgraph/guides/subgraphs) has the composition and `subagents()` wiring, and [What injectAgent() Actually Returns](/blog/what-inject-agent-returns) walks the signal surface those child streams land in.

--- a/apps/website/content/blog/2026-08-27-langgraph-subgraphs-when-to-split.mdx
+++ b/apps/website/content/blog/2026-08-27-langgraph-subgraphs-when-to-split.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'LangGraph Subgraphs: When to Split a Graph and When Not To'
-description: 'When a LangGraph subgraph earns its complexity, how state crosses the boundary, and what your UI sees while a child graph runs.'
+description: 'On LangGraph, a subgraph buys you an observable boundary, not a state boundary. Why our own graphs got split, and what the frontend sees while a child runs.'
 date: 2026-08-27
 tags: [langgraph, subgraphs, agents, streaming, angular]
 author: brian
@@ -9,8 +9,6 @@ draft: false
 ---
 
 Most people reach for a LangGraph subgraph expecting a _state_ boundary, and what they actually get is an _observable_ one.
-
-That's the whole post, so let's start there and then earn it.
 
 If your question is "single agent, approval loop, or multi-agent?", that's an architecture question and the [decision matrix](/docs/langgraph/concepts/agent-architecture) already answers it.
 This post is about the layer underneath: what a subgraph actually changes at runtime, why our own graphs got split, and what the frontend sees while a child is running.
@@ -33,9 +31,17 @@ builder.add_node("research", research_subgraph)  # a compiled graph, used as a n
 
 Two things genuinely change. The child runs as its own graph, with its own nodes and its own step sequence rather than being flattened into the parent's. And LangGraph emits the child's stream events under a namespace, so a consumer can tell parent output from child output.
 
-Here's the part I think gets assumed and shouldn't: state isolation is not one of them.
+Here's the part I think gets assumed and shouldn't: state isolation isn't one of them.
 
 If parent and child share `MessagesState`, the child appends to the same message list the parent is building. Nothing about `add_node` fenced anything off. Isolation is something you design — give the child its own state schema, then map in at the boundary and map the result back out. That's a decision you make and maintain, not a property `compile()` hands you.
+
+### What about context windows and error boundaries?
+
+Those are real reasons to split, and I don't want to wave them away — our own docs lean on them. The [subgraphs guide](/docs/langgraph/guides/subgraphs) points at per-task context windows and failure containment as reasons to reach for subagents, and the docstring on our own research child's only node calls it "a focused contractor."
+
+But look at where each of those actually comes from. A narrow context window is a consequence of what you pass into the child's `ainvoke` — you get it by handing over a topic instead of a transcript. An error boundary is a consequence of how the parent handles a failed child call. Reuse across parents is a consequence of the child being a value you can reference twice.
+
+You can have all three without ever compiling a child graph, and you can compile a child graph and get none of them. The one thing the compile step itself hands you that you can't get another way is the namespace.
 
 So if you're splitting purely to keep state tidy, be honest that you're the one who has to keep it tidy.
 
@@ -43,34 +49,66 @@ So if you're splitting purely to keep state tidy, be honest that you're the one 
 
 In our own repo, the honest answer is: so the frontend can see the delegation.
 
-Let's look at the evidence, because we wrote it down.
+That's a claim about four graphs in one codebase, not a law of the framework. But it's a natural experiment rather than a portfolio — nobody wrote these to prove a point about subgraphs, and the reasons got written down at the time.
 
-The comment sitting above the research subagent in our canonical `examples/chat` graph says the quiet part out loud — running it as an actual subgraph rather than inline logic is what causes LangGraph to emit stream events under a `tools:<id>` namespace for the child run, which is what our `@threadplane/langgraph` `SubagentTracker` keys on to populate `agent.subagents()`. That's not a state argument. That's a visibility argument.
+Here's the comment sitting above the research subagent in our canonical `examples/chat` graph:
 
-The design doc for that feature is even more direct. It lists a plain `@tool` returning a synthesized "subagent" payload as an approach considered, and rejects it for exactly one reason: no subgraph runs, so no `tools:` namespace events are emitted, so the card would render empty. Simpler graph code, invisible to the UI, rejected.
+```python
+# Research subagent — a small compiled child graph the parent dispatches
+# via the `research` @tool. Running it as an actual subgraph (vs. inline
+# logic) is what causes LangGraph to emit stream events under namespace
+# prefix `tools:<id>` for the child run, which is what the @threadplane/langgraph
+# SubagentTracker keys on to populate `agent.subagents()`.
+```
 
-Then there's the conversion. Our `cockpit/chat/subagents` demo originally ran its three specialists as a flat in-process helper. It was rewritten to dispatch a real compiled child graph — and the design doc frames the whole change as a demo-wiring gap: the flat version emitted no namespace events, so `subagents()` stayed empty and no card rendered. A working feature was restructured so a UI card would appear.
+That's not a state argument. That's a visibility argument.
 
-One nuance worth naming, since it cuts against the tidy mental model. In both of those graphs the compiled child is invoked from inside a `@tool` body, not wired in as a plain node. That's deliberate: the tool call is what the tracker registers, and our own docs are blunt that [plain subgraph nodes](/docs/langgraph/guides/subgraphs) don't show up in that map at all. So "subgraph" and "tracked subagent" aren't the same thing — the subgraph is what makes the events observable, and the tool call is what gives them a name.
+The design doc for that feature is even more direct. It lists a plain `@tool` returning a synthesized "subagent" payload as an approach considered, and rejects it for exactly one reason: no subgraph runs, so no `tools:` namespace events are emitted, so the card renders empty.
+
+Then there's the conversion. Our `cockpit/chat/subagents` demo originally ran its three specialists as a flat in-process helper, and was rewritten to dispatch a real compiled child graph — because the flat version emitted no namespace events, so `subagents()` stayed empty and no card rendered. A working feature was restructured so a UI card would appear.
+
+One nuance worth naming, since it cuts against the tidy mental model. In both of those graphs the compiled child is invoked from inside a `@tool` body, not wired in as a plain node. That's deliberate: the tool call is what the tracker registers, and our own docs are blunt that [plain subgraph nodes](/docs/langgraph/guides/subgraphs) don't show up in that map at all.
+
+Which means the thesis is actually sharper for plain `add_node` subgraphs, not weaker. Those still get a namespace, so they're still observable in the raw stream — they just don't get a name, so nothing downstream can attribute them to anything. The subgraph is what makes the events observable; the tool call is what gives them an identity.
 
 ## What does the frontend see while a child runs?
 
 Namespaced events — and nearly everything interesting downstream follows from that one fact.
 
-Let's take it from the wire inward. The event type carries the namespace after a pipe, so the base type is the part before it:
+### What the wire looks like
+
+The event type carries the namespace after a pipe, so the base type is the part before it:
 
 ```text
 messages                 # parent
 messages|tools:call-1    # child run dispatched by tool call "call-1"
 ```
 
-Our transport requests those child streams by default: `streamSubgraphs` defaults to `true`, so it's opt-out, not opt-in. Small naming trap if you're coming from the raw SDK docs — the option on our config is `streamSubgraphs`, not `subgraphs: true`.
+Our transport requests those child streams by default: `streamSubgraphs` defaults to `true`, so it's opt-out, not opt-in. That's the LangGraph JS SDK's own option name, passed straight through — worth knowing if you're coming from the Python API, where the in-process `graph.stream()` equivalent is the `subgraphs=True` kwarg.
 
-Now the hazard. A child graph terminates before the parent does, and a child's terminal event looks an awful lot like the parent's. Without a namespace guard, that child terminal marker gets read as "the run finished" and closes out the parent's still-streaming assistant message. We guard it by refusing namespaced events as top-level terminal evidence, and there's a test that feeds a namespaced terminal marker in and asserts the parent message settles as `interrupted` rather than complete. If you ever write a transport against this stream yourself, that's the bug you'll hit, and it will look like truncation rather than a namespace bug.
+### The terminal-event hazard
 
-Child text also lands in your main transcript by default. `filterSubagentMessages` is optional and off unless you set it, so a child's tokens flow into `messages()` alongside the parent's. Turning it on is usually what you want once you're rendering the child separately, otherwise the same content shows up twice.
+A child graph terminates before the parent does, and a child's terminal event looks an awful lot like the parent's.
 
-Attribution, meanwhile, is a heuristic and I'd rather you know that than discover it. The tracker maps a child namespace onto a parent tool call by comparing the child's first human message against the tool call's `description` argument: exact match first, then substring in either direction, then — if nothing matched — a last-resort fallback to any unmapped subagent that's still pending or running. That fallback is doing real work in practice, since a delegation tool doesn't have to take a `description` argument at all. It's good enough for the demos we ship. It is not structural, and a graph that fans out several look-alike children would be leaning on it hard.
+Without a namespace guard, that child terminal marker gets read as "the run finished" and closes out the parent's still-streaming assistant message. We guard it by refusing namespaced events as top-level terminal evidence, and there's a test that feeds a namespaced terminal marker in and asserts the parent message settles with outcome `interrupted` rather than success.
+
+If you ever write a transport against this stream yourself, that's the bug you'll hit, and it will look like truncation rather than a namespace bug.
+
+### Where child text goes
+
+Into your main transcript, by default. Our `filterSubagentMessages` is off unless you set it, so a child's tokens flow into `messages()` alongside the parent's.
+
+That's not really a config detail specific to us. Any consumer reading a namespaced stream has to decide what a child's tokens mean, and "append them like everything else" is the path of least resistance — so unless something opts out, child text lands in the parent transcript and the same content renders twice.
+
+### How a child gets attributed
+
+Structurally, and this is the part I find genuinely well-designed: the namespace segment _is_ the identifier.
+
+`tools:<id>` carries the parent tool call id, so the tracker slices the prefix off and looks the id up directly against what it recorded when the tool call came through. Marking a child running and routing its messages need no matching at all.
+
+There is also a description-comparison ladder — exact match on the tool call's `description` argument, then substring either direction, then a last-resort fallback to any unmapped subagent still pending. It only runs for children whose state opens with a human message, and neither graph we ship reaches it: both invoke the child with an empty message list, so the first message in child state is the AI response. Treat that path as untested rather than as the mechanism.
+
+The general point survives, though, and it's the one worth carrying to any protocol: a consumer mapping child runs onto delegations is doing string matching unless the protocol gives it an id. LangGraph gives it an id. That's why the ladder is vestigial here and would be load-bearing in a fan-out graph with look-alike children.
 
 One more limit, stated plainly: only the _first_ `tools:` segment of a namespace is read. A subagent that itself delegates will have its inner events attributed to the outer tool call. Deeper nesting isn't exercised anywhere in this repo, so treat it as untested rather than supported.
 
@@ -78,9 +116,18 @@ One more limit, stated plainly: only the _first_ `tools:` segment of a namespace
 
 When there's no observable boundary to draw and no genuinely divergent state.
 
-Let's use the cleanest control group we have. Our AG-UI demo ships the same three-subagent feature as the LangGraph one — same roles, same cards in the UI — with no subgraph anywhere. The specialists are a flat `async` helper, and progress reaches the frontend through a custom `subagent_activity` event dispatched from the tool body.
+The cleanest evidence I have for that is a control group we didn't set out to build. Our AG-UI demo ships the same three-subagent feature as the LangGraph one — same team, same three roles, same cards in the UI — with no subgraph anywhere. Its module docstring says so outright:
 
-Nothing was compromised by staying flat. The AG-UI transport already carries a first-class delegation event, so there was no structural workaround to perform. Same feature, same UI, one fewer graph.
+```python
+Mirrors cockpit/chat/subagents' orchestrator + `task` tool + `_run_subagent`
+structure, but each dispatch emits `subagent_activity` CUSTOM events
+```
+
+One variable changed between the two: whether the transport already carries a first-class delegation event. AG-UI's does, so the specialists stayed a flat `async` helper and progress reaches the frontend as a custom event dispatched from the tool body.
+
+So the subgraph was never required by the feature. It was required by the transport.
+
+Staying flat wasn't free, to be fair. That helper hand-rolls its own per-token streaming to emit progress, the child gets no independent checkpointing, and there's no separate state schema to isolate anything into. What it bought was one fewer graph for a feature that renders identically.
 
 That's the test I'd apply. If your transport already has a way to say "a child is working right now," or your UI doesn't render per-child progress at all, then a subgraph is a boundary you now have to defend: an extra state schema, mapping at both edges, and one more place to look when a message goes missing.
 
@@ -91,3 +138,5 @@ And splitting because a region of the graph _feels_ like a separate concern isn'
 Here's the heuristic. Split when something outside the graph needs to see the child run as its own thing — a card, a progress panel, per-child streaming. Split when the child genuinely needs a different state schema and you're willing to own the mapping at both edges. Don't split for tidiness, and don't assume the split isolated state, because with a shared `MessagesState` it didn't.
 
 The [architecture matrix](/docs/langgraph/concepts/agent-architecture) covers the tiering question, the [subgraphs guide](/docs/langgraph/guides/subgraphs) has the composition and `subagents()` wiring, and [What injectAgent() Actually Returns](/blog/what-inject-agent-returns) walks the signal surface those child streams land in.
+
+If you've got a graph where the split earned itself for a reason that isn't observability, I'd genuinely like to hear it — that's the case this post doesn't have.

--- a/apps/website/content/blog/2026-08-27-langgraph-subgraphs-when-to-split.mdx
+++ b/apps/website/content/blog/2026-08-27-langgraph-subgraphs-when-to-split.mdx
@@ -62,7 +62,7 @@ Notice that's the namespace again, doing a second job.
 
 In our own repo, the honest answer is: so the frontend can see the delegation.
 
-That's four graphs in one codebase, not a law of the framework.
+That's a claim about our own graphs, not a law of the framework — and one of them splits for a different reason entirely, which I'll get to.
 But it's a natural experiment rather than a portfolio — nobody wrote these to prove a point about subgraphs, and the constraint that drove them, a frontend that renders per-child progress, isn't specific to us.
 
 Let's look at what we wrote down at the time.
@@ -140,7 +140,7 @@ By id — and this is the part I find well-designed: the namespace segment _is_ 
 `tools:<id>` carries the parent tool call id, so the tracker slices the prefix off and looks the id up directly against what it recorded when the tool call came through.
 Marking a child running and routing its messages need no matching at all.
 
-There is also a description-comparison ladder — exact match on the tool call's `description` argument, then substring either direction, then a last-resort fallback to any unmapped subagent still pending.
+There is also a description-comparison ladder — exact match on the tool call's `description` argument, then substring either direction, then a last-resort fallback to any unmapped subagent still pending or running.
 It only runs for children whose state opens with a human message, and neither graph we ship reaches it: both invoke the child with an empty message list, so the first message in child state is the AI response.
 Treat that path as untested rather than as the mechanism.
 
@@ -157,7 +157,7 @@ Nothing in this repo exercises deeper nesting, so don't build on it.
 When there's no observable boundary to draw and no genuinely divergent state.
 
 The cleanest evidence I have is a control group we didn't set out to build.
-Our AG-UI demo ships the same three-subagent feature as the LangGraph one — and it's a LangGraph `StateGraph` too, same framework, same orchestrator-plus-`task`-tool shape, same three roles, same cards in the UI — with no subgraph anywhere.
+Our `cockpit/ag-ui/subagents` capability ships the same three-subagent feature as the LangGraph one — and it's a LangGraph `StateGraph` too, same framework, same orchestrator-plus-`task`-tool shape, same three roles, same cards in the UI — with no subgraph anywhere.
 Its module docstring says so outright:
 
 ```text
@@ -184,6 +184,22 @@ If your transport already has a way to say "a child is working right now," or yo
 And splitting because a region of the graph _feels_ like a separate concern isn't a reason on its own.
 A node is already a unit.
 
+### So when does a split earn itself?
+
+When the child really is a different graph — and the repo has exactly one of those, which is the case I owe you after arguing the other side this whole time.
+
+Our `examples/ag-ui` demo runs on that same AG-UI transport, and it emits the same `subagent_activity` events from the tool body.
+So it isn't buying observability; it already had it.
+It compiles a child graph anyway.
+
+Look at what the child is, though.
+Its own state schema — `topic` and an `iterations` counter alongside `messages`, not the parent's `MessagesState`.
+Its own `agent → tools → agent` loop with conditional edges and an iteration cap, which is a different control flow than the parent's, not a slice of it.
+
+That's the shape worth looking for.
+Two demos on one transport, same framework, same delegation events: one stayed flat, one split.
+What flipped wasn't the feature or the frontend — it was whether the child had its own state and its own control flow.
+
 ## Conclusion
 
 Split when something outside the graph needs to see the child run as its own thing — a card, a progress panel, per-child streaming.
@@ -192,4 +208,4 @@ Don't split for tidiness, and don't assume the split isolated state, because wit
 
 The [architecture matrix](/docs/langgraph/concepts/agent-architecture) covers the tiering question, the [subgraphs guide](/docs/langgraph/guides/subgraphs) has the composition and `subagents()` wiring, and [What injectAgent() Actually Returns](/blog/what-inject-agent-returns) walks the signal surface those child streams land in.
 
-If you've split a graph for a reason that isn't observability, I'd like to hear it — that's the case I don't have.
+If you've split a graph for a third reason — not observability, and not a child that's its own graph — I'd like to hear it. Those are the only two I've been able to justify.

--- a/apps/website/content/blog/2026-08-27-langgraph-subgraphs-when-to-split.mdx
+++ b/apps/website/content/blog/2026-08-27-langgraph-subgraphs-when-to-split.mdx
@@ -141,7 +141,7 @@ By id — and this is the part I find well-designed: the namespace segment _is_ 
 Marking a child running and routing its messages need no matching at all.
 
 There is also a description-comparison ladder — exact match on the tool call's `description` argument, then substring either direction, then a last-resort fallback to any unmapped subagent still pending or running.
-It only runs for children whose state opens with a human message, and neither graph we ship reaches it: both invoke the child with an empty message list, so the first message in child state is the AI response.
+It only runs for children whose state opens with a human message, and none of the graphs we ship on the LangGraph transport reach it: they invoke the child with an empty message list, so the first message in child state is the AI response.
 Treat that path as untested rather than as the mechanism.
 
 The general point survives, though, and it's the one worth carrying to any protocol.
@@ -165,8 +165,8 @@ Mirrors cockpit/chat/subagents' orchestrator + `task` tool + `_run_subagent`
 structure, but each dispatch emits `subagent_activity` CUSTOM events
 ```
 
-One variable changed between the two: whether the transport already carries a first-class delegation event.
-AG-UI's does, so the specialists stayed a flat `async` helper and progress reaches the frontend as a custom event dispatched from the tool body.
+The thing that differs is the transport: AG-UI's already carries a first-class delegation event.
+So so the specialists stayed a flat `async` helper and progress reaches the frontend as a custom event dispatched from the tool body.
 
 The subgraph was never required by the feature. It was required by the transport.
 
@@ -175,7 +175,7 @@ What namespaces buy is that you don't have to.
 The boundary emits its own identity for free, and a transport that reads it works against any graph rather than any graph that remembered to instrument itself.
 
 Staying flat wasn't free.
-That helper hand-rolls its own per-token streaming through a callback handler to emit progress, and there's no separate state schema to isolate anything into.
+There's no separate state schema to isolate anything into, and no child step sequence — every specialist gets the parent's shape, one LLM call wide.
 What it bought was one fewer graph for a feature that renders identically.
 
 That's the test I'd apply.
@@ -193,19 +193,22 @@ So it isn't buying observability; it already had it.
 It compiles a child graph anyway.
 
 Look at what the child is, though.
-Its own state schema — `topic` and an `iterations` counter alongside `messages`, not the parent's `MessagesState`.
-Its own `agent → tools → agent` loop with conditional edges and an iteration cap, which is a different control flow than the parent's, not a slice of it.
+It has its own `agent → tools → agent` loop with conditional edges and an iteration cap — a different control flow from the parent's, not a slice of it.
 
-That's the shape worth looking for.
-Two demos on one transport, same framework, same delegation events: one stayed flat, one split.
-What flipped wasn't the feature or the frontend — it was whether the child had its own state and its own control flow.
+And here's the part that took me a second read to see.
+A custom child state schema doesn't discriminate at all: the two graphs I just used as observability evidence _also_ define their own child `TypedDict`s.
+But both of those children are one node and a straight line, so the schema is really just an argument list with a type on it.
+
+So it's the control flow, not the schema.
+A child that carries a `topic` string is a function call wearing a graph costume.
+A child that loops until it's satisfied is a graph.
 
 ## Conclusion
 
 Split when something outside the graph needs to see the child run as its own thing — a card, a progress panel, per-child streaming.
-Split when the child genuinely needs a different state schema and you're willing to own the mapping at both edges.
-Don't split for tidiness, and don't assume the split isolated state, because with a shared `MessagesState` it didn't.
+Split when the child has its own control flow — a loop, a branch, a stopping condition the parent doesn't have — and you're willing to own the mapping at both edges.
+Don't split for tidiness, and don't assume the split isolated state: wire a child in as a node on a shared `MessagesState` and it appends straight to the transcript the parent is building.
 
 The [architecture matrix](/docs/langgraph/concepts/agent-architecture) covers the tiering question, the [subgraphs guide](/docs/langgraph/guides/subgraphs) has the composition and `subagents()` wiring, and [What injectAgent() Actually Returns](/blog/what-inject-agent-returns) walks the signal surface those child streams land in.
 
-If you've split a graph for a third reason — not observability, and not a child that's its own graph — I'd like to hear it. Those are the only two I've been able to justify.
+If you've split a graph for a third reason — not observability, and not a child that's genuinely its own graph — I'd like to hear it. Those are the two I've been able to justify; I doubt they're the only two that exist.

--- a/docs/superpowers/HANDOFF-blog-sequence.md
+++ b/docs/superpowers/HANDOFF-blog-sequence.md
@@ -1,0 +1,138 @@
+# Handoff: GSC-driven blog sequence
+
+**Written:** 2026-08-27
+**Worktree:** `/Users/blove/repos/angular-agent-framework/.claude/worktrees/threadplane-a2ui-migration-94f7b6`
+**Current branch:** `blove/langgraph-subgraphs-post` (3 commits ahead of `origin/main`, **not pushed**)
+
+---
+
+## What this is
+
+Brian ranked 20 blog candidates against a Search Console pull and approved a four-post sequence running three strategic plays in order: convert existing traffic, grow search surface, then earn distribution. Two posts are live; the third is drafted and unpushed; the fourth is unstarted.
+
+The candidates doc lives at `docs/gtm/blog-topic-candidates.md` **on a different worktree branch** (`suspicious-ellis-644600`) and is NOT on main. Read it there if you need the full evidence table.
+
+## Sequence status
+
+| # | Post | Status |
+|---|---|---|
+| #11 | What `injectAgent()` Actually Returns | **Live** — [threadplane.ai/blog/what-inject-agent-returns](https://threadplane.ai/blog/what-inject-agent-returns), PR #836 |
+| #9 | json-render vs A2UI: Choosing a Generative UI Contract | **Live** — [threadplane.ai/blog/json-render-vs-a2ui-choosing](https://threadplane.ai/blog/json-render-vs-a2ui-choosing), PR #837 |
+| #1 | LangGraph Subgraphs: When to Split a Graph and When Not To | **Drafted, unpushed, reviews returned BLOCKING findings** — commit `850573e3` on this branch |
+| #12 | Testing Agents Deterministically: Fixture-Replay for LLM UIs | **Not started** |
+
+## Immediate next step — post #1 needs real work before it ships
+
+Both reviews reported. **The post is NOT ready.** Two of the findings are factual errors, one is an argument hole. Fix these, re-review, then push/PR/merge/verify.
+
+### Blocking: two false technical claims (spec review)
+
+**A. The attribution paragraph is backwards.** The post says attribution "is a heuristic" and that the last-resort fallback is "doing real work in practice." Both wrong:
+
+- The **primary path is structural, not heuristic.** The namespace segment *is* the tool call id — `extractToolCallIdFromNamespace` is `segment.slice(6)` (`libs/langgraph/src/lib/internals/subagent-tracker.ts:271-277`), and `resolveToolCallId` falls back to the namespace id itself (:260-262), which is the key `registerFromToolCalls` already stored. So `markRunningFromNamespace` / `addMessageToSubagent` bind by id with no matching at all.
+- `matchSubgraphToSubagent` is called from exactly one place (`stream-manager.bridge.ts:968-976`), gated on the child's `values.messages[0]` being a **human** message.
+- **Neither shipped graph can satisfy that gate.** `examples/chat/python/src/graph.py:327` invokes with `messages: []`, and `cockpit/chat/subagents/python/src/graph.py:172-174` likewise. Both children start empty; the human message goes straight to `llm.ainvoke([...])` and never enters state. So the first message in child values is the AI response, and the ladder never runs in either demo. There is no `subagent-tracker.spec.ts` either.
+
+Fix: invert the emphasis. Attribution normally rides the namespace, because `tools:<id>` carries the parent tool call id and the tracker resolves it directly. There *is* a description-comparison ladder (exact → substring → last-resort unmapped-pending) for children whose state opens with a human message, but nothing we ship reaches it — treat it as untested rather than as the mechanism. The closing warning survives and gets sharper: the ladder is what a fan-out graph would fall back on.
+
+**B. The `streamSubgraphs` "naming trap" isn't a trap.** `streamSubgraphs` **is** the LangGraph JS SDK's own option name (`node_modules/@langchain/langgraph-sdk/dist/types.d.ts:148,187,240`), passed straight through by `buildRunPayload` (`fetch-stream.transport.ts:152-155`). `subgraphs=True` is the *Python in-process* `graph.stream()` kwarg, not the SDK. Delete the sentence or re-aim it at the Python API. (The default-on half is correct: `streamSubgraphs ?? true` at :154.)
+
+**C. Nit:** the test asserts `phase: 'complete'` with `outcome: 'interrupted'`. "Settles as `interrupted` rather than complete" reads as a phase claim — say "settles with outcome `interrupted` rather than success."
+
+### Blocking: the argument has a hole a skeptic finds immediately (editorial review)
+
+The post never engages the **non-observability** reasons to split, and our own docs assert them: `docs/langgraph/guides/subgraphs.mdx:310` (own context window, isolated error boundaries), `agent-architecture.mdx:689` (State isolation: "Isolated per subagent"), and the post's own evidence file at `examples/chat/python/src/graph.py:288-291` ("the subagent is a focused contractor"). A LangGraph engineer dismisses the piece in one comment: context-window isolation, per-child error boundaries, reuse across parents, parallel fan-out.
+
+Fix (cheap, and it *strengthens* the thesis): a paragraph conceding these are real, then reframing — context isolation and error boundaries come from what you pass into `ainvoke` and how you handle child failures, not from `compile()`. The only thing the compile step itself hands you is the namespace.
+
+### Important, not blocking
+
+- **Show the evidence, don't paraphrase it.** An essay whose method is "we wrote it down" currently quotes nothing. Put the five-line `examples/chat/python/src/graph.py:277-281` comment in a `python` fence. Same for `cockpit/ag-ui/subagents/python/src/graph.py:5-6`, which literally declares itself the control group ("Mirrors `cockpit/chat/subagents`' … structure, but each dispatch emits `subagent_activity` CUSTOM events").
+- **The AG-UI control group is the strongest evidence and gets the least space** (200 words vs 301/404 for the other sections). It needs the controlled-experiment framing stated outright: same team, same feature, same three roles, one variable — whether the transport already carries a delegation primitive. Therefore the subgraph was never required by the feature, only by the transport. That keystone sentence isn't in the post. Fund the space by compressing the two duplicated design-doc paragraphs.
+- **"Nothing was compromised by staying flat" is unsupported** in the place the post can least afford it. Name the cost (hand-rolled per-token streaming in the tool body, no independent checkpointing, no separate state).
+- **`add_node` vs tool-body mismatch:** the canonical opening sample uses `builder.add_node(...)`, but all four pieces of evidence are children invoked via `ainvoke` from a `@tool` body. The post admits the gap but never says whether the thesis holds for plain `add_node` subgraphs. One sentence closes it.
+- **The streaming section is a wall** — 404 words, 30% of the post, no H3s, and the post uses no bullets anywhere (the injectAgent post uses ten). Add three H3s or a lead-in list naming the hazards.
+- **Audience bridge missing** where the post pivots to "in our own repo" — one sentence licensing the generalization (a natural experiment, not a portfolio) buys the next 300 words for a Python-first reader.
+- **Two hazards stop at the API name** where the best paragraph earns its specifics by generalizing. `filterSubagentMessages` → *child text lands in the parent transcript by default in any consumer*; the attribution ladder → *any consumer mapping namespaces to delegations is doing string matching unless the protocol gives it an id*. That second one is a real design insight currently phrased as a config caveat.
+
+### Minor
+
+Cut the structural self-narration ("That's the whole post, so let's start there and then earn it") — neither sibling announces its plan. Drop "says the quiet part out loud." Compress the two design-doc paragraphs that make the same point twice. Fix the elided verb in "gets assumed and shouldn't." The frontmatter description promises "how state crosses the boundary," which is survey-flavored and slightly at odds with a post arguing state largely *doesn't* get a boundary — there's room under the limit to make it carry the thesis. Add a closing invitation (voice.md calls for one; the json-render post ends "Pick a surface you're building this week… and let me know where it lands").
+
+### Verified clean — don't re-litigate
+
+Both reviews independently confirmed: no mention of `cockpit/langgraph/subgraphs` anywhere; no speculation about checkpointers, latency, performance, or parallel fan-out; no line numbers in prose; no emoji, hype, "Introduction" header, CTA, or licensing callout; exactly 2 code blocks; **zero 8-gram prose overlap with either docs page**; frontmatter correct at 127 chars; all links resolve; and every evidence claim about what the cited files say is true. Voice is a strong match to both siblings (five "Let's", H2-as-question, flagged opinions, italics-only emphasis).
+
+### One thing to raise with Brian
+
+The docs matrix row at `agent-architecture.mdx:689` reads "State isolation | … | Isolated per subagent," which sits in tension with this post's thesis. Not a blocker (the matrix is linked, not restated), but if the post lands, that row is arguably the next thing to fix.
+
+**Already verified locally for this post** (no need to redo unless the file changes): frontmatter valid, description 127 chars, renders 200 with correct `<title>` and meta description, both fences highlight (`python`, `text`), listed on `/blog`, working tree clean, and the website suite shows the same 5 pre-existing failures as before (unchanged by this post).
+
+### Post #1's thesis — do not let a reviewer flatten it
+
+The obvious "when to split" essay would co-rank against our own `apps/website/content/docs/langgraph/concepts/agent-architecture.mdx:626-696` decision matrix. Brian approved a sharper angle instead: **on LangGraph, a subgraph buys an *observable* boundary, not a state boundary.** Evidence, all first-hand:
+
+- `examples/chat/python/src/graph.py:276-281` — a code comment stating the motive outright: running it as a real subgraph "is what causes LangGraph to emit stream events under namespace prefix `tools:<id>`… which the SubagentTracker keys on."
+- `cockpit/ag-ui/subagents/python/src/graph.py` — the **strongest single piece**: the same three-subagent feature with no subgraph at all (flat `_run_subagent` at :107, `adispatch_custom_event("subagent_activity", …)` at :166-168), because AG-UI's transport has a first-class delegation event.
+- `docs/superpowers/specs/2026-05-08-*-subagents-design.md:23` — a plain `@tool` alternative rejected because with no subgraph, no `tools:` events fire and the card renders empty.
+- PR #718 (`docs/superpowers/specs/2026-06-19-cockpit-subagents-subgraph-design.md`) — `cockpit/chat/subagents` was converted flat→subgraph purely so a UI card would render.
+
+Full design rationale: `docs/superpowers/specs/2026-08-27-langgraph-subgraphs-post-design.md`. Task-level plan: `docs/superpowers/plans/2026-08-27-langgraph-subgraphs-post.md`.
+
+## Two live defects — NOT fixed
+
+Both were spawned as background tasks and **both sessions were deleted before landing anything**. No branch, no PR. They are still real:
+
+1. **`cockpit/langgraph/subgraphs/python/docs/guide.md:112` states a falsehood** — claims subgraph events surface through `stream.subagents()`. For that example they cannot: it adds a compiled subgraph as a plain node (`python/src/graph.py:55`), emitting namespace `research:<uuid>`, but the tracker only routes `tools:`-prefixed namespaces (`libs/langgraph/src/lib/internals/subagent-tracker.ts:265-269`) and additionally requires `subagentToolNames` + `args.subagent_type` (:78-112). The Angular app sets no `subagentToolNames` and never has. Our published docs already say the opposite at `apps/website/content/docs/langgraph/guides/subgraphs.mdx:114`.
+2. **The example doesn't demonstrate what it advertises** — the docstring at `python/src/graph.py:22` claims the orchestrator "decides when to delegate," but the edge at :57-58 is unconditional. The subagent sidebar (`angular/src/app/subgraphs.component.ts:112-119`) can never populate, and `e2e/manual/subgraphs.manual.ts:12` asserts `text=No active subagents` as its only assertion — a test passing vacuously.
+
+Post #1 is written to neither depend on nor contradict either fix, so it can ship first. Re-spawn these if Brian still wants them.
+
+## Post #12 — research was in flight, results lost
+
+A research pass was running when the session ended; its findings are gone. Re-run it before designing. What it was asked to establish (all read-only):
+
+- How the aimock harness works end to end: what it intercepts, record vs replay, fixture format, how a test selects a fixture set.
+- **Fixture matching semantics** — the matching keys and, critically, the ordering constraint: a `hasToolResult: true` entry must precede the plain `userMessage` entry, or the continuation re-matches the tool call and loops forever.
+- **What replay cannot catch** — replay is roughly atomic (one content snapshot), so streaming re-materialization warnings (NG0956, `@for` recreation) can't fire and console-guard e2e assertions false-pass. There's a live-LLM smoke-gate convention as the counterweight.
+- Concrete war stories from specs and git history; scale facts (fixture count, which suites, runtime) to make "we run our entire e2e suite this way" checkable.
+- What we should NOT publish.
+
+This is the only post with **no search evidence** — it's a bet on being genuinely differentiated and shareable. If the research comes back thin, say so rather than padding it.
+
+## The pipeline (used for all three posts; it works)
+
+1. **Design pass** — research the repo for first-hand material, present 2–3 angles with a recommendation, get Brian's approval. He engages with this and picks.
+2. **Spec** → `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`, commit.
+3. **Plan** → `docs/superpowers/plans/YYYY-MM-DD-<topic>.md`, commit. Include a "Verified facts" block with paths/lines you personally read.
+4. **Implementer subagent** — give it the full task text, the verified facts, hard prohibitions, and the voice gate. Never make it read the plan file.
+5. **Spec-compliance review subagent** — explicitly told not to trust the implementer's report; verifies claims against source.
+6. **Editorial review subagent** — prose, argument, voice fidelity, MDX mechanics; told a separate agent handles spec compliance.
+7. **Apply findings → re-review → validate → PR → auto-merge → verify production.**
+
+Run the two reviews in parallel; they don't conflict.
+
+## Hard-won conventions
+
+**Voice.** `docs/gtm/voice.md` with a 2026 technical override: no invented first-person anecdotes (Brian: "don't make up stories"), no emoji, trimmed rhetoric. Keep contractions, "Let's" transitions, 1–3-line paragraphs, H2-as-question answered in its first line, opinions flagged ("For me," "I think"), no hype, no marketing CTAs. Register references are the two shipped posts.
+
+**No licensing callout.** Brian removed it from post #11 as unnecessary. Don't reintroduce it.
+
+**Don't co-rank against our own docs.** Every post so far had a docs page targeting the same query. The post must answer the *decision* the searcher faces and link the docs page for mechanics. Check for verbatim runs against the docs page before shipping — reviewers caught three in post #9.
+
+**Verify against published tarballs, not just source.** Main routinely runs ahead of npm (releases fire only on a pushed tag). `npm pack @threadplane/<pkg>@latest` into the scratchpad and grep the `.d.ts` for every public member the post names. Drop main-only members.
+
+**`nx test website` does not exist** — it fails silently-ish. Use `cd apps/website && npx vitest run --config vite.config.mts`.
+
+**5 pre-existing test failures**, unrelated to any of this work and red long enough to have drifted: `PostCard.spec.tsx` (expects a raw date the component now formats), `Differentiator.spec.tsx` (assertion drift), `thanks/page.spec.tsx` (3). Confirm the count is unchanged; don't fix them inside a content PR. Worth a separate cleanup — Brian hasn't decided.
+
+**Merge is not a deploy.** Only `Vercel – threadplane` gates merge. Vercel preview URLs are SSO-protected, so verify locally on `npx next dev -p 3111` and then poll the production URL until it returns 200 before claiming shipped. On post #9 the PR merged while two accuracy fixes were still in flight — "merged" wouldn't have proven the right content shipped, so re-check `origin/main` content and the live page.
+
+**Dev server side effect:** `next dev` modifies `apps/website/next-env.d.ts`. `git checkout` it before committing.
+
+## Gotchas that bit us
+
+- A Fable 5 subagent hit a usage limit mid-task and died **leaving its edits uncommitted in the working tree**. Don't assume a dead agent did nothing — check `git status` and verify each expected change before committing on its behalf.
+- An editorial reviewer suggested wording that was itself a factual overreach ("a submit action *always* goes back"); its own re-review caught it. Validation checks can block a submit — `libs/chat/src/lib/a2ui/surface.component.ts:203`. Verify reviewer suggestions in source before applying them.
+- Post #9's snippet needed real schema validation: `Card` has no `title` prop, and the A2UI envelopes were checked against `libs/a2ui/schemas/server_to_client.json` and round-tripped through the published parser. Plausible-looking JSON is not good enough.

--- a/docs/superpowers/HANDOFF-blog-sequence.md
+++ b/docs/superpowers/HANDOFF-blog-sequence.md
@@ -18,76 +18,31 @@ The candidates doc lives at `docs/gtm/blog-topic-candidates.md` **on a different
 |---|---|---|
 | #11 | What `injectAgent()` Actually Returns | **Live** — [threadplane.ai/blog/what-inject-agent-returns](https://threadplane.ai/blog/what-inject-agent-returns), PR #836 |
 | #9 | json-render vs A2UI: Choosing a Generative UI Contract | **Live** — [threadplane.ai/blog/json-render-vs-a2ui-choosing](https://threadplane.ai/blog/json-render-vs-a2ui-choosing), PR #837 |
-| #1 | LangGraph Subgraphs: When to Split a Graph and When Not To | **Drafted, unpushed, reviews returned BLOCKING findings** — commit `850573e3` on this branch |
+| #1 | LangGraph Subgraphs: When to Split a Graph and When Not To | **Shipped** — see the section below for what the reviews changed |
 | #12 | Testing Agents Deterministically: Fixture-Replay for LLM UIs | **Not started** |
 
-## Immediate next step — post #1 needs real work before it ships
+## What the reviews changed in post #1
 
-Both reviews reported. **The post is NOT ready.** Two of the findings are factual errors, one is an argument hole. Fix these, re-review, then push/PR/merge/verify.
+Both reviews returned blocking findings and all were real. Recorded here because two of them are traps a future post could repeat.
 
-### Blocking: two false technical claims (spec review)
+**Attribution is structural, not heuristic.** The `tools:<id>` namespace segment *is* the parent tool call id (`extractToolCallIdFromNamespace` is `segment.slice(6)`; `resolveToolCallId` falls back to the namespace id itself). The description-comparison ladder exists but is unreachable in every shipped graph. Do not describe it as the mechanism.
 
-**A. The attribution paragraph is backwards.** The post says attribution "is a heuristic" and that the last-resort fallback is "doing real work in practice." Both wrong:
+**`streamSubgraphs` is the LangGraph JS SDK's own option name** (`@langchain/langgraph-sdk` `types.d.ts:148,187,240`), not a Threadplane rename. The `subgraphs=True` kwarg is the Python in-process `graph.stream()` API.
 
-- The **primary path is structural, not heuristic.** The namespace segment *is* the tool call id — `extractToolCallIdFromNamespace` is `segment.slice(6)` (`libs/langgraph/src/lib/internals/subagent-tracker.ts:271-277`), and `resolveToolCallId` falls back to the namespace id itself (:260-262), which is the key `registerFromToolCalls` already stored. So `markRunningFromNamespace` / `addMessageToSubagent` bind by id with no matching at all.
-- `matchSubgraphToSubagent` is called from exactly one place (`stream-manager.bridge.ts:968-976`), gated on the child's `values.messages[0]` being a **human** message.
-- **Neither shipped graph can satisfy that gate.** `examples/chat/python/src/graph.py:327` invokes with `messages: []`, and `cockpit/chat/subagents/python/src/graph.py:172-174` likewise. Both children start empty; the human message goes straight to `llm.ainvoke([...])` and never enters state. So the first message in child values is the AI response, and the ladder never runs in either demo. There is no `subagent-tracker.spec.ts` either.
+**The discriminator for an earned split is control flow, not state schema.** `examples/chat` and `cockpit/chat/subagents` both define custom child `TypedDict`s yet are single-node straight lines, so "the child has its own state schema" fails to separate an earned split from an observability split. Only `examples/ag-ui` — child with its own `agent → tools → agent` loop and iteration cap — earns it on the merits.
 
-Fix: invert the emphasis. Attribution normally rides the namespace, because `tools:<id>` carries the parent tool call id and the tracker resolves it directly. There *is* a description-comparison ladder (exact → substring → last-resort unmapped-pending) for children whose state opens with a human message, but nothing we ship reaches it — treat it as untested rather than as the mechanism. The closing warning survives and gets sharper: the ladder is what a fan-out graph would fall back on.
+**`examples/ag-ui` is a counterexample the first draft missed.** It compiles a child on a transport that already emits `subagent_activity`, so that split is not buying observability. The post now owns this rather than claiming no such case exists.
 
-**B. The `streamSubgraphs` "naming trap" isn't a trap.** `streamSubgraphs` **is** the LangGraph JS SDK's own option name (`node_modules/@langchain/langgraph-sdk/dist/types.d.ts:148,187,240`), passed straight through by `buildRunPayload` (`fetch-stream.transport.ts:152-155`). `subgraphs=True` is the *Python in-process* `graph.stream()` kwarg, not the SDK. Delete the sentence or re-aim it at the Python API. (The default-on half is correct: `streamSubgraphs ?? true` at :154.)
+**Checkpointing is a trap in both directions.** Both subgraph children compile bare (`.compile()`, no checkpointer) while the *flat* `cockpit/ag-ui/subagents` graph is the one using `MemorySaver`. So "compile() gives the child its own checkpoint lineage" is false, and so is listing "no independent checkpointing" as a cost of staying flat. An editorial reviewer proposed the first of those as a fix — verify reviewer suggestions in source before applying them.
 
-**C. Nit:** the test asserts `phase: 'complete'` with `outcome: 'interrupted'`. "Settles as `interrupted` rather than complete" reads as a phase claim — say "settles with outcome `interrupted` rather than success."
+## Two live defects — FIXED
 
-### Blocking: the argument has a hole a skeptic finds immediately (editorial review)
-
-The post never engages the **non-observability** reasons to split, and our own docs assert them: `docs/langgraph/guides/subgraphs.mdx:310` (own context window, isolated error boundaries), `agent-architecture.mdx:689` (State isolation: "Isolated per subagent"), and the post's own evidence file at `examples/chat/python/src/graph.py:288-291` ("the subagent is a focused contractor"). A LangGraph engineer dismisses the piece in one comment: context-window isolation, per-child error boundaries, reuse across parents, parallel fan-out.
-
-Fix (cheap, and it *strengthens* the thesis): a paragraph conceding these are real, then reframing — context isolation and error boundaries come from what you pass into `ainvoke` and how you handle child failures, not from `compile()`. The only thing the compile step itself hands you is the namespace.
-
-### Important, not blocking
-
-- **Show the evidence, don't paraphrase it.** An essay whose method is "we wrote it down" currently quotes nothing. Put the five-line `examples/chat/python/src/graph.py:277-281` comment in a `python` fence. Same for `cockpit/ag-ui/subagents/python/src/graph.py:5-6`, which literally declares itself the control group ("Mirrors `cockpit/chat/subagents`' … structure, but each dispatch emits `subagent_activity` CUSTOM events").
-- **The AG-UI control group is the strongest evidence and gets the least space** (200 words vs 301/404 for the other sections). It needs the controlled-experiment framing stated outright: same team, same feature, same three roles, one variable — whether the transport already carries a delegation primitive. Therefore the subgraph was never required by the feature, only by the transport. That keystone sentence isn't in the post. Fund the space by compressing the two duplicated design-doc paragraphs.
-- **"Nothing was compromised by staying flat" is unsupported** in the place the post can least afford it. Name the cost (hand-rolled per-token streaming in the tool body, no independent checkpointing, no separate state).
-- **`add_node` vs tool-body mismatch:** the canonical opening sample uses `builder.add_node(...)`, but all four pieces of evidence are children invoked via `ainvoke` from a `@tool` body. The post admits the gap but never says whether the thesis holds for plain `add_node` subgraphs. One sentence closes it.
-- **The streaming section is a wall** — 404 words, 30% of the post, no H3s, and the post uses no bullets anywhere (the injectAgent post uses ten). Add three H3s or a lead-in list naming the hazards.
-- **Audience bridge missing** where the post pivots to "in our own repo" — one sentence licensing the generalization (a natural experiment, not a portfolio) buys the next 300 words for a Python-first reader.
-- **Two hazards stop at the API name** where the best paragraph earns its specifics by generalizing. `filterSubagentMessages` → *child text lands in the parent transcript by default in any consumer*; the attribution ladder → *any consumer mapping namespaces to delegations is doing string matching unless the protocol gives it an id*. That second one is a real design insight currently phrased as a config caveat.
-
-### Minor
-
-Cut the structural self-narration ("That's the whole post, so let's start there and then earn it") — neither sibling announces its plan. Drop "says the quiet part out loud." Compress the two design-doc paragraphs that make the same point twice. Fix the elided verb in "gets assumed and shouldn't." The frontmatter description promises "how state crosses the boundary," which is survey-flavored and slightly at odds with a post arguing state largely *doesn't* get a boundary — there's room under the limit to make it carry the thesis. Add a closing invitation (voice.md calls for one; the json-render post ends "Pick a surface you're building this week… and let me know where it lands").
-
-### Verified clean — don't re-litigate
-
-Both reviews independently confirmed: no mention of `cockpit/langgraph/subgraphs` anywhere; no speculation about checkpointers, latency, performance, or parallel fan-out; no line numbers in prose; no emoji, hype, "Introduction" header, CTA, or licensing callout; exactly 2 code blocks; **zero 8-gram prose overlap with either docs page**; frontmatter correct at 127 chars; all links resolve; and every evidence claim about what the cited files say is true. Voice is a strong match to both siblings (five "Let's", H2-as-question, flagged opinions, italics-only emphasis).
-
-### One thing to raise with Brian
-
-The docs matrix row at `agent-architecture.mdx:689` reads "State isolation | … | Isolated per subagent," which sits in tension with this post's thesis. Not a blocker (the matrix is linked, not restated), but if the post lands, that row is arguably the next thing to fix.
-
-**Already verified locally for this post** (no need to redo unless the file changes): frontmatter valid, description 127 chars, renders 200 with correct `<title>` and meta description, both fences highlight (`python`, `text`), listed on `/blog`, working tree clean, and the website suite shows the same 5 pre-existing failures as before (unchanged by this post).
-
-### Post #1's thesis — do not let a reviewer flatten it
-
-The obvious "when to split" essay would co-rank against our own `apps/website/content/docs/langgraph/concepts/agent-architecture.mdx:626-696` decision matrix. Brian approved a sharper angle instead: **on LangGraph, a subgraph buys an *observable* boundary, not a state boundary.** Evidence, all first-hand:
-
-- `examples/chat/python/src/graph.py:276-281` — a code comment stating the motive outright: running it as a real subgraph "is what causes LangGraph to emit stream events under namespace prefix `tools:<id>`… which the SubagentTracker keys on."
-- `cockpit/ag-ui/subagents/python/src/graph.py` — the **strongest single piece**: the same three-subagent feature with no subgraph at all (flat `_run_subagent` at :107, `adispatch_custom_event("subagent_activity", …)` at :166-168), because AG-UI's transport has a first-class delegation event.
-- `docs/superpowers/specs/2026-05-08-*-subagents-design.md:23` — a plain `@tool` alternative rejected because with no subgraph, no `tools:` events fire and the card renders empty.
-- PR #718 (`docs/superpowers/specs/2026-06-19-cockpit-subagents-subgraph-design.md`) — `cockpit/chat/subagents` was converted flat→subgraph purely so a UI card would render.
-
-Full design rationale: `docs/superpowers/specs/2026-08-27-langgraph-subgraphs-post-design.md`. Task-level plan: `docs/superpowers/plans/2026-08-27-langgraph-subgraphs-post.md`.
-
-## Two live defects — NOT fixed
-
-Both were spawned as background tasks and **both sessions were deleted before landing anything**. No branch, no PR. They are still real:
+Both were real, and both were fixed by #838 (`cockpit/langgraph/subgraphs` now routes conditionally and gives the child a state schema with no `messages` key). Kept here for the record:
 
 1. **`cockpit/langgraph/subgraphs/python/docs/guide.md:112` states a falsehood** — claims subgraph events surface through `stream.subagents()`. For that example they cannot: it adds a compiled subgraph as a plain node (`python/src/graph.py:55`), emitting namespace `research:<uuid>`, but the tracker only routes `tools:`-prefixed namespaces (`libs/langgraph/src/lib/internals/subagent-tracker.ts:265-269`) and additionally requires `subagentToolNames` + `args.subagent_type` (:78-112). The Angular app sets no `subagentToolNames` and never has. Our published docs already say the opposite at `apps/website/content/docs/langgraph/guides/subgraphs.mdx:114`.
 2. **The example doesn't demonstrate what it advertises** — the docstring at `python/src/graph.py:22` claims the orchestrator "decides when to delegate," but the edge at :57-58 is unconditional. The subagent sidebar (`angular/src/app/subgraphs.component.ts:112-119`) can never populate, and `e2e/manual/subgraphs.manual.ts:12` asserts `text=No active subagents` as its only assertion — a test passing vacuously.
 
-Post #1 is written to neither depend on nor contradict either fix, so it can ship first. Re-spawn these if Brian still wants them.
+Post #1 was held until #838 landed, then re-checked against it — the fixed example is now cited in the post as first-hand evidence that state isolation is designed, not handed to you by `compile()`.
 
 ## Post #12 — research was in flight, results lost
 

--- a/docs/superpowers/plans/2026-08-27-langgraph-subgraphs-post.md
+++ b/docs/superpowers/plans/2026-08-27-langgraph-subgraphs-post.md
@@ -1,0 +1,154 @@
+# LangGraph Subgraphs Blog Post Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish a first-hand essay for the `langgraph subgraphs` query (41 impressions, position 32.3, nothing of ours competing) arguing that the boundary a subgraph really buys you is observability, not state.
+
+**Architecture:** One new MDX file in `apps/website/content/blog/`. No code changes. At most two short code blocks (Python is fine — audience is Python-first).
+
+**Tech Stack:** MDX blog content, Next.js website (`apps/website`), vitest for content validation.
+
+**Spec:** `docs/superpowers/specs/2026-08-27-langgraph-subgraphs-post-design.md`
+**Branch:** `blove/langgraph-subgraphs-post` (off main at `d2e5ce73`)
+
+---
+
+## Verified facts (I re-read each of these in source; drafter must still open them)
+
+**The observability motive, in our own code** — `examples/chat/python/src/graph.py:276-281`, verbatim:
+
+```
+# Research subagent — a small compiled child graph the parent dispatches
+# via the `research` @tool. Running it as an actual subgraph (vs. inline
+# logic) is what causes LangGraph to emit stream events under namespace
+# prefix `tools:<id>` for the child run, which is what the @threadplane/langgraph
+# SubagentTracker keys on to populate `agent.subagents()`.
+```
+
+**Namespace gating** (`libs/langgraph/src/lib/internals/subagent-tracker.ts`):
+- `isSubagentNamespace()` :265-269 — a segment must start with `tools:`.
+- `extractToolCallIdFromNamespace()` :271-277 — returns the FIRST `tools:` segment only, so nested delegation attributes inner events to the outer call.
+- `matchSubgraphToSubagent()` :130-175 — exact description match, then substring either direction, then the fallback at :165-169: any unmapped subagent whose status is `pending` or `running`. Heuristic, not structural.
+
+**Streaming defaults:**
+- `streamSubgraphs: streamSubgraphs ?? true` — `libs/langgraph/src/lib/transport/fetch-stream.transport.ts:154`. Subgraph streaming is opt-OUT. The SDK option is `streamSubgraphs`, not `subgraphs: true`.
+- `filterSubagentMessages?: boolean` — `libs/langgraph/src/lib/agent.types.ts:283`, doc comment "When true, subagent messages are filtered from the main messages signal." Optional, so default OFF: subagent chatter lands in the parent transcript unless you opt in.
+- Events are `|`-delimited (`messages|tools:call-1`), parsed in `fetch-stream.transport.ts:191-198` and `stream-manager.bridge.ts:1311-1318`.
+- Namespaced terminal events would close out the parent's streaming message without a guard — `stream-manager.bridge.ts:314-330`, with `stream-manager.bridge.spec.ts:474-505` asserting outcome `interrupted`.
+
+**The cross-transport A/B:**
+- LangGraph side: `cockpit/chat/subagents` uses a real subgraph; converted from flat to subgraph in PR #718 (spec `docs/superpowers/specs/2026-06-19-cockpit-subagents-subgraph-design.md`) so a UI card would render.
+- AG-UI side: `cockpit/ag-ui/subagents/python/src/graph.py` — flat `async def _run_subagent(...)` at :107 and `adispatch_custom_event("subagent_activity", {...})` at :166-168. No subgraph. Same feature.
+- Rejected alternative on record: `docs/superpowers/specs/2026-05-08-*-subagents-design.md:23` — a plain `@tool` returning a synthesized payload was rejected because no `tools:` namespace events are emitted when no subgraph runs, so the card would render empty.
+
+**Docs to link, not restate:** `apps/website/content/docs/langgraph/concepts/agent-architecture.mdx:626-696` (three-tier breakdown + decision matrix) and `apps/website/content/docs/langgraph/guides/subgraphs.mdx` (note :114 — "Plain subgraph nodes do not appear in this map").
+
+**Hard prohibitions** (from the spec):
+- Do NOT claim `cockpit/langgraph/subgraphs` demonstrates delegation or populates the sidebar — it does neither (unconditional edge `orchestrate → research → END` at `python/src/graph.py:57-58`; no `subagentToolNames` in `angular/src/app/app.config.ts`). Two separate tasks are correcting that example; the post must not depend on or contradict their outcome. Cite `cockpit/chat/subagents` and `examples/chat` for working delegation instead.
+- Do NOT speculate about split performance/latency, parallel subagent fan-out, or child-specific checkpointers/state schemas. Nothing in the repo measures or exercises those.
+
+---
+
+### Task 1: Author the post
+
+**Files:**
+- Create: `apps/website/content/blog/2026-08-27-langgraph-subgraphs-when-to-split.mdx`
+
+- [ ] **Step 1: Frontmatter**
+
+```yaml
+---
+title: 'LangGraph Subgraphs: When to Split a Graph and When Not To'
+description: 'When a LangGraph subgraph earns its complexity, how state crosses the boundary, and what your UI sees while a child graph runs.'
+date: 2026-08-27
+tags: [langgraph, subgraphs, agents, streaming, angular]
+author: brian
+featured: false
+draft: false
+---
+```
+
+Description is 127 chars (≤155). The drafter may sharpen the title toward the observability thesis but MUST keep "Subgraphs" early for the query, and must re-count the description if changed. No licensing callout.
+
+- [ ] **Step 2: Body**
+
+1. **Lede** (no header): restate the searcher's question, then land the thesis early — the boundary a subgraph really draws is usually observability, not state.
+2. `## What does a subgraph actually give you?` — first line answers. The canonical pattern (compile a child, add it as a node). What genuinely changes: nested execution and namespaced stream events. What does NOT change automatically: state isolation — if parent and child share a `MessagesState`, the child appends to the parent's list. Link the architecture matrix for the tiering question rather than restating it. At most one short Python block here.
+3. `## Why do people really split?` — the thesis, evidenced: quote or closely paraphrase the `examples/chat/python/src/graph.py:276-281` comment (attribute it as our own code), the rejected `@tool` alternative, and the flat→subgraph conversion done so a card would render.
+4. `## What does the frontend see while a child runs?` — the differentiated section. Namespaced `|`-delimited events; `streamSubgraphs` defaults on; without namespace guards a child's terminal event closes the parent's message; `filterSubagentMessages` defaults off so child text lands in the parent transcript; attribution is heuristic (`matchSubgraphToSubagent` falls back to any unmapped pending/running subagent) and nested `tools:` collapses to the outer call — say plainly that deeper nesting is untested here.
+5. `## When should you not split?` — the honest counterweight. If you don't need the observable boundary and don't have genuinely divergent state, a subgraph adds a boundary you then have to defend. Cite AG-UI doing the same feature flat because its transport has a first-class delegation event.
+6. `## Conclusion` — the heuristic in a short paragraph; forward links to `/docs/langgraph/concepts/agent-architecture`, `/docs/langgraph/guides/subgraphs`, and `/blog/what-inject-agent-returns`. No CTA.
+
+- [ ] **Step 3: Voice pass**
+
+`docs/gtm/voice.md` with the 2026 technical override. Register references: `apps/website/content/blog/2026-08-26-what-inject-agent-returns.mdx` and `apps/website/content/blog/2026-08-26-json-render-vs-a2ui-choosing.mdx` — this post must read as the same author. Checklist: title-restating lede, no "Introduction" header, contractions, 1–3-line paragraphs, H2-as-question answered in its first line, ≥1 "Let's" per major section, opinions flagged ("I think"/"For me"), no invented anecdotes, no emoji, no hype, no CTAs. Don't copy sentences from our docs pages verbatim.
+
+- [ ] **Step 4: Accuracy pass**
+
+- Open every file cited in Verified Facts and confirm the claim before it ships. Cite behavior, not line numbers, in the prose — line numbers rot.
+- Confirm the hard prohibitions above are respected.
+- Published-release check: `npm pack @threadplane/langgraph@latest @threadplane/chat@latest` in the scratchpad; grep the `.d.ts` for any public member named (`subagents`, `filterSubagentMessages`, `subagentToolNames`, `streamSubgraphs`). Drop main-only members.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/website/content/blog/2026-08-27-langgraph-subgraphs-when-to-split.mdx
+git commit -m "feat(website): add 'LangGraph Subgraphs' blog post"
+```
+
+---
+
+### Task 2: Validate
+
+- [ ] **Step 1: Frontmatter + description length**
+
+```bash
+cd apps/website && node -e "
+const matter = require('/Users/blove/repos/angular-agent-framework/node_modules/gray-matter');
+const fs = require('fs');
+const f = matter(fs.readFileSync('content/blog/2026-08-27-langgraph-subgraphs-when-to-split.mdx','utf8'));
+console.log('desc length:', f.data.description.length);
+if (f.data.description.length > 155) throw new Error('description too long');
+if (!f.data.title || !f.data.date || f.data.author !== 'brian') throw new Error('frontmatter incomplete');
+console.log('OK');
+"
+```
+
+- [ ] **Step 2: Test suite** (`nx test website` does not exist):
+
+```bash
+cd apps/website && npx vitest run --config vite.config.mts
+```
+
+`blog.spec.ts` and `sitemap-dates.spec.ts` must pass. Known pre-existing failures, do NOT fix, confirm the count is unchanged at 5: `PostCard.spec.tsx` (1), `Differentiator.spec.tsx` (1), `thanks/page.spec.tsx` (3).
+
+- [ ] **Step 3: Render check** — `npx next dev -p 3111` from `apps/website` in the background, then curl:
+  - `/blog/langgraph-subgraphs-when-to-split` → 200, correct `<title>`, meta description matches frontmatter, code blocks carry `data-language` with a theme
+  - `/blog` lists the post
+
+  Kill the server, confirm port 3111 free, and `git checkout apps/website/next-env.d.ts` if the dev server modified it.
+
+- [ ] **Step 4: Commit fixes** (skip if none):
+
+```bash
+git add -A apps/website/content/blog/ && git commit -m "fix(website): render fixes for subgraphs post"
+```
+
+---
+
+### Task 3: PR and merge
+
+- [ ] **Step 1: Push and open PR**
+
+```bash
+git push -u origin HEAD
+gh pr create --title "feat(website): add 'LangGraph Subgraphs' blog post" --body "Third post of the GSC-driven blog sequence (spec: docs/superpowers/specs/2026-08-27-langgraph-subgraphs-post-design.md).
+
+Targets \`langgraph subgraphs\` — 41 impressions at position 32.3, the second-highest-impression query on the site with nothing of ours competing. Argues from first-hand repo evidence that a subgraph's real payoff on LangGraph is an observable boundary rather than a state boundary.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+- [ ] **Step 2: Merge on green, then verify production**
+
+Arm auto-merge (`gh pr merge <n> --squash --auto`); only `Vercel – threadplane` gates. After merge, confirm `origin/main` carries the final content, then poll `https://threadplane.ai/blog/langgraph-subgraphs-when-to-split` until it returns 200 and spot-check the live title and meta description. Do not report "shipped" before the production URL answers 200 — a merge is not a deploy.

--- a/docs/superpowers/specs/2026-08-27-langgraph-subgraphs-post-design.md
+++ b/docs/superpowers/specs/2026-08-27-langgraph-subgraphs-post-design.md
@@ -1,0 +1,59 @@
+# Post #1 design: LangGraph subgraphs — the observability boundary
+
+**Date:** 2026-08-27
+**Status:** Approved (angle + scope approved in session; third post of the sequence in `docs/superpowers/specs/2026-08-26-blog-sequence-inject-agent-design.md`)
+
+## Intent and evidence
+
+`langgraph subgraphs` — 41 impressions, position 32.3, 0 clicks. Second-highest impression query on the site and we're effectively invisible for it. Nothing of ours competes.
+
+This is the "grow the search surface" play: the searcher is a LangGraph-core engineer, often Python-first, not necessarily looking for an Angular UI framework. Per the candidates doc, serving them well may mean content only incidentally about Threadplane. That's the deliberate choice here.
+
+**Slug:** `langgraph-subgraphs-when-to-split`
+**File:** `apps/website/content/blog/2026-08-27-langgraph-subgraphs-when-to-split.mdx`
+**Title:** working title "LangGraph Subgraphs: When to Split a Graph and When Not To" — the drafter may sharpen it toward the observability thesis, but must keep "subgraphs" early in the title for the query.
+**Meta description (≤155 chars):** "When a LangGraph subgraph earns its complexity, how state crosses the boundary, and what your UI sees while a child graph runs."
+**No licensing callout.**
+
+## The angle: the observability boundary
+
+**Rejected:** a generic "when to split" decision essay. `apps/website/content/docs/langgraph/concepts/agent-architecture.mdx:626-696` already carries a three-tier breakdown and a decision matrix; a generic post would co-rank against our own docs and lose the first-hand advantage. Link that section for the architecture question instead of restating it.
+
+**The thesis:** most people reach for a subgraph expecting a *state* boundary, but in practice — at least on LangGraph — the thing a subgraph actually buys you is an *observable* boundary. That is the claim only we can make, and the repo says it out loud.
+
+Supporting first-hand material (all verified; cite by path):
+
+1. **Our own code says the motive is observability.** `examples/chat/python/src/graph.py:277-281` states that running the work as a real subgraph "is what causes LangGraph to emit stream events under namespace prefix `tools:<id>`… which the SubagentTracker keys on." The subgraph exists for the UI.
+2. **A controlled A/B across transports.** The same three-subagent feature exists twice: with a subgraph on LangGraph (`cockpit/chat/subagents`) and with no subgraph at all on AG-UI (`cockpit/ag-ui/subagents/python/src/graph.py` — flat `_run_subagent()` at :107-135 plus `adispatch_custom_event("subagent_activity", …)` at :167). Same feature, opposite structural answer, because AG-UI's transport has a first-class delegation event and LangGraph's doesn't.
+3. **A rejected alternative on record.** `docs/superpowers/specs/2026-05-08-*-subagents-design.md:23` rejected a plain `@tool` returning a synthesized payload because "no `tools:` namespace events get emitted because no subgraph runs. The card would render empty."
+4. **A reverse migration.** `cockpit/chat/subagents` was converted from flat to subgraph (spec `2026-06-19-cockpit-subagents-subgraph-design.md`, PR #718) purely so a UI card would render.
+5. **Splitting has real streaming costs the docs don't cover.** Namespaced terminal events would close out the parent's streaming message without a guard (`libs/chat`… see `stream-manager.bridge.ts:314-330`, test at `:474-505` asserting outcome `interrupted`); subagent text lands in the parent transcript unless you opt into `filterSubagentMessages` (default off, `agent.types.ts:282-283`).
+6. **Attribution across the boundary is heuristic, not structural.** `matchSubgraphToSubagent()` (`subagent-tracker.ts:130-175`) falls back to "any unmapped pending/running subagent" (:165-169), and `extractToolCallIdFromNamespace` takes only the first `tools:` segment (:271-277) — so a subagent that itself delegates attributes inner events to the outer call. Nested delegation is untested here; say so plainly.
+
+## Structure
+
+1. **Lede** (no header): restate the question the searcher has, then land the thesis early — the useful boundary a subgraph draws is usually observability, not state.
+2. `## What does a subgraph actually give you?` — the canonical pattern (compiled child as a node), what genuinely changes (nested execution, namespaced events) and what doesn't (state isolation isn't automatic; a shared `MessagesState` means the child appends to the parent's list). Point to the docs' architecture matrix for the tiering question rather than restating it.
+3. `## Why do people really split?` — the observability thesis with the evidence above: our code comment, the rejected `@tool` alternative, the reverse migration.
+4. `## What does the frontend see while a child runs?` — the differentiated section. Namespaced events (`messages|tools:call-1`), `streamSubgraphs` defaulting on, what breaks without namespace guards, `filterSubagentMessages` defaulting off, heuristic attribution and its fallback.
+5. `## When should you not split?` — the honest counterweight: if you don't need the observable boundary and don't need genuinely divergent state, nesting adds a boundary you have to defend. Cite AG-UI doing the same feature flat.
+6. `## Conclusion` — the heuristic, plus forward links to `/docs/langgraph/concepts/agent-architecture`, `/docs/langgraph/guides/subgraphs`, and `/blog/what-inject-agent-returns` (the `subagents()` signal is part of that return surface).
+
+## Voice and register
+
+Same as posts #11 and #9: `docs/gtm/voice.md` with the 2026 technical override — H2-as-question answered in the first line, contractions, 1–3-line paragraphs, "Let's" transitions, opinions flagged, no anecdotes, no emoji, no hype, no CTAs. Register reference: the two shipped posts.
+
+Python code is fine here (the audience is Python-first); keep code to at most two short blocks.
+
+## Accuracy requirements (drafting gate)
+
+- Every claim cited to a real path/line, verified by reading the file — not from this spec's summary.
+- **Do not claim the `cockpit/langgraph/subgraphs` example demonstrates delegation or populates the subagent sidebar.** It does neither (unconditional edge; no `subagentToolNames`; sidebar permanently empty). Two separate tasks are correcting the example and its guide; this post must not depend on or contradict their outcome — prefer citing `cockpit/chat/subagents` and `examples/chat` for working delegation.
+- **Do not speculate about:** performance/latency of splitting (nothing measures it); parallel subagent fan-out (explicitly out of scope, e2e dispatches sequentially); child-specific checkpointers or state schemas (nothing exercises a separate checkpointer).
+- Verify named public members against published 0.0.58 tarballs; drop main-only members.
+- Frontmatter per existing posts; tags along the lines of [langgraph, subgraphs, agents, streaming, angular].
+
+## Out of scope
+
+- Fixing the subgraphs example or its guide (routed as separate tasks).
+- Post #12 (own pass later).


### PR DESCRIPTION
Post #1 of the GSC-driven blog sequence, following [#836](https://github.com/cacheplane/angular-agent-framework/pull/836) and [#837](https://github.com/cacheplane/angular-agent-framework/pull/837).

## Thesis

On LangGraph, a subgraph buys an **observable** boundary, not a state boundary. Deliberately not a generic "when to split" survey — that would co-rank against our own [agent-architecture decision matrix](https://threadplane.ai/docs/langgraph/concepts/agent-architecture).

## What the reviews changed

Two review passes returned blocking findings. All were real and verified in source:

- **Attribution is structural, not heuristic.** The `tools:<id>` namespace segment *is* the parent tool call id. The description-comparison ladder exists but is unreachable in every graph we ship. The draft had this backwards.
- **`streamSubgraphs` is the SDK's own option name**, not a Threadplane rename. The draft's "naming trap" was fabricated.
- **`examples/ag-ui` is a counterexample** the draft missed — it compiles a child on a transport that already emits `subagent_activity`, so that split isn't buying observability. The post now owns this in a "So when does a split earn itself?" section.
- **The discriminator is control flow, not state schema.** `examples/chat` and `cockpit/chat/subagents` both define custom child `TypedDict`s yet are single-node straight lines.
- **Dropped two false claims about checkpointing** — both subgraph children compile bare, while the *flat* AG-UI graph is the one using `MemorySaver`.

## Held for #838

This post was held unpushed until [#838](https://github.com/cacheplane/angular-agent-framework/pull/838) landed, then re-checked against it. The fixed `cockpit/langgraph/subgraphs` example is now cited as first-hand evidence that state isolation is designed, not handed to you by `compile()`.

## Verification

- Renders 200 locally with correct `<title>` and full 156-char meta description (under the 180 truncation)
- All 4 internal links resolve; listed on `/blog`; 5 fences syntax-highlight
- **Zero 8-gram prose overlap** against both docs pages it links
- Website suite: 10 failures, identical to `main` — 5 documented pre-existing, plus `route.spec.ts` / `server.spec.ts` failing on unresolved `posthog-node` (declared at `apps/website/package.json:11`, not installed in any checkout; pre-existing and unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)