### PR TITLE
fix(website): AnnouncementToast mobile presentation and a11y

### DIFF
--- a/apps/website/src/components/shared/AnnouncementToast.tsx
+++ b/apps/website/src/components/shared/AnnouncementToast.tsx
@@ -85,11 +85,18 @@ export function AnnouncementToast() {
   if (!visible) return null;
 
   return (
+    // Non-modal dialog, not role="alert": an alert/live region must not hold
+    // interactive content (the CTA button and email form live here), and
+    // assertive announcement of a marketing prompt is hostile. Focus is never
+    // stolen on entry; Escape dismisses once focus is inside.
     <div
-      role="alert"
-      aria-live="polite"
+      role="dialog"
+      aria-labelledby="toast-title"
       className="toast-root"
       data-mounted={mounted || undefined}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') dismiss();
+      }}
     >
       {/* Dismiss button */}
       <button
@@ -106,7 +113,7 @@ export function AnnouncementToast() {
       </p>
 
       {/* Title */}
-      <p className="toast-title">
+      <p id="toast-title" className="toast-title">
         From Prototype to Production
       </p>
 
@@ -184,7 +191,8 @@ export function AnnouncementToast() {
 
       {step === 'sent' && (
         <div className="toast-mt-section">
-          <p className="toast-success-text">
+          {/* role=status: the step swap is announced without stealing focus. */}
+          <p role="status" className="toast-success-text">
             ✓ Check your inbox — the guide is on its way!
           </p>
         </div>

--- a/apps/website/src/styles/chrome.css
+++ b/apps/website/src/styles/chrome.css
@@ -335,6 +335,19 @@
   opacity: 1;
   transform: translateY(0);
 }
+/* On phones the 360px right-hugging card read as a wall (327px of a
+ * 375px screen, findings §6): present it as a centered bottom sheet
+ * with even margins instead. */
+@media (max-width: 480px) {
+  .toast-root {
+    left: 16px;
+    right: 16px;
+    bottom: 16px;
+    width: auto;
+    max-width: none;
+    padding: 16px 18px;
+  }
+}
 .toast-close {
   position: absolute;
   top: 10px;
@@ -346,6 +359,20 @@
   font-size: 18px;
   line-height: 1;
   padding: 4px;
+  border-radius: var(--radius-sm);
+}
+.toast-close:hover {
+  color: var(--color-text-primary);
+}
+/* 44px touch target without visual growth (findings §7). */
+.toast-close::after {
+  content: '';
+  position: absolute;
+  inset: -12px -13px;
+}
+.toast-close:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
 }
 .toast-eyebrow {
   font-family: var(--font-mono);


### PR DESCRIPTION
## Summary

The last two toast items from the polish-arc deferred list:

- **Mobile width (findings §6):** below 480px the 360px right-hugging card covered 327px of a 375px screen. It now presents as a centered bottom sheet — even 16px side/bottom margins, tighter padding. Desktop unchanged.
- **A11y:** the root was `role="alert"` + `aria-live` wrapped around interactive content (the CTA button and email form) — an alert/live region must not hold interactive controls. It's now a non-modal `role="dialog"` labelled by the title, which never steals focus on entry. Escape dismisses once focus is inside (and persists the dismissal). The close button gains a hover state, a `:focus-visible` ring, and a 44px touch target via `::after` (findings §7) without visual growth. The "sent" success message is `role="status"` so the step swap is still announced to screen readers.

## Verification

Browser-measured at 375: toast rect `left: 16 / right: 359` (even margins), close hit target 46×50, Escape fires `dismiss()` and sets the localStorage key, `role`/`aria-labelledby` present. `nx test website` green, lint **0 errors**, production build green (exit codes verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)