### PR TITLE
refactor(website): substrate migration batch 6a — docs pages off inline styles

### DIFF
--- a/apps/website/src/app/docs/[library]/[section]/[slug]/page.tsx
+++ b/apps/website/src/app/docs/[library]/[section]/[slug]/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
-import { tokens } from '@threadplane/design-tokens';
 import { DocsSidebar } from '../../../../../components/docs/DocsSidebar';
 import { MdxRenderer } from '../../../../../components/docs/MdxRenderer';
 import { DocsSearch } from '../../../../../components/docs/DocsSearch';
@@ -86,18 +85,12 @@ export default async function DocsPage({ params }: DocsRouteProps) {
   ]);
 
   return (
-    <div
-      className="flex min-h-screen overflow-x-hidden"
-      style={{ background: tokens.surfaces.canvas, paddingTop: 80 }}
-    >
+    <div className="flex min-h-screen overflow-x-hidden docs-shell-page">
       <JsonLd data={articleData} />
       <JsonLd data={breadcrumbs} />
       <DocsSearch library={library as LibraryId} />
       <DocsSidebar activeLibrary={library as LibraryId} activeSection={section} activeSlug={slug} />
-      <div
-        className="flex-1 flex min-w-0"
-        style={{ background: tokens.surfaces.surface }}
-      >
+      <div className="flex-1 flex min-w-0 docs-shell-body">
         <div className="flex-1 min-w-0">
           <div className="px-6 md:px-12 pt-6">
             <DocsBreadcrumb library={library as LibraryId} section={section} slug={slug} title={doc.title} />

--- a/apps/website/src/app/docs/choosing-an-adapter/page.tsx
+++ b/apps/website/src/app/docs/choosing-an-adapter/page.tsx
@@ -71,8 +71,8 @@ export default function ChoosingAnAdapterPage() {
     <>
       <Section surface="canvas" ariaLabelledBy="choosing-an-adapter-heading">
         <Container>
-          <div style={{ maxWidth: 720 }}>
-            <Eyebrow tone="accent" style={{ marginBottom: 16 }}>
+          <div className="adapter-hero-inner">
+            <Eyebrow tone="accent" className="adapter-eyebrow-spaced">
               Documentation
             </Eyebrow>
             <div id="choosing-an-adapter-heading" />
@@ -83,10 +83,9 @@ export default function ChoosingAnAdapterPage() {
       <Section surface="canvas">
         <Container>
           <article
-            className="docs-prose prose prose-slate max-w-none"
+            className="docs-prose prose prose-slate max-w-none adapter-article"
             style={
               {
-                maxWidth: 760,
                 '--tw-prose-body': tokens.colors.textSecondary,
                 '--tw-prose-headings': tokens.colors.textPrimary,
                 '--tw-prose-code': tokens.colors.accent,

--- a/apps/website/src/app/docs/licensing/page.tsx
+++ b/apps/website/src/app/docs/licensing/page.tsx
@@ -1,5 +1,4 @@
 import Link from 'next/link';
-import { tokens } from '@threadplane/design-tokens';
 import { Container } from '../../../components/ui/Container';
 import { Section } from '../../../components/ui/Section';
 import { Eyebrow } from '../../../components/ui/Eyebrow';
@@ -14,105 +13,17 @@ export const metadata = createPageMetadata({
   type: 'website',
 });
 
-const headingStyle = {
-  fontFamily: tokens.typography.h2.family,
-  fontSize: tokens.typography.h2.size,
-  lineHeight: tokens.typography.h2.line,
-  fontWeight: 700,
-  color: tokens.colors.textPrimary,
-  margin: 0,
-  marginBottom: 16,
-  letterSpacing: '-0.01em',
-} as const;
-
-const h3Style = {
-  fontFamily: tokens.typography.h3.family,
-  fontSize: tokens.typography.h3.size,
-  lineHeight: tokens.typography.h3.line,
-  fontWeight: 600,
-  color: tokens.colors.textPrimary,
-  margin: 0,
-  marginTop: 24,
-  marginBottom: 8,
-} as const;
-
-const bodyStyle = {
-  fontFamily: tokens.typography.body.family,
-  fontSize: tokens.typography.body.size,
-  lineHeight: tokens.typography.body.line,
-  color: tokens.colors.textSecondary,
-  margin: '0 0 16px',
-  maxWidth: '64ch',
-} as const;
-
-const codeBlockStyle = {
-  fontFamily: tokens.typography.fontMono,
-  fontSize: 13,
-  lineHeight: 1.6,
-  background: tokens.surfaces.surfaceTinted,
-  border: `1px solid ${tokens.surfaces.border}`,
-  borderRadius: 8,
-  padding: 16,
-  overflow: 'auto',
-  color: tokens.colors.textPrimary,
-  margin: '0 0 16px',
-  whiteSpace: 'pre' as const,
-} as const;
-
-const tableStyle = {
-  width: '100%',
-  borderCollapse: 'collapse' as const,
-  fontFamily: tokens.typography.body.family,
-  fontSize: 14,
-  color: tokens.colors.textSecondary,
-  margin: '0 0 24px',
-} as const;
-
-const cellStyle = {
-  padding: '10px 12px',
-  borderBottom: `1px solid ${tokens.surfaces.border}`,
-  verticalAlign: 'top' as const,
-} as const;
-
-const headerCellStyle = {
-  ...cellStyle,
-  color: tokens.colors.textPrimary,
-  fontWeight: 600,
-  background: tokens.surfaces.surfaceTinted,
-} as const;
-
 export default function LicensingPage() {
   return (
     <>
       <Section surface="canvas" ariaLabelledBy="licensing-heading">
         <Container>
-          <div style={{ maxWidth: 720 }}>
-            <Eyebrow tone="accent" style={{ marginBottom: 16 }}>Documentation</Eyebrow>
-            <h1
-              id="licensing-heading"
-              style={{
-                fontFamily: tokens.typography.h1.family,
-                fontSize: tokens.typography.h1.size,
-                lineHeight: tokens.typography.h1.line,
-                fontWeight: 700,
-                color: tokens.colors.textPrimary,
-                margin: 0,
-                marginBottom: 16,
-                letterSpacing: '-0.02em',
-              }}
-            >
+          <div className="licensing-hero-inner">
+            <Eyebrow tone="accent" className="licensing-eyebrow-spaced">Documentation</Eyebrow>
+            <h1 id="licensing-heading" className="licensing-h1">
               Licensing
             </h1>
-            <p
-              style={{
-                fontFamily: tokens.typography.bodyLg.family,
-                fontSize: tokens.typography.bodyLg.size,
-                lineHeight: tokens.typography.bodyLg.line,
-                color: tokens.colors.textSecondary,
-                margin: 0,
-                maxWidth: '60ch',
-              }}
-            >
+            <p className="licensing-subtitle">
               How the Threadplane licensing model works, who needs a paid license, and how to install your license token.
             </p>
           </div>
@@ -121,35 +32,35 @@ export default function LicensingPage() {
 
       <Section surface="canvas">
         <Container>
-          <div style={{ maxWidth: 760 }}>
-            <h2 style={headingStyle}>The model</h2>
-            <p style={bodyStyle}>
+          <div className="licensing-section-inner">
+            <h2 className="licensing-h2">The model</h2>
+            <p className="licensing-body">
               Threadplane is a suite of libraries. Most are{' '}
-              <strong style={{ color: tokens.colors.textPrimary }}>MIT-licensed</strong> and free for any use,
-              commercial or not. Only <code style={{ fontFamily: tokens.typography.fontMono }}>@threadplane/chat</code> is
+              <strong className="licensing-strong">MIT-licensed</strong> and free for any use,
+              commercial or not. Only <code className="licensing-code-inline">@threadplane/chat</code> is
               dual-licensed.
             </p>
-            <p style={bodyStyle}>
-              <code style={{ fontFamily: tokens.typography.fontMono }}>@threadplane/chat</code> is source-available under{' '}
-              <strong style={{ color: tokens.colors.textPrimary }}>PolyForm Noncommercial 1.0.0</strong> for free
-              noncommercial use, or a <strong style={{ color: tokens.colors.textPrimary }}>Threadplane Commercial license</strong>{' '}
+            <p className="licensing-body">
+              <code className="licensing-code-inline">@threadplane/chat</code> is source-available under{' '}
+              <strong className="licensing-strong">PolyForm Noncommercial 1.0.0</strong> for free
+              noncommercial use, or a <strong className="licensing-strong">Threadplane Commercial license</strong>{' '}
               for production use inside a for-profit context. The same source ships under both — you don't get a
               different build.
             </p>
 
-            <h3 style={h3Style}>Do you need a paid license?</h3>
-            <p style={bodyStyle}>
-              You need a Threadplane Commercial license if you use <code style={{ fontFamily: tokens.typography.fontMono }}>@threadplane/chat</code>{' '}
+            <h3 className="licensing-h3">Do you need a paid license?</h3>
+            <p className="licensing-body">
+              You need a Threadplane Commercial license if you use <code className="licensing-code-inline">@threadplane/chat</code>{' '}
               in any of:
             </p>
-            <ul style={{ ...bodyStyle, paddingLeft: 24 }}>
+            <ul className="licensing-body licensing-list">
               <li>A commercial product or SaaS</li>
               <li>An internal business tool inside a for-profit company</li>
               <li>An agency deliverable or paid client project</li>
               <li>Any application operated by or for a for-profit entity</li>
             </ul>
-            <p style={bodyStyle}>You do <strong style={{ color: tokens.colors.textPrimary }}>not</strong> need a paid license for:</p>
-            <ul style={{ ...bodyStyle, paddingLeft: 24 }}>
+            <p className="licensing-body">You do <strong className="licensing-strong">not</strong> need a paid license for:</p>
+            <ul className="licensing-body licensing-list">
               <li>Personal, hobby, student, academic, or nonprofit projects</li>
               <li>Public demos and tutorials</li>
               <li>Open-source applications released under an OSI-approved license</li>
@@ -161,14 +72,14 @@ export default function LicensingPage() {
 
       <Section surface="canvas">
         <Container>
-          <div style={{ maxWidth: 760 }}>
-            <h2 style={headingStyle}>Install your license</h2>
-            <p style={bodyStyle}>
+          <div className="licensing-section-inner">
+            <h2 className="licensing-h2">Install your license</h2>
+            <p className="licensing-body">
               After purchase, Threadplane emails a signed license token to the address on your receipt. Paste it
-              into your app's <code style={{ fontFamily: tokens.typography.fontMono }}>provideChat()</code>{' '}
+              into your app's <code className="licensing-code-inline">provideChat()</code>{' '}
               configuration:
             </p>
-            <pre style={codeBlockStyle}>{`// app.config.ts
+            <pre className="licensing-code-block">{`// app.config.ts
 import { ApplicationConfig } from '@angular/core';
 import { provideChat } from '@threadplane/chat';
 
@@ -179,13 +90,13 @@ export const appConfig: ApplicationConfig = {
     }),
   ],
 };`}</pre>
-            <p style={bodyStyle}>
+            <p className="licensing-body">
               The library verifies the token's Ed25519 signature on boot. The check is{' '}
-              <strong style={{ color: tokens.colors.textPrimary }}>advisory-only</strong>: a missing, expired, or
-              tampered token logs a <code style={{ fontFamily: tokens.typography.fontMono }}>console.warn</code> but
+              <strong className="licensing-strong">advisory-only</strong>: a missing, expired, or
+              tampered token logs a <code className="licensing-code-inline">console.warn</code> but
               never blocks rendering. Verification is fully offline; no calls leave your app at runtime.
             </p>
-            <p style={bodyStyle}>
+            <p className="licensing-body">
               The token is safe to commit to a private repository, or to read from a build-time environment variable
               for public repos. Public-repo demos are exempt from the commercial-use definition, but if your
               public repo backs a commercial product, the deployed bundle does need a license.
@@ -196,41 +107,41 @@ export const appConfig: ApplicationConfig = {
 
       <Section surface="canvas">
         <Container>
-          <div style={{ maxWidth: 900 }}>
-            <h2 style={headingStyle}>Tier scoping</h2>
-            <p style={bodyStyle}>
+          <div className="licensing-section-inner licensing-section-inner-wide">
+            <h2 className="licensing-h2">Tier scoping</h2>
+            <p className="licensing-body">
               Pick the tier that matches how you'll deploy. All paid tiers grant the same{' '}
               Threadplane Commercial license; the difference is the scope of use and the number of seats.
             </p>
-            <div style={{ overflow: 'auto' }}>
-              <table style={tableStyle}>
+            <div className="licensing-table-scroll">
+              <table className="licensing-table">
                 <thead>
                   <tr>
-                    <th style={headerCellStyle}>Tier</th>
-                    <th style={headerCellStyle}>Developers</th>
-                    <th style={headerCellStyle}>Best for</th>
+                    <th className="licensing-cell licensing-header-cell">Tier</th>
+                    <th className="licensing-cell licensing-header-cell">Developers</th>
+                    <th className="licensing-cell licensing-header-cell">Best for</th>
                   </tr>
                 </thead>
                 <tbody>
                   <tr>
-                    <td style={cellStyle}><strong style={{ color: tokens.colors.textPrimary }}>Developer Seat</strong> — $29/dev/mo or $299/dev/yr</td>
-                    <td style={cellStyle}>Per seat</td>
-                    <td style={cellStyle}>Solo devs, growing teams</td>
+                    <td className="licensing-cell"><strong className="licensing-strong">Developer Seat</strong> — $29/dev/mo or $299/dev/yr</td>
+                    <td className="licensing-cell">Per seat</td>
+                    <td className="licensing-cell">Solo devs, growing teams</td>
                   </tr>
                   <tr>
-                    <td style={cellStyle}><strong style={{ color: tokens.colors.textPrimary }}>Team</strong> — $149/mo or $1,495/yr</td>
-                    <td style={cellStyle}>5 seats included</td>
-                    <td style={cellStyle}>Small teams that want a single SKU and renewal</td>
+                    <td className="licensing-cell"><strong className="licensing-strong">Team</strong> — $149/mo or $1,495/yr</td>
+                    <td className="licensing-cell">5 seats included</td>
+                    <td className="licensing-cell">Small teams that want a single SKU and renewal</td>
                   </tr>
                   <tr>
-                    <td style={cellStyle}><strong style={{ color: tokens.colors.textPrimary }}>Enterprise</strong> — from $4,000/mo</td>
-                    <td style={cellStyle}>Custom</td>
-                    <td style={cellStyle}>SLA, security review, Pilot-to-Prod engagement, Slack Connect</td>
+                    <td className="licensing-cell"><strong className="licensing-strong">Enterprise</strong> — from $4,000/mo</td>
+                    <td className="licensing-cell">Custom</td>
+                    <td className="licensing-cell">SLA, security review, Pilot-to-Prod engagement, Slack Connect</td>
                   </tr>
                 </tbody>
               </table>
             </div>
-            <p style={{ ...bodyStyle, fontSize: 13, color: tokens.colors.textMuted }}>
+            <p className="licensing-body licensing-footnote">
               Paid tiers are recurring subscriptions. Annual saves ~15% vs monthly. Cancel anytime — the license
               stays valid through the end of the current paid period.
             </p>
@@ -240,47 +151,36 @@ export const appConfig: ApplicationConfig = {
 
       <Section surface="canvas">
         <Container>
-          <div style={{ maxWidth: 760 }}>
-            <h2 style={headingStyle}>Evaluation</h2>
-            <p style={bodyStyle}>
-              You may use <code style={{ fontFamily: tokens.typography.fontMono }}>@threadplane/chat</code> commercially
-              for <strong style={{ color: tokens.colors.textPrimary }}>30 calendar days</strong> from your first
+          <div className="licensing-section-inner">
+            <h2 className="licensing-h2">Evaluation</h2>
+            <p className="licensing-body">
+              You may use <code className="licensing-code-inline">@threadplane/chat</code> commercially
+              for <strong className="licensing-strong">30 calendar days</strong> from your first
               commercial use as a good-faith evaluation. There is no telemetry, no registration, no email check —
               we trust you to count the days. After 30 days you must either purchase a license or stop the
               commercial use.
             </p>
 
-            <h2 style={{ ...headingStyle, marginTop: 32 }}>Refunds</h2>
-            <p style={bodyStyle}>
+            <h2 className="licensing-h2 licensing-h2-spaced">Refunds</h2>
+            <p className="licensing-body">
               If you refund a license through Stripe, the token is revoked automatically and we email a confirmation.
               The verification check warns on boot. There's no clawback of the source code you already have —
               everything is source-available under PolyForm Noncommercial by default.
             </p>
 
-            <h2 style={{ ...headingStyle, marginTop: 32 }}>Questions</h2>
-            <p style={bodyStyle}>
+            <h2 className="licensing-h2 licensing-h2-spaced">Questions</h2>
+            <p className="licensing-body">
               Volume pricing, multi-app licensing, audit clauses, custom terms — any of those, reach out and we'll
               work it out.
             </p>
-            <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', marginTop: 16 }}>
+            <div className="licensing-cta-row">
               <Button variant="primary" size="md" href="/pricing">
                 See pricing
               </Button>
               <Button variant="ghost" size="md" href="/contact">
                 Contact us
               </Button>
-              <Link
-                href="/pricing#faq"
-                style={{
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  fontFamily: tokens.typography.body.family,
-                  fontSize: 14,
-                  color: tokens.colors.accent,
-                  textDecoration: 'none',
-                  padding: '8px 12px',
-                }}
-              >
+              <Link href="/pricing#faq" className="licensing-faq-link">
                 Pricing FAQ →
               </Link>
             </div>

--- a/apps/website/src/app/docs/page.tsx
+++ b/apps/website/src/app/docs/page.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from 'react';
 import Link from 'next/link';
-import { tokens } from '@threadplane/design-tokens';
 import { Container } from '../../components/ui/Container';
 import { Section } from '../../components/ui/Section';
 import { Eyebrow } from '../../components/ui/Eyebrow';
@@ -136,180 +135,35 @@ function MiddlewareGlyph() {
 
 const GLYPHS = { key: KeyGlyph, middleware: MiddlewareGlyph, pulse: PulseGlyph } as const;
 
-const stepLabelStyle = {
-  fontFamily: tokens.typography.eyebrow.family,
-  fontSize: tokens.typography.eyebrow.size,
-  fontWeight: tokens.typography.eyebrow.weight,
-  letterSpacing: tokens.typography.eyebrow.letterSpacing,
-  textTransform: tokens.typography.eyebrow.transform,
-  lineHeight: tokens.typography.eyebrow.line,
-  color: tokens.colors.textMuted,
-  margin: 0,
-  marginBottom: 16,
-  display: 'flex',
-  alignItems: 'center',
-  gap: 10,
-} as const;
-
-const stepBadgeStyle = {
-  width: 20,
-  height: 20,
-  borderRadius: tokens.radius.full,
-  background: tokens.colors.accent,
-  color: '#fff',
-  fontSize: 12,
-  fontWeight: 700,
-  display: 'inline-flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  flex: '0 0 auto',
-} as const;
-
 function StepLabel({ id, step, children }: { id: string; step?: number; children: ReactNode }) {
   return (
-    <h2 id={id} style={stepLabelStyle}>
+    <h2 id={id} className="docs-index-step-label">
       {step != null ? (
-        <span aria-hidden="true" style={stepBadgeStyle}>{step}</span>
+        <span aria-hidden="true" className="docs-index-step-badge">{step}</span>
       ) : null}
       {children}
     </h2>
   );
 }
 
-const logoChipStyle = {
-  width: 30,
-  height: 30,
-  borderRadius: tokens.radius.md,
-  background: tokens.surfaces.surface,
-  border: `1px solid ${tokens.surfaces.border}`,
-  display: 'inline-flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  flex: '0 0 auto',
-} as const;
-
-const glyphChipStyle = {
-  borderRadius: tokens.radius.md,
-  background: tokens.colors.accentSurface,
-  border: `1px solid ${tokens.colors.accentBorder}`,
-  color: tokens.colors.accent,
-  display: 'inline-flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  flex: '0 0 auto',
-} as const;
-
 function LogoChip({ src }: { src: string }) {
   return (
-    <span style={logoChipStyle}>
+    <span className="docs-index-logo-chip">
       <img
         src={src}
         alt=""
         aria-hidden="true"
         loading="lazy"
         decoding="async"
-        style={{ width: 18, height: 18, objectFit: 'contain' }}
+        className="docs-index-logo-img"
       />
     </span>
   );
 }
 
 function GlyphChip({ size, children }: { size: number; children: ReactNode }) {
-  return <span style={{ ...glyphChipStyle, width: size, height: size }}>{children}</span>;
+  return <span className="docs-index-glyph-chip" style={{ width: size, height: size }}>{children}</span>;
 }
-
-const cardHeaderStyle = {
-  display: 'flex',
-  alignItems: 'center',
-  gap: 12,
-  marginBottom: 12,
-} as const;
-
-const cardTitleStyle = {
-  fontFamily: tokens.typography.h3.family,
-  fontSize: 18,
-  lineHeight: 1.3,
-  fontWeight: 600,
-  color: tokens.colors.textPrimary,
-  margin: 0,
-} as const;
-
-const attributionStyle = {
-  fontFamily: tokens.typography.fontMono,
-  fontSize: 10,
-  lineHeight: 1.4,
-  textTransform: 'uppercase',
-  letterSpacing: '0.08em',
-  color: tokens.colors.textMuted,
-  marginTop: 2,
-} as const;
-
-const cardBlurbStyle = {
-  fontFamily: tokens.typography.body.family,
-  fontSize: tokens.typography.body.size,
-  lineHeight: tokens.typography.body.line,
-  color: tokens.colors.textSecondary,
-  margin: 0,
-} as const;
-
-const ctaStyle = {
-  fontFamily: tokens.typography.fontSans,
-  fontSize: 14,
-  fontWeight: 600,
-  color: tokens.colors.accent,
-} as const;
-
-const snippetRowStyle = {
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'space-between',
-  gap: 8,
-  background: tokens.surfaces.surface,
-  border: `1px solid ${tokens.surfaces.border}`,
-  borderRadius: tokens.radius.md,
-  padding: '5px 6px 5px 12px',
-  margin: '14px 0 16px',
-} as const;
-
-const snippetCodeStyle = {
-  fontFamily: tokens.typography.fontMono,
-  fontSize: 13,
-  color: tokens.colors.textSecondary,
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  whiteSpace: 'nowrap',
-} as const;
-
-const gridStyle = {
-  display: 'grid',
-  gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))',
-  gap: 16,
-} as const;
-
-const helperStyle = {
-  fontFamily: tokens.typography.body.family,
-  fontSize: 14,
-  color: tokens.colors.textSecondary,
-  margin: 0,
-  marginTop: 16,
-  textAlign: 'center',
-} as const;
-
-const helperLinkStyle = {
-  color: tokens.colors.accent,
-  fontWeight: 600,
-} as const;
-
-const fillHeightStyle = {
-  height: '100%',
-} as const;
-
-const dividerStyle = {
-  height: 1,
-  background: tokens.surfaces.border,
-  border: 'none',
-  margin: '0 0 40px',
-} as const;
 
 export default function DocsLandingPage() {
   return (
@@ -318,35 +172,14 @@ export default function DocsLandingPage() {
       {/* Hero */}
       <Section surface="canvas" ariaLabelledBy="docs-heading">
         <Container>
-          <div style={{ maxWidth: 720 }}>
-            <Eyebrow tone="accent" style={{ marginBottom: 16 }}>
+          <div className="docs-index-hero-inner">
+            <Eyebrow tone="accent" className="docs-index-eyebrow-spaced">
               Documentation
             </Eyebrow>
-            <h1
-              id="docs-heading"
-              style={{
-                fontFamily: tokens.typography.h1.family,
-                fontSize: tokens.typography.h1.size,
-                lineHeight: tokens.typography.h1.line,
-                fontWeight: 700,
-                color: tokens.colors.textPrimary,
-                margin: 0,
-                marginBottom: 16,
-                letterSpacing: '-0.02em',
-              }}
-            >
+            <h1 id="docs-heading" className="docs-index-h1">
               Start building with Threadplane
             </h1>
-            <p
-              style={{
-                fontFamily: tokens.typography.bodyLg.family,
-                fontSize: tokens.typography.bodyLg.size,
-                lineHeight: tokens.typography.bodyLg.line,
-                color: tokens.colors.textSecondary,
-                margin: 0,
-                maxWidth: '52ch',
-              }}
-            >
+            <p className="docs-index-subtitle">
               Streaming agent interfaces with runtime adapters, a shared Agent contract,
               and a drop-in chat surface. Most packages are MIT; @threadplane/chat is
               dual-licensed for noncommercial/evaluation and commercial production use.
@@ -359,34 +192,34 @@ export default function DocsLandingPage() {
       <Section surface="canvas" tight ariaLabelledBy="backend-heading">
         <Container>
           <StepLabel id="backend-heading" step={1}>Pick your backend</StepLabel>
-          <div style={gridStyle}>
+          <div className="docs-index-grid">
             {BACKENDS.map((b) => (
-              <Link key={b.href} href={b.href} style={{ textDecoration: 'none' }}>
-                <Card padding="lg" hoverable accent style={fillHeightStyle}>
-                  <div style={cardHeaderStyle}>
+              <Link key={b.href} href={b.href} className="docs-index-card-link">
+                <Card padding="lg" hoverable accent className="docs-index-fill-height">
+                  <div className="docs-index-card-header">
                     <LogoChip src={b.logoSrc} />
                     <div>
-                      <h3 style={cardTitleStyle}>{b.title}</h3>
-                      <div style={attributionStyle}>{b.attribution}</div>
+                      <h3 className="docs-index-card-title">{b.title}</h3>
+                      <div className="docs-index-attribution">{b.attribution}</div>
                     </div>
                   </div>
-                  <p style={cardBlurbStyle}>{b.blurb}</p>
-                  <div style={snippetRowStyle}>
-                    <code style={snippetCodeStyle}>{b.install}</code>
+                  <p className="docs-index-card-blurb">{b.blurb}</p>
+                  <div className="docs-index-snippet-row">
+                    <code className="docs-index-snippet-code">{b.install}</code>
                     <CopyButton text={b.install} />
                   </div>
-                  <span style={ctaStyle}>Adapter quickstart →</span>
+                  <span className="docs-index-cta">Adapter quickstart →</span>
                 </Card>
               </Link>
             ))}
           </div>
-          <p style={helperStyle}>
+          <p className="docs-index-helper">
             Not sure which to use?{' '}
-            <Link href="/docs/choosing-an-adapter" style={helperLinkStyle}>
+            <Link href="/docs/choosing-an-adapter" className="docs-index-helper-link">
               Choosing an adapter →
             </Link>
             {' '}Want the drop-in UI first?{' '}
-            <Link href="/docs/chat/getting-started/quickstart" style={helperLinkStyle}>
+            <Link href="/docs/chat/getting-started/quickstart" className="docs-index-helper-link">
               Chat quickstart →
             </Link>
           </p>
@@ -396,28 +229,28 @@ export default function DocsLandingPage() {
       {/* Step 2 — generative UI */}
       <Section surface="canvas" tight ariaLabelledBy="genui-heading">
         <Container>
-          <div style={dividerStyle} />
+          <div className="docs-index-divider" />
           <StepLabel id="genui-heading" step={2}>Generative UI</StepLabel>
-          <div style={gridStyle}>
+          <div className="docs-index-grid">
             {GENERATIVE_UI.map((g) => (
-              <Link key={g.href} href={g.href} style={{ textDecoration: 'none' }}>
-                <Card padding="lg" hoverable accent style={fillHeightStyle}>
-                  <div style={cardHeaderStyle}>
+              <Link key={g.href} href={g.href} className="docs-index-card-link">
+                <Card padding="lg" hoverable accent className="docs-index-fill-height">
+                  <div className="docs-index-card-header">
                     <LogoChip src={g.logoSrc} />
                     <div>
-                      <h3 style={cardTitleStyle}>{g.title}</h3>
-                      <div style={attributionStyle}>{g.attribution}</div>
+                      <h3 className="docs-index-card-title">{g.title}</h3>
+                      <div className="docs-index-attribution">{g.attribution}</div>
                     </div>
                   </div>
-                  <p style={cardBlurbStyle}>{g.blurb}</p>
-                  <span style={{ ...ctaStyle, display: 'inline-block', marginTop: 14 }}>Get started →</span>
+                  <p className="docs-index-card-blurb">{g.blurb}</p>
+                  <span className="docs-index-cta docs-index-cta-block">Get started →</span>
                 </Card>
               </Link>
             ))}
           </div>
-          <p style={helperStyle}>
+          <p className="docs-index-helper">
             Which fits my use case?{' '}
-            <Link href="/docs/render/concepts/json-render-vs-a2ui" style={helperLinkStyle}>
+            <Link href="/docs/render/concepts/json-render-vs-a2ui" className="docs-index-helper-link">
               json-render vs A2UI →
             </Link>
           </p>
@@ -427,18 +260,18 @@ export default function DocsLandingPage() {
       {/* Step 3 — chat */}
       <Section surface="canvas" tight ariaLabelledBy="chat-heading">
         <Container>
-          <div style={dividerStyle} />
+          <div className="docs-index-divider" />
           <StepLabel id="chat-heading" step={3}>Chat UI</StepLabel>
-          <Link href="/docs/chat/getting-started/introduction" style={{ textDecoration: 'none' }}>
-            <Card padding="lg" hoverable style={fillHeightStyle}>
-              <div style={cardHeaderStyle}>
+          <Link href="/docs/chat/getting-started/introduction" className="docs-index-card-link">
+            <Card padding="lg" hoverable className="docs-index-fill-height">
+              <div className="docs-index-card-header">
                 <GlyphChip size={30}><ChatGlyph /></GlyphChip>
                 <div>
-                  <h3 style={cardTitleStyle}>Chat</h3>
-                  <div style={attributionStyle}>Threadplane</div>
+                  <h3 className="docs-index-card-title">Chat</h3>
+                  <div className="docs-index-attribution">Threadplane</div>
                 </div>
               </div>
-              <p style={cardBlurbStyle}>
+              <p className="docs-index-card-blurb">
                 Drop-in chat components — message list, input, streaming, tool
                 calls, interrupts, subagents. Renders A2UI & json-render surfaces
                 inline.
@@ -451,19 +284,19 @@ export default function DocsLandingPage() {
       {/* Supporting libraries */}
       <Section surface="canvas" tight ariaLabelledBy="supporting-heading">
         <Container>
-          <div style={dividerStyle} />
+          <div className="docs-index-divider" />
           <StepLabel id="supporting-heading">Supporting libraries</StepLabel>
-          <div style={gridStyle}>
+          <div className="docs-index-grid">
             {SUPPORTING.map((s) => {
               const Glyph = GLYPHS[s.glyph];
               return (
-                <Link key={s.href} href={s.href} style={{ textDecoration: 'none' }}>
-                  <Card padding="lg" hoverable style={fillHeightStyle}>
-                    <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+                <Link key={s.href} href={s.href} className="docs-index-card-link">
+                  <Card padding="lg" hoverable className="docs-index-fill-height">
+                    <div className="docs-index-card-header-inline">
                       <GlyphChip size={26}><Glyph /></GlyphChip>
                       <div>
-                        <h3 style={{ ...cardTitleStyle, fontSize: 16 }}>{s.title}</h3>
-                        <p style={{ ...cardBlurbStyle, fontSize: 13, marginTop: 2 }}>{s.blurb}</p>
+                        <h3 className="docs-index-card-title docs-index-card-title-sm">{s.title}</h3>
+                        <p className="docs-index-card-blurb docs-index-card-blurb-sm">{s.blurb}</p>
                       </div>
                     </div>
                   </Card>
@@ -477,33 +310,11 @@ export default function DocsLandingPage() {
       {/* Search prompt */}
       <Section surface="tinted" tight ariaLabelledBy="search-prompt-heading">
         <Container>
-          <div style={{ textAlign: 'center', maxWidth: 640, margin: '0 auto' }}>
-            <h2
-              id="search-prompt-heading"
-              style={{
-                fontFamily: tokens.typography.h3.family,
-                fontSize: 22,
-                lineHeight: 1.3,
-                fontWeight: 600,
-                color: tokens.colors.textPrimary,
-                margin: 0,
-                marginBottom: 12,
-              }}
-            >
+          <div className="docs-index-search-inner">
+            <h2 id="search-prompt-heading" className="docs-index-search-heading">
               Looking for something specific?
             </h2>
-            <p
-              style={{
-                fontFamily: tokens.typography.body.family,
-                fontSize: tokens.typography.body.size,
-                lineHeight: tokens.typography.body.line,
-                color: tokens.colors.textSecondary,
-                margin: 0,
-                display: 'inline-flex',
-                alignItems: 'center',
-                gap: 8,
-              }}
-            >
+            <p className="docs-index-search-copy">
               Press <Pill variant="neutral">⌘K</Pill> to search the docs.
             </p>
           </div>

--- a/apps/website/src/styles/pages.css
+++ b/apps/website/src/styles/pages.css
@@ -347,3 +347,25 @@
   gap: 8px;
 }
 
+/* Choosing-an-adapter page — app/docs/choosing-an-adapter/page.tsx */
+.adapter-hero-inner {
+  max-width: 720px;
+}
+.adapter-eyebrow-spaced {
+  margin-bottom: 16px;
+}
+.adapter-article {
+  max-width: 760px;
+}
+
+/* Docs shell — app/docs/[library]/[section]/[slug]/page.tsx
+ * paddingTop: 80 and the overflow-x-hidden utility are known defects
+ * (nav-height coupling) migrated VERBATIM here; a later project fixes them,
+ * not this migration. */
+.docs-shell-page {
+  background: var(--color-canvas);
+  padding-top: 80px;
+}
+.docs-shell-body {
+  background: var(--color-surface);
+}

--- a/apps/website/src/styles/pages.css
+++ b/apps/website/src/styles/pages.css
@@ -8,3 +8,342 @@
  *
  * Migration: docs/superpowers/plans/2026-08-29-inline-style-substrate-migration.md
  */
+
+/* Licensing page — app/docs/licensing/page.tsx */
+.licensing-hero-inner {
+  max-width: 720px;
+}
+.licensing-eyebrow-spaced {
+  margin-bottom: 16px;
+}
+.licensing-h1 {
+  font-family: var(--font-garamond);
+  font-size: var(--text-h1);
+  line-height: var(--text-h1--line-height);
+  font-weight: 700;
+  color: var(--color-text-primary);
+  margin: 0;
+  margin-bottom: 16px;
+  letter-spacing: -0.02em;
+}
+.licensing-subtitle {
+  font-family: var(--font-inter);
+  font-size: var(--text-body-lg);
+  line-height: var(--text-body-lg--line-height);
+  color: var(--color-text-secondary);
+  margin: 0;
+  max-width: 60ch;
+}
+.licensing-section-inner {
+  max-width: 760px;
+}
+.licensing-section-inner-wide {
+  max-width: 900px;
+}
+.licensing-h2 {
+  font-family: var(--font-garamond);
+  font-size: var(--text-h2);
+  line-height: var(--text-h2--line-height);
+  font-weight: 700;
+  color: var(--color-text-primary);
+  margin: 0;
+  margin-bottom: 16px;
+  letter-spacing: -0.01em;
+}
+.licensing-h2-spaced {
+  margin-top: 32px;
+}
+.licensing-h3 {
+  font-family: var(--font-inter);
+  font-size: var(--text-h3);
+  line-height: var(--text-h3--line-height);
+  font-weight: 600;
+  color: var(--color-text-primary);
+  margin: 0;
+  margin-top: 24px;
+  margin-bottom: 8px;
+}
+.licensing-body {
+  font-family: var(--font-inter);
+  font-size: var(--text-body);
+  line-height: var(--text-body--line-height);
+  color: var(--color-text-secondary);
+  margin: 0 0 16px;
+  max-width: 64ch;
+}
+.licensing-list {
+  padding-left: 24px;
+}
+.licensing-strong {
+  color: var(--color-text-primary);
+}
+.licensing-code-inline {
+  /* raw font stack, not the `.family` var — see the font-exception note atop ui.css */
+  font-family: "JetBrains Mono", monospace;
+}
+.licensing-code-block {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 13px;
+  line-height: 1.6;
+  background: var(--color-surface-tinted);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 16px;
+  overflow: auto;
+  color: var(--color-text-primary);
+  margin: 0 0 16px;
+  white-space: pre;
+}
+.licensing-table-scroll {
+  overflow: auto;
+}
+.licensing-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--font-inter);
+  font-size: 14px;
+  color: var(--color-text-secondary);
+  margin: 0 0 24px;
+}
+.licensing-cell {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--color-border);
+  vertical-align: top;
+}
+.licensing-header-cell {
+  color: var(--color-text-primary);
+  font-weight: 600;
+  background: var(--color-surface-tinted);
+}
+.licensing-footnote {
+  font-size: 13px;
+  color: var(--color-text-muted);
+}
+.licensing-cta-row {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-top: 16px;
+}
+.licensing-faq-link {
+  display: inline-flex;
+  align-items: center;
+  font-family: var(--font-inter);
+  font-size: 14px;
+  color: var(--color-accent);
+  text-decoration: none;
+  padding: 8px 12px;
+}
+
+/* Docs index page — app/docs/page.tsx */
+.docs-index-hero-inner {
+  max-width: 720px;
+}
+.docs-index-eyebrow-spaced {
+  margin-bottom: 16px;
+}
+.docs-index-h1 {
+  font-family: var(--font-garamond);
+  font-size: var(--text-h1);
+  line-height: var(--text-h1--line-height);
+  font-weight: 700;
+  color: var(--color-text-primary);
+  margin: 0;
+  margin-bottom: 16px;
+  letter-spacing: -0.02em;
+}
+.docs-index-subtitle {
+  font-family: var(--font-inter);
+  font-size: var(--text-body-lg);
+  line-height: var(--text-body-lg--line-height);
+  color: var(--color-text-secondary);
+  margin: 0;
+  max-width: 52ch;
+}
+.docs-index-step-label {
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  font-weight: var(--text-eyebrow--font-weight);
+  letter-spacing: var(--text-eyebrow--letter-spacing);
+  text-transform: uppercase;
+  line-height: var(--text-eyebrow--line-height);
+  color: var(--color-text-muted);
+  margin: 0;
+  margin-bottom: 16px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.docs-index-step-badge {
+  width: 20px;
+  height: 20px;
+  border-radius: var(--radius-full);
+  background: var(--color-accent);
+  color: #fff;
+  font-size: 12px;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+}
+.docs-index-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
+}
+.docs-index-card-link {
+  text-decoration: none;
+}
+.docs-index-fill-height {
+  height: 100%;
+}
+.docs-index-card-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+/* Supporting-libraries card header omits the bottom margin in the source —
+ * a separate class rather than a shared one plus a zeroing modifier, since
+ * "cancel a shorthand's margin-bottom back to nothing" is not otherwise
+ * needed anywhere else in this file. */
+.docs-index-card-header-inline {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.docs-index-logo-chip {
+  width: 30px;
+  height: 30px;
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+}
+.docs-index-logo-img {
+  width: 18px;
+  height: 18px;
+  object-fit: contain;
+}
+/* GlyphChip's width/height come from a `size: number` prop (unbounded) and
+ * stay inline; everything else in glyphChipStyle moves here. */
+.docs-index-glyph-chip {
+  border-radius: var(--radius-md);
+  background: var(--color-accent-surface);
+  border: 1px solid var(--color-accent-border);
+  color: var(--color-accent);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+}
+.docs-index-card-title {
+  font-family: var(--font-inter);
+  font-size: 18px;
+  line-height: 1.3;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  margin: 0;
+}
+.docs-index-card-title-sm {
+  font-size: 16px;
+}
+.docs-index-attribution {
+  /* raw font stack, not the `.family` var — see the font-exception note atop ui.css */
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10px;
+  line-height: 1.4;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-muted);
+  margin-top: 2px;
+}
+.docs-index-card-blurb {
+  font-family: var(--font-inter);
+  font-size: var(--text-body);
+  line-height: var(--text-body--line-height);
+  color: var(--color-text-secondary);
+  margin: 0;
+}
+.docs-index-card-blurb-sm {
+  font-size: 13px;
+  margin-top: 2px;
+}
+.docs-index-cta {
+  /* raw font stack, not the `.family` var — see the font-exception note atop ui.css */
+  font-family: Inter, system-ui, sans-serif;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-accent);
+}
+.docs-index-cta-block {
+  display: inline-block;
+  margin-top: 14px;
+}
+.docs-index-snippet-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 5px 6px 5px 12px;
+  margin: 14px 0 16px;
+}
+.docs-index-snippet-code {
+  /* raw font stack, not the `.family` var — see the font-exception note atop ui.css */
+  font-family: "JetBrains Mono", monospace;
+  font-size: 13px;
+  color: var(--color-text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.docs-index-helper {
+  font-family: var(--font-inter);
+  font-size: 14px;
+  color: var(--color-text-secondary);
+  margin: 0;
+  margin-top: 16px;
+  text-align: center;
+}
+.docs-index-helper-link {
+  color: var(--color-accent);
+  font-weight: 600;
+}
+.docs-index-divider {
+  height: 1px;
+  background: var(--color-border);
+  border: none;
+  margin: 0 0 40px;
+}
+.docs-index-search-inner {
+  text-align: center;
+  max-width: 640px;
+  margin: 0 auto;
+}
+.docs-index-search-heading {
+  font-family: var(--font-inter);
+  font-size: 22px;
+  line-height: 1.3;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  margin: 0;
+  margin-bottom: 12px;
+}
+.docs-index-search-copy {
+  font-family: var(--font-inter);
+  font-size: var(--text-body);
+  line-height: var(--text-body--line-height);
+  color: var(--color-text-secondary);
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+


### PR DESCRIPTION
## What

Batch 6a of the substrate migration ([plan](https://github.com/cacheplane/angular-agent-framework/blob/main/docs/superpowers/plans/2026-08-29-inline-style-substrate-migration.md), Task 6a): the four docs-adjacent route files move to `src/styles/pages.css`. This is the shape-D showcase — 23 named `CSSProperties` variables covering 111 style sites collapse to 45 classes.

The docs shell (`[library]/[section]/[slug]/page.tsx`) migrates its `paddingTop: 80` and keeps `overflow-x-hidden` **verbatim** — those are known defects owned by the polish arc, not this migration.

## Verified: four pages signature-identical to production

| page | elements | result |
|---|---:|---|
| `/docs` | 110 | identical to prod |
| `/docs/licensing` | 90 | identical to prod |
| `/docs/choosing-an-adapter` | 328 | identical to prod |
| `/docs/chat/components/chat` (full shell) | 1252 | identical to prod |

Plus `nx test website` fully green (347), 0 lint errors, prod build green (294 pages).

## A caught near-miss worth reading

The implementer's self-review caught a genuine zero-visual-change violation before it shipped: three docs-index card headers share a `cardHeaderStyle` with `marginBottom: 12`, but a fourth call site *omits* the margin. The first collapse pass unified all four onto one class — which would have added 12px to that card. It now has its own `.docs-index-card-header-inline` class, documented in `pages.css`. The signature match on `/docs` confirms the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
