### PR TITLE
docs: worktree-only Turbopack panic when website .next caches exist

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,22 @@ Do not run `npm install` in a worktree on macOS either: it rewrites
 `package-lock.json` and drops the Linux `@next/swc-*` bindings, which breaks CI.
 `npm ci` is the safe command.
 
+One more worktree-only trap, after install: `nx build cockpit` can die with a
+Turbopack panic — `FileSystemPath(...).join(...) leaves the filesystem root` —
+whenever a website `.next` cache exists anywhere in the workspace
+(`apps/website/.next` from `next dev`/e2e, or `dist/apps/website` from a build).
+Those caches contain a `node_modules` symlink whose relative target resolves
+through the *main* checkout's root; the path is valid on disk, but Turbopack's
+virtual filesystem refuses to traverse above its project root and panics.
+Pinning `turbopack.root` does not help. Clear the caches instead:
+
+```bash
+rm -rf apps/website/.next dist/apps/website && npx nx build cockpit
+```
+
+CI never hits this — its jobs build from fresh checkouts that are not nested
+inside another checkout.
+
 ## Testing
 
 New functionality and bug fixes must include automated tests. Run a project's


### PR DESCRIPTION
Closes the last open follow-up from the worktree investigation. Docs-only.

`nx build cockpit` panics in a git worktree — `FileSystemPath(…).join(…) leaves the filesystem root` — whenever **any** website `.next` cache exists in the workspace: `apps/website/.next` (left by `next dev` / the website e2e) or `dist/apps/website` (left by a build). Those caches contain a `node_modules` symlink whose relative target routes through the *main* checkout's root. The path is valid on disk; Turbopack's virtual filesystem refuses to traverse above its project root and panics.

What I verified before writing a word of documentation:

- Reproduced with both cache locations independently (the second one surfaced only after the first was cleared — my initial single-cause model was wrong).
- **Pinning `turbopack.root` does not fix it** — tested, same two panics. The error message's own suggestion is a dead end for this case.
- Clearing the caches does: build goes exit 1 → exit 0.
- CI never hits this: its checkouts are fresh and not nested inside another checkout.

A real fix belongs upstream (Turbopack rejecting a disk-valid symlink), so the honest artifact here is the documented workaround in CONTRIBUTING's worktree section:

```bash
rm -rf apps/website/.next dist/apps/website && npx nx build cockpit
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)