### PR TITLE
feat(cockpit): wire the dark design tokens into the example apps

### DIFF
--- a/cockpit/chat/timeline/angular/src/styles.css
+++ b/cockpit/chat/timeline/angular/src/styles.css
@@ -1,3 +1,9 @@
+/* Dark design tokens — the real values behind every var(--ds-*, fallback)
+ * in this app. The fallbacks were hand-copies of darkOverrides and 32 uses
+ * across the cockpit had NO fallback at all (silently invalid until this
+ * import). Path resolves from src/ up to the workspace root. */
+@import '../../../../../libs/design-tokens/src/lib/tokens-dark.css';
+
 @import "@threadplane/example-layouts/theme.css";
 
 /* App-specific globals (none for now; add below this line if needed). */

--- a/cockpit/langgraph/client-tools/angular/src/styles.css
+++ b/cockpit/langgraph/client-tools/angular/src/styles.css
@@ -1,3 +1,9 @@
+/* Dark design tokens — the real values behind every var(--ds-*, fallback)
+ * in this app. The fallbacks were hand-copies of darkOverrides and 32 uses
+ * across the cockpit had NO fallback at all (silently invalid until this
+ * import). Path resolves from src/ up to the workspace root. */
+@import '../../../../../libs/design-tokens/src/lib/tokens-dark.css';
+
 @import "@threadplane/example-layouts/theme.css";
 
 html, body {

--- a/cockpit/langgraph/durable-execution/angular/src/styles.css
+++ b/cockpit/langgraph/durable-execution/angular/src/styles.css
@@ -1,3 +1,9 @@
+/* Dark design tokens — the real values behind every var(--ds-*, fallback)
+ * in this app. The fallbacks were hand-copies of darkOverrides and 32 uses
+ * across the cockpit had NO fallback at all (silently invalid until this
+ * import). Path resolves from src/ up to the workspace root. */
+@import '../../../../../libs/design-tokens/src/lib/tokens-dark.css';
+
 @import "@threadplane/example-layouts/theme.css";
 
 html, body {

--- a/cockpit/langgraph/interrupts/angular/src/styles.css
+++ b/cockpit/langgraph/interrupts/angular/src/styles.css
@@ -1,3 +1,9 @@
+/* Dark design tokens — the real values behind every var(--ds-*, fallback)
+ * in this app. The fallbacks were hand-copies of darkOverrides and 32 uses
+ * across the cockpit had NO fallback at all (silently invalid until this
+ * import). Path resolves from src/ up to the workspace root. */
+@import '../../../../../libs/design-tokens/src/lib/tokens-dark.css';
+
 @import "@threadplane/example-layouts/theme.css";
 
 html, body {

--- a/cockpit/langgraph/memory/angular/src/styles.css
+++ b/cockpit/langgraph/memory/angular/src/styles.css
@@ -1,3 +1,9 @@
+/* Dark design tokens — the real values behind every var(--ds-*, fallback)
+ * in this app. The fallbacks were hand-copies of darkOverrides and 32 uses
+ * across the cockpit had NO fallback at all (silently invalid until this
+ * import). Path resolves from src/ up to the workspace root. */
+@import '../../../../../libs/design-tokens/src/lib/tokens-dark.css';
+
 @import "@threadplane/example-layouts/theme.css";
 
 html, body {

--- a/cockpit/langgraph/persistence/angular/src/styles.css
+++ b/cockpit/langgraph/persistence/angular/src/styles.css
@@ -1,3 +1,9 @@
+/* Dark design tokens — the real values behind every var(--ds-*, fallback)
+ * in this app. The fallbacks were hand-copies of darkOverrides and 32 uses
+ * across the cockpit had NO fallback at all (silently invalid until this
+ * import). Path resolves from src/ up to the workspace root. */
+@import '../../../../../libs/design-tokens/src/lib/tokens-dark.css';
+
 @import "@threadplane/example-layouts/theme.css";
 
 html, body {

--- a/cockpit/langgraph/subgraphs/angular/src/styles.css
+++ b/cockpit/langgraph/subgraphs/angular/src/styles.css
@@ -1,3 +1,9 @@
+/* Dark design tokens — the real values behind every var(--ds-*, fallback)
+ * in this app. The fallbacks were hand-copies of darkOverrides and 32 uses
+ * across the cockpit had NO fallback at all (silently invalid until this
+ * import). Path resolves from src/ up to the workspace root. */
+@import '../../../../../libs/design-tokens/src/lib/tokens-dark.css';
+
 @import "@threadplane/example-layouts/theme.css";
 
 html, body {

--- a/cockpit/langgraph/time-travel/angular/src/styles.css
+++ b/cockpit/langgraph/time-travel/angular/src/styles.css
@@ -1,3 +1,9 @@
+/* Dark design tokens — the real values behind every var(--ds-*, fallback)
+ * in this app. The fallbacks were hand-copies of darkOverrides and 32 uses
+ * across the cockpit had NO fallback at all (silently invalid until this
+ * import). Path resolves from src/ up to the workspace root. */
+@import '../../../../../libs/design-tokens/src/lib/tokens-dark.css';
+
 @import "@threadplane/example-layouts/theme.css";
 
 html, body {

--- a/cockpit/render/computed-functions/angular/src/app/computed-functions.component.ts
+++ b/cockpit/render/computed-functions/angular/src/app/computed-functions.component.ts
@@ -96,7 +96,7 @@ class DemoHeadingComponent {
       background: var(--ds-surface, #1c1c1c);
       border: 1px solid var(--ds-border, #2d2d2d);
       border-radius: var(--ds-radius-lg, 14px);
-      box-shadow: var(--ds-shadow-md, 0 4px 6px -1px rgba(0, 0, 0, 0.3));
+      box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.3) /* dark-tuned; the --ds-shadow tokens are light-tuned and vanish on dark surfaces */;
     }
     .card__title {
       margin: 0 0 0.625rem;

--- a/cockpit/render/computed-functions/angular/src/styles.css
+++ b/cockpit/render/computed-functions/angular/src/styles.css
@@ -1,3 +1,9 @@
+/* Dark design tokens — the real values behind every var(--ds-*, fallback)
+ * in this app. The fallbacks were hand-copies of darkOverrides and 32 uses
+ * across the cockpit had NO fallback at all (silently invalid until this
+ * import). Path resolves from src/ up to the workspace root. */
+@import '../../../../../libs/design-tokens/src/lib/tokens-dark.css';
+
 @import "@threadplane/example-layouts/theme.css";
 
 html,

--- a/cockpit/render/element-rendering/angular/src/app/element-rendering.component.ts
+++ b/cockpit/render/element-rendering/angular/src/app/element-rendering.component.ts
@@ -76,7 +76,7 @@ class DemoHeadingComponent {
       background: var(--ds-surface, #1c1c1c);
       border: 1px solid var(--ds-border, #2d2d2d);
       border-radius: var(--ds-radius-lg, 14px);
-      box-shadow: var(--ds-shadow-md, 0 4px 6px -1px rgba(0, 0, 0, 0.3));
+      box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.3) /* dark-tuned; the --ds-shadow tokens are light-tuned and vanish on dark surfaces */;
     }
     .card__title {
       margin: 0 0 0.625rem;

--- a/cockpit/render/element-rendering/angular/src/styles.css
+++ b/cockpit/render/element-rendering/angular/src/styles.css
@@ -1,3 +1,9 @@
+/* Dark design tokens — the real values behind every var(--ds-*, fallback)
+ * in this app. The fallbacks were hand-copies of darkOverrides and 32 uses
+ * across the cockpit had NO fallback at all (silently invalid until this
+ * import). Path resolves from src/ up to the workspace root. */
+@import '../../../../../libs/design-tokens/src/lib/tokens-dark.css';
+
 @import "@threadplane/example-layouts/theme.css";
 
 html,

--- a/cockpit/render/registry/angular/src/app/registry.component.ts
+++ b/cockpit/render/registry/angular/src/app/registry.component.ts
@@ -103,7 +103,7 @@ class DemoBadgeComponent {
       background: var(--ds-surface, #1c1c1c);
       border: 1px solid var(--ds-border, #2d2d2d);
       border-radius: var(--ds-radius-lg, 14px);
-      box-shadow: var(--ds-shadow-md, 0 4px 6px -1px rgba(0, 0, 0, 0.3));
+      box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.3) /* dark-tuned; the --ds-shadow tokens are light-tuned and vanish on dark surfaces */;
     }
     .card__title {
       margin: 0 0 0.625rem;

--- a/cockpit/render/registry/angular/src/styles.css
+++ b/cockpit/render/registry/angular/src/styles.css
@@ -1,3 +1,9 @@
+/* Dark design tokens — the real values behind every var(--ds-*, fallback)
+ * in this app. The fallbacks were hand-copies of darkOverrides and 32 uses
+ * across the cockpit had NO fallback at all (silently invalid until this
+ * import). Path resolves from src/ up to the workspace root. */
+@import '../../../../../libs/design-tokens/src/lib/tokens-dark.css';
+
 @import "@threadplane/example-layouts/theme.css";
 
 html,

--- a/cockpit/render/repeat-loops/angular/src/app/repeat-loops.component.ts
+++ b/cockpit/render/repeat-loops/angular/src/app/repeat-loops.component.ts
@@ -76,7 +76,7 @@ class DemoHeadingComponent {
       background: var(--ds-surface, #1c1c1c);
       border: 1px solid var(--ds-border, #2d2d2d);
       border-radius: var(--ds-radius-lg, 14px);
-      box-shadow: var(--ds-shadow-md, 0 4px 6px -1px rgba(0, 0, 0, 0.3));
+      box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.3) /* dark-tuned; the --ds-shadow tokens are light-tuned and vanish on dark surfaces */;
     }
     .card__title {
       margin: 0 0 0.625rem;

--- a/cockpit/render/repeat-loops/angular/src/styles.css
+++ b/cockpit/render/repeat-loops/angular/src/styles.css
@@ -1,3 +1,9 @@
+/* Dark design tokens — the real values behind every var(--ds-*, fallback)
+ * in this app. The fallbacks were hand-copies of darkOverrides and 32 uses
+ * across the cockpit had NO fallback at all (silently invalid until this
+ * import). Path resolves from src/ up to the workspace root. */
+@import '../../../../../libs/design-tokens/src/lib/tokens-dark.css';
+
 @import "@threadplane/example-layouts/theme.css";
 
 html,

--- a/cockpit/render/spec-rendering/angular/src/app/spec-rendering.component.ts
+++ b/cockpit/render/spec-rendering/angular/src/app/spec-rendering.component.ts
@@ -103,7 +103,7 @@ class DemoBadgeComponent {
       background: var(--ds-surface, #1c1c1c);
       border: 1px solid var(--ds-border, #2d2d2d);
       border-radius: var(--ds-radius-lg, 14px);
-      box-shadow: var(--ds-shadow-md, 0 4px 6px -1px rgba(0, 0, 0, 0.3));
+      box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.3) /* dark-tuned; the --ds-shadow tokens are light-tuned and vanish on dark surfaces */;
     }
     .card__title {
       margin: 0 0 0.625rem;

--- a/cockpit/render/spec-rendering/angular/src/styles.css
+++ b/cockpit/render/spec-rendering/angular/src/styles.css
@@ -1,3 +1,9 @@
+/* Dark design tokens — the real values behind every var(--ds-*, fallback)
+ * in this app. The fallbacks were hand-copies of darkOverrides and 32 uses
+ * across the cockpit had NO fallback at all (silently invalid until this
+ * import). Path resolves from src/ up to the workspace root. */
+@import '../../../../../libs/design-tokens/src/lib/tokens-dark.css';
+
 @import "@threadplane/example-layouts/theme.css";
 
 html,

--- a/cockpit/render/state-management/angular/src/app/state-management.component.ts
+++ b/cockpit/render/state-management/angular/src/app/state-management.component.ts
@@ -116,7 +116,7 @@ class DemoLabelComponent {
       background: var(--ds-surface, #1c1c1c);
       border: 1px solid var(--ds-border, #2d2d2d);
       border-radius: var(--ds-radius-lg, 14px);
-      box-shadow: var(--ds-shadow-md, 0 4px 6px -1px rgba(0, 0, 0, 0.3));
+      box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.3) /* dark-tuned; the --ds-shadow tokens are light-tuned and vanish on dark surfaces */;
     }
     .card__title {
       margin: 0 0 0.625rem;

--- a/cockpit/render/state-management/angular/src/styles.css
+++ b/cockpit/render/state-management/angular/src/styles.css
@@ -1,3 +1,9 @@
+/* Dark design tokens — the real values behind every var(--ds-*, fallback)
+ * in this app. The fallbacks were hand-copies of darkOverrides and 32 uses
+ * across the cockpit had NO fallback at all (silently invalid until this
+ * import). Path resolves from src/ up to the workspace root. */
+@import '../../../../../libs/design-tokens/src/lib/tokens-dark.css';
+
 @import "@threadplane/example-layouts/theme.css";
 
 html,

--- a/libs/design-tokens/src/lib/theme.css
+++ b/libs/design-tokens/src/lib/theme.css
@@ -49,7 +49,7 @@
   /* Fonts */
   --font-garamond: "EB Garamond", Georgia, serif;
   --font-inter: Inter, system-ui, sans-serif;
-  --font-mono: "JetBrains Mono", monospace;
+  --font-mono: "JetBrains Mono", ui-monospace, monospace;
 
   /* Type scale */
   --text-h1: clamp(48px, 6vw, 72px);

--- a/libs/design-tokens/src/lib/tokens-dark.css
+++ b/libs/design-tokens/src/lib/tokens-dark.css
@@ -47,7 +47,7 @@
   /* Typography */
   --ds-font-serif: "EB Garamond", Georgia, serif;
   --ds-font-sans: Inter, system-ui, sans-serif;
-  --ds-font-mono: "JetBrains Mono", monospace;
+  --ds-font-mono: "JetBrains Mono", ui-monospace, monospace;
 
   /* Typography — type scale */
   --ds-h1-size: clamp(48px, 6vw, 72px);

--- a/libs/design-tokens/src/lib/tokens.css
+++ b/libs/design-tokens/src/lib/tokens.css
@@ -47,7 +47,7 @@
   /* Typography */
   --ds-font-serif: "EB Garamond", Georgia, serif;
   --ds-font-sans: Inter, system-ui, sans-serif;
-  --ds-font-mono: "JetBrains Mono", monospace;
+  --ds-font-mono: "JetBrains Mono", ui-monospace, monospace;
 
   /* Typography — type scale */
   --ds-h1-size: clamp(48px, 6vw, 72px);

--- a/libs/design-tokens/src/lib/typography.ts
+++ b/libs/design-tokens/src/lib/typography.ts
@@ -15,8 +15,10 @@ export const typography = {
   fontSerif: '"EB Garamond", Georgia, serif',
   /** Sans-serif font for body text */
   fontSans: 'Inter, system-ui, sans-serif',
-  /** Monospace font for code and labels */
-  fontMono: '"JetBrains Mono", monospace',
+  /** Monospace font for code and labels. ui-monospace before the generic
+   * keyword: consumers that don't load JetBrains Mono (the cockpit example
+   * apps) get the platform mono (SF Mono) instead of Courier. */
+  fontMono: '"JetBrains Mono", ui-monospace, monospace',
 
   h1: {
     size: 'clamp(48px, 6vw, 72px)',


### PR DESCRIPTION
## What

The wiring half of the last arc follow-up ([#867](https://github.com/cacheplane/angular-agent-framework/pull/867) built the file): the 14 dark-designed cockpit example apps import `tokens-dark.css`, so their `var(--ds-*)` references finally resolve to real tokens.

| bucket | uses | effect |
|---|---:|---|
| fallback == dark token | 216 | zero change |
| **no fallback — silently invalid until now** | **32** | **fixed** — client-tools' weather/confirm cards rendered transparent with unset text; they now get their intended dark surfaces |
| drifted fallbacks (accentBorder .25→.2, white-alpha surfaceTinted→solid, radius-xl 18→20) | 6 | micro-shifts, tokens adopted |
| dark-tuned 0.3-alpha shadows | 6 | **kept as literals** — the `--ds-shadow` tokens are light-tuned and vanish on dark surfaces (commented at each site) |

## One token improvement riding along

`fontMono` becomes `"JetBrains Mono", ui-monospace, monospace` in `typography.ts`. Without it, wiring would have regressed these apps' mono text from SF Mono to Courier (none load JetBrains Mono). The website is unaffected — it loads JetBrains Mono via next/font so the first entry always wins; its 40 verbatim CSS literals keep the old stack with zero rendering difference.

## Verified

All 14 apps build with the import resolving; the built `element-rendering` app renders its dark design pixel-for-pixel with tokens live (`--ds-canvas rgb(17,17,17)`, SF Mono via the new chain); client-tools' bundle carries the tokens; 6 affected projects' unit tests green; design-tokens suite green (regenerated files under the byte-drift guard).

This closes the last follow-up from the docs-review arc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
