### PR TITLE
chore(website): lint guard against new static inline styles

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -54,4 +54,34 @@ export default [
     // Override or add rules here
     rules: {},
   },
+  // Inline-style guard — apps/website migrated off static inline styles
+  // (docs/superpowers/specs/2026-08-29-inline-style-substrate-migration-design.md,
+  // batches #848–#857). Flags identifier-keyed members of a style object
+  // literal. The escape hatch for dynamic values — style={{ '--x': value }} —
+  // uses string-literal keys and passes. Genuinely dynamic identifier-keyed
+  // values (rare) get a targeted eslint-disable-next-line with a reason.
+  // Ships as 'warn' for one release, then 'error'.
+  {
+    files: ['apps/website/src/**/*.tsx'],
+    ignores: [
+      // Satori-rendered OG images: inline styles are the only mechanism there.
+      'apps/website/src/app/opengraph-image.tsx',
+      // NOTE: [slug] would be a glob character class, so match by wildcard.
+      'apps/website/src/app/blog/*/opengraph-image.tsx',
+      // Dev-only route slated for deletion.
+      'apps/website/src/app/dev/primitives/page.tsx',
+      'apps/website/src/**/*.spec.tsx',
+    ],
+    rules: {
+      'no-restricted-syntax': [
+        'warn',
+        {
+          selector:
+            'JSXAttribute[name.name="style"] > JSXExpressionContainer > ObjectExpression > Property[key.type="Identifier"]',
+          message:
+            "Static presentation belongs in src/styles/*.css (see the substrate-migration spec). For dynamic values, set a CSS custom property: style={{ '--x': value }}.",
+        },
+      ],
+    },
+  },
 ];


### PR DESCRIPTION
## What

The final PR of the substrate migration ([plan](https://github.com/cacheplane/angular-agent-framework/blob/main/docs/superpowers/plans/2026-08-29-inline-style-substrate-migration.md), Task 7): an ESLint guard so new code cannot quietly reintroduce static inline styles. Deliberately last — landing it before batch 6b would have meant hundreds of suppressions; landing it now, it only ever sees new code.

`no-restricted-syntax` (`warn`) on identifier-keyed members of a `style` object literal in `apps/website/src/**/*.tsx`. The dynamic-value escape hatch — `style={{ '--x': value }}` — uses string-literal keys and passes untouched.

## Verified with raw eslint (nx's lint cache can serve stale results on rapid re-runs)

- Identifier-key probe (`style={{ color: "red" }}`) → **fires**.
- Custom-property probe (`style={{ '--x': v }}`) → **silent**.
- Satori OG file → **zero hits** (note: `[slug]` in an ignore glob is a character class — matched by wildcard instead).
- Baseline: **18 warnings, 0 errors** — the 18 are exactly the documented dynamic-value sites from the batch reports (per-page accent props, unbounded size props, `TIERS`-driven grid templates, the toast's entrance animation). The warn list *is* the exception ledger.

Escalation to `error` is a deliberate follow-up one release later, per the plan.

## The arc this closes

Project 2 is complete: ~877 style-prop sites and 12 embedded `<style>` tags across 88 files migrated in 7 PRs (#848–#857), each verified element-by-element against production. Project 3 (the docs polish arc, from the [findings audit](https://github.com/cacheplane/angular-agent-framework/blob/main/docs/superpowers/audits/2026-08-29-docs-visual-review-findings.md)) is now unblocked — every fix it needs (`:hover`, `:focus-visible`, `:last-child`, media queries) has a stylesheet to live in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
