### PR TITLE
docs(website): filterSubagentMessages is a no-op for plain subgraph nodes

### DIFF
--- a/apps/website/content/blog/2026-08-27-langgraph-subgraphs-when-to-split.mdx
+++ b/apps/website/content/blog/2026-08-27-langgraph-subgraphs-when-to-split.mdx
@@ -140,6 +140,16 @@ Our `filterSubagentMessages` is off unless you set it, so a child's tokens flow 
 That isn't a quirk of our config.
 Any consumer reading a namespaced stream has to decide what a child's tokens mean, and "append them like everything else" is the path of least resistance — so unless something opts out, child text lands in the parent transcript and the same content renders twice.
 
+There's a trap in that option's name, and it bites the exact graph shape this post has been holding up.
+`filterSubagentMessages` only fires inside a branch guarded by the `tools:` namespace check.
+A plain subgraph node's namespace looks like `research:<uuid>`, never reaches that branch, and so ignores the option entirely — its tokens merge into the transcript however you set it.
+The lever for that shape is `transcriptNodeNames`, which whitelists the graph nodes whose messages count as transcript.
+
+It's also a mid-stream bug with a clean end state, which is the part that will waste your afternoon.
+The parent's final `values` event rewrites the message list from authoritative graph state, so the stray bubble disappears on its own once the run settles.
+Assert on the finished DOM and everything looks right; watch the streaming pass and you'll see the child's internal notes render as their own message and then vanish.
+A final-state test cannot catch it.
+
 ### How does a child get attributed?
 
 By id — and this is the part I find well-designed: the namespace segment _is_ the identifier.


### PR DESCRIPTION
A correction to the subgraphs post that landed in #839.

## The problem

The "Where child text goes" section tells readers child tokens flow into `messages()` unless `filterSubagentMessages` opts out. That's true for a child dispatched from a `@tool` body. It is **not** true for a plain subgraph node — and that's the shape the post spends its best material on.

```ts
if (isSubagentNamespace(namespace)) {   // matches only `tools:`
  …
  if (options.filterSubagentMessages) return;
}
```

A plain subgraph node emits `research:<uuid>`. It never enters that branch, so the option is ignored entirely and its tokens merge into the transcript however you set it. `transcriptNodeNames` is the lever for that shape.

This matters specifically because #839 showcases `cockpit/langgraph/subgraphs` as its clean look at the primitive — which is exactly the plain-node shape. A reader who follows that example, sees the child's brief render as its own bubble, and reaches for `filterSubagentMessages` will find it does nothing.

## The part that costs an afternoon

The leak is **mid-stream with a clean end state**. The parent's final `values` event rewrites the message list from authoritative graph state, so the stray bubble vanishes once the run settles. Assert on the finished DOM and everything looks correct.

That's not inferred from reading the code — I measured it against a live model while building [#838](https://github.com/cacheplane/angular-agent-framework/pull/838): without `transcriptNodeNames` the message count transiently reached 3 and collapsed back to 2; with it, it never exceeded 2 at any sampled point. The aimock e2e passes either way, because fixture replay is atomic.

## Scope

Ten added lines in one section, matching the surrounding semantic-linefeed style. Nothing else touched.

## Note on #840

I had a PR open with this post from an earlier draft. #839 landed first from a later, more developed version — it already covers the state-boundary mechanism, cites the new example, and adds the context-windows/error-boundaries section. Merging mine would have regressed the post, so I closed it and kept only the correction above, which #839 doesn't contain.

## Verification

- `nx build website` green; post still prerenders at `/blog/langgraph-subgraphs-when-to-split` with its OG image.
- `blog.spec.ts` + `sitemap-dates.spec.ts`: 26/26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)