### PR TITLE
docs(langgraph): state isolation is designed, not automatic

### DIFF
--- a/apps/website/content/docs/langgraph/concepts/agent-architecture.mdx
+++ b/apps/website/content/docs/langgraph/concepts/agent-architecture.mdx
@@ -686,8 +686,10 @@ builder.add_conditional_edges("supervisor", route_to_agent)
 | Tool count | 1-10 | 1-10 | 10+ across specialists |
 | Task complexity | Single domain | Single domain, high stakes | Cross-domain |
 | Latency budget | Low | Medium (human wait) | Higher (multiple LLM calls) |
-| State isolation | Shared | Shared + interrupt | Isolated per subagent |
+| State isolation | Shared | Shared + interrupt | Only if you design it |
 | Angular complexity | Low | Medium | Higher |
+
+State isolation is the one row that is not automatic. Adding a compiled graph as a node — as in the supervisor example above — runs the child against the parent's state schema, so parent and child read and write the same channels. To actually isolate a specialist, give its `StateGraph` its own state schema and share only the keys you want crossing the boundary: LangGraph passes a subgraph node through the keys the two schemas have in common.
 
 <Callout type="tip" title="Start simple">
 Begin with a single agent and tools. Add human-in-the-loop when you need approval flows. Graduate to multi-agent only when a single agent's context window cannot hold all the tools and instructions it needs.


### PR DESCRIPTION
Follow-up to [#839](https://github.com/cacheplane/angular-agent-framework/pull/839).

## The contradiction

The **Multi-Agent Supervisor** code sample adds compiled children as plain nodes on a shared `OrchestratorState`:

```python
builder = StateGraph(OrchestratorState)
builder.add_node("researcher", researcher_subgraph)
builder.add_node("analyst", analyst_subgraph)
```

The decision matrix immediately below it then claimed that pattern gives you `State isolation: Isolated per subagent`. It doesn't — with a shared schema, parent and child read and write the same channels. The doc showed the non-isolating pattern and promised isolation from it, in adjacent lines.

## The fix

- Matrix cell → `Only if you design it`
- One paragraph under the matrix giving the actual mechanism: give the child's `StateGraph` its own state schema and share only the keys you want crossing the boundary, since LangGraph passes a subgraph node through the keys the two schemas have in common.

The mechanism is stated inline rather than linked, because the [subgraphs guide](https://threadplane.ai/docs/langgraph/guides/subgraphs) also uses a shared `MessagesState` throughout and so can't serve as the pointer. That guide is worth a follow-up.

The shipped example of the isolating pattern is `cockpit/langgraph/subgraphs` after [#838](https://github.com/cacheplane/angular-agent-framework/pull/838) — child state deliberately omits `messages`, sharing only `research_topic` and `research_brief`.

## Verification

- Docs page renders 200; old string gone, new cell and paragraph present
- No other occurrence of `Isolated per subagent` in `apps/website/content/`
- Website suite: 10 failures, identical to `main` (5 documented pre-existing + 2 files on unresolved `posthog-node`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)