### PR TITLE
feat(examples/chat): announce the research subagent's stream identity

### DIFF
--- a/examples/chat/python/pyproject.toml
+++ b/examples/chat/python/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
     "langchain-openai>=0.3",
     "langgraph-api>=0.8.7",
     "python-dotenv>=1.0",
-    "threadplane-middleware>=0.0.1",
+    "threadplane-middleware>=0.0.2",
 ]
 
 [tool.uv]

--- a/examples/chat/python/src/graph.py
+++ b/examples/chat/python/src/graph.py
@@ -38,11 +38,12 @@ from langchain_core.messages import (
     ToolMessage,
 )
 from langchain_core.runnables import RunnableConfig
+from langchain_core.tools import InjectedToolCallId
 from langchain_core.tools import tool
 from langgraph_sdk import get_client
 from langsmith import traceable
 
-from threadplane.middleware.langgraph import bind_client_tools, client_tool_names
+from threadplane.middleware.langgraph import announce_subagent, bind_client_tools, client_tool_names
 
 from src.streaming.a2ui_partial_handler import A2uiPartialHandler
 from src.streaming.envelope_tool import render_a2ui_surface
@@ -310,7 +311,12 @@ research_subgraph = _research_builder.compile()
 
 
 @tool
-async def research(topic: str, subagent_type: str = "research") -> str:
+async def research(
+    topic: str,
+    subagent_type: str = "research",
+    tool_call_id: Annotated[str, InjectedToolCallId] = None,
+    config: RunnableConfig = None,
+) -> str:
     """Dispatch a research subagent to gather facts on a focused topic.
     The subagent returns a concise summary; pass that summary back to
     the user, citing it with the inline citation syntax if appropriate.
@@ -324,6 +330,11 @@ async def research(topic: str, subagent_type: str = "research") -> str:
     # it travels in the tool call args so the SubagentTracker can
     # register the dispatch and surface a card while the child graph runs.
     del subagent_type
+    # Bind the child's `tools:<uuid>` stream namespace to this tool-call id.
+    # The namespace is a checkpoint id with no wire-level link to `call_*`;
+    # announcing the pair lets the frontend attribute the stream exactly —
+    # including under parallel fan-out, where guessing is unsound.
+    announce_subagent(config, tool_call_id)
     result = await research_subgraph.ainvoke({"topic": topic, "messages": []})
     msgs = result.get("messages") if isinstance(result, dict) else None
     if not msgs:

--- a/examples/chat/python/uv.lock
+++ b/examples/chat/python/uv.lock
@@ -304,7 +304,7 @@ requires-dist = [
     { name = "langgraph", specifier = ">=0.3" },
     { name = "langgraph-api", specifier = ">=0.8.7" },
     { name = "python-dotenv", specifier = ">=1.0" },
-    { name = "threadplane-middleware", specifier = ">=0.0.1" },
+    { name = "threadplane-middleware", specifier = ">=0.0.2" },
 ]
 
 [package.metadata.requires-dev]
@@ -1492,15 +1492,15 @@ wheels = [
 
 [[package]]
 name = "threadplane-middleware"
-version = "0.0.1"
+version = "0.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/01/5f/fee360e3547bede9388bb72a9ad20ca811935582b989c78dafeaae57558a/threadplane_middleware-0.0.1.tar.gz", hash = "sha256:60c931d0248ed2e701a3aa1330c6fd647e611a949500269c5ba82f3607102cef", size = 95505, upload-time = "2026-06-16T20:55:18.335Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/f6/4f5bce0536c584677f191223821c74d0617bde36d45640008e8adf123c79/threadplane_middleware-0.0.2.tar.gz", hash = "sha256:964925aef5cc5ed8a9a9bb1c7ea7f740ee010291b6ad0bec35f50ac3f41d9809", size = 97651, upload-time = "2026-08-30T18:35:45.87Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/55/28e6b752f3f53f2c5d2c2fa3ef27ac62a255a3b29376384f2dfc96d8acb0/threadplane_middleware-0.0.1-py3-none-any.whl", hash = "sha256:c14e49d506e8bd3078f54df381c150d390f2d129f844694d8f5154a2cd8710ea", size = 4315, upload-time = "2026-06-16T20:55:19.044Z" },
+    { url = "https://files.pythonhosted.org/packages/96/a4/0bc72be56ee222a15e151a8eb99decb749acf44c964ef12c240ec6a8f76f/threadplane_middleware-0.0.2-py3-none-any.whl", hash = "sha256:3bf42291b06b49f6e59eb92672fa88d9f14467a5222fec806531714d4349f17b", size = 5517, upload-time = "2026-08-30T18:35:45.074Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Final piece of the subagent-identity arc (#869 → middleware 0.0.2 on PyPI → `@threadplane/langgraph` 0.0.62 on npm → this).

The canonical demo's `research` tool now calls `announce_subagent(config, tool_call_id)`, binding the child graph's `tools:<uuid>` stream namespace to the dispatching `call_*` id. The frontend attributes the stream exactly instead of relying on the single-candidate positional fallback.

Notable as a supply-chain checkpoint: this is the **first consumer resolving `announce_subagent` from PyPI** (`threadplane-middleware>=0.0.2`, lock pinned to the registry artifact) rather than from in-repo source — so it validates the published package, not just the code that produced it.

## Verification

- `uv.lock` resolves `threadplane-middleware 0.0.2` from `pypi.org` (not a path source)
- examples/chat e2e **54/54**, including the `research-subagent` `@drift` spec — aimock mocks only the OpenAI layer, so the real graph ran with the real binding event through the real published middleware
- Python syntax + imports verified; `Annotated`/`InjectedToolCallId` wired the same way as the cockpit demo

🤖 Generated with [Claude Code](https://claude.com/claude-code)