### PR TITLE
ci: PEP 740 attestations via astral-sh/attest-action; middleware 0.0.3

### DIFF
--- a/.github/workflows/publish-middleware-python.yml
+++ b/.github/workflows/publish-middleware-python.yml
@@ -76,6 +76,17 @@ jobs:
         working-directory: packages/threadplane-middleware
         run: uv publish --dry-run dist/*
 
+      # PEP 740 attestations: `uv publish` uploads attestation files found
+      # next to the dists (on by default) but does not mint them — Astral's
+      # own publishing example pairs it with their attest-action for exactly
+      # this. Generated for the real release only; a dry run uploads nothing
+      # for them to accompany. SHA pin verified against tag v0.0.6.
+      - name: Generate PEP 740 attestations
+        if: ${{ inputs.dry_run == false }}
+        uses: astral-sh/attest-action@f589a42a7efb6fe400b4f400de60b4bc90390027 # v0.0.6
+        with:
+          paths: packages/threadplane-middleware/dist/*
+
       # uv publish, not the pypa action: the pinned action image's twine
       # rejected the Metadata-Version 2.5 that current `uv build` emits
       # ("InvalidDistribution: '2.5' is not a valid metadata version"), while

--- a/packages/threadplane-middleware/pyproject.toml
+++ b/packages/threadplane-middleware/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "threadplane-middleware"
-version = "0.0.2"
+version = "0.0.3"
 description = "LangGraph middleware for binding client-declared tool stubs and routing client tool calls to END so the browser executes them."
 readme = "README.md"
 license = { text = "MIT" }

--- a/packages/threadplane-middleware/uv.lock
+++ b/packages/threadplane-middleware/uv.lock
@@ -763,7 +763,7 @@ wheels = [
 
 [[package]]
 name = "threadplane-middleware"
-version = "0.0.2"
+version = "0.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "langchain-core" },


### PR DESCRIPTION
Resolves the attestation trade-off from #873 — it turns out there wasn't one.

## What I had wrong in #873

I wrote "uv publish doesn't support attestations yet." Half-wrong: `uv publish` **uploads** attestation files found beside the dists *by default* (`--no-attestations` is the opt-out) — it just doesn't **mint** them. Astral's own GHA publishing example pairs it with their `attest-action` for the minting step. So we can have one toolchain end to end **and** attestations; no version skew re-enters because nothing validates metadata twice with different tools.

## Changes

- `Generate PEP 740 attestations` step (real release only — a dry run uploads nothing for them to accompany), pinned `astral-sh/attest-action@f589a42a # v0.0.6`, **SHA verified against the tag** per the action-pin discipline. The input is `paths` (whitespace-separated globs) — caught by reading `action.yml` at the pinned SHA rather than trusting my first guess of `path`.
- Middleware bumped **0.0.2 → 0.0.3**, no code change: PyPI files are immutable, so attestations are only provable on a fresh upload. Consumers (`examples/chat`, `cockpit/langgraph/client-tools`) pin `>=0.0.2`/`>=0.0.1` and are unaffected.

## Verification plan (after merge)

1. Dry-run dispatch (attest step correctly skipped, tests + build green)
2. Real dispatch for 0.0.3
3. **The check that counts**: PyPI simple API `files[].provenance` for the 0.0.3 wheel + sdist must be non-null — the same query that showed `none` for 0.0.2

Also verified while investigating: current twine passes our Metadata-Version 2.5 artifacts, so the pypa-action path would work again today too — but it re-arms the two-toolchain skew, which is how #873 happened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)