### PR TITLE
test(cockpit): repair the rotted manual specs and guard them in CI

### DIFF
--- a/apps/cockpit/scripts/manual-spec-freshness.spec.ts
+++ b/apps/cockpit/scripts/manual-spec-freshness.spec.ts
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MIT
+//
+// Tripwire for the `*.manual.ts` tier.
+//
+// Manual specs are live-LLM checks a human runs by hand: every cockpit
+// playwright config matches `**/*.spec.ts`, so nothing executes these and CI
+// can never notice when they drift. When this guard was written, 10 of 34 were
+// asserting UI copy that existed nowhere in the repo — panel headings that had
+// been renamed, and empty-state strings from sidebars that no longer exist.
+//
+// Running the specs themselves in CI isn't viable (real model, per-example dev
+// server). What IS cheap is checking that everything they assert still exists
+// in the source. That catches the rot this tier actually suffers — stale copy
+// and dropped selectors — without booting anything.
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(__dirname, '../../..');
+const SKIP_DIRS = new Set(['node_modules', 'dist', '.angular', '.venv', '.next', 'coverage']);
+
+function walk(dir: string, out: string[] = []): string[] {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (!SKIP_DIRS.has(entry.name)) walk(join(dir, entry.name), out);
+    } else {
+      out.push(join(dir, entry.name));
+    }
+  }
+  return out;
+}
+
+const allFiles = walk(join(REPO_ROOT, 'cockpit')).concat(walk(join(REPO_ROOT, 'libs')));
+const manualSpecs = allFiles.filter((f) => f.endsWith('.manual.ts'));
+
+/** Every source file a manual spec could legitimately be asserting against. */
+const sourceCorpus = allFiles
+  .filter((f) => /\.(ts|html|css)$/.test(f) && !f.endsWith('.manual.ts'))
+  .map((f) => {
+    try {
+      return readFileSync(f, 'utf8');
+    } catch {
+      return '';
+    }
+  })
+  .join('\n');
+
+/** `text=Some copy` and `getByText('Some copy')` assertions. */
+function assertedText(spec: string): string[] {
+  const out = new Set<string>();
+  for (const m of spec.matchAll(/text=([^'"`)]{4,80})/g)) out.add(m[1].trim());
+  for (const m of spec.matchAll(/getByText\(\s*['"]([^'"]{4,80})['"]/g)) out.add(m[1].trim());
+  return [...out];
+}
+
+/** `page.locator('some-element')` custom-element selectors. */
+function assertedSelectors(spec: string): string[] {
+  const out = new Set<string>();
+  for (const m of spec.matchAll(/locator\(\s*['"]([a-z][a-z0-9]*(?:-[a-z0-9]+)+)['"]/g)) out.add(m[1]);
+  return [...out];
+}
+
+describe('manual e2e specs stay in sync with the source', () => {
+  it('finds the manual tier', () => {
+    // Guards the guard: if the glob ever stops matching, every assertion below
+    // would pass over an empty list and this file would be worthless.
+    expect(manualSpecs.length).toBeGreaterThan(20);
+  });
+
+  it.each(manualSpecs.map((f) => [f.slice(REPO_ROOT.length + 1), f]))(
+    '%s asserts only text that still exists',
+    (_label, file) => {
+      const spec = readFileSync(file, 'utf8');
+      const missing = assertedText(spec).filter((t) => !sourceCorpus.includes(t));
+      expect(missing, `copy asserted by this manual spec no longer exists anywhere in the repo`).toEqual([]);
+    },
+  );
+
+  it.each(manualSpecs.map((f) => [f.slice(REPO_ROOT.length + 1), f]))(
+    '%s targets only selectors that still exist',
+    (_label, file) => {
+      const spec = readFileSync(file, 'utf8');
+      const missing = assertedSelectors(spec).filter((s) => !sourceCorpus.includes(s));
+      expect(missing, `element selectors targeted by this manual spec no longer exist`).toEqual([]);
+    },
+  );
+});

--- a/cockpit/ag-ui/interrupts/angular/e2e/manual/interrupts.manual.ts
+++ b/cockpit/ag-ui/interrupts/angular/e2e/manual/interrupts.manual.ts
@@ -18,10 +18,10 @@ test.describe('AG-UI Interrupts Example', () => {
     await page.waitForSelector('app-interrupts', { state: 'attached' });
   });
 
-  test('renders the chat interface with approvals sidebar', async ({ page }) => {
+  test('renders the chat interface with refund suggestions', async ({ page }) => {
     await expect(page.locator('chat')).toBeVisible();
     await expect(page.locator('textarea[name="messageText"]')).toBeVisible();
-    await expect(page.locator('text=No pending approvals')).toBeVisible();
+    await expect(page.locator('text=Refund a duplicate charge')).toBeVisible();
   });
 
   test('sends a message and receives a response', async ({ page }) => {

--- a/cockpit/deep-agents/filesystem/angular/e2e/manual/filesystem.manual.ts
+++ b/cockpit/deep-agents/filesystem/angular/e2e/manual/filesystem.manual.ts
@@ -9,7 +9,7 @@ test.describe('Deep Agents Filesystem Example', () => {
   test('renders the chat interface with file operations sidebar', async ({ page }) => {
     await expect(page.locator('chat')).toBeVisible();
     await expect(page.locator('textarea[name="messageText"]')).toBeVisible();
-    await expect(page.locator('text=Ask the agent to read or write a file.')).toBeVisible();
+    await expect(page.locator('text=No file operations yet')).toBeVisible();
   });
 
   test('sends a message and receives a response', async ({ page }) => {

--- a/cockpit/deep-agents/memory/angular/e2e/manual/memory.manual.ts
+++ b/cockpit/deep-agents/memory/angular/e2e/manual/memory.manual.ts
@@ -9,7 +9,7 @@ test.describe('Deep Agents Memory Example', () => {
   test('renders the chat interface with memory sidebar', async ({ page }) => {
     await expect(page.locator('chat')).toBeVisible();
     await expect(page.locator('textarea[name="messageText"]')).toBeVisible();
-    await expect(page.locator('text=Tell the agent something about yourself to see it remember.')).toBeVisible();
+    await expect(page.locator('text=No facts learned yet')).toBeVisible();
   });
 
   test('sends a message and receives a response', async ({ page }) => {

--- a/cockpit/deep-agents/planning/angular/e2e/manual/planning.manual.ts
+++ b/cockpit/deep-agents/planning/angular/e2e/manual/planning.manual.ts
@@ -9,7 +9,7 @@ test.describe('Deep Agents Planning Example', () => {
   test('renders the chat interface with plan sidebar', async ({ page }) => {
     await expect(page.locator('chat')).toBeVisible();
     await expect(page.locator('textarea[name="messageText"]')).toBeVisible();
-    await expect(page.locator('text=Ask a complex question to see the plan.')).toBeVisible();
+    await expect(page.locator('text=No plan yet')).toBeVisible();
   });
 
   test('sends a message and receives a response', async ({ page }) => {

--- a/cockpit/deep-agents/sandboxes/angular/e2e/manual/sandboxes.manual.ts
+++ b/cockpit/deep-agents/sandboxes/angular/e2e/manual/sandboxes.manual.ts
@@ -9,7 +9,7 @@ test.describe('Deep Agents Sandboxes Example', () => {
   test('renders the chat interface with execution log sidebar', async ({ page }) => {
     await expect(page.locator('chat')).toBeVisible();
     await expect(page.locator('textarea[name="messageText"]')).toBeVisible();
-    await expect(page.locator('text=Ask the agent to write and run Python code.')).toBeVisible();
+    await expect(page.locator('text=No code executed yet')).toBeVisible();
   });
 
   test('sends a message and receives a response', async ({ page }) => {

--- a/cockpit/deep-agents/skills/angular/e2e/manual/skills.manual.ts
+++ b/cockpit/deep-agents/skills/angular/e2e/manual/skills.manual.ts
@@ -9,7 +9,7 @@ test.describe('Deep Agents Skills Example', () => {
   test('renders the chat interface with skill invocation sidebar', async ({ page }) => {
     await expect(page.locator('chat')).toBeVisible();
     await expect(page.locator('textarea[name="messageText"]')).toBeVisible();
-    await expect(page.locator('text=Ask the agent to calculate, count words, or summarize text.')).toBeVisible();
+    await expect(page.locator('text=No skills invoked yet')).toBeVisible();
   });
 
   test('sends a message and receives a response', async ({ page }) => {

--- a/cockpit/deep-agents/subagents/angular/e2e/manual/subagents.manual.ts
+++ b/cockpit/deep-agents/subagents/angular/e2e/manual/subagents.manual.ts
@@ -9,7 +9,7 @@ test.describe('Deep Agents Subagents Example', () => {
   test('renders the chat interface with subagents sidebar', async ({ page }) => {
     await expect(page.locator('chat')).toBeVisible();
     await expect(page.locator('textarea[name="messageText"]')).toBeVisible();
-    await expect(page.locator('text=Ask a question to see subagent activity.')).toBeVisible();
+    await expect(page.locator('text=No delegations yet')).toBeVisible();
   });
 
   test('sends a message and receives a response', async ({ page }) => {

--- a/cockpit/langgraph/durable-execution/angular/e2e/manual/durable-execution.manual.ts
+++ b/cockpit/langgraph/durable-execution/angular/e2e/manual/durable-execution.manual.ts
@@ -9,7 +9,7 @@ test.describe('LangGraph Durable Execution Example', () => {
   test('renders the chat interface with execution status sidebar', async ({ page }) => {
     await expect(page.locator('chat')).toBeVisible();
     await expect(page.locator('textarea[name="messageText"]')).toBeVisible();
-    await expect(page.locator('text=Execution Status')).toBeVisible();
+    await expect(page.locator('text=Pipeline')).toBeVisible();
   });
 
   test('sends a message and receives a response', async ({ page }) => {

--- a/cockpit/langgraph/interrupts/angular/e2e/manual/interrupts.manual.ts
+++ b/cockpit/langgraph/interrupts/angular/e2e/manual/interrupts.manual.ts
@@ -6,10 +6,10 @@ test.describe('LangGraph Interrupts Example', () => {
     await page.waitForSelector('app-interrupts', { state: 'attached' });
   });
 
-  test('renders the chat interface with approvals sidebar', async ({ page }) => {
+  test('renders the chat interface with refund suggestions', async ({ page }) => {
     await expect(page.locator('chat')).toBeVisible();
     await expect(page.locator('textarea[name="messageText"]')).toBeVisible();
-    await expect(page.locator('text=No pending approvals')).toBeVisible();
+    await expect(page.locator('text=Refund a duplicate charge')).toBeVisible();
   });
 
   test('sends a message and receives a response', async ({ page }) => {

--- a/cockpit/langgraph/memory/angular/e2e/manual/memory.manual.ts
+++ b/cockpit/langgraph/memory/angular/e2e/manual/memory.manual.ts
@@ -9,7 +9,7 @@ test.describe('LangGraph Memory Example', () => {
   test('renders the chat interface with memory sidebar', async ({ page }) => {
     await expect(page.locator('chat')).toBeVisible();
     await expect(page.locator('textarea[name="messageText"]')).toBeVisible();
-    await expect(page.locator('text=Agent Memory')).toBeVisible();
+    await expect(page.locator('text=Learned Facts')).toBeVisible();
   });
 
   test('sends a message and receives a response', async ({ page }) => {


### PR DESCRIPTION
The `*.manual.ts` tier is **unreachable**. All 38 cockpit playwright configs use `testMatch: '**/*.spec.ts'`, and nothing in any config, project target, or workflow references it. That's 34 live-LLM specs nobody runs and CI cannot see.

## Audit of all 34

Two things came back clean, and I'd rather report that than pad the diff:

- **Ports: 0 drift.** Every hardcoded `localhost:NNNN` still matches its `cockpit/ports.mjs` assignment.
- **No vacuous assertions left.** The neg-only pattern that started this whole thread was confined to the one spec already fixed in #838.

**10 of 34 asserted UI copy that exists nowhere in the repo:**

| Spec | Asserted | Reality |
|---|---|---|
| deep-agents/{filesystem,memory,planning,sandboxes,skills,subagents} | welcome-prompt strings | empty-state copy (`No delegations yet`, `No plan yet`, …) |
| langgraph/durable-execution | `Execution Status` | `Pipeline` |
| langgraph/memory | `Agent Memory` | `Learned Facts` |
| {langgraph,ag-ui}/interrupts | `No pending approvals` | **no approvals sidebar exists** — moved to a `chat-approval-card` modal + welcome suggestions |

The interrupts pair is the worst: the test name promised "approvals sidebar", and the UI hasn't had one for a long time. Those now assert the welcome suggestion, and the test names no longer describe a sidebar.

## The part that matters

Repairing 10 files fixes today and changes nothing about tomorrow — the tier would drift again the same way, silently. Running the specs in CI isn't viable (real model, per-example dev server), but **checking that what they assert still exists is cheap**.

`apps/cockpit/scripts/manual-spec-freshness.spec.ts` verifies every text assertion and element selector in every manual spec still appears in the source. It lives in `apps/cockpit` deliberately: `nx test cockpit` runs in CI. My first instinct was `libs/e2e-harness`, which would have reproduced the original bug exactly — that project isn't in the Library job's `LIBS` list, so its tests don't run either.

**69 assertions** — 34 specs × 2 checks, plus a self-guard asserting the glob still matches >20 specs, so the suite can't quietly pass over an empty list.

**Mutation-tested:** reintroducing the exact stale string this PR removes turns it red and names the offending file.

## Note on local verification

`nx build cockpit` fails in my worktree, and I confirmed it fails **identically on pristine main with zero changes** (Next.js can't infer the workspace root; the worktree's `node_modules` is incomplete). Environmental, not from this diff — which touches only a vitest spec under `scripts/` and text inside `*.manual.ts` files, neither of which Next compiles. `nx test cockpit` passes. CI does a clean `npm ci` and will exercise the build properly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)