### PR TITLE
ci: publish threadplane-middleware with uv, ending the twine metadata skew

### DIFF
--- a/.github/workflows/publish-middleware-python.yml
+++ b/.github/workflows/publish-middleware-python.yml
@@ -76,9 +76,14 @@ jobs:
         working-directory: packages/threadplane-middleware
         run: uv publish --dry-run dist/*
 
+      # uv publish, not the pypa action: the pinned action image's twine
+      # rejected the Metadata-Version 2.5 that current `uv build` emits
+      # ("InvalidDistribution: '2.5' is not a valid metadata version"), while
+      # the dry-run path — which already uses uv — passed. One toolchain for
+      # build, dry-run, and publish removes that skew permanently. PyPI
+      # trusted publishing is bound to repo + workflow filename, so the same
+      # OIDC token works; uv picks it up via --trusted-publishing.
       - name: Publish to PyPI (real release — OIDC trusted publishing)
         if: ${{ inputs.dry_run == false }}
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
-        with:
-          packages-dir: packages/threadplane-middleware/dist
-          attestations: true
+        working-directory: packages/threadplane-middleware
+        run: uv publish --trusted-publishing always dist/*


### PR DESCRIPTION
The first real publish attempt for middleware 0.0.2 failed **after a green dry-run**, uploading nothing:

```
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

Root cause is toolchain skew inside our own workflow: `uv build` (latest) emits Metadata-Version **2.5**; the **dry-run** step validates with `uv publish --dry-run` (accepts it); the **real** step used the pinned `pypa/gh-action-pypi-publish` image whose bundled twine predates 2.5 (rejects it). The two paths disagreed about the same artifact, so the dry-run could not have caught this — by construction.

## Fix

Real release now uses `uv publish --trusted-publishing always` — the same toolchain as build and dry-run, so this class of skew is gone rather than patched. PyPI trusted publishing binds to **repo + workflow filename**, not to the publishing action, so the existing OIDC grant works unchanged (`id-token: write` already present).

## Trade-offs stated plainly

- **PEP 740 attestations are lost** — the pypa action uploaded them (`attestations: true`); `uv publish` doesn't support them yet. Acceptable against a publish path that cannot ship at all; worth revisiting when uv grows support.
- Alternative considered: bumping the action pin to v1.14.2 (tag dereferenced to `dc37677b`). Rejected because it re-introduces the same skew the next time uv's metadata gets ahead of the action's twine — this failure mode recurs by design with two toolchains.

## Verification note

This can only be truly verified by the next real publish (workflow_dispatch is manual). YAML validated; the dry-run path is untouched and stays green. I'll run the 0.0.2 publish immediately after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)