### PR TITLE
style(website): bring all 13 blog posts into Brian's 2026 voice

### DIFF
--- a/apps/website/content/blog/2026-05-17-build-a-streaming-chat-ui-in-angular-with-langgraph.mdx
+++ b/apps/website/content/blog/2026-05-17-build-a-streaming-chat-ui-in-angular-with-langgraph.mdx
@@ -34,9 +34,13 @@ The seams come first, before any code.
 You do not write the transport.
 LangGraph does.
 
-**`@threadplane/langgraph` adapter.** This is the Angular-side translator. It takes LangGraph's `ThreadState` and turns it into a signal-shaped `AgentCheckpoint` that the chat UI knows how to render. It also owns the run lifecycle — submit, cancel, retry — and the thread CRUD.
+**`@threadplane/langgraph` adapter.** This is the Angular-side translator.
+It takes LangGraph's `ThreadState` and turns it into a signal-shaped `AgentCheckpoint` that the chat UI knows how to render.
+It also owns the run lifecycle — submit, cancel, retry — and the thread CRUD.
 
-**`@threadplane/chat` UI.** This is the rendering layer. Message list, input, suggestions, interrupt panels, tool-call cards, reasoning blocks. Every piece is a signal, every signal flows through OnPush change detection, and everything is themeable through CSS custom properties.
+**`@threadplane/chat` UI.** This is the rendering layer.
+Message list, input, suggestions, interrupt panels, tool-call cards, reasoning blocks.
+Every piece is a signal, every signal flows through OnPush change detection, and everything is themeable through CSS custom properties.
 
 The contract between the adapter and the UI is small on purpose.
 The chat does not know it is talking to LangGraph.
@@ -133,10 +137,14 @@ export class ChatPageComponent {
 </Steps>
 
 That is the entire wiring.
-No global stylesheet to import. No PostCSS config. No Tailwind setup.
+No global stylesheet to import.
+No PostCSS config.
+No Tailwind setup.
 The chat ships with its own design tokens and component-scoped styles.
 
-One thing worth calling out is the `assistantId`. That is the name of your LangGraph graph — the entry point the run will execute against. If you have multiple graphs, you have multiple `agent()` instances, and you decide which one mounts where: a support graph in one route, a coding graph in another, the same chat shell rendering both.
+One thing worth calling out is the `assistantId`.
+That is the name of your LangGraph graph — the entry point the run will execute against.
+If you have multiple graphs, you have multiple `agent()` instances, and you decide which one mounts where: a support graph in one route, a coding graph in another, the same chat shell rendering both.
 
 ## Render the chat
 
@@ -174,7 +182,9 @@ template: `
 
 The slot pattern is intentional: the chat does not set your welcome copy, pick your suggestions, or own your empty states. It exposes those as slots so you can grow past the demo phase without fighting the component.
 
-Theming is a separate concern. The chat reads from CSS custom properties — `--chat-bg`, `--chat-fg`, `--chat-accent`, and a few dozen more. If you already use a design system, map your tokens onto theirs in a single stylesheet and the chat picks them up.
+Theming is a separate concern.
+The chat reads from CSS custom properties — `--chat-bg`, `--chat-fg`, `--chat-accent`, and a few dozen more.
+If you already use a design system, map your tokens onto theirs in a single stylesheet and the chat picks them up.
 
 ## What's happening under the hood?
 
@@ -189,18 +199,28 @@ The contract is roughly:
 - `cancel()` — abort the current run
 - `retry()` — re-run the last user message
 
-Notice what *is not* in there. No event emitters. No observables to subscribe to. No imperative `subscribe(messages, render)` plumbing.
+Notice what *is not* in there.
+No event emitters.
+No observables to subscribe to.
+No imperative `subscribe(messages, render)` plumbing.
 
-Everything is a signal. The chat template reads `messages()` directly. OnPush change detection picks up the writes and re-renders only the components that depend on the changed signal.
+Everything is a signal.
+The chat template reads `messages()` directly.
+OnPush change detection picks up the writes and re-renders only the components that depend on the changed signal.
 
 Angular's signal model maps cleanly onto streaming: at the data-shape level, streaming is a sequence of small writes to a growing list, and so are signals.
 That is why the chat does not need an internal store, a reducer, or a state machine.
 The agent is the state, the signal is the read, the template is the render.
 
-It also matters for testing. Because the contract is signals all the way down, you can mock the agent with a plain object — no harness, no fakes, no subscription bookkeeping. Write a signal, the chat re-renders. Write another signal, the chat re-renders again.
+It also matters for testing.
+Because the contract is signals all the way down, you can mock the agent with a plain object — no harness, no fakes, no subscription bookkeeping.
+Write a signal, the chat re-renders.
+Write another signal, the chat re-renders again.
 That is the entire testing story for the UI layer.
 
-The transport story is the same shape one level down. The adapter reads from LangGraph's SSE stream and writes the parsed events into the agent's signals. You can swap the transport — a fake stream, a recorded fixture, a different backend entirely — and the chat does not know the difference.
+The transport story is the same shape one level down.
+The adapter reads from LangGraph's SSE stream and writes the parsed events into the agent's signals.
+You can swap the transport — a fake stream, a recorded fixture, a different backend entirely — and the chat does not know the difference.
 That is the boundary the contract was designed to enforce.
 
 ## Production patterns
@@ -210,7 +230,9 @@ Each one is covered below.
 
 ### 1. Errors and retries
 
-Models fail. Networks fail. Tools time out.
+Models fail.
+Networks fail.
+Tools time out.
 The default behavior is to surface the error in the chat with a retry affordance, but most teams want more than the default.
 
 For me, two patterns are worth setting up early:
@@ -218,7 +240,12 @@ For me, two patterns are worth setting up early:
 - **Per-message retry**, so a failed assistant response can be re-run without resubmitting the user's message.
 - **Transport-level retry with backoff**, so transient SSE drops do not surface as errors at all.
 
-The adapter exposes both as configuration on `provideAgent`. A third pattern worth thinking about early: **graceful degradation when streaming is unavailable**. Some networks strip SSE. Some corporate proxies buffer it. The chat will fall back to a non-streaming render, but you should know that path exists before a customer finds it. The depth of what you can do here is in the [error handling guide](/docs/chat/guides/lifecycle).
+The adapter exposes both as configuration on `provideAgent`.
+A third pattern worth thinking about early: **graceful degradation when streaming is unavailable**.
+Some networks strip SSE.
+Some corporate proxies buffer it.
+The chat will fall back to a non-streaming render, but you should know that path exists before a customer finds it.
+The depth of what you can do here is in the [error handling guide](/docs/chat/guides/lifecycle).
 
 ### 2. Threads and persistence
 
@@ -236,11 +263,19 @@ If you are building a multi-thread sidebar, the [`<chat-sidebar>`](/docs/chat/co
 ### 3. Generative UI fallbacks
 
 Sometimes the model wants to do more than render text.
-Tool calls produce structured output. Interrupts ask for human input. Subagents return their own state.
+Tool calls produce structured output.
+Interrupts ask for human input.
+Subagents return their own state.
 
 The chat handles each of these as a first-class message type. You do not need to write a custom renderer to get the default behavior — tool calls become cards, interrupts become panels, subagents become collapsible blocks.
 
-When you do need custom rendering — and you will — every one of these is a templatable slot. Pass a template, override the default, ship the variant you actually want. This is the seam where a generic chat becomes *your* chat. The branded card for your most important tool. The custom approval flow for your most sensitive interrupt. The product-specific summary block when a subagent finishes a long task. The [generative UI guide](/docs/chat/guides/generative-ui) walks through each surface in depth.
+When you do need custom rendering — and you will — every one of these is a templatable slot.
+Pass a template, override the default, ship the variant you actually want.
+This is the seam where a generic chat becomes *your* chat.
+The branded card for your most important tool.
+The custom approval flow for your most sensitive interrupt.
+The product-specific summary block when a subagent finishes a long task.
+The [generative UI guide](/docs/chat/guides/generative-ui) walks through each surface in depth.
 
 ## Where to go from here
 

--- a/apps/website/content/blog/2026-05-17-build-a-streaming-chat-ui-in-angular-with-langgraph.mdx
+++ b/apps/website/content/blog/2026-05-17-build-a-streaming-chat-ui-in-angular-with-langgraph.mdx
@@ -7,9 +7,10 @@ author: brian
 featured: true
 ---
 
-Let's build a real streaming chat UI in Angular, wired to a LangGraph backend, using `@threadplane/chat` and `@threadplane/langgraph`.
+A real streaming chat UI in Angular, wired to a LangGraph backend, comes together with `@threadplane/chat` and `@threadplane/langgraph`.
 
-Most AI chat features still ship without streaming — they buffer the full response on the server, then drop it into the UI in one paste. Streaming is the difference between a user waiting two seconds and waiting eight, and between an interface that feels alive and one that feels broken.
+Most AI chat features still ship without streaming — they buffer the full response on the server, then drop it into the UI in one paste.
+Streaming is the difference between a user waiting two seconds and waiting eight, and between an interface that feels alive and one that feels broken.
 
 ## Goals
 
@@ -19,29 +20,40 @@ Most AI chat features still ship without streaming — they buffer the full resp
 
 ## Why does streaming matter?
 
-A user reads at roughly 200 to 300 words per minute; a modern model produces tokens faster than that. If you stream, the user starts reading before the model has finished. If you buffer, every response feels like a page load with no progress indicator.
+A user reads at roughly 200 to 300 words per minute; a modern model produces tokens faster than that.
+If you stream, the user starts reading before the model has finished.
+If you buffer, every response feels like a page load with no progress indicator.
 
-Streaming also enables **interruption**: if the response is incremental, the user can stop a run that's going the wrong direction before it finishes burning tokens.
+Streaming also enables **interruption**: if the response is incremental, the user can stop a run that is going the wrong direction before it finishes burning tokens.
 
 ## The architecture in three boxes
 
-Let's look at the seams before we touch any code.
+The seams come first, before any code.
 
-**LangGraph backend.** This is where your agent graph lives — nodes, edges, tools, interrupts. It exposes a streaming endpoint over SSE. You don't write the transport. LangGraph does.
+**LangGraph backend.** This is where your agent graph lives — nodes, edges, tools, interrupts. It exposes a streaming endpoint over SSE.
+You do not write the transport.
+LangGraph does.
 
 **`@threadplane/langgraph` adapter.** This is the Angular-side translator. It takes LangGraph's `ThreadState` and turns it into a signal-shaped `AgentCheckpoint` that the chat UI knows how to render. It also owns the run lifecycle — submit, cancel, retry — and the thread CRUD.
 
 **`@threadplane/chat` UI.** This is the rendering layer. Message list, input, suggestions, interrupt panels, tool-call cards, reasoning blocks. Every piece is a signal, every signal flows through OnPush change detection, and everything is themeable through CSS custom properties.
 
-The contract between the adapter and the UI is small on purpose. The chat doesn't know it's talking to LangGraph. The adapter doesn't know how messages get rendered. That separation is what lets you swap the backend, theme the UI, or replace a single component without touching the rest.
+The contract between the adapter and the UI is small on purpose.
+The chat does not know it is talking to LangGraph.
+The adapter does not know how messages get rendered.
+That separation is what lets you swap the backend, theme the UI, or replace a single component without touching the rest.
 
-It's also what makes the stack viable for teams that don't control the backend. If your backend is LangGraph, the adapter is what you reach for. If your backend is something else, the adapter is the only piece that changes. The chat — and every component, theme, and slot inside it — is the same.
+It is also what makes the stack viable for teams that do not control the backend.
+If your backend is LangGraph, the adapter is what you reach for.
+If your backend is something else, the adapter is the only piece that changes.
+The chat — and every component, theme, and slot inside it — is the same.
 
 <ArchFlowDiagram />
 
 ## Scaffold
 
-Let's start with a fresh Angular 20 app. Three commands and three files.
+Start with a fresh Angular 20 app.
+Three commands and three files.
 
 <Steps>
 <Step title="Install the packages">
@@ -70,7 +82,7 @@ yarn add @threadplane/chat @threadplane/langgraph marked
 </Tab>
 </Tabs>
 
-`marked` is the markdown renderer the chat uses for assistant messages. It's a peer dependency so you can swap it if you need to.
+`marked` is the markdown renderer the chat uses for assistant messages. It is a peer dependency so you can swap it if you need to.
 
 </Step>
 <Step title="Wire the providers">
@@ -89,7 +101,7 @@ export const appConfig: ApplicationConfig = {
 };
 ```
 
-`provideAgent` is the transport. `provideChat` is the UI configuration. They're independent on purpose — you can use one without the other.
+`provideAgent` is the transport. `provideChat` is the UI configuration. They are independent on purpose — you can use one without the other.
 
 </Step>
 <Step title="Create the agent in your component">
@@ -120,19 +132,23 @@ export class ChatPageComponent {
 </Step>
 </Steps>
 
-That's the entire wiring. No global stylesheet to import. No PostCSS config. No Tailwind setup. The chat ships with its own design tokens and component-scoped styles.
+That is the entire wiring.
+No global stylesheet to import. No PostCSS config. No Tailwind setup.
+The chat ships with its own design tokens and component-scoped styles.
 
-One thing worth calling out is the `assistantId`. That's the name of your LangGraph graph — the entry point the run will execute against. If you have multiple graphs, you have multiple `agent()` instances, and you decide which one mounts where: a support graph in one route, a coding graph in another, the same chat shell rendering both.
+One thing worth calling out is the `assistantId`. That is the name of your LangGraph graph — the entry point the run will execute against. If you have multiple graphs, you have multiple `agent()` instances, and you decide which one mounts where: a support graph in one route, a coding graph in another, the same chat shell rendering both.
 
 ## Render the chat
 
-Let's look at the rendering surface. The `<chat>` component handles the standard stuff — message list, input, send button, suggestion chips, scroll behavior, autosizing, the lot.
+The rendering surface is next.
+The `<chat>` component handles the standard stuff — message list, input, send button, suggestion chips, scroll behavior, autosizing, the lot.
 
 ```html
 <chat [agent]="chatAgent" />
 ```
 
-That's the minimum. You'll quickly want a welcome state, suggestions, and a header.
+That is the minimum.
+You will quickly want a welcome state, suggestions, and a header.
 
 ```ts
 template: `
@@ -156,13 +172,14 @@ template: `
 `,
 ```
 
-The slot pattern is intentional: the chat doesn't set your welcome copy, pick your suggestions, or own your empty states. It exposes those as slots so you can grow past the demo phase without fighting the component.
+The slot pattern is intentional: the chat does not set your welcome copy, pick your suggestions, or own your empty states. It exposes those as slots so you can grow past the demo phase without fighting the component.
 
 Theming is a separate concern. The chat reads from CSS custom properties — `--chat-bg`, `--chat-fg`, `--chat-accent`, and a few dozen more. If you already use a design system, map your tokens onto theirs in a single stylesheet and the chat picks them up.
 
 ## What's happening under the hood?
 
-Let's peek at the contract. The adapter exposes a small surface, the chat consumes it, and everything else is implementation detail.
+Start with the contract.
+The adapter exposes a small surface, the chat consumes it, and everything else is implementation detail.
 
 The contract is roughly:
 
@@ -172,54 +189,63 @@ The contract is roughly:
 - `cancel()` — abort the current run
 - `retry()` — re-run the last user message
 
-Notice what *isn't* in there. No event emitters. No observables to subscribe to. No imperative `subscribe(messages, render)` plumbing.
+Notice what *is not* in there. No event emitters. No observables to subscribe to. No imperative `subscribe(messages, render)` plumbing.
 
 Everything is a signal. The chat template reads `messages()` directly. OnPush change detection picks up the writes and re-renders only the components that depend on the changed signal.
 
-Angular's signal model maps cleanly onto streaming: at the data-shape level, streaming is a sequence of small writes to a growing list, and so are signals. That's why the chat doesn't need an internal store, a reducer, or a state machine. The agent is the state, the signal is the read, the template is the render.
+Angular's signal model maps cleanly onto streaming: at the data-shape level, streaming is a sequence of small writes to a growing list, and so are signals.
+That is why the chat does not need an internal store, a reducer, or a state machine.
+The agent is the state, the signal is the read, the template is the render.
 
-It also matters for testing. Because the contract is signals all the way down, you can mock the agent with a plain object — no harness, no fakes, no subscription bookkeeping. Write a signal, the chat re-renders. Write another signal, the chat re-renders again. That's the entire testing story for the UI layer.
+It also matters for testing. Because the contract is signals all the way down, you can mock the agent with a plain object — no harness, no fakes, no subscription bookkeeping. Write a signal, the chat re-renders. Write another signal, the chat re-renders again.
+That is the entire testing story for the UI layer.
 
-The transport story is the same shape one level down. The adapter reads from LangGraph's SSE stream and writes the parsed events into the agent's signals. You can swap the transport — a fake stream, a recorded fixture, a different backend entirely — and the chat doesn't know the difference. That's the boundary the contract was designed to enforce.
+The transport story is the same shape one level down. The adapter reads from LangGraph's SSE stream and writes the parsed events into the agent's signals. You can swap the transport — a fake stream, a recorded fixture, a different backend entirely — and the chat does not know the difference.
+That is the boundary the contract was designed to enforce.
 
 ## Production patterns
 
-The scaffold above gets you to a working chat in about ten minutes. The remaining ninety percent of the work is in three buckets. Let's walk through each one.
+The scaffold above gets you to a working chat in about ten minutes. The remaining ninety percent of the work is in three buckets.
+Each one is covered below.
 
 ### 1. Errors and retries
 
-Models fail. Networks fail. Tools time out. The default behavior is to surface the error in the chat with a retry affordance, but most teams want more than the default.
+Models fail. Networks fail. Tools time out.
+The default behavior is to surface the error in the chat with a retry affordance, but most teams want more than the default.
 
-Two patterns are worth setting up early:
+For me, two patterns are worth setting up early:
 
 - **Per-message retry**, so a failed assistant response can be re-run without resubmitting the user's message.
-- **Transport-level retry with backoff**, so transient SSE drops don't surface as errors at all.
+- **Transport-level retry with backoff**, so transient SSE drops do not surface as errors at all.
 
 The adapter exposes both as configuration on `provideAgent`. A third pattern worth thinking about early: **graceful degradation when streaming is unavailable**. Some networks strip SSE. Some corporate proxies buffer it. The chat will fall back to a non-streaming render, but you should know that path exists before a customer finds it. The depth of what you can do here is in the [error handling guide](/docs/chat/guides/lifecycle).
 
 ### 2. Threads and persistence
 
-A single-thread chat is a demo. A real product remembers conversations across sessions and across devices.
+A single-thread chat is a demo.
+A real product remembers conversations across sessions and across devices.
 
 LangGraph handles persistence on the backend. The adapter exposes thread CRUD through `@langchain/langgraph-sdk` — list threads, create a thread, switch threads, delete a thread.
 
 Bind your `threadId` signal to your router or sidebar selection. When the signal changes, the chat re-reads from the new thread automatically — no manual unsubscribe, no race conditions.
 
-How you scope threads is a product decision: per project, per task, or per session with the agent's memory doing the cross-session work. The one thing to avoid is shipping a chat where every refresh starts from zero.
+How you scope threads is a product decision: per project, per task, or per session with the agent's memory doing the cross-session work. For me, the one thing to avoid is shipping a chat where every refresh starts from zero.
 
-If you're building a multi-thread sidebar, the [`<chat-sidebar>`](/docs/chat/components/chat-sidebar) primitive gives you the layout without locking you into a specific persistence model.
+If you are building a multi-thread sidebar, the [`<chat-sidebar>`](/docs/chat/components/chat-sidebar) primitive gives you the layout without locking you into a specific persistence model.
 
 ### 3. Generative UI fallbacks
 
-Sometimes the model wants to do more than render text. Tool calls produce structured output. Interrupts ask for human input. Subagents return their own state.
+Sometimes the model wants to do more than render text.
+Tool calls produce structured output. Interrupts ask for human input. Subagents return their own state.
 
-The chat handles each of these as a first-class message type. You don't need to write a custom renderer to get the default behavior — tool calls become cards, interrupts become panels, subagents become collapsible blocks.
+The chat handles each of these as a first-class message type. You do not need to write a custom renderer to get the default behavior — tool calls become cards, interrupts become panels, subagents become collapsible blocks.
 
 When you do need custom rendering — and you will — every one of these is a templatable slot. Pass a template, override the default, ship the variant you actually want. This is the seam where a generic chat becomes *your* chat. The branded card for your most important tool. The custom approval flow for your most sensitive interrupt. The product-specific summary block when a subagent finishes a long task. The [generative UI guide](/docs/chat/guides/generative-ui) walks through each surface in depth.
 
 ## Where to go from here
 
-The scaffold above is the smallest possible production-shaped chat. It's not the whole story.
+The scaffold above is the smallest possible production-shaped chat.
+It is not the whole story.
 
 Three places to look next:
 
@@ -228,9 +254,10 @@ Three places to look next:
 - The [interrupts guide](/docs/chat/guides/streaming) — how to handle human-in-the-loop pauses without breaking the streaming model.
 
 <Callout type="info" title="Building this for an enterprise team?">
-If you're wiring `@threadplane/chat` into a regulated, multi-tenant, or design-system-heavy environment, we have a paid track for that. [Talk to us about the enterprise track →](/contact?source=blog_streaming_pillar&track=enterprise)
+If you are wiring `@threadplane/chat` into a regulated, multi-tenant, or design-system-heavy environment, we have a paid track for that. [Talk to us about the enterprise track →](/contact?source=blog_streaming_pillar&track=enterprise)
 </Callout>
 
 ## Conclusion
 
-`@threadplane/chat` plus `@threadplane/langgraph` gets an Angular app to a streaming, production-shaped chat in three files: signals all the way down, and a contract small enough that you can swap the backend without touching the UI.
+`@threadplane/chat` plus `@threadplane/langgraph` gets an Angular app to a streaming, production-shaped chat in three files.
+Signals all the way down, and a contract small enough that you can swap the backend without touching the UI.

--- a/apps/website/content/blog/2026-05-21-build-fullstack-agentic-angular-apps-using-ag-ui.mdx
+++ b/apps/website/content/blog/2026-05-21-build-fullstack-agentic-angular-apps-using-ag-ui.mdx
@@ -172,7 +172,10 @@ Three files, maybe twenty lines of code, and you have a working streaming chat b
   <figcaption>The AG-UI streaming demo running on @threadplane/chat with the @threadplane/ag-ui adapter — FakeAgent provides the events, but the same code drives real LangGraph/CrewAI/Mastra backends.</figcaption>
 </figure>
 
-No `EventSource`. No reducer. No manual subscribe-and-render plumbing. No store.
+No `EventSource`.
+No reducer.
+No manual subscribe-and-render plumbing.
+No store.
 
 Spin up your agent backend, point `url` at it, and the chat just works.
 
@@ -213,7 +216,9 @@ Your template reads these directly:
 }
 ```
 
-No `async` pipe gymnastics. No `OnDestroy` to clean up a subscription. No manual change-detection plumbing.
+No `async` pipe gymnastics.
+No `OnDestroy` to clean up a subscription.
+No manual change-detection plumbing.
 
 This works because streaming, at the data-shape level, is a sequence of small writes to a growing list — and so are signals.
 For me, the shape of the state is what makes Angular a good fit for agentic UIs, more than the templates or standalone components.
@@ -336,8 +341,12 @@ The framework intentionally hides the parts you do not want to think about on da
 
 The parts you will want on day thirty:
 
-- **Errors and retries.** Per-message retry, transport-level backoff for transient SSE drops, graceful degradation when streaming is unavailable. Some corporate proxies buffer SSE. You will find out the hard way if you do not plan for it.
-- **Generative UI.** When the agent wants to render a richer surface than a tool-call card, `@threadplane/render` lets the backend stream a UI spec and the frontend resolves it against a registry of your approved Angular components. No arbitrary code, no `eval`, no design-system bypass. The agent picks from a menu you control.
+- **Errors and retries.** Per-message retry, transport-level backoff for transient SSE drops, graceful degradation when streaming is unavailable.
+  Some corporate proxies buffer SSE.
+  You will find out the hard way if you do not plan for it.
+- **Generative UI.** When the agent wants to render a richer surface than a tool-call card, `@threadplane/render` lets the backend stream a UI spec and the frontend resolves it against a registry of your approved Angular components.
+  No arbitrary code, no `eval`, no design-system bypass.
+  The agent picks from a menu you control.
 - **Observability.** `@threadplane/telemetry` ships a PostHog-shaped sink that is *off by default*. Turn it on per-environment, point it at your own analytics, never ship app content to a vendor you did not pick.
 - **Testing.** Because the contract is signals all the way down, the testing story is "write a signal, the chat re-renders." `@threadplane/ag-ui` ships a `FakeAgent` you can hand-feed events to in a unit test. No SSE harness, no fixture loader, no test-only DI dance.
 

--- a/apps/website/content/blog/2026-05-21-build-fullstack-agentic-angular-apps-using-ag-ui.mdx
+++ b/apps/website/content/blog/2026-05-21-build-fullstack-agentic-angular-apps-using-ag-ui.mdx
@@ -9,7 +9,9 @@ featured: true
 
 This is how to build a fullstack agentic Angular app on the AG-UI protocol, from the backend event stream to a signal-driven chat surface in your component.
 
-The protocol between the agent and the UI is the durable piece of an agentic app — the model and the framework get the attention, but an open, shared wire format is what makes the work portable. AG-UI's event model maps onto Angular signals cleanly, which is what this post builds on.
+The protocol between the agent and the UI is the durable piece of an agentic app.
+The model and the framework get the attention, but an open, shared wire format is what makes the work portable.
+AG-UI's event model maps onto Angular signals cleanly, which is what this post builds on.
 
 ## Goals
 
@@ -19,45 +21,60 @@ The protocol between the agent and the UI is the durable piece of an agentic app
 
 ## What is AG-UI?
 
-AG-UI is the **Agent-User Interaction Protocol**. It's an open, event-based protocol for streaming an agent's state to a user-facing app over plain HTTP.
+AG-UI is the **Agent-User Interaction Protocol**.
+It is an open, event-based protocol for streaming an agent's state to a user-facing app over plain HTTP.
 
 The official one-liner from the docs:
 
 > An open, lightweight, event-based protocol that standardizes how AI agents connect to user-facing applications.
 
-That's the whole pitch. It standardizes the wire so the agent doesn't care what frontend you use, and the frontend doesn't care what backend you wrote.
+That is the whole pitch.
+It standardizes the wire so the agent does not care what frontend you use, and the frontend does not care what backend you wrote.
 
-It was introduced in 2025 and open-sourced after years of integrating agent runtimes into frontend apps. The wire format became the durable piece. It's now the third member of an emerging triad of agent protocols:
+It was introduced in 2025 and open-sourced after years of integrating agent runtimes into frontend apps.
+The wire format became the durable piece.
+It is now the third member of an emerging triad of agent protocols:
 
 - **MCP**: agent ↔ tools.
 - **A2A**: agent ↔ other agents.
 - **AG-UI**: agent ↔ user.
 
-A real production agent typically speaks all three. The interesting one for us is AG-UI, because it's the one your *users* see.
+A real production agent typically speaks all three.
+The interesting one for us is AG-UI, because it is the one your *users* see.
 
 ### Why Angular devs should care
 
-For the last two years, the most visible agentic UI libraries have been React-first. If you were building an Angular app, your options were:
+For the last two years, the most visible agentic UI libraries have been React-first.
+If you were building an Angular app, your options were:
 
 1. Reach for `EventSource`, hand-roll the SSE parsing, and reinvent message lists, status, tool cards, and interrupts for the fifth time.
-2. Iframe a React app into your Angular app. (Please don't.)
+2. Iframe a React app into your Angular app. (Please do not.)
 3. Wait.
 
-AG-UI changes the math. The protocol is framework-agnostic, the official `@ag-ui/client` SDK is plain TypeScript with RxJS, and the event model is a sequence of small writes to a growing list — exactly what Angular signals are. The whole protocol is seventeen events; you can hold it in your head.
+AG-UI changes the math.
+The protocol is framework-agnostic, the official `@ag-ui/client` SDK is plain TypeScript with RxJS, and the event model is a sequence of small writes to a growing list — exactly what Angular signals are.
+The whole protocol is seventeen events; you can hold it in your head.
 
 ## The fullstack picture
 
-Before any code, let's draw the seams.
+The seams come first, before any code.
 
 <AgUiArchDiagram />
 
 Three boxes. Two seams.
 
-**The backend.** Whatever you want, as long as it can emit AG-UI events. LangGraph, CrewAI, Mastra, Microsoft Agent Framework, Pydantic AI, AG2, AWS Strands, Agno. They all have first-party or partnership adapters. If your backend isn't on that list, you write a small middleware that yields AG-UI events. The [middleware guide](https://docs.ag-ui.com/quickstart/middleware) walks through it.
+**The backend.** Whatever you want, as long as it can emit AG-UI events.
+LangGraph, CrewAI, Mastra, Microsoft Agent Framework, Pydantic AI, AG2, AWS Strands, Agno. They all have first-party or partnership adapters.
+If your backend is not on that list, you write a small middleware that yields AG-UI events. The [middleware guide](https://docs.ag-ui.com/quickstart/middleware) walks through it.
 
-**The wire.** Server-Sent Events. Plain HTTP, no WebSocket gymnastics, no custom binary framing. Your firewall, load balancer, and reverse proxy already know what to do with it.
+**The wire.** Server-Sent Events.
+Plain HTTP, no WebSocket gymnastics, no custom binary framing.
+Your firewall, load balancer, and reverse proxy already know what to do with it.
 
-**The Angular side.** This is what Threadplane provides. `@threadplane/ag-ui` is the adapter. It consumes the AG-UI event stream and exposes a runtime-neutral `Agent` contract built from signals. `@threadplane/chat` is the UI. It reads from that contract and renders. The two are decoupled on purpose. We'll get to why.
+**The Angular side.** This is what Threadplane provides.
+`@threadplane/ag-ui` is the adapter. It consumes the AG-UI event stream and exposes a runtime-neutral `Agent` contract built from signals.
+`@threadplane/chat` is the UI. It reads from that contract and renders.
+The two are decoupled on purpose. We will get to why.
 
 ## Let's wire it up
 
@@ -89,7 +106,8 @@ yarn add @threadplane/ag-ui @threadplane/chat marked
 </Tab>
 </Tabs>
 
-`marked` is the markdown renderer the chat uses for assistant messages. It's a peer dep so you can swap it.
+`marked` is the markdown renderer the chat uses for assistant messages.
+It is a peer dep so you can swap it.
 
 ### Provide the agent
 
@@ -107,9 +125,14 @@ export const appConfig: ApplicationConfig = {
 };
 ```
 
-That's the whole bootstrap. `provideAgent` is the AG-UI transport. It wraps the official `@ag-ui/client` `HttpAgent` and exposes the signal-shaped contract via DI. `provideChat` is the chat UI's configuration.
+That is the whole bootstrap.
+`provideAgent` is the AG-UI transport. It wraps the official `@ag-ui/client` `HttpAgent` and exposes the signal-shaped contract via DI.
+`provideChat` is the chat UI's configuration.
 
-Notice they're independent. `@threadplane/chat` doesn't know it's talking to an AG-UI backend. It just reads from the `Agent` contract. We'll lean on that boundary later.
+Notice they are independent.
+`@threadplane/chat` does not know it is talking to an AG-UI backend.
+It just reads from the `Agent` contract.
+We will lean on that boundary later.
 
 ### Render the chat
 
@@ -135,7 +158,8 @@ export class ChatPageComponent {
 }
 ```
 
-That's it. Three files, maybe twenty lines of code, and you have a working streaming chat backed by any AG-UI-compatible agent.
+That is it.
+Three files, maybe twenty lines of code, and you have a working streaming chat backed by any AG-UI-compatible agent.
 
 <figure>
   <img
@@ -162,7 +186,10 @@ The AG-UI protocol has seventeen event types, grouped into five families:
 - **State sync**: `STATE_SNAPSHOT`, `STATE_DELTA`, `MESSAGES_SNAPSHOT`.
 - **Reasoning**: for thinking-style models like o1 and Claude with extended thinking.
 
-The families each do specific work. Lifecycle answers "is something happening?" Text messages are the streaming triad familiar from chat UIs. Tool calls are deliberately incremental so you can render the *intent* before the arguments are fully formed. State sync uses RFC 6902 JSON Patch so the wire stays small even when the agent's state is large.
+The families each do specific work.
+Lifecycle answers "is something happening?" Text messages are the streaming triad familiar from chat UIs.
+Tool calls are deliberately incremental so you can render the *intent* before the arguments are fully formed.
+State sync uses RFC 6902 JSON Patch so the wire stays small even when the agent's state is large.
 
 Threadplane's `@threadplane/ag-ui` runs each event through a small reducer that updates a handful of signals on the `Agent` contract:
 
@@ -188,11 +215,13 @@ Your template reads these directly:
 
 No `async` pipe gymnastics. No `OnDestroy` to clean up a subscription. No manual change-detection plumbing.
 
-This works because streaming, at the data-shape level, is a sequence of small writes to a growing list — and so are signals. The shape of the state is what makes Angular a good fit for agentic UIs, more than the templates or standalone components.
+This works because streaming, at the data-shape level, is a sequence of small writes to a growing list — and so are signals.
+For me, the shape of the state is what makes Angular a good fit for agentic UIs, more than the templates or standalone components.
 
 ## Tool calls and interrupts
 
-Two surfaces that separate a "chat with a model" from a "real agent" are tool calls and interrupts. Let's look at both.
+Two surfaces separate a "chat with a model" from a "real agent": tool calls and interrupts.
+Both are worth a close look.
 
 ### Tool calls
 
@@ -207,9 +236,11 @@ TOOL_CALL_END   { id: "1" }
 TOOL_CALL_RESULT { id: "1", result: { files: [...] } }
 ```
 
-The `<chat>` component renders this as a tool-call card by default. A small block in the message list showing the tool name, the args (formatted, even mid-stream), a spinner while it's running, and the result when it returns.
+The `<chat>` component renders this as a tool-call card by default.
+A small block in the message list showing the tool name, the args (formatted, even mid-stream), a spinner while it is running, and the result when it returns.
 
-You almost never want the default forever. You want *your* card for your most important tools: branded, with a click-through to the data, an approve/reject button, whatever your product needs.
+I think you almost never want the default forever.
+You want *your* card for your most important tools: branded, with a click-through to the data, an approve/reject button, whatever your product needs.
 
 ```html
 <chat [agent]="agent">
@@ -219,13 +250,15 @@ You almost never want the default forever. You want *your* card for your most im
 </chat>
 ```
 
-The slot pattern is intentional. The chat ships defaults so you can demo in a day, and it gets out of your way the moment you have a real design system to hit.
+The slot pattern is intentional.
+The chat ships defaults so you can demo in a day, and it gets out of your way the moment you have a real design system to hit.
 
 ### Interrupts
 
 An interrupt is the agent saying *"I need a human before I do this thing."*
 
-You see them in production agents constantly: approve this database write, confirm this email send, choose between these three branches, fill in this missing field. AG-UI surfaces interrupts as state on the agent, and `@threadplane/chat` renders them inline in the message list with whatever resume affordance you give it.
+You see them in production agents constantly: approve this database write, confirm this email send, choose between these three branches, fill in this missing field.
+AG-UI surfaces interrupts as state on the agent, and `@threadplane/chat` renders them inline in the message list with whatever resume affordance you give it.
 
 ```html
 @if (agent.interrupt(); as pause) {
@@ -237,20 +270,25 @@ You see them in production agents constantly: approve this database write, confi
 }
 ```
 
-The agent stays paused until you call `resume()`. On the backend, your graph picks up exactly where it left off — which is the entire point of human-in-the-loop.
+The agent stays paused until you call `resume()`.
+On the backend, your graph picks up exactly where it left off — which is the entire point of human-in-the-loop.
 
 ## Threads, persistence, and the things demos skip
 
-A single-thread chat is a demo. A real product remembers conversations across sessions and across devices.
+A single-thread chat is a demo.
+A real product remembers conversations across sessions and across devices.
 
-AG-UI itself is stateless on the wire. Every run carries a `threadId`, and the backend is responsible for persistence. Most adapters expose thread CRUD as a small API:
+AG-UI itself is stateless on the wire.
+Every run carries a `threadId`, and the backend is responsible for persistence.
+Most adapters expose thread CRUD as a small API:
 
 - list threads
 - create a thread
 - switch threads
 - delete a thread
 
-The Angular-side pattern is to bind the `threadId` to a signal (usually from your router or a sidebar selection) and the chat re-reads the new thread automatically. No manual unsubscribe. No race conditions.
+The Angular-side pattern is to bind the `threadId` to a signal (usually from your router or a sidebar selection) and the chat re-reads the new thread automatically.
+No manual unsubscribe. No race conditions.
 
 ```ts
 protected readonly threadId = signal<string | null>(null);
@@ -263,7 +301,8 @@ constructor() {
 }
 ```
 
-How you scope threads — per project, per task, per user session — is a product decision. The one thing to avoid is shipping a chat where every refresh starts from zero.
+How you scope threads — per project, per task, per user session — is a product decision.
+The one thing to avoid is shipping a chat where every refresh starts from zero.
 
 If you want a starting point, `@threadplane/chat` exposes a `<chat-sidebar>` primitive that handles the layout without locking you into a persistence model.
 
@@ -271,7 +310,9 @@ If you want a starting point, `@threadplane/chat` exposes a `<chat-sidebar>` pri
 
 This is the part that pays off the protocol bet.
 
-Say you started with a Python LangGraph backend, shipped to production, and a quarter later you decide you want to migrate one graph to Mastra because the team writing it lives in TypeScript. With AG-UI, that's a backend change. Your Angular code does not move.
+Say you started with a Python LangGraph backend, shipped to production, and a quarter later you decide you want to migrate one graph to Mastra because the team writing it lives in TypeScript.
+With AG-UI, that is a backend change.
+Your Angular code does not move.
 
 ```ts
 // before
@@ -281,25 +322,33 @@ provideAgent({ url: '/agents/langgraph' }),
 provideAgent({ url: '/agents/mastra' }),
 ```
 
-That's the diff.
+That is the diff.
 
-The same applies in reverse. If you're already on a LangGraph stack and want tighter coupling than AG-UI gives you, `@threadplane/langgraph` is a direct adapter for LangGraph's native streaming API. It speaks the same `Agent` contract to `@threadplane/chat`, so your UI doesn't change either way. Pick whichever fits your team — the list of backends that already speak AG-UI covers most of what you'd reach for, and the protocol is small enough to stay stable.
+The same applies in reverse.
+If you are already on a LangGraph stack and want tighter coupling than AG-UI gives you, `@threadplane/langgraph` is a direct adapter for LangGraph's native streaming API.
+It speaks the same `Agent` contract to `@threadplane/chat`, so your UI does not change either way.
+Pick whichever fits your team — the list of backends that already speak AG-UI covers most of what you would reach for, and the protocol is small enough to stay stable.
 
 ## A note on the rest of the iceberg
 
-The scaffold above is *short* on purpose. The framework intentionally hides the parts you don't want to think about on day one.
+The scaffold above is *short* on purpose.
+The framework intentionally hides the parts you do not want to think about on day one.
 
-The parts you'll want on day thirty:
+The parts you will want on day thirty:
 
-- **Errors and retries.** Per-message retry, transport-level backoff for transient SSE drops, graceful degradation when streaming is unavailable. Some corporate proxies buffer SSE. You'll find out the hard way if you don't plan for it.
+- **Errors and retries.** Per-message retry, transport-level backoff for transient SSE drops, graceful degradation when streaming is unavailable. Some corporate proxies buffer SSE. You will find out the hard way if you do not plan for it.
 - **Generative UI.** When the agent wants to render a richer surface than a tool-call card, `@threadplane/render` lets the backend stream a UI spec and the frontend resolves it against a registry of your approved Angular components. No arbitrary code, no `eval`, no design-system bypass. The agent picks from a menu you control.
-- **Observability.** `@threadplane/telemetry` ships a PostHog-shaped sink that is *off by default*. Turn it on per-environment, point it at your own analytics, never ship app content to a vendor you didn't pick.
+- **Observability.** `@threadplane/telemetry` ships a PostHog-shaped sink that is *off by default*. Turn it on per-environment, point it at your own analytics, never ship app content to a vendor you did not pick.
 - **Testing.** Because the contract is signals all the way down, the testing story is "write a signal, the chat re-renders." `@threadplane/ag-ui` ships a `FakeAgent` you can hand-feed events to in a unit test. No SSE harness, no fixture loader, no test-only DI dance.
 
-Each of those is its own post. The point here is just that the protocol-to-signal-to-template chain is the *spine*, and everything else hangs off it.
+Each of those is its own post.
+The point here is just that the protocol-to-signal-to-template chain is the *spine*, and everything else hangs off it.
 
 ## Conclusion
 
-AG-UI standardizes the wire between the agent and the UI: it's small enough to hold in your head, and the event model maps onto Angular signals cleanly. With Threadplane (`@threadplane/ag-ui` and `@threadplane/chat` on npm), the wiring is three lines — a provider, an inject, and a `<chat>` — which leaves the interesting work (tool cards, interrupt flows, generative UI, your design system) as the part you spend the day on.
+AG-UI standardizes the wire between the agent and the UI: it is small enough to hold in your head, and the event model maps onto Angular signals cleanly.
+With Threadplane (`@threadplane/ag-ui` and `@threadplane/chat` on npm), the wiring is three lines — a provider, an inject, and a `<chat>` — which leaves the interesting work (tool cards, interrupt flows, generative UI, your design system) as the part you spend the day on.
+That is the trade the protocol buys you.
 
-Every Threadplane package is MIT-licensed. If you're building this inside an enterprise Angular app and want production assurance or delivery support, [talk to us](/contact?source=blog_ag_ui_pillar&track=enterprise).
+Every Threadplane package is MIT-licensed.
+If you are building this inside an enterprise Angular app and want production assurance or delivery support, [talk to us](/contact?source=blog_ag_ui_pillar&track=enterprise).

--- a/apps/website/content/blog/2026-05-28-human-in-the-loop-langgraph-agents-in-angular.mdx
+++ b/apps/website/content/blog/2026-05-28-human-in-the-loop-langgraph-agents-in-angular.mdx
@@ -11,7 +11,8 @@ This is how to pause a LangGraph agent in Angular for human approval before it r
 
 The example is a refund agent: it drafts a refund, then stops and asks an operator to approve, edit, or cancel before any charge is reversed.
 
-Everything below is running code from the cockpit example at `cockpit/langgraph/interrupts`. Clone the repo, run `nx serve cockpit-langgraph-interrupts-angular`, and follow along.
+Everything below is running code from the cockpit example at `cockpit/langgraph/interrupts`.
+Clone the repo, run `nx serve cockpit-langgraph-interrupts-angular`, and follow along.
 
 <div style={{ marginTop: 40, marginBottom: 44 }}>
 <CardGroup cols={2}>
@@ -32,9 +33,13 @@ Everything below is running code from the cockpit example at `cockpit/langgraph/
 
 ## When should you use an interrupt?
 
-Most tool calls don't need approval. Reads, searches, and lookups can run unattended. Reach for an interrupt when a tool does something the operator wouldn't want to undo by hand: moves money, sends a customer-facing message, deletes a record, or triggers a deploy.
+Most tool calls do not need approval.
+Reads, searches, and lookups can run unattended.
+Reach for an interrupt when a tool does something the operator would not want to undo by hand: moves money, sends a customer-facing message, deletes a record, or triggers a deploy.
 
-Two practical reasons: it caps the cost of a misfiring agent looping over a write API, and it gives the operator a checkpoint to catch a wrong action before it lands.
+For me, there are two practical reasons.
+It caps the cost of a misfiring agent looping over a write API.
+And it gives the operator a checkpoint to catch a wrong action before it lands.
 
 ## The architecture
 
@@ -44,7 +49,8 @@ Three pieces:
 - **`@threadplane/langgraph` adapter.** Surfaces the pending interrupt on an `agent.interrupt()` signal. `agent.submit({ resume })` writes a value back to the paused graph.
 - **`@threadplane/chat` UI.** `<chat-approval-card>` reads the pending interrupt, opens a native `<dialog>` modal, and emits `'approve' | 'edit' | 'cancel'`.
 
-The LangGraph node doesn't know how the UI renders, and the Angular component doesn't know which graph it's paused inside. That lets you reuse one approval dialog across multiple agents.
+The LangGraph node does not know how the UI renders, and the Angular component does not know which graph it is paused inside.
+That lets you reuse one approval dialog across multiple agents.
 
 <figure>
   <img src="/blog/2026-05-28-human-in-the-loop-langgraph-agents-in-angular/1.png" alt="The refund agent's welcome screen with two suggestion chips: 'Refund a duplicate charge' and 'Refund a chargeback.'" width="1280" height="800" />
@@ -58,7 +64,8 @@ Three files.
 <Steps>
 <Step title="The LangGraph node">
 
-A structured-output call populates the fields the approval card displays. Then `request_approval` pauses with `interrupt()`:
+A structured-output call populates the fields the approval card displays.
+Then `request_approval` pauses with `interrupt()`:
 
 ```python
 # graph.py — cockpit/langgraph/interrupts/python/src/graph.py
@@ -100,7 +107,9 @@ def request_approval(state: RefundState) -> dict:
     }
 ```
 
-`interrupt()` pauses the graph and persists its payload. The graph stays paused until `agent.submit({ resume })` runs against the same thread — and that value becomes the return value of `interrupt()` when the node re-executes. That's why `request_approval` can branch on `decision["approved"]` and pick up an edited `amount`.
+`interrupt()` pauses the graph and persists its payload.
+The graph stays paused until `agent.submit({ resume })` runs against the same thread — and that value becomes the return value of `interrupt()` when the node re-executes.
+That is why `request_approval` can branch on `decision["approved"]` and pick up an edited `amount`.
 
 </Step>
 <Step title="Wire the providers">
@@ -167,9 +176,13 @@ export class InterruptsComponent {
 }
 ```
 
-`<chat-approval-card>` reads `agent.interrupt()`, matches the `kind` you pass to `matchKind`, opens a native `<dialog>`, and emits an action on each button click. The body is a content-projected template — render whatever fits the payload.
+`<chat-approval-card>` reads `agent.interrupt()`, matches the `kind` you pass to `matchKind`, opens a native `<dialog>`, and emits an action on each button click.
+The body is a content-projected template — render whatever fits the payload.
 
-Approve and Cancel are terminal: they resolve the interrupt and close the dialog. Edit is not. Clicking Edit leaves the dialog open so you can reveal an inline editor and submit the resume yourself. That distinction lives in the composition.
+Approve and Cancel are terminal: they resolve the interrupt and close the dialog.
+Edit is not.
+Clicking Edit leaves the dialog open so you can reveal an inline editor and submit the resume yourself.
+That distinction lives in the composition.
 
 </Step>
 </Steps>
@@ -191,7 +204,8 @@ Approve and Cancel are terminal: they resolve the interrupt and close the dialog
 8. `request_approval` re-runs; `interrupt()` returns `{ approved: true }` instead of pausing.
 9. The graph continues to `issue_refund` and finishes.
 
-It's one thread and one persisted state. If the operator closes the tab and returns later, the interrupt is still pending.
+It is one thread and one persisted state.
+If the operator closes the tab and returns later, the interrupt is still pending.
 
 <figure>
   <img src="/blog/2026-05-28-human-in-the-loop-langgraph-agents-in-angular/3.png" alt="The chat after approval, showing the agent's draft summary and a confirmation: 'Refund of $47.50 issued to cus_a8x2k. Refund ID: re_demo__a8x2k.'" width="1280" height="800" />
@@ -202,7 +216,9 @@ It's one thread and one persisted state. If the operator closes the tab and retu
 
 ### Idempotency
 
-`interrupt()` re-executes the node on resume. Side effects before the call have already run; side effects after run again on resume. Put the write (the Stripe `refund.create`) on the resumed side, and pass an idempotency key through state so a double-click doesn't issue two refunds.
+`interrupt()` re-executes the node on resume.
+Side effects before the call have already run; side effects after run again on resume.
+Put the write (the Stripe `refund.create`) on the resumed side, and pass an idempotency key through state so a double-click does not issue two refunds.
 
 ### Audit trail
 
@@ -222,7 +238,8 @@ protected async onAction(action: ChatApprovalAction): Promise<void> {
 
 ### What not to interrupt
 
-Interrupt on writes the operator wouldn't want to undo by hand — money movement, customer-facing messages, destructive deletes. If you can undo it with a script in under a minute, let the agent run.
+My rule is simple: interrupt on writes the operator would not want to undo by hand — money movement, customer-facing messages, destructive deletes.
+If you can undo it with a script in under a minute, let the agent run.
 
 ## Next
 

--- a/apps/website/content/blog/2026-06-04-human-in-the-loop-ag-ui-agents-in-angular.mdx
+++ b/apps/website/content/blog/2026-06-04-human-in-the-loop-ag-ui-agents-in-angular.mdx
@@ -72,9 +72,18 @@ The `<chat-approval-card>` you build today survives the backend you swap in next
 
 Three pieces:
 
-- **AG-UI-fronted LangGraph backend.** The same compiled graph as the LangGraph post, duplicated under `cockpit/ag-ui/interrupts/python` because cockpit examples are standalone. Wrapped with `ag-ui-langgraph`'s `LangGraphAgent(name, graph)` + `add_langgraph_fastapi_endpoint(app, agent, path='/agent')` and served by `uvicorn`. When `interrupt()` fires inside the graph, `ag-ui-langgraph` emits a `CUSTOM` AG-UI event with `name: 'on_interrupt'` and a `value` carrying the interrupt payload — serialized as a JSON string via `dump_json_safe`. The uvicorn server needs a `MemorySaver` checkpointer (`langgraph dev` and LangGraph Platform inject one automatically; plain uvicorn does not, and `aget_state` raises "No checkpointer set" without it).
-- **`@threadplane/ag-ui` adapter.** The reducer recognizes the `CUSTOM`/`on_interrupt` event, JSON-parses the string `value` so consumers see the structured object, and sets `agent.interrupt()` to `{ id, value, resumable: true }`. `agent.submit({ resume })` short-circuits the message-append path and calls `source.runAgent({ forwardedProps: { command: { resume } } })`. The server reads `forwarded_props.command.resume`. The adapter exposes the same `Agent` contract as `@threadplane/langgraph`.
-- **`@threadplane/chat` UI.** `<chat-approval-card matchKind="refund_approval">` reads `agent.interrupt()`, opens a `<dialog>`-backed modal, and emits `'approve' | 'edit' | 'cancel'`. Resume actions call `agent.submit({ resume: { approved, amount? } })`. Reject calls `submit({ resume: { approved: false } })`. The component does not know which adapter is wired. That is the point.
+- **AG-UI-fronted LangGraph backend.** The same compiled graph as the LangGraph post, duplicated under `cockpit/ag-ui/interrupts/python` because cockpit examples are standalone.
+  Wrapped with `ag-ui-langgraph`'s `LangGraphAgent(name, graph)` + `add_langgraph_fastapi_endpoint(app, agent, path='/agent')` and served by `uvicorn`.
+  When `interrupt()` fires inside the graph, `ag-ui-langgraph` emits a `CUSTOM` AG-UI event with `name: 'on_interrupt'` and a `value` carrying the interrupt payload — serialized as a JSON string via `dump_json_safe`.
+  The uvicorn server needs a `MemorySaver` checkpointer (`langgraph dev` and LangGraph Platform inject one automatically; plain uvicorn does not, and `aget_state` raises "No checkpointer set" without it).
+- **`@threadplane/ag-ui` adapter.** The reducer recognizes the `CUSTOM`/`on_interrupt` event, JSON-parses the string `value` so consumers see the structured object, and sets `agent.interrupt()` to `{ id, value, resumable: true }`. `agent.submit({ resume })` short-circuits the message-append path and calls `source.runAgent({ forwardedProps: { command: { resume } } })`.
+  The server reads `forwarded_props.command.resume`.
+  The adapter exposes the same `Agent` contract as `@threadplane/langgraph`.
+- **`@threadplane/chat` UI.** `<chat-approval-card matchKind="refund_approval">` reads `agent.interrupt()`, opens a `<dialog>`-backed modal, and emits `'approve' | 'edit' | 'cancel'`.
+  Resume actions call `agent.submit({ resume: { approved, amount? } })`.
+  Reject calls `submit({ resume: { approved: false } })`.
+  The component does not know which adapter is wired.
+  That is the point.
 
 The data flow on resume:
 

--- a/apps/website/content/blog/2026-06-04-human-in-the-loop-ag-ui-agents-in-angular.mdx
+++ b/apps/website/content/blog/2026-06-04-human-in-the-loop-ag-ui-agents-in-angular.mdx
@@ -7,9 +7,12 @@ author: brian
 featured: true
 ---
 
-This is how to pause an AG-UI agent in Angular for human approval before it runs a high-stakes tool, using a `CUSTOM` `on_interrupt` event and the `<chat-approval-card>` composition from `@threadplane/chat`. The example is the same refund agent from [Human-in-the-Loop LangGraph Agents in Angular](/blog/2026-05-28-human-in-the-loop-langgraph-agents-in-angular) — wired through the AG-UI adapter instead. The Angular component is byte-identical except the import.
+This is how to pause an AG-UI agent in Angular for human approval before it runs a high-stakes tool, using a `CUSTOM` `on_interrupt` event and the `<chat-approval-card>` composition from `@threadplane/chat`.
+The example is the same refund agent from [Human-in-the-Loop LangGraph Agents in Angular](/blog/2026-05-28-human-in-the-loop-langgraph-agents-in-angular) — wired through the AG-UI adapter instead.
+The Angular component is byte-identical except the import.
 
-Everything below is running code from the cockpit example at `cockpit/ag-ui/interrupts`. Clone the repo, run `nx serve cockpit-ag-ui-interrupts-angular`, and follow along.
+Everything below is running code from the cockpit example at `cockpit/ag-ui/interrupts`.
+Clone the repo, run `nx serve cockpit-ag-ui-interrupts-angular`, and follow along.
 
 <div style={{ marginTop: 40, marginBottom: 44 }}>
 <CardGroup cols={2}>
@@ -44,17 +47,26 @@ The `app.config.ts` adapter swap is one line in the providers array:
 + provideAgent({ url: '/agent' }),
 ```
 
-That's the whole client-side delta. The rest of the file — the template binding `<chat-approval-card>`, the `(action)` handler, the approve / edit / cancel branches, the `submit({ resume })` call — is unchanged.
+That is the whole client-side delta.
+The rest of the file — the template binding `<chat-approval-card>`, the `(action)` handler, the approve / edit / cancel branches, the `submit({ resume })` call — is unchanged.
 
-`<chat-approval-card>` reads `agent.interrupt()` (a `Signal<AgentInterrupt | undefined>`), and `submit({ resume })` is part of the runtime-neutral `Agent` contract declared in `@threadplane/chat`. Both adapters populate the signal and forward the resume; the chat surface above doesn't see the wire format.
+`<chat-approval-card>` reads `agent.interrupt()` (a `Signal<AgentInterrupt | undefined>`), and `submit({ resume })` is part of the runtime-neutral `Agent` contract declared in `@threadplane/chat`.
+Both adapters populate the signal and forward the resume.
+The chat surface above does not see the wire format.
 
 ## When should you use an interrupt?
 
-Most tool calls don't need approval. Reads, searches, and lookups can run unattended. Reach for an interrupt when a tool does something the operator wouldn't want to undo by hand: moves money, sends a customer-facing message, deletes a record, or triggers a deploy.
+Most tool calls do not need approval.
+Reads, searches, and lookups can run unattended.
+Reach for an interrupt when a tool does something the operator would not want to undo by hand: moves money, sends a customer-facing message, deletes a record, or triggers a deploy.
 
-Two practical reasons hold up: it caps the cost of a misfiring agent looping over a write API, and it gives the operator a checkpoint to catch a wrong action before it lands.
+For me, two practical reasons hold up.
+An interrupt caps the cost of a misfiring agent looping over a write API, and it gives the operator a checkpoint to catch a wrong action before it lands.
 
-The AG-UI angle adds a third. Because AG-UI normalizes the wire across many backends, the same operator-approval checkpoint plugs into LangGraph, CrewAI, Mastra, Pydantic AI, or anything else that speaks AG-UI — with no UI rewrite. If your shop runs more than one agent backend, that's a real benefit. The `<chat-approval-card>` you build today survives the backend you swap in next year.
+The AG-UI angle adds a third.
+Because AG-UI normalizes the wire across many backends, the same operator-approval checkpoint plugs into LangGraph, CrewAI, Mastra, Pydantic AI, or anything else that speaks AG-UI — with no UI rewrite.
+If your shop runs more than one agent backend, I think that is a real benefit.
+The `<chat-approval-card>` you build today survives the backend you swap in next year.
 
 ## The architecture
 
@@ -62,7 +74,7 @@ Three pieces:
 
 - **AG-UI-fronted LangGraph backend.** The same compiled graph as the LangGraph post, duplicated under `cockpit/ag-ui/interrupts/python` because cockpit examples are standalone. Wrapped with `ag-ui-langgraph`'s `LangGraphAgent(name, graph)` + `add_langgraph_fastapi_endpoint(app, agent, path='/agent')` and served by `uvicorn`. When `interrupt()` fires inside the graph, `ag-ui-langgraph` emits a `CUSTOM` AG-UI event with `name: 'on_interrupt'` and a `value` carrying the interrupt payload — serialized as a JSON string via `dump_json_safe`. The uvicorn server needs a `MemorySaver` checkpointer (`langgraph dev` and LangGraph Platform inject one automatically; plain uvicorn does not, and `aget_state` raises "No checkpointer set" without it).
 - **`@threadplane/ag-ui` adapter.** The reducer recognizes the `CUSTOM`/`on_interrupt` event, JSON-parses the string `value` so consumers see the structured object, and sets `agent.interrupt()` to `{ id, value, resumable: true }`. `agent.submit({ resume })` short-circuits the message-append path and calls `source.runAgent({ forwardedProps: { command: { resume } } })`. The server reads `forwarded_props.command.resume`. The adapter exposes the same `Agent` contract as `@threadplane/langgraph`.
-- **`@threadplane/chat` UI.** `<chat-approval-card matchKind="refund_approval">` reads `agent.interrupt()`, opens a `<dialog>`-backed modal, and emits `'approve' | 'edit' | 'cancel'`. Resume actions call `agent.submit({ resume: { approved, amount? } })`. Reject calls `submit({ resume: { approved: false } })`. The component doesn't know which adapter is wired. That's the point.
+- **`@threadplane/chat` UI.** `<chat-approval-card matchKind="refund_approval">` reads `agent.interrupt()`, opens a `<dialog>`-backed modal, and emits `'approve' | 'edit' | 'cancel'`. Resume actions call `agent.submit({ resume: { approved, amount? } })`. Reject calls `submit({ resume: { approved: false } })`. The component does not know which adapter is wired. That is the point.
 
 The data flow on resume:
 
@@ -74,7 +86,8 @@ The data flow on resume:
         → ag-ui-langgraph: Command(resume=value) → graph continues
 ```
 
-On the LangGraph adapter, the same `submit({ resume })` becomes a native `Client.submit(thread, command={resume:…})` call. Different wire, same Angular surface.
+On the LangGraph adapter, the same `submit({ resume })` becomes a native `Client.submit(thread, command={resume:…})` call.
+Different wire, same Angular surface.
 
 <figure>
   <img src="/blog/2026-06-04-human-in-the-loop-ag-ui-agents-in-angular/1.png" alt="The cockpit ag-ui/interrupts welcome screen showing two suggestion chips: 'Refund a duplicate charge' and 'Refund a chargeback.'" width="1280" height="800" />
@@ -144,12 +157,14 @@ def request_approval(state: RefundState) -> dict:
     }
 ```
 
-This file is **duplicated** into `cockpit/ag-ui/interrupts/python/src/graph.py` per the cockpit standalone-examples convention — copy, don't import across examples. The graph itself doesn't know it'll be served over AG-UI.
+This file is **duplicated** into `cockpit/ag-ui/interrupts/python/src/graph.py` per the cockpit standalone-examples convention — copy, do not import across examples.
+The graph itself does not know it will be served over AG-UI.
 
 </Step>
 <Step title="Wrap the graph with ag-ui-langgraph + uvicorn">
 
-`ag-ui-langgraph` translates LangGraph runtime events into AG-UI protocol events and mounts a FastAPI endpoint. We add a `/ok` route for the e2e harness's readiness check:
+`ag-ui-langgraph` translates LangGraph runtime events into AG-UI protocol events and mounts a FastAPI endpoint.
+We add a `/ok` route for the e2e harness's readiness check:
 
 ```python
 # server.py — cockpit/ag-ui/interrupts/python/src/server.py
@@ -204,7 +219,8 @@ export default {
 };
 ```
 
-AG-UI's `provideAgent({ url })` and LangGraph's `provideAgent({ apiUrl, assistantId })` share the symmetric provider name but take different config shapes because the wire protocols differ. The provider+inject names are deliberately symmetric across both adapters — that's what makes the component code unchanged.
+AG-UI's `provideAgent({ url })` and LangGraph's `provideAgent({ apiUrl, assistantId })` share the symmetric provider name but take different config shapes because the wire protocols differ.
+The provider+inject names are deliberately symmetric across both adapters — that is what makes the component code unchanged.
 
 </Step>
 <Step title="The Angular component">
@@ -328,9 +344,14 @@ export class InterruptsComponent {
 }
 ```
 
-This is the same file as `cockpit/langgraph/interrupts/angular/src/app/interrupts.component.ts` from the LangGraph post — **byte-identical except for the `injectAgent` import**. The template binds `<chat-approval-card matchKind="refund_approval">` to the agent. When `agent.interrupt()` becomes non-undefined, the dialog opens. The `(action)` event fires `'approve' | 'edit' | 'cancel'`; the handler calls `agent.submit({ resume: { approved, amount? } })`. The `{ approved, amount? }` shape couples back to whatever the LangGraph node will read from `Command(resume=…)` — keep them in sync.
+This is the same file as `cockpit/langgraph/interrupts/angular/src/app/interrupts.component.ts` from the LangGraph post — **byte-identical except for the `injectAgent` import**.
+The template binds `<chat-approval-card matchKind="refund_approval">` to the agent.
+When `agent.interrupt()` becomes non-undefined, the dialog opens.
+The `(action)` event fires `'approve' | 'edit' | 'cancel'`; the handler calls `agent.submit({ resume: { approved, amount? } })`.
+The `{ approved, amount? }` shape couples back to whatever the LangGraph node will read from `Command(resume=…)` — keep them in sync.
 
-The `matchKind` input is the discriminator pattern that keeps the dialog component reusable across interrupt kinds. If your graph emits `interrupt({ kind: 'deploy_approval', … })`, a separate `<chat-approval-card matchKind="deploy_approval">` instance picks that up — same component, different match.
+The `matchKind` input is the discriminator pattern that keeps the dialog component reusable across interrupt kinds.
+If your graph emits `interrupt({ kind: 'deploy_approval', … })`, a separate `<chat-approval-card matchKind="deploy_approval">` instance picks that up — same component, different match.
 
 </Step>
 </Steps>
@@ -339,11 +360,14 @@ The `matchKind` input is the discriminator pattern that keeps the dialog compone
 
 ### Streaming start → the draft
 
-The user clicks "Refund a duplicate charge." A run starts; token-level `TEXT_MESSAGE_CONTENT` events stream the assistant's draft and `messages()` updates incrementally. For more on the AG-UI streaming model, see [Build Fullstack Agentic Angular Apps Using AG-UI](/blog/2026-05-21-build-fullstack-agentic-angular-apps-using-ag-ui).
+The user clicks "Refund a duplicate charge."
+A run starts; token-level `TEXT_MESSAGE_CONTENT` events stream the assistant's draft and `messages()` updates incrementally.
+For more on the AG-UI streaming model, see [Build Fullstack Agentic Angular Apps Using AG-UI](/blog/2026-05-21-build-fullstack-agentic-angular-apps-using-ag-ui).
 
 ### The interrupt arrives
 
-The structured-output call finishes, the graph hits `request_approval`, and `interrupt({ kind: 'refund_approval', … })` fires. `ag-ui-langgraph` emits the `CUSTOM` event on the SSE stream:
+The structured-output call finishes, the graph hits `request_approval`, and `interrupt({ kind: 'refund_approval', … })` fires.
+`ag-ui-langgraph` emits the `CUSTOM` event on the SSE stream:
 
 ```jsonc
 // AG-UI event on the wire
@@ -354,7 +378,8 @@ The structured-output call finishes, the graph hits `request_approval`, and `int
 }
 ```
 
-`value` is a JSON string — that's the `dump_json_safe` quirk. The `@threadplane/ag-ui` reducer parses it and sets:
+`value` is a JSON string — that is the `dump_json_safe` quirk.
+The `@threadplane/ag-ui` reducer parses it and sets:
 
 ```ts
 agent.interrupt() // → { id: 'r3w…', value: { kind, amount, customer_id, reason }, resumable: true }
@@ -365,7 +390,9 @@ agent.interrupt() // → { id: 'r3w…', value: { kind, amount, customer_id, rea
   <figcaption>The approval card with structured payload fields.</figcaption>
 </figure>
 
-`<chat-approval-card matchKind="refund_approval">` is bound to `agent.interrupt()`. The moment the signal becomes non-undefined, the dialog opens with the structured payload. The run has already finished (`RUN_FINISHED` arrived); the graph is parked at its checkpoint until something resumes it.
+`<chat-approval-card matchKind="refund_approval">` is bound to `agent.interrupt()`.
+The moment the signal becomes non-undefined, the dialog opens with the structured payload.
+The run has already finished (`RUN_FINISHED` arrived); the graph is parked at its checkpoint until something resumes it.
 
 ### Approve, edit, or cancel → resume
 
@@ -381,9 +408,13 @@ The adapter clears `agent.interrupt()` immediately for snappy UX, then forwards 
 source.runAgent({ forwardedProps: { command: { resume: { approved: true, amount: 99 } } } });
 ```
 
-A new `POST /agent` request fires. `ag-ui-langgraph` reads `forwarded_props.command.resume`, constructs a `Command(resume=…)`, and continues the graph from the checkpoint. Token-level streaming resumes; the assistant confirms the refund issued. Reject (`{ approved: false }`) takes the alternate branch in the graph; edit-then-approve carries a new `amount` through `Command(resume=…)`.
+A new `POST /agent` request fires.
+`ag-ui-langgraph` reads `forwarded_props.command.resume`, constructs a `Command(resume=…)`, and continues the graph from the checkpoint.
+Token-level streaming resumes; the assistant confirms the refund issued.
+Reject (`{ approved: false }`) takes the alternate branch in the graph; edit-then-approve carries a new `amount` through `Command(resume=…)`.
 
-On the langgraph adapter the same `submit({ resume })` becomes a native `Client.submit(thread, command={resume:…})` call. Different wire, same Angular surface.
+On the langgraph adapter the same `submit({ resume })` becomes a native `Client.submit(thread, command={resume:…})` call.
+Different wire, same Angular surface.
 
 <figure>
   <img src="/blog/2026-06-04-human-in-the-loop-ag-ui-agents-in-angular/3.png" alt="The chat history after the refund was approved and the run completed, showing the assistant's confirmation." width="1280" height="800" />
@@ -392,7 +423,13 @@ On the langgraph adapter the same `submit({ resume })` becomes a native `Client.
 
 ## Closing
 
-The runtime-neutral `Agent` contract isn't a marketing line; it's the reason this post existed without rewriting the component. `<chat-approval-card>`, `agent.interrupt()`, and `submit({ resume })` are the stable surface. `on_interrupt` and `forwardedProps.command.resume` are the AG-UI-specific wire details the adapter hides. Pick the adapter that matches your backend — LangGraph SDK direct → `@threadplane/langgraph`; anything AG-UI-fronted, including LangGraph-via-`ag-ui-langgraph` → `@threadplane/ag-ui`. Your chat surface doesn't pick.
+The runtime-neutral `Agent` contract is not a marketing line.
+It is the reason this post existed without rewriting the component.
+`<chat-approval-card>`, `agent.interrupt()`, and `submit({ resume })` are the stable surface.
+`on_interrupt` and `forwardedProps.command.resume` are the AG-UI-specific wire details the adapter hides.
+
+My recommendation is simple: pick the adapter that matches your backend — LangGraph SDK direct → `@threadplane/langgraph`; anything AG-UI-fronted, including LangGraph-via-`ag-ui-langgraph` → `@threadplane/ag-ui`.
+Your chat surface does not pick.
 
 Pointers:
 

--- a/apps/website/content/blog/2026-06-24-threadplane-earns-grade-a-hvtrust.mdx
+++ b/apps/website/content/blog/2026-06-24-threadplane-earns-grade-a-hvtrust.mdx
@@ -14,7 +14,9 @@ I would rather you measure it.
 
 In the Agent Frameworks category, that is #7 of 75. And it is the #1 — really the *only* — Angular agent framework on the list.
 
-I did not fill out a questionnaire or pay for a badge. HVTracker scores from public signals only: the GitHub API, the npm and PyPI registries, and the OpenSSF Scorecard CLI, refreshed daily. The grade is what their analysis says about us, not what we say about ourselves.
+I did not fill out a questionnaire or pay for a badge.
+HVTracker scores from public signals only: the GitHub API, the npm and PyPI registries, and the OpenSSF Scorecard CLI, refreshed daily.
+The grade is what their analysis says about us, not what we say about ourselves.
 
 For me, that is the whole point.
 A trust claim you make about yourself is not worth much.
@@ -38,16 +40,24 @@ Look at the stars column.
 
 Threadplane ranks *above* CrewAI, AutoGen, and LangChain on trust — with 99 GitHub stars against their tens of thousands.
 
-That is not a glitch. HVTrust is weighted toward supply-chain integrity and provenance, not popularity. A package can be downloaded millions of times a week and still have thin security signals. A smaller one can have every signal in place. The grade rewards the second kind, which is the whole reason a tracker like this exists.
+That is not a glitch.
+HVTrust is weighted toward supply-chain integrity and provenance, not popularity.
+A package can be downloaded millions of times a week and still have thin security signals.
+A smaller one can have every signal in place.
+The grade rewards the second kind, which is the whole reason a tracker like this exists.
 
 And I will be just as honest about where we are weak.
-Our lowest signal is adoption. With 99 stars, that is the part of the profile we have the most room to grow, and it is the one place the big projects above us are genuinely ahead. I am not going to dress that up.
+Our lowest signal is adoption.
+With 99 stars, that is the part of the profile we have the most room to grow, and it is the one place the big projects above us are genuinely ahead.
+I am not going to dress that up.
 
 ## What does a Grade A actually mean?
 
 HVTracker is careful about its own claims, and I want to be too. Right on the listing, they print this:
 
-> Not a safety endorsement. HVTracker describes what public signals show, not whether a project is safe for your use case. Run your own security review before adopting in production.
+> Not a safety endorsement.
+> HVTracker describes what public signals show, not whether a project is safe for your use case.
+> Run your own security review before adopting in production.
 
 That caveat is exactly why the grade is worth anything.
 
@@ -59,17 +69,24 @@ It is not a sticker that says "trust us." It is a measurement across five dimens
 - **Maintenance** — commit freshness and cadence.
 - **Adoption** — stars and downloads.
 
-Grade A just means the score lands in the top band (A is 80 and up). It does not mean anyone audited your threat model for you. It means the public evidence is strong, and you can go verify every piece of it yourself.
+Grade A just means the score lands in the top band (A is 80 and up).
+It does not mean anyone audited your threat model for you.
+It means the public evidence is strong, and you can go verify every piece of it yourself.
 
 ## Why this matters more for agent frameworks
 
 Most software you install does one job in one place. An agent framework is different.
 
-It runs models. It executes tool calls. It reaches for credentials and acts on behalf of your users, often with real authority over real systems.
+It runs models.
+It executes tool calls.
+It reaches for credentials and acts on behalf of your users, often with real authority over real systems.
 
 So the blast radius of a compromised dependency underneath an agent is bigger than almost anything else in your stack. That is what makes "is this thing's supply chain in order" a real question and not a checkbox.
 
-It is also the gap the tooling exists to close. The OpenSSF Scorecard — the engine behind a big part of HVTrust — checks the parts of the chain attackers actually go after: source, build, dependencies, signing, and maintenance. As [OpenSSF puts it](https://openssf.org/projects/scorecard/), a lot of open source is run by small teams with limited resources, which is exactly the soft target supply-chain attacks look for. And a [Sonatype analysis](https://github.com/ossf/scorecard) found a project's Scorecard score was one of the best available predictors of whether it carried known vulnerabilities.
+It is also the gap the tooling exists to close.
+The OpenSSF Scorecard — the engine behind a big part of HVTrust — checks the parts of the chain attackers actually go after: source, build, dependencies, signing, and maintenance.
+As [OpenSSF puts it](https://openssf.org/projects/scorecard/), a lot of open source is run by small teams with limited resources, which is exactly the soft target supply-chain attacks look for.
+And a [Sonatype analysis](https://github.com/ossf/scorecard) found a project's Scorecard score was one of the best available predictors of whether it carried known vulnerabilities.
 
 From my experience, that is the question worth asking before you install anything an agent will run: how much of your app are you handing to code you did not write, and can you prove where it came from?
 

--- a/apps/website/content/blog/2026-06-24-threadplane-earns-grade-a-hvtrust.mdx
+++ b/apps/website/content/blog/2026-06-24-threadplane-earns-grade-a-hvtrust.mdx
@@ -7,19 +7,22 @@ author: brian
 featured: true
 ---
 
-Every agent framework asks you to trust it. I'd rather you measure it.
+Every agent framework asks you to trust it.
+I would rather you measure it.
 
 [HVTracker](https://hvtracker.net/agents/threadplane/) is an independent trust tracker for AI agent software. It just scored Threadplane at **82.8/100 — a Grade A**.
 
-In the Agent Frameworks category, that's #7 of 75. And it's the #1 — really the *only* — Angular agent framework on the list.
+In the Agent Frameworks category, that is #7 of 75. And it is the #1 — really the *only* — Angular agent framework on the list.
 
-I didn't fill out a questionnaire or pay for a badge. HVTracker scores from public signals only: the GitHub API, the npm and PyPI registries, and the OpenSSF Scorecard CLI, refreshed daily. The grade is what their analysis says about us, not what we say about ourselves.
+I did not fill out a questionnaire or pay for a badge. HVTracker scores from public signals only: the GitHub API, the npm and PyPI registries, and the OpenSSF Scorecard CLI, refreshed daily. The grade is what their analysis says about us, not what we say about ourselves.
 
-For me, that's the whole point. A trust claim you make about yourself isn't worth much.
+For me, that is the whole point.
+A trust claim you make about yourself is not worth much.
 
 ## Who else is on the list?
 
-This is the part I keep coming back to. Let's look at the company we're keeping.
+This is the part I keep coming back to.
+Start with the company we are keeping.
 
 | Rank | Framework | Trust | Stars |
 | --- | --- | --- | --- |
@@ -35,9 +38,10 @@ Look at the stars column.
 
 Threadplane ranks *above* CrewAI, AutoGen, and LangChain on trust — with 99 GitHub stars against their tens of thousands.
 
-That isn't a glitch. HVTrust is weighted toward supply-chain integrity and provenance, not popularity. A package can be downloaded millions of times a week and still have thin security signals. A smaller one can have every signal in place. The grade rewards the second kind, which is the whole reason a tracker like this exists.
+That is not a glitch. HVTrust is weighted toward supply-chain integrity and provenance, not popularity. A package can be downloaded millions of times a week and still have thin security signals. A smaller one can have every signal in place. The grade rewards the second kind, which is the whole reason a tracker like this exists.
 
-And I'll be just as honest about where we're weak. Our lowest signal is adoption. With 99 stars, that's the part of the profile we have the most room to grow, and it's the one place the big projects above us are genuinely ahead. I'm not going to dress that up.
+And I will be just as honest about where we are weak.
+Our lowest signal is adoption. With 99 stars, that is the part of the profile we have the most room to grow, and it is the one place the big projects above us are genuinely ahead. I am not going to dress that up.
 
 ## What does a Grade A actually mean?
 
@@ -47,7 +51,7 @@ HVTracker is careful about its own claims, and I want to be too. Right on the li
 
 That caveat is exactly why the grade is worth anything.
 
-It's not a sticker that says "trust us." It's a measurement across five dimensions:
+It is not a sticker that says "trust us." It is a measurement across five dimensions:
 
 - **Safety / Integrity** — OSSF Scorecard, provenance, signatures.
 - **Identity / Provenance** — a verifiable link between the published package and the source that built it. This is our *strongest* signal.
@@ -55,7 +59,7 @@ It's not a sticker that says "trust us." It's a measurement across five dimensio
 - **Maintenance** — commit freshness and cadence.
 - **Adoption** — stars and downloads.
 
-Grade A just means the score lands in the top band (A is 80 and up). It doesn't mean anyone audited your threat model for you. It means the public evidence is strong, and you can go verify every piece of it yourself.
+Grade A just means the score lands in the top band (A is 80 and up). It does not mean anyone audited your threat model for you. It means the public evidence is strong, and you can go verify every piece of it yourself.
 
 ## Why this matters more for agent frameworks
 
@@ -63,15 +67,16 @@ Most software you install does one job in one place. An agent framework is diffe
 
 It runs models. It executes tool calls. It reaches for credentials and acts on behalf of your users, often with real authority over real systems.
 
-So the blast radius of a compromised dependency underneath an agent is bigger than almost anything else in your stack. That's what makes "is this thing's supply chain in order" a real question and not a checkbox.
+So the blast radius of a compromised dependency underneath an agent is bigger than almost anything else in your stack. That is what makes "is this thing's supply chain in order" a real question and not a checkbox.
 
-It's also the gap the tooling exists to close. The OpenSSF Scorecard — the engine behind a big part of HVTrust — checks the parts of the chain attackers actually go after: source, build, dependencies, signing, and maintenance. As [OpenSSF puts it](https://openssf.org/projects/scorecard/), a lot of open source is run by small teams with limited resources, which is exactly the soft target supply-chain attacks look for. And a [Sonatype analysis](https://github.com/ossf/scorecard) found a project's Scorecard score was one of the best available predictors of whether it carried known vulnerabilities.
+It is also the gap the tooling exists to close. The OpenSSF Scorecard — the engine behind a big part of HVTrust — checks the parts of the chain attackers actually go after: source, build, dependencies, signing, and maintenance. As [OpenSSF puts it](https://openssf.org/projects/scorecard/), a lot of open source is run by small teams with limited resources, which is exactly the soft target supply-chain attacks look for. And a [Sonatype analysis](https://github.com/ossf/scorecard) found a project's Scorecard score was one of the best available predictors of whether it carried known vulnerabilities.
 
-From my experience, that's the question worth asking before you install anything an agent will run: how much of your app are you handing to code you didn't write, and can you prove where it came from?
+From my experience, that is the question worth asking before you install anything an agent will run: how much of your app are you handing to code you did not write, and can you prove where it came from?
 
 ## The work behind the grade
 
-The grade is the output. Here's the input — the boring, unglamorous hygiene that earns it.
+The grade is the output.
+Here is the input — the boring, unglamorous hygiene that earns it.
 
 - **OSSF Scorecard 7.7/10** — branch protection, signed releases, dependency review, code review, run continuously.
 - **MIT licensed** — a declared, OSI-approved, permissive license. No ambiguity about what you can do with it.
@@ -99,6 +104,7 @@ The full breakdown — every dimension, the Scorecard checks, and the raw JSON �
 
 A trust grade is a starting point, not a finish line. The real way to evaluate a framework is to build something with it.
 
-So if you're curious: read the [listing](https://hvtracker.net/agents/threadplane/) and the [Agent Frameworks leaderboard](https://hvtracker.net/categories/agent-frameworks/), browse the [source on GitHub](https://github.com/cacheplane/angular-agent-framework) (all of it — it's almost all open), and ship your first streaming agent UI with the [quickstart](/docs/chat/getting-started/quickstart).
+So if you are curious: read the [listing](https://hvtracker.net/agents/threadplane/) and the [Agent Frameworks leaderboard](https://hvtracker.net/categories/agent-frameworks/), browse the [source on GitHub](https://github.com/cacheplane/angular-agent-framework) (all of it — it is almost all open), and ship your first streaming agent UI with the [quickstart](/docs/chat/getting-started/quickstart).
 
-We'll keep the signals fresh, keep the framework open, and keep working on the one number I'm not proud of yet. The rest, you can verify. 💚
+We will keep the signals fresh, keep the framework open, and keep working on the one number I am not proud of yet.
+The rest, you can verify.

--- a/apps/website/content/blog/2026-08-09-agentic-ui-in-angular-production-patterns.mdx
+++ b/apps/website/content/blog/2026-08-09-agentic-ui-in-angular-production-patterns.mdx
@@ -15,15 +15,15 @@ A production agent UI has to make a long-running, partially autonomous system un
 
 That difference matters.
 An agent can call tools, pause for a decision, change application state, and continue work after the user closes the tab.
-A transcript alone doesn't explain what the system is doing or give the user enough control over what happens next.
+A transcript alone does not explain what the system is doing or give the user enough control over what happens next.
 
 If you came here looking for an AG-UI Angular setup, the [fullstack AG-UI tutorial](/blog/build-fullstack-agentic-angular-apps-using-ag-ui) covers the wire-up.
 This post begins after that connection works.
 
-For me, the production question isn't, “Can the agent stream?”
-It's, “Can the user understand, interrupt, resume, and trust the work?”
+For me, the production question is not, “Can the agent stream?”
+It is, “Can the user understand, interrupt, resume, and trust the work?”
 
-Let's look at the patterns that answer that question.
+These are the patterns that answer that question.
 
 ## When is plain chat enough?
 
@@ -38,7 +38,7 @@ Every visible tool, checkpoint, approval, and generated component adds product b
 The boundary moves when the system starts doing work _outside_ the conversation.
 If it can modify data, contact another person, spend money, run for minutes, delegate work, or resume later, the UI needs more than bubbles and a spinner.
 
-The spinner isn't a product model (poor spinner).
+The spinner is not a product model (poor spinner).
 
 ## Pattern 1: Put the runtime behind an Angular contract
 
@@ -46,7 +46,7 @@ The first pattern is a boring boundary, and I mean that as a compliment.
 
 Your components should read messages, status, tool calls, errors, state, and interrupts from one stable interface.
 They should submit user intent through that same interface.
-They shouldn't know whether the backend emitted LangGraph stream chunks, AG-UI events, or something custom.
+They should not know whether the backend emitted LangGraph stream chunks, AG-UI events, or something custom.
 
 Threadplane calls this runtime-neutral boundary the [`Agent` contract](/docs/langgraph/concepts/agent-contract).
 Runtime adapters translate their wire format into Signals and a small action surface that chat components can consume.
@@ -55,10 +55,10 @@ This keeps protocol details out of your design system and route-level components
 It also gives tests a clean seam: replace the contract with writable Signals instead of recreating a server stream.
 
 There is a cost.
-A neutral contract can't pretend every runtime has the same capabilities.
+A neutral contract cannot pretend every runtime has the same capabilities.
 Checkpoint history, branching, subagents, and interrupts may be optional or adapter-specific, so feature-detect them and keep runtime-specific behavior at a deliberate edge.
 
-I think that's healthier than finding AG-UI event names scattered through a dozen Angular components six months later.
+I think that is healthier than finding AG-UI event names scattered through a dozen Angular components six months later.
 
 ## Pattern 2: Treat the stream as state, not text
 
@@ -70,7 +70,7 @@ Those values change at different rates, but the template needs a coherent answer
 Signals fit this work well.
 The adapter reduces runtime events into stable state, Angular tracks the parts each view reads, and `computed()` can turn those Signals into product decisions such as “can submit,” “show cancel,” or “this task is waiting for approval.”
 
-The important part isn't avoiding RxJS.
+The important part is not avoiding RxJS.
 RxJS is still a good fit for transport streams.
 The important part is stopping raw event order from becoming the component API.
 
@@ -81,25 +81,25 @@ The [Signals guide](/docs/langgraph/concepts/angular-signals) shows the boundary
 ![LangGraph stream chunks and AG-UI SSE events both enter a runtime adapter that owns accumulation, deduplication and lifecycle transitions, and the adapter publishes one Agent contract of Angular signals - messages, status, toolCalls, state, error and interrupt - that chat components and an approved component registry read, with user intent travelling back through the same contract.](/blog/diagrams/agent-contract-boundary.svg)
 
 The tradeoff is that normalization can hide useful runtime detail.
-Keep an explicit event escape hatch for information that isn't durable UI state, but don't publish messages or tool calls through two competing sources.
+Keep an explicit event escape hatch for information that is not durable UI state, but do not publish messages or tool calls through two competing sources.
 Two sources of truth create timing bugs that are difficult to reproduce and even harder to explain to a user.
 
 ## Pattern 3: Make tool progress part of the product
 
-Tool calls aren't developer logs.
-They're the part of the product that explains where the time went and what authority the agent used.
+Tool calls are not developer logs.
+They are the part of the product that explains where the time went and what authority the agent used.
 
 “Working…” tells the user almost nothing.
 “Searching 12 policies,” “Drafting the refund,” and “Waiting for the billing service” set an expectation and make a slow run legible.
 
-Let's treat each important tool as a small state machine:
+Treat each important tool as a small state machine:
 
 - what the agent intends to do;
 - what is running now;
 - what completed, with a useful result;
 - what failed, and whether the user can recover.
 
-Raw JSON arguments usually aren't the right UI.
+Raw JSON arguments usually are not the right UI.
 Map high-value tools to product-specific Angular components, group repetitive background calls, and keep low-value orchestration noise out of the main reading path.
 Threadplane's [tool-call templates](/docs/chat/components/chat-tool-call-template) let a team replace the default card one tool at a time.
 
@@ -109,15 +109,15 @@ The rest can use a compact default.
 
 ## Pattern 4: Pause before consequential writes
 
-An approval shown after a write isn't human-in-the-loop.
-It's a receipt.
+An approval shown after a write is not human-in-the-loop.
+It is a receipt.
 
 For a consequential action, the backend should pause _before_ execution and persist enough state to resume from the same point.
 The UI should show what will change, which resource is affected, and the values the agent intends to use.
 Then the user can approve, reject, or edit the proposal.
 
 Keep authorization on the server.
-An Angular approval card expresses a decision; it doesn't replace permission checks, idempotency, or an audit record.
+An Angular approval card expresses a decision; it does not replace permission checks, idempotency, or an audit record.
 
 Not every tool needs an interrupt.
 Approving every search or read turns safety into click fatigue.
@@ -128,13 +128,13 @@ The [AG-UI approval tutorial](/blog/human-in-the-loop-ag-ui-agents-in-angular) a
 
 ## Pattern 5: Give threads durable semantics
 
-A thread ID isn't just a sidebar key.
+A thread ID is not just a sidebar key.
 It is the identity of work that may cross runs, routes, browser sessions, and deployments.
 
 Decide what a thread belongs to: a user, case, project, or task.
 Scope access on the server, use stable identifiers, and make a reload restore the same conversation from durable backend state.
 
-Let's also separate a _thread_ from a _run_.
+Separate a _thread_ from a _run_ as well.
 One thread can contain many attempts, tool calls, pauses, and resumptions.
 If those concepts collapse into one loading boolean, retry and recovery behavior becomes ambiguous.
 
@@ -143,7 +143,7 @@ The URL can restore the active ID, but only the backend can restore the work beh
 The [thread-routing guide](/docs/chat/guides/thread-routing) calls out that dependency, and the [LangGraph persistence guide](/docs/langgraph/guides/persistence) covers checkpoints and thread restoration.
 
 This is also where backend differences matter.
-The runtime-neutral `Agent` contract isn't a message database, and the AG-UI adapter doesn't currently provide LangGraph's history and time-travel APIs.
+The runtime-neutral `Agent` contract is not a message database, and the AG-UI adapter does not currently provide LangGraph's history and time-travel APIs.
 Choose the adapter whose durability surface matches the product, or add an application-owned thread service instead of assuming the protocol solved persistence.
 
 ## Pattern 6: Let agents choose components, not invent UI
@@ -151,26 +151,26 @@ Choose the adapter whose durability surface matches the product, or add an appli
 Generative UI gets useful when the agent can choose the right surface for the job.
 It gets risky when “generate a surface” means “ship arbitrary code into the application.”
 
-The production pattern is a registry of approved Angular components.
+For me, the production pattern is a registry of approved Angular components.
 The agent returns a structured spec, and the frontend resolves each type against components your team owns.
 
 That boundary keeps accessibility, localization, analytics, validation, and theming inside the design system.
 It also limits what the agent can render.
-An unregistered type can't instantiate an Angular component.
+An unregistered type cannot instantiate an Angular component.
 
 Threadplane supports this with a `ViewRegistry` for json-render and A2UI surfaces.
 You can add, override, or remove components as the product evolves; the [generative UI guide](/docs/chat/guides/generative-ui) and [custom catalog patterns](/docs/chat/guides/custom-catalogs) show how.
 
 The tradeoff is intentional constraint.
-A small catalog won't express every layout the model imagines, but it will produce a UI your team can test and support.
+A small catalog will not express every layout the model imagines, but it will produce a UI your team can test and support.
 For unknown or invalid specs, define a plain-text fallback and capture enough diagnostic context to fix the contract without exposing private content.
 
 ## Pattern 7: Design the unhappy path first
 
 Agent UI failures are rarely one clean exception.
-A stream can stop halfway through a sentence, a tool can time out after other tools completed, an approval can outlive its session, or a saved link can point to a thread the user can't access.
+A stream can stop halfway through a sentence, a tool can time out after other tools completed, an approval can outlive its session, or a saved link can point to a thread the user cannot access.
 
-Let's define the recovery behavior before polishing the happy path.
+The recovery behavior comes before polishing the happy path.
 
 - Classify errors so the UI retries only when retrying can help.
 - Preserve enough completed work to explain what happened.
@@ -200,17 +200,17 @@ The [adapter guide](/docs/choosing-an-adapter) documents that common boundary.
 But portability has limits.
 If the product depends on LangGraph checkpoint history, a runtime-specific branch model, or a custom AG-UI event, that feature needs an explicit adapter boundary and its own tests.
 
-That's fine.
-The goal isn't to erase useful backend capabilities.
-It's to make the coupling visible, small, and intentional.
+That is fine.
+The goal is not to erase useful backend capabilities.
+It is to make the coupling visible, small, and intentional.
 
 ## Conclusion
 
-Agentic UI in Angular isn't a more animated chat transcript.
-It's the product layer that turns asynchronous agent work into state a user can understand and actions a user can control.
+Agentic UI in Angular is not a more animated chat transcript.
+It is the product layer that turns asynchronous agent work into state a user can understand and actions a user can control.
 
 Start with plain chat when plain chat is enough.
 When the agent gains more time, authority, or persistence, add the patterns that make those capabilities legible: a neutral contract, Signals, meaningful tool progress, approvals, durable threads, constrained components, and rehearsed recovery.
 
 These are the production patterns I think are worth carrying into an Angular architecture review.
-If your team has found another one, I'd like to hear what made the difference.
+If your team has found another one, I would like to hear what made the difference.

--- a/apps/website/content/blog/2026-08-09-build-an-aws-strands-agent-ui-in-angular-with-ag-ui.mdx
+++ b/apps/website/content/blog/2026-08-09-build-an-aws-strands-agent-ui-in-angular-with-ag-ui.mdx
@@ -13,8 +13,8 @@ Build a Strands agent in Python, stream it over AG-UI, and render it in Angular 
 The useful boundary is straightforward.
 Strands owns the model loop and tools, AG-UI owns the wire, and your Angular app owns the experience.
 
-Amazon Bedrock AgentCore can host the same server later, but it isn't required for local development.
-Let's start with the smaller thing that works.
+Amazon Bedrock AgentCore can host the same server later, but it is not required for local development.
+Start with the smaller thing that works.
 
 ## Goals
 
@@ -39,10 +39,10 @@ Angular <chat>
 ```
 
 The Strands integration translates framework-specific streaming output into AG-UI lifecycle, text, tool-call, state, and reasoning events.
-The Angular side doesn't need to know how `Agent.stream_async()` works.
+The Angular side does not need to know how `Agent.stream_async()` works.
 It only needs the protocol contract.
 
-For me, that's the point of this split.
+For me, that is the point of this split.
 The extra adapter is a small cost, and it keeps Strands internals out of the UI.
 
 <Callout type="info" title="AgentCore is optional">
@@ -57,7 +57,7 @@ This tutorial stays focused on the [official Strands integration](https://github
 ## Why put AG-UI between Strands and Angular?
 
 A Strands callback stream is useful inside a Python process.
-It isn't a frontend API by itself.
+It is not a frontend API by itself.
 
 The official `ag-ui-strands` package handles that translation.
 Its `StrandsAgent` wrapper consumes the Strands async stream and emits typed AG-UI events, while `create_strands_app()` adds a FastAPI POST endpoint that encodes those events for SSE.
@@ -75,7 +75,7 @@ The [AG-UI architecture documentation](https://docs.ag-ui.com/concepts/architect
 
 ## How do we build the Strands AG-UI server?
 
-Let's build the backend first.
+The backend comes first.
 Use Python 3.12 or 3.13 so the project satisfies both the current `ag-ui-strands` package constraint and the AgentCore guide.
 
 Strands uses Amazon Bedrock as its default model provider.
@@ -92,7 +92,7 @@ source .venv/bin/activate
 python -m pip install "ag-ui-strands==0.2.4" "uvicorn[standard]"
 ```
 
-I'm pinning `ag-ui-strands` because this tutorial uses the `0.2.4` helper API.
+I am pinning `ag-ui-strands` because this tutorial uses the `0.2.4` helper API.
 That release declares FastAPI, the AG-UI Python protocol package, and `strands-agents>=1.15.0` as dependencies.
 Keep the resolved versions in your lockfile when you move beyond the tutorial.
 
@@ -221,7 +221,7 @@ npm install @threadplane/chat @threadplane/ag-ui @ag-ui/client @ag-ui/core marke
 ```
 
 `@threadplane/ag-ui` constructs the official `HttpAgent` for the endpoint you provide.
-`@threadplane/chat` consumes Threadplane's runtime-neutral `Agent` contract, so the component doesn't import Strands types or parse SSE.
+`@threadplane/chat` consumes Threadplane's runtime-neutral `Agent` contract, so the component does not import Strands types or parse SSE.
 
 ### Provide the agent
 
@@ -278,7 +278,7 @@ The [Threadplane AG-UI installation guide](/docs/ag-ui/getting-started/installat
 
 ## What happens when the user submits a message?
 
-Let's follow one turn across the seam.
+One turn, followed across the seam.
 
 1. `<chat>` submits through the injected Threadplane `Agent`.
 2. `@threadplane/ag-ui` delegates to AG-UI's `HttpAgent`.
@@ -291,7 +291,7 @@ Let's follow one turn across the seam.
 No browser code knows which Bedrock model is running.
 No Python code knows which Angular components render the response.
 
-That separation is useful, but it isn't magic.
+That separation is useful, but it is not magic.
 The [Threadplane event mapping](/docs/ag-ui/reference/event-mapping) is the compatibility checklist when you add richer Strands behavior.
 
 ## What still needs work before production?
@@ -307,7 +307,7 @@ There are a few more seams to make explicit:
 
 - **CORS:** `http://localhost:4200` is a development origin. Use your exact production origin, or remove cross-origin traffic by routing through the same application domain.
 - **Authentication:** protect `/invocations` before exposing it. Never put AWS access keys, Bedrock credentials, or SigV4 signing secrets in an Angular bundle.
-- **Remote content:** version 0.2.4 can fetch URL-backed image, document, and video inputs from the server. Reject URL sources if you don't need them. Otherwise, validate them before the adapter sees the request: allowlist schemes and hosts, block redirects to private, link-local, and metadata addresses, and cap response size and time.
+- **Remote content:** version 0.2.4 can fetch URL-backed image, document, and video inputs from the server. Reject URL sources if you do not need them. Otherwise, validate them before the adapter sees the request: allowlist schemes and hosts, block redirects to private, link-local, and metadata addresses, and cap response size and time.
 - **Proxy streaming:** if a gateway or backend-for-frontend sits in front of the agent, disable response buffering and preserve the streaming content type. A proxy that collects the whole response turns streaming chat back into a spinner.
 - **Authorization:** bind threads to the authenticated user on the server. A client-provided `threadId` is an identifier, not proof that the caller may access that conversation.
 - **Operations:** set timeouts intentionally, propagate cancellation where your stack supports it, rate-limit runs, and record errors without logging sensitive prompts or tool results by default.
@@ -317,7 +317,7 @@ Production is where identity, durability, and observability become part of the a
 
 ## How does optional AgentCore deployment change the picture?
 
-It doesn't change the Angular-to-AG-UI contract.
+It does not change the Angular-to-AG-UI contract.
 It changes where the Strands server runs and how requests reach it.
 
 AgentCore Runtime supports AG-UI servers as a proxy layer.
@@ -336,7 +336,7 @@ Treat that as a development deployment path.
 AWS says the CLI-generated IAM policies are broad development defaults, so replace them with least-privilege execution and invocation policies before production.
 The [AgentCore Runtime security guide](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-security-best-practices.html) is the checklist.
 
-AgentCore is a reasonable choice when you want its authentication integration, runtime session isolation, and scaling.
+For me, AgentCore is a reasonable choice when you want its authentication integration, runtime session isolation, and scaling.
 The tradeoff is an AWS-specific deployment and invocation layer around the open AG-UI endpoint.
 
 ### Keep the production identities separate

--- a/apps/website/content/blog/2026-08-09-build-an-aws-strands-agent-ui-in-angular-with-ag-ui.mdx
+++ b/apps/website/content/blog/2026-08-09-build-an-aws-strands-agent-ui-in-angular-with-ag-ui.mdx
@@ -307,7 +307,9 @@ There are a few more seams to make explicit:
 
 - **CORS:** `http://localhost:4200` is a development origin. Use your exact production origin, or remove cross-origin traffic by routing through the same application domain.
 - **Authentication:** protect `/invocations` before exposing it. Never put AWS access keys, Bedrock credentials, or SigV4 signing secrets in an Angular bundle.
-- **Remote content:** version 0.2.4 can fetch URL-backed image, document, and video inputs from the server. Reject URL sources if you do not need them. Otherwise, validate them before the adapter sees the request: allowlist schemes and hosts, block redirects to private, link-local, and metadata addresses, and cap response size and time.
+- **Remote content:** version 0.2.4 can fetch URL-backed image, document, and video inputs from the server.
+  Reject URL sources if you do not need them.
+  Otherwise, validate them before the adapter sees the request: allowlist schemes and hosts, block redirects to private, link-local, and metadata addresses, and cap response size and time.
 - **Proxy streaming:** if a gateway or backend-for-frontend sits in front of the agent, disable response buffering and preserve the streaming content type. A proxy that collects the whole response turns streaming chat back into a spinner.
 - **Authorization:** bind threads to the authenticated user on the server. A client-provided `threadId` is an identifier, not proof that the caller may access that conversation.
 - **Operations:** set timeouts intentionally, propagate cancellation where your stack supports it, rate-limit runs, and record errors without logging sensitive prompts or tool results by default.

--- a/apps/website/content/blog/2026-08-13-angular-chat-app-tutorial-with-ag-ui.mdx
+++ b/apps/website/content/blog/2026-08-13-angular-chat-app-tutorial-with-ag-ui.mdx
@@ -8,11 +8,14 @@ featured: false
 draft: false
 ---
 
-Let's build an Angular chat app on AG-UI where the interesting tools run in the _browser_.
+This post builds an Angular chat app on AG-UI where the interesting tools run in the _browser_.
 
-Most chat tutorials stop at streaming text. The app in this one saves links to a reading list, renders each one as a real Angular component inside the transcript, and asks the user to confirm before it clears anything — and none of that work happens on the server.
+Most chat tutorials stop at streaming text.
+The app in this one saves links to a reading list, renders each one as a real Angular component inside the transcript, and asks the user to confirm before it clears anything.
+None of that work happens on the server.
 
-That's the part AG-UI makes straightforward, because the protocol carries a tool catalog in both directions. The browser ships what it can do; the model calls it; the browser executes and answers.
+That is the part AG-UI makes straightforward, because the protocol carries a tool catalog in both directions.
+The browser ships what it can do, the model calls it, and the browser executes and answers.
 
 ## Goals
 
@@ -20,7 +23,7 @@ That's the part AG-UI makes straightforward, because the protocol carries a tool
 - Bind it to Angular with `@threadplane/ag-ui` and `@threadplane/chat`.
 - Declare `action`, `view`, and `ask` client tools the model can call.
 - Read agent-shared state as an Angular signal.
-- Be clear about what AG-UI gives you and what it doesn't.
+- Be clear about what AG-UI gives you and what it does not.
 - Have fun!
 
 <Callout type="info" title="MIT-licensed packages">
@@ -42,7 +45,9 @@ Angular <chat [clientTools]>
   -> your graph
 ```
 
-A reading list. The user asks the assistant to save something; the assistant calls `add_link`, which runs in the browser and mutates an Angular signal store. Then it calls `link_card` to show it, and `confirm_clear` when the user wants the list emptied.
+A reading list.
+The user asks the assistant to save something, and the assistant calls `add_link`, which runs in the browser and mutates an Angular signal store.
+Then it calls `link_card` to show it, and `confirm_clear` when the user wants the list emptied.
 
 Three tools, three different shapes, and the server implements none of them.
 
@@ -58,7 +63,8 @@ source .venv/bin/activate
 pip install "ag-ui-langgraph==0.0.40" langchain-openai "fastapi>=0.115" "uvicorn[standard]" "threadplane-middleware>=0.0.1"
 ```
 
-I'm using the LangGraph integration because it's the shortest path to a running endpoint, but this is the interchangeable half. CrewAI, Mastra, Pydantic AI, AG2, and AWS Strands all expose the same AG-UI endpoint shape, and the Angular half below doesn't change for any of them.
+I am using the LangGraph integration because it is the shortest path to a running endpoint, but this is the interchangeable half.
+CrewAI, Mastra, Pydantic AI, AG2, and AWS Strands all expose the same AG-UI endpoint shape, and the Angular half below does not change for any of them.
 
 Now `server.py`:
 
@@ -128,11 +134,16 @@ add_langgraph_fastapi_endpoint(app, LangGraphAgent(name="chat", graph=graph), pa
 
 The load-bearing line is `bind_client_tools(llm, [], state)`.
 
-AG-UI's `RunAgentInput` has a `tools` field, and `ag-ui-langgraph` merges it into `state["tools"]`. So the catalog the browser declared this run is sitting right there in graph state. `bind_client_tools` turns those entries into function-tool stubs and binds them alongside your server tools — an empty list, here, since this app has none.
+AG-UI's `RunAgentInput` has a `tools` field, and `ag-ui-langgraph` merges it into `state["tools"]`.
+So the catalog the browser declared this run is sitting right there in graph state.
+`bind_client_tools` turns those entries into function-tool stubs and binds them alongside your server tools — an empty list, here, since this app has none.
 
-Bind it _inside_ the node, not once at module scope. The catalog arrives per run and can differ between runs.
+Bind it _inside_ the node, not once at module scope.
+The catalog arrives per run and can differ between runs.
 
-The routing is worth a sentence too. In an app with server tools you'd add a conditional edge to a `ToolNode`, and route to `END` when every call is a client tool. Here there are no server tools at all, so the graph always ends its turn after the model speaks, and the browser picks it up.
+The routing is worth a sentence too.
+In an app with server tools you would add a conditional edge to a `ToolNode`, and route to `END` when every call is a client tool.
+Here there are no server tools at all, so the graph always ends its turn after the model speaks, and the browser picks it up.
 
 Run it:
 
@@ -143,7 +154,7 @@ uvicorn server:app --port 8000
 
 <Callout type="warning" title="Only export what you need">
   Sourcing a whole shared `.env` here is a good way to switch on auth middleware
-  you didn't mean to enable and get a confusing 401 on `/agent`. Export the one
+  you did not mean to enable and get a confusing 401 on `/agent`. Export the one
   key.
 </Callout>
 
@@ -168,13 +179,15 @@ export const appConfig: ApplicationConfig = {
 };
 ```
 
-`provideAgent` also takes `headers` for auth tokens and `agentId` when one endpoint serves several agents. That's the whole config.
+`provideAgent` also takes `headers` for auth tokens and `agentId` when one endpoint serves several agents.
+That is the whole config.
 
 ## How does the browser get its own tools?
 
 This is the part worth the trip.
 
-A client tool is declared in Angular, shipped to the model as part of the catalog, and executed in the browser. There are three kinds, and they differ in what produces the result:
+A client tool is declared in Angular, shipped to the model as part of the catalog, and executed in the browser.
+There are three kinds, and they differ in what produces the result:
 
 | Helper | What it does | Result comes from |
 |---|---|---|
@@ -182,11 +195,12 @@ A client tool is declared in Angular, shipped to the model as part of the catalo
 | `view()` | Renders a component inline | Auto-acknowledged when it mounts |
 | `ask()` | Renders an interactive component | The value the user's interaction emits |
 
-Let's build all three over one signal store.
+All three are built over one signal store.
 
 ### The store
 
-Ordinary Angular. The agent never sees this — it only calls tools.
+Ordinary Angular.
+The agent never sees this — it only calls tools.
 
 ```ts
 @Injectable({ providedIn: 'root' })
@@ -240,13 +254,15 @@ export function readingListTools(): ClientToolRegistry {
 }
 ```
 
-The object keys are the tool names the model sees. The descriptions are the _only_ steering the model gets about when to call them, so write them like instructions, not labels — "Afterwards, show it with `link_card`" is doing real work in that first one.
+The object keys are the tool names the model sees.
+The descriptions are the _only_ steering the model gets about when to call them, so write them like instructions, not labels — "Afterwards, show it with `link_card`" is doing real work in that first one.
 
 Arguments are typed by a [Standard Schema](https://standardschema.dev), so Zod works directly and `action` handlers infer their argument type from it.
 
 ### A `view` component
 
-The model fills the component's inputs from the schema. Under `strict: true` the typed overload fails the build if the component's inputs and the schema disagree, which is a nice place for that mistake to surface:
+The model fills the component's inputs from the schema.
+Under `strict: true` the typed overload fails the build if the component's inputs and the schema disagree, which is a nice place for that mistake to surface:
 
 ```ts
 export const LINK_CARD_SCHEMA = z.object({
@@ -273,11 +289,12 @@ export class LinkCardComponent {
 }
 ```
 
-Derive the input types with `ViewProps<typeof LINK_CARD_SCHEMA>` if you'd rather not repeat them by hand.
+Derive the input types with `ViewProps<typeof LINK_CARD_SCHEMA>` if you would rather not repeat them by hand.
 
 ### An `ask` component
 
-`ask` is the interesting one, because the component decides the result. It announces it through `injectRenderHost().result(...)`, and _that_ becomes the tool result that resumes the run:
+`ask` is the interesting one, because the component decides the result.
+It announces it through `injectRenderHost().result(...)`, and _that_ becomes the tool result that resumes the run:
 
 ```ts
 @Component({
@@ -318,7 +335,9 @@ export class ConfirmClearComponent {
 
 Two details make this behave well.
 
-The mutation happens _here_, in the component, not in a handler — an `ask` emits its own result and nothing sits in between to intercept it. And once it resolves, the adapter writes the emitted value back onto the local tool call, so the component re-renders with `cleared` and `removed` as props. That's why the template branches: the live card only shows while `cleared()` is still `undefined`, and afterwards the transcript shows a frozen line instead of buttons the user could press again.
+The mutation happens _here_, in the component, not in a handler — an `ask` emits its own result and nothing sits in between to intercept it.
+Once it resolves, the adapter writes the emitted value back onto the local tool call, so the component re-renders with `cleared` and `removed` as props.
+That is why the template branches: the live card only shows while `cleared()` is still `undefined`, and afterwards the transcript shows a frozen line instead of buttons the user could press again.
 
 ### Binding it
 
@@ -331,7 +350,8 @@ protected readonly agent = injectAgent();
 protected readonly clientTools = readingListTools();
 ```
 
-That's it. Ask the assistant to save a link, and you'll watch `add_link` execute in the browser, the sidebar count go up, and `link_card` mount inside the transcript as a real component.
+That is it.
+Ask the assistant to save a link, and you will watch `add_link` execute in the browser, the sidebar count go up, and `link_card` mount inside the transcript as a real component.
 
 ## How does the agent share state?
 
@@ -343,9 +363,12 @@ protected readonly savedCount = computed(
 );
 ```
 
-Which brings up a detail that's easy to lose an hour to.
+Which brings up a detail that is easy to lose an hour to.
 
-The graph counts completed `add_link` calls. The obvious implementation is to look for `ToolMessage`s named `add_link` — and it silently returns zero forever. **Client-tool results come back carrying a `tool_call_id` but no `name`**, because the adapter adds them as `{ id, role: 'tool', toolCallId, content }`. Match on the id instead:
+The graph counts completed `add_link` calls.
+The obvious implementation is to look for `ToolMessage`s named `add_link`, and it silently returns zero forever.
+**Client-tool results come back carrying a `tool_call_id` but no `name`**, because the adapter adds them as `{ id, role: 'tool', toolCallId, content }`.
+Match on the id instead:
 
 ```python
 def count_saved(messages: list) -> int:
@@ -366,7 +389,8 @@ For progress _during_ a run rather than state after it, AG-UI `CUSTOM` events ac
 
 ## What happens when we swap the backend?
 
-The Angular half doesn't change. That's the payoff, and it's worth being precise about what it costs.
+The Angular half does not change.
+That is the payoff, and it is worth being precise about what it costs.
 
 Swapping runtimes is the provider line:
 
@@ -377,34 +401,44 @@ Swapping runtimes is the provider line:
 + providers: [provideAgent({ apiUrl: '…', assistantId: 'chat' })],
 ```
 
-Those are two different functions from two different packages, not one symbol that takes both shapes. Components stay identical because both adapters produce the same runtime-neutral `Agent` contract — and client tools are declared against `@threadplane/chat`, so the registry above moves across untouched.
+Those are two different functions from two different packages, not one symbol that takes both shapes.
+Components stay identical because both adapters produce the same runtime-neutral `Agent` contract — and client tools are declared against `@threadplane/chat`, so the registry above moves across untouched.
 
-The cost is a thin translation layer per adapter, and a real compatibility surface: your new backend has to emit the AG-UI events the UI reads. The [event mapping reference](/docs/ag-ui/reference/event-mapping) is the checklist when a stream renders as nothing.
+The cost is a thin translation layer per adapter, and a real compatibility surface: your new backend has to emit the AG-UI events the UI reads.
+The [event mapping reference](/docs/ag-ui/reference/event-mapping) is the checklist when a stream renders as nothing.
 
 ## What doesn't AG-UI give you?
 
-Thread history, and it's a protocol fact rather than a gap in any library.
+Thread history, and it is a protocol fact rather than a gap in any library.
 
-AG-UI is event-stream-only. It defines no server-side thread-lookup endpoint, so there's nothing to enumerate past conversations with and nothing to validate a thread id against. `injectThreadRouting()` still works for a single id in the URL, but its `validate` callback has no backend to ask.
+AG-UI is event-stream-only.
+It defines no server-side thread-lookup endpoint, so there is nothing to enumerate past conversations with and nothing to validate a thread id against.
+`injectThreadRouting()` still works for a single id in the URL, but its `validate` callback has no backend to ask.
 
-So a conversation sidebar over AG-UI is app-owned: you keep the list, you title the threads, you decide what "restore" means. If server-backed thread history is the feature you actually want, LangGraph exposes per-thread checkpoints and a thread API, and I walked through building exactly that in [Angular Chat App Tutorial with LangChain and LangGraph](/blog/angular-chat-app-tutorial-with-langchain-langgraph).
+So a conversation sidebar over AG-UI is app-owned: you keep the list, you title the threads, you decide what "restore" means.
+If server-backed thread history is the feature you actually want, LangGraph exposes per-thread checkpoints and a thread API, and I walked through building exactly that in [Angular Chat App Tutorial with LangChain and LangGraph](/blog/angular-chat-app-tutorial-with-langchain-langgraph).
 
-Worth saying plainly: pick the protocol for the backend you have, not for the sidebar. Portability across agent frameworks and server-managed thread history are different features, and AG-UI is unambiguously the better answer to the first one.
+My recommendation is simple: pick the protocol for the backend you have, not for the sidebar.
+Portability across agent frameworks and server-managed thread history are different features, and AG-UI is unambiguously the better answer to the first one.
 
 ## What still needs work before production?
 
 - **Client tools run in the browser, so they run with the user's authority.** A handler that calls your API is a client calling your API. Authorize on the server; a tool description is not an access-control policy.
-- **Side effects need a guard.** Tools are non-idempotent by default. If a handler moves money or sends mail, pair it with a `[clientToolExecutionGuard]` so a reload can't run it twice, and mark only genuinely safe tools `idempotent: true`.
+- **Side effects need a guard.** Tools are non-idempotent by default. If a handler moves money or sends mail, pair it with a `[clientToolExecutionGuard]` so a reload cannot run it twice, and mark only genuinely safe tools `idempotent: true`.
 - **Runaway loops are capped, but tune the cap.** A model that keeps calling client tools stops after 10 continuation groups per user turn. Adjust with `[clientToolContinuationPolicy]` and decide what the UI says when it trips.
 - **CORS and auth.** `http://localhost:4200` is a development origin. Use your real one, or route through the same domain and skip cross-origin entirely. Pass tokens with `headers`.
 - **A buffering proxy breaks streaming.** Disable response buffering and preserve the streaming content type, or the whole thing collapses into a spinner.
-- **`MemorySaver` is not persistence.** It's in this tutorial because `ag-ui-langgraph` needs a checkpointer to read state. It is not a store.
+- **`MemorySaver` is not persistence.** It is in this tutorial because `ag-ui-langgraph` needs a checkpointer to read state. It is not a store.
 
 ## Conclusion
 
-The good boundary in an AG-UI app is that the protocol carries capability in both directions. The server streams events; the browser declares tools. Once both halves are true, "which framework is behind this" stops being a question your components can answer — and that's the point.
+The good boundary in an AG-UI app is that the protocol carries capability in both directions.
+The server streams events, and the browser declares tools.
+Once both halves are true, "which framework is behind this" stops being a question your components can answer.
+That is the point.
 
-Start with one `action`, get it mutating a signal store, then add a `view` for how the result should look and an `ask` for the moments that need a human. That order keeps each step small enough to debug.
+Start with one `action`, get it mutating a signal store, then add a `view` for how the result should look and an `ask` for the moments that need a human.
+That order keeps each step small enough to debug.
 
 And when you need a conversation sidebar with real history, reach for a runtime that stores threads rather than making the protocol do something it never claimed to.
 

--- a/apps/website/content/blog/2026-08-13-angular-chat-app-tutorial-with-ag-ui.mdx
+++ b/apps/website/content/blog/2026-08-13-angular-chat-app-tutorial-with-ag-ui.mdx
@@ -426,7 +426,9 @@ Portability across agent frameworks and server-managed thread history are differ
 - **Client tools run in the browser, so they run with the user's authority.** A handler that calls your API is a client calling your API. Authorize on the server; a tool description is not an access-control policy.
 - **Side effects need a guard.** Tools are non-idempotent by default. If a handler moves money or sends mail, pair it with a `[clientToolExecutionGuard]` so a reload cannot run it twice, and mark only genuinely safe tools `idempotent: true`.
 - **Runaway loops are capped, but tune the cap.** A model that keeps calling client tools stops after 10 continuation groups per user turn. Adjust with `[clientToolContinuationPolicy]` and decide what the UI says when it trips.
-- **CORS and auth.** `http://localhost:4200` is a development origin. Use your real one, or route through the same domain and skip cross-origin entirely. Pass tokens with `headers`.
+- **CORS and auth.** `http://localhost:4200` is a development origin.
+  Use your real one, or route through the same domain and skip cross-origin entirely.
+  Pass tokens with `headers`.
 - **A buffering proxy breaks streaming.** Disable response buffering and preserve the streaming content type, or the whole thing collapses into a spinner.
 - **`MemorySaver` is not persistence.** It is in this tutorial because `ag-ui-langgraph` needs a checkpointer to read state. It is not a store.
 

--- a/apps/website/content/blog/2026-08-13-angular-chat-app-tutorial-with-langchain-langgraph.mdx
+++ b/apps/website/content/blog/2026-08-13-angular-chat-app-tutorial-with-langchain-langgraph.mdx
@@ -205,7 +205,9 @@ export const appConfig: ApplicationConfig = {
 
 The two options that make this an app rather than a demo:
 
-- `threadId: ACTIVE_THREAD` — the adapter _watches_ this signal. Set it, and the conversation switches. You never call a "load thread" method.
+- `threadId: ACTIVE_THREAD` — the adapter _watches_ this signal.
+  Set it, and the conversation switches.
+  You never call a "load thread" method.
 - `onThreadId` — fires when the adapter creates a thread on the first submit. Writing it back into the same signal is what closes the loop.
 
 `LANGGRAPH_THREADS_CONFIG` is separate because the thread list is a separate concern from the agent.
@@ -374,7 +376,10 @@ It is a bailout warning, not an error.
 The app runs now.
 It is not finished.
 
-- **The checkpointer has to be durable.** `langgraph dev` keeps threads in memory. Bookmarkable URLs against an in-memory store are a lie — the link survives, the conversation does not. Move to Postgres before you ship the sidebar. Persistence UI should match what the backend can actually restore.
+- **The checkpointer has to be durable.** `langgraph dev` keeps threads in memory.
+  Bookmarkable URLs against an in-memory store are a lie — the link survives, the conversation does not.
+  Move to Postgres before you ship the sidebar.
+  Persistence UI should match what the backend can actually restore.
 - **Threads need owners.** A `threadId` in a URL is an identifier, not proof the caller may read that conversation. Bind threads to the authenticated user on the server; `client.threads.search()` will happily list everything otherwise.
 - **The API key cannot live in the browser.** Right now Angular talks to `localhost:2024` directly. In production put a same-origin backend-for-frontend in front, and make `apiUrl` point at that.
 - **A buffering proxy breaks streaming.** If a gateway sits in the path, disable response buffering and preserve the streaming content type, or your token-by-token UI becomes a spinner.

--- a/apps/website/content/blog/2026-08-13-angular-chat-app-tutorial-with-langchain-langgraph.mdx
+++ b/apps/website/content/blog/2026-08-13-angular-chat-app-tutorial-with-langchain-langgraph.mdx
@@ -8,12 +8,14 @@ featured: false
 draft: false
 ---
 
-Let's build an Angular chat _app_ on LangGraph — not a single chat surface, but the whole thing: a conversation sidebar, threads that keep their history, and URLs you can bookmark.
+This is how to build an Angular chat _app_ on LangGraph — not a single chat surface, but the whole thing: a conversation sidebar, threads that keep their history, and URLs you can bookmark.
 
 One conversation is a demo.
 A list of them, each restoring on reload, is a product.
 
-The difference is smaller than you'd think, because the durable part lives on the server. LangGraph already checkpoints every thread and exposes a thread API. Our job in Angular is mostly to stop throwing that away.
+The difference is smaller than you would think, because the durable part lives on the server.
+LangGraph already checkpoints every thread and exposes a thread API.
+Our job in Angular is mostly to stop throwing that away.
 
 ## Goals
 
@@ -30,11 +32,12 @@ The difference is smaller than you'd think, because the durable part lives on th
   guide](/docs/chat/getting-started/installation) covers setup.
 </Callout>
 
-If you only want the streaming surface and none of the app around it, read [Build a Streaming Chat UI in Angular with LangGraph](/blog/build-a-streaming-chat-ui-in-angular-with-langgraph) instead. This post picks up where that one stops.
+If you only want the streaming surface and none of the app around it, read [Build a Streaming Chat UI in Angular with LangGraph](/blog/build-a-streaming-chat-ui-in-angular-with-langgraph) instead.
+This post picks up where that one stops.
 
 ## What are we building?
 
-Here's the whole path:
+Here is the whole path:
 
 ```text
 Angular <chat> + <chat-sidenav>
@@ -48,13 +51,15 @@ Angular <chat> + <chat-sidenav>
 Two Angular pieces, and they read from different places.
 `<chat>` renders the active conversation from the agent. `<chat-sidenav>` renders the thread _list_ from the LangGraph thread API.
 
-That split is the thing to hold onto. The agent knows about one conversation. The thread adapter knows about all of them.
+That split is the thing to hold onto.
+The agent knows about one conversation.
+The thread adapter knows about all of them.
 
 ![chat-sidenav renders every conversation from LangGraphThreadsAdapter while chat renders the active one from the @threadplane/langgraph agent; selecting a row sets the ACTIVE_THREAD signal, the agent adapter watches that signal and switches conversations, and onThreadId writes a newly created thread id back into it.](/blog/diagrams/langgraph-threads-and-runs.svg)
 
 ## How do we get a LangGraph server running?
 
-Let's do the backend first, because the Angular side has nothing to bind to without it.
+The backend comes first, because the Angular side has nothing to bind to without it.
 
 Install the CLI and the model package into a virtualenv:
 
@@ -64,7 +69,8 @@ source .venv/bin/activate
 pip install "langgraph-cli[inmem]" langgraph langgraph-sdk langchain-openai
 ```
 
-Now `graph.py`. A generate node, and a second node that gives the thread a title:
+Now `graph.py`.
+A generate node, and a second node that gives the thread a title:
 
 ```python
 import os
@@ -123,9 +129,12 @@ graph = builder.compile()
 
 Two things there are worth calling out.
 
-**No checkpointer.** `graph.compile()` takes no argument. `langgraph dev` — and LangGraph Platform — provide persistence themselves, and compiling one in fights the server. This trips people up because most LangGraph tutorials you'll read are about invoking a graph in-process, where you _do_ pass `MemorySaver()`.
+**No checkpointer.** `graph.compile()` takes no argument.
+`langgraph dev` — and LangGraph Platform — provide persistence themselves, and compiling one in fights the server.
+This trips people up because most LangGraph tutorials you will read are about invoking a graph in-process, where you _do_ pass `MemorySaver()`.
 
-**`title_thread` calls back into the server.** It's the same SDK your Angular app will use, pointed at the thread it's currently running inside. Leaving `url` as `None` lets the SDK use its in-process transport instead of an HTTP round trip.
+**`title_thread` calls back into the server.** It is the same SDK your Angular app will use, pointed at the thread it is currently running inside.
+Leaving `url` as `None` lets the SDK use its in-process transport instead of an HTTP round trip.
 
 Add `langgraph.json`:
 
@@ -144,7 +153,8 @@ Put `OPENAI_API_KEY=…` in `.env`, then start it:
 langgraph dev --no-browser --port 2024
 ```
 
-The `chat` key in `graphs` is what you'll pass to Angular as `assistantId`. That mapping is easy to forget later when the id doesn't match and every run 404s.
+The `chat` key in `graphs` is what you will pass to Angular as `assistantId`.
+That mapping is easy to forget later when the id does not match and every run 404s.
 
 ## How do we bind Angular to it?
 
@@ -152,7 +162,8 @@ The `chat` key in `graphs` is what you'll pass to Angular as `assistantId`. That
 npm install @threadplane/chat @threadplane/langgraph @langchain/core @langchain/langgraph-sdk marked
 ```
 
-Now `app.config.ts`. This is the file that does the most work in the whole app:
+Now `app.config.ts`.
+This is the file that does the most work in the whole app:
 
 ```ts
 import {
@@ -189,18 +200,22 @@ export const appConfig: ApplicationConfig = {
 };
 ```
 
-`ACTIVE_THREAD` sits at module scope on purpose. `provideAgent()` runs when providers are registered — before any component exists — so it can't reference a class field.
+`ACTIVE_THREAD` sits at module scope on purpose.
+`provideAgent()` runs when providers are registered — before any component exists — so it cannot reference a class field.
 
 The two options that make this an app rather than a demo:
 
 - `threadId: ACTIVE_THREAD` — the adapter _watches_ this signal. Set it, and the conversation switches. You never call a "load thread" method.
 - `onThreadId` — fires when the adapter creates a thread on the first submit. Writing it back into the same signal is what closes the loop.
 
-`LANGGRAPH_THREADS_CONFIG` is separate because the thread list is a separate concern from the agent. It's the config for `LangGraphThreadsAdapter`, which wraps `client.threads.*`.
+`LANGGRAPH_THREADS_CONFIG` is separate because the thread list is a separate concern from the agent.
+It is the config for `LangGraphThreadsAdapter`, which wraps `client.threads.*`.
 
 ## How do we render the sidebar?
 
-`<chat-sidenav>` is the conversation list. One thing to know before you write the template: it has named projection slots for its own regions, but no default slot. The chat goes _beside_ it, not inside it.
+`<chat-sidenav>` is the conversation list.
+One thing to know before you write the template: it has named projection slots for its own regions, but no default slot.
+The chat goes _beside_ it, not inside it.
 
 ```ts
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
@@ -278,19 +293,26 @@ export class ShellComponent {
 
 Notice how little of this is thread _logic_.
 
-Selecting a conversation is `activeThread.set($event)`. Starting a new one is `activeThread.set(null)`. Both work because the adapter is watching the signal — the sidebar doesn't talk to the agent at all.
+Selecting a conversation is `activeThread.set($event)`.
+Starting a new one is `activeThread.set(null)`.
+Both work because the adapter is watching the signal — the sidebar does not talk to the agent at all.
 
-`ThreadActionAdapter` is the right-click menu contract: rename, delete, archive, unarchive, pin, move to a project. `LangGraphThreadsAdapter` already implements each of those against the SDK, so wiring them is mostly forwarding. The `refresh()` after each call matters: the framework clears its optimistic override in a `finally` block, so an action that doesn't change the input list will re-render the old row.
+`ThreadActionAdapter` is the right-click menu contract: rename, delete, archive, unarchive, pin, move to a project.
+`LangGraphThreadsAdapter` already implements each of those against the SDK, so wiring them is mostly forwarding.
+The `refresh()` after each call matters: the framework clears its optimistic override in a `finally` block, so an action that does not change the input list will re-render the old row.
 
 `refreshOnRunEnd` re-fetches the list when a run finishes, which is how a brand-new conversation shows up in the sidebar.
 
 ## How do links survive a refresh?
 
-That's `injectThreadRouting()`, and it's three lines in the constructor above.
+That is `injectThreadRouting()`, and it is three lines in the constructor above.
 
-It restores the thread id from the URL on load, stamps signal changes back into the URL, and keeps the two in sync across back/forward. **The URL is the only source of truth — nothing is written to localStorage**, which is what makes links shareable without extra plumbing.
+It restores the thread id from the URL on load, stamps signal changes back into the URL, and keeps the two in sync across back/forward.
+**The URL is the only source of truth — nothing is written to localStorage**, which is what makes links shareable without extra plumbing.
 
-The `validate` callback earns its place the first time someone pastes a stale link. It runs on any id that appears in the URL; returning `false` redirects to the bare path with `replaceUrl: true`, so the dead URL doesn't sit in history. `LangGraphThreadsAdapter.getThread()` returns `null` on a 404 and rethrows genuine network errors, so `.then(Boolean)` is the whole implementation.
+The `validate` callback earns its place the first time someone pastes a stale link.
+It runs on any id that appears in the URL; returning `false` redirects to the bare path with `replaceUrl: true`, so the dead URL does not sit in history.
+`LangGraphThreadsAdapter.getThread()` returns `null` on a 404 and rethrows genuine network errors, so `.then(Boolean)` is the whole implementation.
 
 Your routes just need both shapes:
 
@@ -307,25 +329,34 @@ Bare path means no thread, which is the welcome state.
 
 The server, which is why `title_thread` is in the graph at all.
 
-`LangGraphThreadsAdapter` maps each SDK thread to the framework's `Thread` type and reads the label from `metadata.title`. Threads that don't have one yet render as `Untitled` — configurable with `titleFallback` on `LANGGRAPH_THREADS_CONFIG`.
+`LangGraphThreadsAdapter` maps each SDK thread to the framework's `Thread` type and reads the label from `metadata.title`.
+Threads that do not have one yet render as `Untitled` — configurable with `titleFallback` on `LANGGRAPH_THREADS_CONFIG`.
 
-There's a wrinkle worth knowing, and it shows up on the very first conversation.
+There is a wrinkle worth knowing, and it shows up on the very first conversation.
 
-A new conversation appears in the sidebar as **Untitled** and _stays_ Untitled for a while. The title node writes `metadata.title` during the run, but the thread list keeps returning the old value for several seconds after the run ends — so the `refreshOnRunEnd` fetch reads a thread that isn't titled yet.
+A new conversation appears in the sidebar as **Untitled** and _stays_ Untitled for a while.
+The title node writes `metadata.title` during the run, but the thread list keeps returning the old value for several seconds after the run ends — so the `refreshOnRunEnd` fetch reads a thread that is not titled yet.
 
-My first instinct was to refresh a second time on a delay. That doesn't work, and I'd rather save you the detour: against `langgraph dev` I tried a 1.5s follow-up, then a 4s one, then a bounded poll refreshing five times at 1.5s intervals. All three finished before the new title showed up in the list, while a direct fetch of that same thread already had it.
+My first instinct was to refresh a second time on a delay.
+That does not work, and I would rather save you the detour: against `langgraph dev` I tried a 1.5s follow-up, then a 4s one, then a bounded poll refreshing five times at 1.5s intervals.
+All three finished before the new title showed up in the list, while a direct fetch of that same thread already had it.
 
-So don't engineer around it with a timer. The label settles on the next list refresh you were going to do anyway — the next message, a navigation, or a reload.
+So do not engineer around it with a timer.
+The label settles on the next list refresh you were going to do anyway — the next message, a navigation, or a reload.
 
-If you want the row correct immediately, own the label instead of waiting for it: title the thread optimistically in your own state from the first user message, and let the server's value replace it whenever the list catches up. That sidesteps the race rather than racing it.
+If you want the row correct immediately, own the label instead of waiting for it: title the thread optimistically in your own state from the first user message, and let the server's value replace it whenever the list catches up.
+That sidesteps the race rather than racing it.
 
-Either way, don't make the title node block the run to keep a sidebar label in sync. For me that's the wrong trade — the title is a nicety, and the conversation shouldn't wait on it.
+Either way, do not make the title node block the run to keep a sidebar label in sync.
+For me that is the wrong trade — the title is a nicety, and the conversation should not wait on it.
 
 ## What about the bundle?
 
-One practical note, because it'll be your first failed build.
+One practical note, because it will be your first failed build.
 
-A fresh `ng new` sets a 500 kB warning and 1 MB error budget. A chat UI plus the LangGraph SDK lands around 1.4 MB raw, so `ng build` fails on budget before it fails on anything real. Raise it in `angular.json`:
+A fresh `ng new` sets a 500 kB warning and 1 MB error budget.
+A chat UI plus the LangGraph SDK lands around 1.4 MB raw, so `ng build` fails on budget before it fails on anything real.
+Raise it in `angular.json`:
 
 ```json
 {
@@ -335,23 +366,27 @@ A fresh `ng new` sets a 500 kB warning and 1 MB error budget. A chat UI plus the
 }
 ```
 
-You'll also see a warning that `p-queue`, used by `@langchain/core`, isn't ESM. It's a bailout warning, not an error.
+You will also see a warning that `p-queue`, used by `@langchain/core`, is not ESM.
+It is a bailout warning, not an error.
 
 ## What still needs work before production?
 
-The app runs now. It isn't finished.
+The app runs now.
+It is not finished.
 
-- **The checkpointer has to be durable.** `langgraph dev` keeps threads in memory. Bookmarkable URLs against an in-memory store are a lie — the link survives, the conversation doesn't. Move to Postgres before you ship the sidebar. Persistence UI should match what the backend can actually restore.
+- **The checkpointer has to be durable.** `langgraph dev` keeps threads in memory. Bookmarkable URLs against an in-memory store are a lie — the link survives, the conversation does not. Move to Postgres before you ship the sidebar. Persistence UI should match what the backend can actually restore.
 - **Threads need owners.** A `threadId` in a URL is an identifier, not proof the caller may read that conversation. Bind threads to the authenticated user on the server; `client.threads.search()` will happily list everything otherwise.
-- **The API key can't live in the browser.** Right now Angular talks to `localhost:2024` directly. In production put a same-origin backend-for-frontend in front, and make `apiUrl` point at that.
+- **The API key cannot live in the browser.** Right now Angular talks to `localhost:2024` directly. In production put a same-origin backend-for-frontend in front, and make `apiUrl` point at that.
 - **A buffering proxy breaks streaming.** If a gateway sits in the path, disable response buffering and preserve the streaming content type, or your token-by-token UI becomes a spinner.
 - **Errors need a path back.** The `Agent` contract has `retry()` and `regenerate()`; `<chat>` wires both. Decide what a failed run should look like before a user finds out for you.
 
 ## Conclusion
 
-The useful split here is that the server already owns everything durable. LangGraph checkpoints the conversation and stores the thread; the Angular app subscribes to one thread through a signal and lists the rest through the thread adapter.
+The useful split here is that the server already owns everything durable.
+LangGraph checkpoints the conversation and stores the thread; the Angular app subscribes to one thread through a signal and lists the rest through the thread adapter.
 
-Once `threadId` is a signal, most of what feels like "app" is just setting it — from a click, from the URL, from a new run. That's the part I'd take away from this even if you build the UI yourself.
+Once `threadId` is a signal, most of what feels like "app" is just setting it — from a click, from the URL, from a new run.
+That is the part I would take away from this even if you build the UI yourself.
 
 Start with `langgraph dev`, get the sidebar listing real threads, then swap in a durable checkpointer and put an authenticated proxy in front.
 

--- a/apps/website/content/blog/2026-08-26-json-render-vs-a2ui-choosing.mdx
+++ b/apps/website/content/blog/2026-08-26-json-render-vs-a2ui-choosing.mdx
@@ -10,12 +10,12 @@ draft: false
 
 Threadplane gives you two ways to let an agent build UI — a json-render spec or an A2UI surface — and this post is about how to pick.
 
-There's a ladder here: markdown when text is the best UI → a fixed spec when you can validate the whole thing up front → a live protocol when the surface keeps changing.
+There is a ladder here: markdown when text is the best UI → a fixed spec when you can validate the whole thing up front → a live protocol when the surface keeps changing.
 The [mechanical comparison](/docs/render/concepts/json-render-vs-a2ui) covers what each layer does; this post answers the question that page ends on: which rung is yours?
 
 ## What's actually different?
 
-This isn't a renderer shootout. The tradeoff is contract shape.
+This is not a renderer shootout. The tradeoff is contract shape.
 
 With json-render, the contract is _application-owned_.
 You define the schema, you validate the spec before anything mounts, and your handlers own what every event means.
@@ -23,7 +23,7 @@ You define the schema, you validate the spec before anything mounts, and your ha
 With A2UI, the surface is _agent-owned_.
 The agent creates it, keeps updating it over the life of the conversation, and gets structured actions back when the user interacts.
 
-Let's look at the same order card in both shapes.
+Here is the same order card in both shapes.
 First as a json-render spec:
 
 ```json
@@ -52,12 +52,12 @@ One is a document you can validate before you show it; the other is a conversati
 
 ## When does the fixed spec win?
 
-Whenever the UI is one answer — the agent responds once, the UI renders once, and it's done.
+Whenever the UI is one answer — the agent responds once, the UI renders once, and it is done.
 
-Let's walk two scenarios to a verdict.
+Two scenarios, each walked to a verdict.
 
 A _structured result card_ in chat: the agent looks up an order and answers with a summary card.
-Nothing about that card changes after it lands, so there's no ongoing surface to manage.
+Nothing about that card changes after it lands, so there is no ongoing surface to manage.
 Verdict: json-render.
 You get to validate the whole spec before mount, and your handlers — not the protocol — decide what a click means.
 
@@ -66,15 +66,15 @@ Verdict: json-render again, driven directly through `<render-spec>`.
 The fixed contract is the feature here: explicit inputs on your own custom components, a schema you can lint, a spec you can snapshot in a test.
 
 One security note: in both paths, the registry is doing allowlist duty.
-A component name the model emits that isn't registered falls back instead of executing — json-render and A2UI share that posture, so it's not a reason to pick either.
+A component name the model emits that is not registered falls back instead of executing — json-render and A2UI share that posture, so it is not a reason to pick either.
 
 ## When does the protocol win?
 
 Whenever the surface has to live past its first render.
 
-Let's take the itinerary case.
+Consider the itinerary case.
 The agent proposes a three-day trip mid-conversation: the component structure arrives first, prices and times fill in as `updateDataModel` messages land, and two turns later the agent swaps day two entirely.
-That's not one spec becoming one component tree — it's a surface being edited over time, and that's exactly what the envelope stream models.
+That is not one spec becoming one component tree — it is a surface being edited over time, and that is exactly what the envelope stream models.
 
 Now a form the _agent_ needs back.
 A _valid_ submit goes back to the agent as a structured action message on its own; create the surface with `sendDataModel` and the current data model rides along.
@@ -87,17 +87,17 @@ Envelopes have to be valid and arrive in a sensible order, the catalog has to su
 
 ## What does it cost to switch?
 
-Inside chat, less than you'd think.
+Inside chat, less than you would think.
 
-Let's look at why. The same `[views]` catalog feeds both paths, and chat detects the contract from the first bytes: `{` means a json-render spec, `---a2ui_JSON---` means A2UI JSONL.
-So the choice is per-surface, not per-app — and it's revisable.
+Here is why. The same `[views]` catalog feeds both paths, and chat detects the contract from the first bytes: `{` means a json-render spec, `---a2ui_JSON---` means A2UI JSONL.
+So the choice is per-surface, not per-app — and it is revisable.
 
 For me, the default is: start with json-render, and step up to A2UI only when a surface genuinely needs to live past its first render.
-You're not locked in either way, so the cheap contract is the right place to begin.
+You are not locked in either way, so the cheap contract is the right place to begin.
 
 ## Conclusion
 
 The heuristic is short: if you can validate the entire UI before it renders, start with json-render; if the surface keeps changing after it lands — data trickling in, actions coming back, edits across turns — use A2UI.
 
 The [mechanical comparison](/docs/render/concepts/json-render-vs-a2ui) has the layer-by-layer details, the [generative UI guide](/docs/chat/guides/generative-ui) wires up the json-render path end to end, and the [A2UI overview](/docs/chat/a2ui/overview) does the same for surfaces.
-Pick a surface you're building this week, run it up the ladder, and let me know where it lands.
+Pick a surface you are building this week, run it up the ladder, and let me know where it lands.

--- a/apps/website/content/blog/2026-08-26-what-inject-agent-returns.mdx
+++ b/apps/website/content/blog/2026-08-26-what-inject-agent-returns.mdx
@@ -8,63 +8,64 @@ featured: false
 draft: false
 ---
 
-You call `injectAgent()` once, you get one object back — this post is about what's actually in it.
+You call `injectAgent()` once, you get one object back — this post is about what is actually in it.
 
 The [API page](/docs/langgraph/api/inject-agent) answers "what's the signature."
-That's the right question when you're mid-keystroke.
+That is the right question when you are mid-keystroke.
 This post answers the other one: what is each piece of the return value _for_, and why is it shaped the way it is?
 
 ## What are the signals?
 
-Six core signals, and together they're the reactive picture most apps need.
+Six core signals, and together they are the reactive picture most apps need.
 
-Let's take them one at a time:
+One at a time:
 
 - `messages` — the conversation as a `Message[]`, updated as tokens stream in. This is what you `@for` over.
 - `status` — where the agent is in its run lifecycle, as a single value you can switch on.
 - `isLoading` — `true` while a run is in flight. The signal behind every "Thinking…" indicator.
-- `error` — the last run's failure, or `undefined`. Render it; don't `try/catch` your template.
+- `error` — the last run's failure, or `undefined`. Render it; do not `try/catch` your template.
 - `toolCalls` — the tool calls the model has made, so you can show work-in-progress instead of dead air.
 - `state` — the graph's custom state, typed to your `T` when you use a typed agent ref.
 
-There's a little more on the contract: optional `interrupt` and `subagents` signals when the adapter supports those capabilities, and an `events$` observable for everything that doesn't fit a signal.
+There is a little more on the contract: optional `interrupt` and `subagents` signals when the adapter supports those capabilities, and an `events$` observable for everything that does not fit a signal.
 
-That's the surface you bind templates to.
+That is the surface you bind templates to.
 No subscriptions, no `async` pipe bookkeeping, no manual change detection — a streaming token lands in `messages`, and Angular's reactivity does the rest.
 
 ## What are the methods?
 
-Four, and they're the imperative half — the things user actions call.
+Four, and they are the imperative half — the things user actions call.
 
-Let's take them in the order you'll reach for them:
+In the order you will reach for them:
 
 - `submit(input, opts?)` — send a user message (or a resume payload, or a state patch) and start a run. Returns a promise that settles when the run does.
 - `stop()` — cancel the in-flight run.
-- `retry()` — re-run the last submission after a failure. It's deliberately safe to wire to a button: it's a no-op if a run is already in flight or there's nothing to retry.
+- `retry()` — re-run the last submission after a failure. It is deliberately safe to wire to a button: it is a no-op if a run is already in flight or there is nothing to retry.
 - `regenerate(assistantMessageIndex)` — discard the assistant message at that index and everything after it, then re-submit the user message that preceded it. This is how "regenerate response" works without you managing message surgery yourself.
 
-Signals tell the template what's true; these methods are how the user changes it.
+Signals tell the template what is true; these methods are how the user changes it.
 
 ## Why is the return type two types?
 
-Because most of what you get back isn't LangGraph-shaped — and that's on purpose.
+Because most of what you get back is not LangGraph-shaped — and that is on purpose.
 
-`injectAgent()` from `@threadplane/langgraph` returns a `LangGraphAgent<T>`, which extends the runtime-neutral `Agent` contract (by way of `AgentWithHistory`, which adds a `history` signal — a sub-contract, so don't count on `history` surviving a runtime swap; the AG-UI agent implements plain `Agent`).
+`injectAgent()` from `@threadplane/langgraph` returns a `LangGraphAgent<T>`, which extends the runtime-neutral `Agent` contract (by way of `AgentWithHistory`, which adds a `history` signal — a sub-contract, so do not count on `history` surviving a runtime swap; the AG-UI agent implements plain `Agent`).
 Everything above — the six signals, the four methods — lives on that neutral contract.
 
 The neutral slice is what `<chat>` and the other primitives consume.
-They don't know they're talking to LangGraph.
+They do not know they are talking to LangGraph.
 
-Let's look at what sits on top. `LangGraphAgent` adds the runtime-specific members — raw `langGraph*`-prefixed signals that expose the underlying `BaseMessage` and thread-state shapes, plus things like `value`, `branch`/`setBranch`, `switchThread`, and `lifecycle`.
-They're additive. You reach for them when you need LangGraph itself; you ignore them when you don't.
+The layer on top is where the runtime shows through.
+`LangGraphAgent` adds the runtime-specific members — raw `langGraph*`-prefixed signals that expose the underlying `BaseMessage` and thread-state shapes, plus things like `value`, `branch`/`setBranch`, `switchThread`, and `lifecycle`.
+They are additive. You reach for them when you need LangGraph itself; you ignore them when you do not.
 
-Here's the payoff: the AG-UI adapter's `injectAgent()` returns the same neutral slice.
+Here is the payoff: the AG-UI adapter's `injectAgent()` returns the same neutral slice.
 Swap the adapter, and every component bound to `messages`, `isLoading`, and `submit` keeps working.
-For me, that's the strongest reason to keep your components on the neutral surface and treat the `langGraph*` members as an escape hatch — [choosing an adapter](/docs/choosing-an-adapter) walks through the tradeoff.
+For me, that is the strongest reason to keep your components on the neutral surface and treat the `langGraph*` members as an escape hatch — [choosing an adapter](/docs/choosing-an-adapter) walks through the tradeoff.
 
 ## What does this look like in a component?
 
-Let's put the whole thing in one small component:
+The whole thing fits in one small component:
 
 ```ts
 import { Component } from '@angular/core';
@@ -87,11 +88,11 @@ export class SupportComponent {
 ```
 
 Sending is the same object: a submit button calls `chat.submit({ message: text })`, and the response streams into `messages` on its own.
-This isn't the full setup — `injectAgent()` needs `provideAgent()` configured first, and the [quickstart](/docs/langgraph/getting-started/quickstart) covers that.
+This is not the full setup — `injectAgent()` needs `provideAgent()` configured first, and the [quickstart](/docs/langgraph/getting-started/quickstart) covers that.
 
 ## Conclusion
 
-One call returns the whole agent surface: reactive signals for the template, imperative methods for user actions, and a contract that isn't LangGraph-shaped underneath.
+One call returns the whole agent surface: reactive signals for the template, imperative methods for user actions, and a contract that is not LangGraph-shaped underneath.
 That last part is the one I think matters most — bind to the neutral slice and the runtime becomes a swappable detail.
 
-The [API reference](/docs/langgraph/api/inject-agent) has the full signatures, [choosing an adapter](/docs/choosing-an-adapter) covers when the neutral contract earns its keep, and if you haven't built the streaming surface yet, start with [Build a Streaming Chat UI in Angular with LangGraph](/blog/build-a-streaming-chat-ui-in-angular-with-langgraph).
+The [API reference](/docs/langgraph/api/inject-agent) has the full signatures, [choosing an adapter](/docs/choosing-an-adapter) covers when the neutral contract earns its keep, and if you have not built the streaming surface yet, start with [Build a Streaming Chat UI in Angular with LangGraph](/blog/build-a-streaming-chat-ui-in-angular-with-langgraph).

--- a/apps/website/content/blog/2026-08-27-langgraph-subgraphs-when-to-split.mdx
+++ b/apps/website/content/blog/2026-08-27-langgraph-subgraphs-when-to-split.mdx
@@ -10,14 +10,15 @@ draft: false
 
 Most people reach for a LangGraph subgraph expecting a _state_ boundary, and what they actually get is an _observable_ one.
 
-If your question is "single agent, approval loop, or multi-agent?", that's an architecture question and the [decision matrix](/docs/langgraph/concepts/agent-architecture) already answers it.
+If your question is "single agent, approval loop, or multi-agent?", that is an architecture question and the [decision matrix](/docs/langgraph/concepts/agent-architecture) already answers it.
 This post is about the layer underneath: what a subgraph actually changes at runtime, why our own graphs got split, and what the frontend sees while a child is running.
 
 ## What does a subgraph actually give you?
 
-Nested execution and namespaced stream events. That's the honest list.
+Nested execution and namespaced stream events.
+That is the honest list.
 
-Let's start with the canonical pattern, which is small.
+Start with the canonical pattern, which is small.
 Compile a child `StateGraph`, then add the compiled graph as a node in the parent:
 
 ```python
@@ -34,17 +35,17 @@ Two things change.
 The child runs as its own graph, with its own nodes and its own step sequence rather than being flattened into the parent's.
 And LangGraph emits the child's stream events under a namespace, so a consumer can tell parent output from child output.
 
-Here's the part I think gets assumed and shouldn't: state isolation isn't a third.
+Here is the part I think gets assumed and should not be: state isolation is not a third.
 
 If parent and child share `MessagesState`, the child appends to the same message list the parent is building.
 Nothing about `add_node` fenced anything off.
 
 Isolation is something you design — give the child its own state schema, then map in at the boundary and map the result back out.
-That's a decision you make and maintain, not a property `compile()` hands you.
+That is a decision you make and maintain, not a property `compile()` hands you.
 
-We ship one graph that does exactly that, and because it's a capability demo built to show the primitive, it's a clean look at the shape.
+We ship one graph that does exactly that, and because it is a capability demo built to show the primitive, it is a clean look at the shape.
 Its child state schema has no `messages` key at all.
-Parent and child share exactly two keys, `research_topic` and `research_brief`, so the child is handed a topic and hands back a brief — it can't read the transcript, and it can't append to one.
+Parent and child share exactly two keys, `research_topic` and `research_brief`, so the child is handed a topic and hands back a brief — it cannot read the transcript, and it cannot append to one.
 
 That boundary is real, and none of it came from `compile()`.
 It came from writing two `TypedDict`s and being deliberate about what they share.
@@ -61,19 +62,20 @@ Reuse across parents is a consequence of the child being a value you can referen
 
 You can have all three without ever compiling a child graph, and you can compile a child graph and get none of them.
 
-There is one more, and it's worth stating because it looks like a counterexample.
+There is one more, and it is worth stating because it looks like a counterexample.
 Wire the child in as a node under a parent that has a checkpointer, and the child's steps get checkpointed under its namespace — which is what lets you interrupt and resume at child granularity.
-Notice that's the namespace again, doing a second job.
+Notice that is the namespace again, doing a second job.
 
 ## Why do people really split?
 
 In our own repo, the honest answer is: so the frontend can see the delegation.
 
-That's a claim about our own graphs, not a law of the framework — and one of them splits for a different reason entirely, which I'll get to.
-But it's a natural experiment rather than a portfolio — nobody wrote these to prove a point about subgraphs, and the constraint that drove them, a frontend that renders per-child progress, isn't specific to us.
+That is a claim about our own graphs, not a law of the framework — and one of them splits for a different reason entirely, which I will get to.
+But it is a natural experiment rather than a portfolio.
+Nobody wrote these to prove a point about subgraphs, and the constraint that drove them, a frontend that renders per-child progress, is not specific to us.
 
-Let's look at what we wrote down at the time.
-Here's the comment sitting above the research subagent in our canonical `examples/chat` graph:
+Start with what we wrote down at the time.
+Here is the comment sitting above the research subagent in our canonical `examples/chat` graph:
 
 ```python
 # Research subagent — a small compiled child graph the parent dispatches
@@ -83,9 +85,11 @@ Here's the comment sitting above the research subagent in our canonical `example
 # SubagentTracker keys on to populate `agent.subagents()`.
 ```
 
-That's not a state argument. It's a visibility argument.
+That is not a state argument.
+It is a visibility argument.
 
-The design doc for that feature is blunter still. Here's the alternative it rejected:
+The design doc for that feature is blunter still.
+Here is the alternative it rejected:
 
 ```text
 Plain `@tool` returning a synthesized "subagent" payload — Simpler graph
@@ -94,15 +98,15 @@ namespace events get emitted because no subgraph runs. The card would
 render empty. Rejected.
 ```
 
-Then there's the conversion.
+Then there is the conversion.
 Our `cockpit/chat/subagents` demo originally ran its three specialists as a flat in-process helper, and was rewritten to dispatch a real compiled child graph — because the flat version emitted no namespace events, so `subagents()` stayed empty and no card rendered.
 A working feature was restructured so a UI card would appear.
 
 In both of those graphs the compiled child is invoked from inside a `@tool` body, not wired in as a plain node.
-That's deliberate: the tool call carries the identity — an id the tracker can attribute the child's stream to, and a `subagent_type` to name it.
+That is deliberate: the tool call carries the identity — an id the tracker can attribute the child's stream to, and a `subagent_type` to name it.
 
-For a long time that was also the only way into the map: plain `add_node` subgraphs streamed under a namespace nobody claimed, so [our own docs](/docs/langgraph/guides/subgraphs) were blunt that they didn't show up at all.
-That's no longer true.
+For a long time that was also the only way into the map: plain `add_node` subgraphs streamed under a namespace nobody claimed, so [our own docs](/docs/langgraph/guides/subgraphs) were blunt that they did not show up at all.
+That is no longer true.
 The namespace segment is itself a workable identity — unique per invocation, prefixed with the node name — so a plain subgraph child now registers in `subagents()` under its namespace key the moment it first streams, named by its node.
 The subgraph is what makes the events observable; the tool call upgrades that identity from a node name to a real delegation record, with arguments a UI can render.
 
@@ -116,7 +120,7 @@ Namespaced events — and nearly everything interesting downstream follows from 
 
 ### What the wire looks like
 
-Let's take it from the wire inward.
+Take it from the wire inward.
 The event type carries the namespace after a pipe, so the base type is the part before it:
 
 ```text
@@ -125,16 +129,16 @@ messages|tools:call-1    # child run dispatched by tool call "call-1"
 ```
 
 Our transport requests those child streams by default — `streamSubgraphs` is `true` unless you turn it off.
-That's the LangGraph JS SDK's own option name, passed straight through, and worth knowing if you're coming from the Python API, where the in-process `graph.stream()` equivalent is the `subgraphs=True` kwarg.
+That is the LangGraph JS SDK's own option name, passed straight through, and worth knowing if you are coming from the Python API, where the in-process `graph.stream()` equivalent is the `subgraphs=True` kwarg.
 
 ### The terminal-event hazard
 
 A child graph terminates before the parent does, and a child's terminal event looks an awful lot like the parent's.
 
 Without a namespace guard, that child terminal marker gets read as "the run finished" and closes out the parent's still-streaming assistant message.
-We guard it by refusing namespaced events as top-level terminal evidence, and there's a test that feeds a namespaced terminal marker in and asserts the parent message settles with outcome `interrupted` rather than success.
+We guard it by refusing namespaced events as top-level terminal evidence, and there is a test that feeds a namespaced terminal marker in and asserts the parent message settles with outcome `interrupted` rather than success.
 
-If you ever write a transport against this stream yourself, that's the bug you'll hit, and it will look like truncation rather than a namespace bug.
+If you ever write a transport against this stream yourself, that is the bug you will hit, and it will look like truncation rather than a namespace bug.
 
 ### Where child text goes
 
@@ -145,12 +149,13 @@ Ours took that path for a long time: child tokens merged into `messages()` unles
 
 What made that bug expensive is that it self-corrected.
 The parent's final `values` event rewrites the message list from authoritative graph state, so the stray bubble disappeared on its own once the run settled.
-Assert on the finished DOM and everything looks right; watch the streaming pass and you'd see the child's notes appear and then vanish.
+Assert on the finished DOM and everything looks right.
+Watch the streaming pass and you would see the child's notes appear and then vanish.
 A final-state test cannot catch it — we found it by watching a live model with the DOM under a polling probe.
 
 The fix was to stop making it a decision at all.
 A namespaced event belongs to its child, structurally: it feeds that child's `messages()` on the subagent stream and never merges into the parent transcript.
-The opt-out flag is gone because there's nothing left to opt out of.
+The opt-out flag is gone because there is nothing left to opt out of.
 What the transcript shows at settle is decided by state — a shared `messages` key delivers the child's message through the final `values` sync; an isolated child schema means it never arrives.
 `transcriptNodeNames` still exists for the genuinely separate problem of *top-level* side-effect nodes, like routers and title generators.
 
@@ -164,23 +169,23 @@ Marking a child running and routing its messages need no matching at all.
 There is also a description-comparison ladder — exact match on the tool call's `description` argument, then substring either direction, then a last-resort fallback to any unmapped subagent still pending or running.
 It only runs for children whose state opens with a human message, and none of the graphs we ship reach it.
 The ones dispatched through a tool call invoke the child with an empty message list, so the first message in child state is the AI response.
-The one wired in as a plain node doesn't keep a `messages` key in child state at all.
+The one wired in as a plain node does not keep a `messages` key in child state at all.
 Treat that path as untested rather than as the mechanism.
 
-The general point survives, though, and it's the one worth carrying to any protocol.
+The general point survives, though, and it is the one worth carrying to any protocol.
 A consumer mapping child runs onto delegations is doing string matching unless the protocol gives it an id.
 LangGraph gives it an id — which is why the ladder is vestigial here and would be load-bearing in a fan-out graph with look-alike children.
 
 One limit, though: only the _first_ `tools:` segment of a namespace is read.
 A subagent that itself delegates will have its inner events attributed to the outer tool call.
-Nothing in this repo exercises deeper nesting, so don't build on it.
+Nothing in this repo exercises deeper nesting, so do not build on it.
 
 ## When should you not split?
 
-When there's no observable boundary to draw and no genuinely divergent state.
+When there is no observable boundary to draw and no genuinely divergent state.
 
-The cleanest evidence I have is a control group we didn't set out to build.
-Our `cockpit/ag-ui/subagents` capability ships the same three-subagent feature as the LangGraph one — and it's a LangGraph `StateGraph` too, same framework, same orchestrator-plus-`task`-tool shape, same three roles, same cards in the UI — with no subgraph anywhere.
+The cleanest evidence I have is a control group we did not set out to build.
+Our `cockpit/ag-ui/subagents` capability ships the same three-subagent feature as the LangGraph one — and it is a LangGraph `StateGraph` too, same framework, same orchestrator-plus-`task`-tool shape, same three roles, same cards in the UI — with no subgraph anywhere.
 Its module docstring says so outright:
 
 ```text
@@ -189,22 +194,23 @@ structure, but each dispatch emits `subagent_activity` CUSTOM events
 ```
 
 The thing that differs is the transport: AG-UI's already carries a first-class delegation event.
-So so the specialists stayed a flat `async` helper and progress reaches the frontend as a custom event dispatched from the tool body.
+So the specialists stayed a flat `async` helper and progress reaches the frontend as a custom event dispatched from the tool body.
 
-The subgraph was never required by the feature. It was required by the transport.
+The subgraph was never required by the feature.
+It was required by the transport.
 
 You could dispatch custom events from the LangGraph graph too — nothing stops you, and `adispatch_custom_event` is a LangChain primitive, not an AG-UI one.
-What namespaces buy is that you don't have to.
+What namespaces buy is that you do not have to.
 The boundary emits its own identity for free, and a transport that reads it works against any graph rather than any graph that remembered to instrument itself.
 
-Staying flat wasn't free.
-There's no separate state schema to isolate anything into, and no child step sequence — every specialist gets the parent's shape, one LLM call wide.
+Staying flat was not free.
+There is no separate state schema to isolate anything into, and no child step sequence — every specialist gets the parent's shape, one LLM call wide.
 What it bought was one fewer graph for a feature that renders identically.
 
-That's the test I'd apply.
-If your transport already has a way to say "a child is working right now," or your UI doesn't render per-child progress at all, then a subgraph is a boundary you now have to defend: an extra state schema, mapping at both edges, and one more place to look when a message goes missing.
+For me, that is the test.
+If your transport already has a way to say "a child is working right now," or your UI does not render per-child progress at all, then a subgraph is a boundary you now have to defend: an extra state schema, mapping at both edges, and one more place to look when a message goes missing.
 
-And splitting because a region of the graph _feels_ like a separate concern isn't a reason on its own.
+And splitting because a region of the graph _feels_ like a separate concern is not a reason on its own.
 A node is already a unit.
 
 ### So when does a split earn itself?
@@ -212,26 +218,28 @@ A node is already a unit.
 When the child really is a different graph — and the repo has exactly one of those, which is the case I owe you after arguing the other side this whole time.
 
 Our `examples/ag-ui` demo runs on that same AG-UI transport, and it emits the same `subagent_activity` events from the tool body.
-So it isn't buying observability; it already had it.
+So it is not buying observability.
+It already had it.
 It compiles a child graph anyway.
 
 Look at what the child is, though.
 It has its own `agent → tools → agent` loop with conditional edges and an iteration cap — a different control flow from the parent's, not a slice of it.
 
-And here's the part that took me a second read to see.
-A custom child state schema doesn't discriminate at all: the two graphs I just used as observability evidence _also_ define their own child `TypedDict`s.
+And here is the part that took me a second read to see.
+A custom child state schema does not discriminate at all: the two graphs I just used as observability evidence _also_ define their own child `TypedDict`s.
 But both of those children are one node and a straight line, so the schema is really just an argument list with a type on it.
 
-So it's the control flow, not the schema.
+So it is the control flow, not the schema.
 A child that carries a `topic` string is a function call wearing a graph costume.
-A child that loops until it's satisfied is a graph.
+A child that loops until it is satisfied is a graph.
 
 ## Conclusion
 
 Split when something outside the graph needs to see the child run as its own thing — a card, a progress panel, per-child streaming.
-Split when the child has its own control flow — a loop, a branch, a stopping condition the parent doesn't have — and you're willing to own the mapping at both edges.
-Don't split for tidiness, and don't assume the split isolated state: wire a child in as a node on a shared `MessagesState` and it appends straight to the transcript the parent is building.
+Split when the child has its own control flow — a loop, a branch, a stopping condition the parent does not have — and you are willing to own the mapping at both edges.
+Do not split for tidiness, and do not assume the split isolated state: wire a child in as a node on a shared `MessagesState` and it appends straight to the transcript the parent is building.
 
 The [architecture matrix](/docs/langgraph/concepts/agent-architecture) covers the tiering question, the [subgraphs guide](/docs/langgraph/guides/subgraphs) has the composition and `subagents()` wiring, and [What injectAgent() Actually Returns](/blog/what-inject-agent-returns) walks the signal surface those child streams land in.
 
-If you've split a graph for a third reason — not observability, and not a child that's genuinely its own graph — I'd like to hear it. Those are the two I've been able to justify; I doubt they're the only two that exist.
+If you have split a graph for a third reason — not observability, and not a child that is genuinely its own graph — I would like to hear it.
+Those are the two I have been able to justify, and I doubt they are the only two that exist.

--- a/apps/website/content/blog/2026-08-29-what-fixture-replay-cant-catch.mdx
+++ b/apps/website/content/blog/2026-08-29-what-fixture-replay-cant-catch.mdx
@@ -82,7 +82,9 @@ That something is `hasToolResult`, and matching is first-match-wins:
 Swap those two entries and the run never terminates.
 
 The continuation arrives carrying the same user message, matches the looser entry first, and gets handed the response that asks for the tool call again.
-The model calls the tool. The result comes back. It matches the looser entry again.
+The model calls the tool.
+The result comes back.
+It matches the looser entry again.
 Nothing errors. The assistant simply never finalizes.
 
 For me that is the sharpest thing about fixture files: they are data, so they look inert, but the ordering is executable.

--- a/apps/website/content/blog/2026-08-29-what-fixture-replay-cant-catch.mdx
+++ b/apps/website/content/blog/2026-08-29-what-fixture-replay-cant-catch.mdx
@@ -8,19 +8,23 @@ featured: false
 draft: false
 ---
 
-Agents are hard to test end to end for one boring reason: the model doesn't return the same thing twice.
-Ask it the same question in two runs and you get two different sentences, two different orderings, sometimes a tool call and sometimes not. Write an assertion against that and you've written a coin flip.
+Agents are hard to test end to end for one boring reason: the model does not return the same thing twice.
+Ask it the same question in two runs and you get two different sentences, two different orderings, sometimes a tool call and sometimes not.
+Write an assertion against that and you have written a coin flip.
 
 The usual fix is to stop calling the model.
-You capture its responses once, save them to disk as _fixtures_, and _replay_ them on every run — same request in, same bytes back, forever. The tests go deterministic, CI stops spending money on tokens, and the agent under test never knows it's talking to a recording.
+You capture its responses once, save them to disk as _fixtures_, and _replay_ them on every run — same request in, same bytes back, forever.
+The tests go deterministic, CI stops spending money on tokens, and the agent under test never knows it is talking to a recording.
 
-We test our whole demo fleet that way. This post is about the bill, because replay isn't free and the charge doesn't show up where you'd look for it.
+We test our whole demo fleet that way.
+This post is about the bill, because replay is not free and the charge does not show up where you would look for it.
 
-Here's the shape of it. Every deterministic harness buys its determinism by deleting a dimension of the real thing.
+Here is the shape of it.
+Every deterministic harness buys its determinism by deleting a dimension of the real thing.
 Ours deletes _time_ — deliberately, with the reason written in the source — and one specific class of bug vanishes along with it.
 
-So the interesting question about a harness isn't whether it's green.
-It's which dimension you deleted, because that's the list of bugs it can't report.
+So the interesting question about a harness is not whether it is green.
+It is which dimension you deleted, because that is the list of bugs it cannot report.
 
 ## Where do you put the mock?
 
@@ -44,14 +48,16 @@ Everything above that line is the real thing.
 A real Angular app, the real streaming transport, a real Python server, real graph nodes with their edges and conditional routing.
 The model is the only stand-in.
 
-Let's take the alternative.
-A test that mocks the agent at the app boundary proves your component renders what you handed it. It cannot tell you that your graph's conditional edge routes correctly, that your transport merges deltas in the right order, or that a tool call round-trips.
+The alternative is worth naming.
+A test that mocks the agent at the app boundary proves your component renders what you handed it.
+It cannot tell you that your graph's conditional edge routes correctly, that your transport merges deltas in the right order, or that a tool call round-trips.
 Push the seam out to the provider and all of that is under test, because none of it was replaced.
 
 Replacing the model — and only the model — is also what makes it cheap enough to run everywhere: no API spend, no rate limits, no coin flips.
 We have 50 fixture files holding 129 entries across 34 apps — 32 cockpit capabilities and two example apps — all on the same harness.
 
-This is the outer tier. For in-process fakes at the unit level, the [testing guide](/docs/langgraph/guides/testing) covers `provideFakeAgent()`, `mockLangGraphAgent()`, and `MockAgentTransport`, which are a different tool for a different job.
+This is the outer tier.
+For in-process fakes at the unit level, the [testing guide](/docs/langgraph/guides/testing) covers `provideFakeAgent()`, `mockLangGraphAgent()`, and `MockAgentTransport`, which are a different tool for a different job.
 
 ## What does a fixture match on?
 
@@ -59,7 +65,8 @@ The shape of the request — and the order you list the entries decides which on
 
 A fixture file is a list of entries, and each one is a pair: a `match` block describing which request it answers, and the response to hand back when a request fits.
 
-The obvious discriminator is the user message, but there are richer ones: a parent LLM's first call and its continuation after a tool round carry the same user message. Something has to tell them apart.
+The obvious discriminator is the user message, but there are richer ones: a parent LLM's first call and its continuation after a tool round carry the same user message.
+Something has to tell them apart.
 
 That something is `hasToolResult`, and matching is first-match-wins:
 
@@ -78,13 +85,14 @@ The continuation arrives carrying the same user message, matches the looser entr
 The model calls the tool. The result comes back. It matches the looser entry again.
 Nothing errors. The assistant simply never finalizes.
 
-For me that's the sharpest thing about fixture files: they're data, so they look inert, but the ordering is executable.
+For me that is the sharpest thing about fixture files: they are data, so they look inert, but the ordering is executable.
 
 ## What did we trade away?
 
 The streaming, on purpose.
 
-The mock is constructed with a chunk size large enough that every response arrives in one or two server-sent events. Here's the whole note that sits above it:
+The mock is constructed with a chunk size large enough that every response arrives in one or two server-sent events.
+Here is the whole note that sits above it:
 
 ```typescript
 // Use a large chunkSize so each response arrives in 1-2 SSE deltas. This
@@ -99,20 +107,27 @@ The mock is constructed with a chunk size large enough that every response arriv
 const mock = new LLMock({ port: 0, chunkSize: 4096 });
 ```
 
-A real rendering bug, but a *streaming* one, and it was making structural assertions flaky for reasons that had nothing to do with what they asserted. So the timing went away and the property moved down a tier.
+A real rendering bug, but a *streaming* one, and it was making structural assertions flaky for reasons that had nothing to do with what they asserted.
+So the timing went away and the property moved down a tier.
 
-I think that's the right trade, and the reason isn't that the flakiness went away — it's that the property didn't.
+I think that is the right trade, and the reason is not that the flakiness went away — it is that the property did not.
 
 The tempting alternative is to replay the recorded chunk boundaries instead of re-chunking, so you get the timing back for free.
-That doesn't buy what it looks like it buys. Faithful boundaries make the fence failure *deterministic* rather than absent — the parser bug is still there, and now every structural assertion in the suite fails for a reason none of them are about.
+That does not buy what it looks like it buys.
+Faithful boundaries make the fence failure *deterministic* rather than absent — the parser bug is still there, and now every structural assertion in the suite fails for a reason none of them are about.
 
-Now the part that's easy to get wrong without going looking, and it's the useful half.
+Now the part that is easy to get wrong without going looking, and it is the useful half.
 
-That 4096 is a _default_, not a law. A second harness serves our two example apps, and its version of that comment says so outright — ordinary fixtures get the big chunk size, and *targeted streaming regressions opt into smaller per-fixture chunks*. Those fixtures set chunk sizes of three, four, six, twenty-three, thirty-six, with latencies from 25 to 750 milliseconds. There are e2e tests over there that sample the mid-stream DOM while it renders.
+That 4096 is a _default_, not a law.
+A second harness serves our two example apps, and its version of that comment says so outright — ordinary fixtures get the big chunk size, and *targeted streaming regressions opt into smaller per-fixture chunks*.
+Those fixtures set chunk sizes of three, four, six, twenty-three, thirty-six, with latencies from 25 to 750 milliseconds.
+There are e2e tests over there that sample the mid-stream DOM while it renders.
 
-So "we deleted time" is too tidy. What we did was delete it by default and buy it back per fixture, in the places somebody decided it was worth the cost.
+So "we deleted time" is too tidy.
+What we did was delete it by default and buy it back per fixture, in the places somebody decided it was worth the cost.
 
-Which turns the question into a better one. Not *what did the harness give up*, but *which tier opted back in* — because the tier that didn't is the one flying blind.
+Which turns the question into a better one.
+Not *what did the harness give up*, but *which tier opted back in* — because the tier that did not is the one flying blind.
 
 ## What does that hide?
 
@@ -120,56 +135,76 @@ Bugs that exist only while the stream is open and fix themselves before it close
 
 We shipped one recently and fixed it, and where it lived is the whole argument: a cockpit capability, on the harness with no per-fixture opt-in.
 
-A demo runs a child graph as a plain node — the shape [the subgraphs post](/blog/langgraph-subgraphs-when-to-split) ends on. A plain subgraph node's events aren't tagged as a delegated subagent, so the bridge merges the child's tokens into the transcript as they arrive.
+A demo runs a child graph as a plain node — the shape [the subgraphs post](/blog/langgraph-subgraphs-when-to-split) ends on.
+A plain subgraph node's events are not tagged as a delegated subagent, so the bridge merges the child's tokens into the transcript as they arrive.
 
-The child in that graph produces an internal research brief, meant for the parent to write its answer from. Without the option that whitelists which nodes count as transcript, that brief renders as its own chat bubble, and the message list transiently reaches three.
+The child in that graph produces an internal research brief, meant for the parent to write its answer from.
+Without the option that whitelists which nodes count as transcript, that brief renders as its own chat bubble, and the message list transiently reaches three.
 
-Then the run settles. The parent publishes its authoritative state, the transcript is rebuilt from it, and the extra bubble vanishes.
+Then the run settles.
+The parent publishes its authoritative state, the transcript is rebuilt from it, and the extra bubble vanishes.
 
 Read that sequence again from a test's point of view.
 The end state is correct. Two messages, in the right order.
 Assert on the finished DOM and it passes — not by luck.
 
-Confirming the fix meant driving it against a live model and sampling the DOM on a tight interval for the length of a full run, watching that the message count never crossed two. Not something the suite does, and not something it could tell us.
+Confirming the fix meant driving it against a live model and sampling the DOM on a tight interval for the length of a full run, watching that the message count never crossed two.
+Not something the suite does, and not something it could tell us.
 
-Let's generalize, because this isn't specific to us.
-Any assertion that runs after an `await` sees a settled system. A self-correcting bug is precisely one that settles.
-So the class of defects a final-state suite cannot see isn't random — it's exactly the ones that repair themselves.
+That generalizes, because this is not specific to us.
+Any assertion that runs after an `await` sees a settled system.
+A self-correcting bug is precisely one that settles.
+So the class of defects a final-state suite cannot see is not random — it is exactly the ones that repair themselves.
 
 ## What runs alongside it?
 
-A live pass for what replay structurally can't see, and a weekly drift run for the model itself.
+A live pass for what replay structurally cannot see, and a weekly drift run for the model itself.
 
-The live pass is unglamorous: for anything whose failure mode is mid-stream, drive it against a real model in a real browser before it ships. That's how the bubble above got caught. There's no clever tooling in it — the point is just that the deterministic suite was never going to be the thing that found it.
+The live pass is unglamorous: for anything whose failure mode is mid-stream, drive it against a real model in a real browser before it ships.
+That is how the bubble above got caught.
+There is no clever tooling in it — the point is just that the deterministic suite was never going to be the thing that found it.
 
-Drift is the other half, and it got built properly on the way to this post. Our first design re-recorded fixtures and compared byte size — which detects that a response changed *size* while saying nothing about whether it changed *meaning*. The same trade again, one layer up. A model that starts returning something equally long and completely different sails straight through a size check.
+Drift is the other half, and it got built properly on the way to this post.
+Our first design re-recorded fixtures and compared byte size — which detects that a response changed *size* while saying nothing about whether it changed *meaning*.
+The same trade again, one layer up.
+A model that starts returning something equally long and completely different sails straight through a size check.
 
 So we threw the metric away and kept the thing we already trusted.
 
 The assertions are the drift check.
 
-The drift run takes a tagged subset of the same e2e suite — contract assertions only: a reply renders, the research dispatch surfaces a subagent card, the interrupt panel appears — and points it at the live provider through the mock's record-proxy. No fixtures judged, no thresholds invented.
-If today's model stops calling the research tool, or the graph's prompts stop eliciting the interrupt, a spec we already believe in goes red and a weekly job opens an issue. Meaning drift is caught by construction.
+The drift run takes a tagged subset of the same e2e suite — contract assertions only: a reply renders, the research dispatch surfaces a subagent card, the interrupt panel appears — and points it at the live provider through the mock's record-proxy.
+No fixtures judged, no thresholds invented.
+If today's model stops calling the research tool, or the graph's prompts stop eliciting the interrupt, a spec we already believe in goes red and a weekly job opens an issue.
+Meaning drift is caught by construction.
 
-One rule makes the subset work: a tagged assertion may depend on structure or on the prompt's own terms — an element exists, a reply to "say hi" matches `/hi/i` — never on the content of a canned response. A spec that expects the fixture's exact words fails against a live model whether or not anything drifted, so it stays in replay where it belongs.
+One rule makes the subset work: a tagged assertion may depend on structure or on the prompt's own terms — an element exists, a reply to "say hi" matches `/hi/i` — never on the content of a canned response.
+A spec that expects the fixture's exact words fails against a live model whether or not anything drifted, so it stays in replay where it belongs.
 
-The first run flagged drift that wasn't there.
-The diagnostic differ reported that both tool-calling responses had "drifted" to plain text — while the specs proving those tools fired were green. The recorder had saved empty content because it couldn't parse tool-call deltas out of the stream, warning "fixture may be incomplete." The check's first finding was a blind spot in its own instrument; it now reports that case in its own category instead of as drift.
-It's run clean against the live model since.
+The first run flagged drift that was not there.
+The diagnostic differ reported that both tool-calling responses had "drifted" to plain text — while the specs proving those tools fired were green.
+The recorder had saved empty content because it could not parse tool-call deltas out of the stream, warning "fixture may be incomplete."
+The check's first finding was a blind spot in its own instrument; it now reports that case in its own category instead of as drift.
+It has run clean against the live model since.
 
 ## Conclusion
 
-Push your seam as far out as you can afford. The further out it goes, the more of your stack is under test rather than simulated, and provider base URL is far out for how little it costs.
+My recommendation is simple: push your seam as far out as you can afford.
+The further out it goes, the more of your stack is under test rather than simulated, and provider base URL is far out for how little it costs.
 
-Then write down which dimension you deleted to make it deterministic, in the file where you deleted it. Not in a wiki. Six months later that comment is the difference between "the suite is green" and "the suite is green, and here is what green does not cover."
+Then write down which dimension you deleted to make it deterministic, in the file where you deleted it.
+Not in a wiki.
+Six months later that comment is the difference between "the suite is green" and "the suite is green, and here is what green does not cover."
 
 Ours was written down, which is the only reason it could be checked at all.
 Checking it surfaced two things: the deletion was a default two of our apps had already bought back, and our first drift design was measuring the wrong thing.
 
 For us the list is short and specific: anything whose failure mode is mid-stream on a capability that never opted back into real chunking, and the model itself moving under the fixtures.
 Both are answered by pointing what you already trust at the real thing — the tagged specs at the live provider on a schedule, a live browser at anything mid-stream before it ships.
-Widening the drift net is tagging more specs, plus one chore: porting record mode to the harness the other thirty-two apps share. Widening the stream check is opting more fixtures into real chunking. Neither is designing anything new.
+Widening the drift net is tagging more specs, plus one chore: porting record mode to the harness the other thirty-two apps share.
+Widening the stream check is opting more fixtures into real chunking.
+Neither is designing anything new.
 
 The [testing guide](/docs/langgraph/guides/testing) has the in-process tier, and [the subgraphs post](/blog/langgraph-subgraphs-when-to-split) has the bug that started this.
 
-If your agent suite is green today, I'd like to know what you think it can't see.
+If your agent suite is green today, I would like to know what you think it cannot see.

--- a/docs/gtm/voice.md
+++ b/docs/gtm/voice.md
@@ -1,12 +1,41 @@
 # Voice: Brian Love
 
-> The canonical voice + tone reference for any post drafted on Brian's behalf — blog, social, threads, replies. Synthesized from his pre-2026 blog corpus (`~/repos/brianflove/src/content/posts/`, 2012–2024, ~141 posts). The 2026 technical voice is intentionally excluded — that register was tuned for the streaming-chat pillar post and is narrower than how Brian actually writes.
+> The canonical voice + tone reference for any post drafted on Brian's behalf — blog, social, threads, replies. Two layers, and they come from different places: **sentence-level register** is measured from Brian's 2026 posts (`~/repos/brianflove/src/content/posts/`, see "The 2026 register" below — this governs); **structural scaffolding** comes from the 2012–2024 tutorial corpus (~141 posts) documented in the rest of this file. Where the two conflict at the sentence level, 2026 wins.
+
+## The 2026 register (governs sentence-level style)
+
+Measured 2026-08-31 across every 2026 post in the corpus. These are counts, not
+impressions:
+
+| Marker | 2026 corpus | Notes |
+|---|---|---|
+| Contractions | **zero** | The A2UI post has one apostrophe in 2,252 words: the possessive "Google's". He writes *It is*, *That would be*, *you are*. |
+| "Let's" | **zero** | Not a 2026 move, despite the 2012–2020 sections below. |
+| Opinion flags | frequent | "For me, the core idea is simple", "That is why I think memory is going to become foundational" — 9 in one post. |
+| Emoji | zero | |
+
+**Sentence-level rules (these override the historical guidance further down):**
+
+- **No contractions.** Full forms throughout. This is the single most reliable tell.
+- **No "Let's."** Move with a declarative sentence instead.
+- **One sentence per line.** Hard returns inside paragraphs are the norm, not the exception.
+- **Declarative fragments carry emphasis.** *"That is the part that matters." "Memory is becoming policy."*
+- **Flag opinions often**, and early: "For me, …", "My recommendation is simple:", "I think …".
+- **Close on a declarative beat**, not a sign-off: *"That is what makes this interesting."*
+
+**Keep from the tutorial corpus (structure, not sentences):** `## Goals` blocks,
+H2-as-question, series cross-links, an explicit `## Conclusion`, and a closing
+invitation. Reader is a peer. No hype, no marketing CTAs.
+
+**Never fabricate a first-person anecdote.** Warmth comes from opinion and
+directness, not from invented experiences.
+
 
 ## tl;dr
 
 - One thought per line. Most paragraphs are 1–3 short sentences. Hard returns inside a paragraph are normal.
 - Openings restate the title in a single sentence, then jump into the work. No "Introduction" header, no "in this article we'll explore."
-- Contractions are normal ("it's," "don't," "let's"). Brian writes the way a senior engineer talks at a meetup.
+- *(2012–2024 only — superseded, see "The 2026 register" above.)* Contractions were normal in the older corpus. In 2026 he uses full forms.
 - Warm, low-stakes humor — "freakin' cool," "giddy up and get onboard," the occasional emoji (🤔 💚 😆 👍). Not bro-voice. Closer to "fun coworker."
 - Reader addressed directly ("Let's look at," "I suggest you check it out"); opinions flagged as opinions ("For me," "In my opinion," "what I think").
 - A small set of recurring values across 12 years: ship the boring thing, do it well, have fun, name the people you're thankful to.
@@ -33,7 +62,7 @@ Brian writes in three distinct registers. Pick one and stay in it.
 
 - **One sentence per line.** From "Year in Review": *"In 2023, I began development of Polaris in earnest. / This was my first step into bootstrapping a startup."*
 - **Short, direct, most under 20 words.** *"I like ordinary. / Ordinary is welcoming, accepting, inclusive, diverse, unapologetic, and authentic."*
-- **Contractions default.** *"Let's dive into the core concepts,"* *"You're finally getting the opportunity to build something."*
+- **Contractions default** *(2012–2024 only; superseded — 2026 uses full forms).*
 - **Italics for single-word emphasis.** *"Bootstrapping a startup is *hard*,"* *"build for mobile and *then* respond to users."* Rarely bold.
 - **Bold reserved for must-do callouts.** *"This is a **must** for smaller screen devices."*
 - **Em-dashes sparingly for asides.** He more often reaches for a period.
@@ -47,7 +76,7 @@ Brian writes in three distinct registers. Pick one and stay in it.
 - **Opening: title restated as the lede.** *"Learn the basics of implementing the Redux pattern in Angular applications."*
 - **`## Goals` block, 3–5 bullets, near the top.** The last bullet is sometimes literally *"Have fun!"*
 - **Series cross-link block** with the current post marked: *"1. NgRX: The Basics (this post) / 2. NgRX: Getting Started…"*
-- **"Let's" as workhorse transition.** *"Let's break each of these down," "Let's look at an example," "Let's quickly review."* 3–10 times in a long tutorial. **Signature move.**
+- **"Let's" as workhorse transition** *(2012–2020 only; superseded — zero occurrences in the 2026 corpus).*
 - **H2-as-question, body-as-answer.** *"## What are Operators? / ## How are they composable? / ## How do I import?"*
 - **Three-bullet spine, each bullet becoming an H3.** Personal essays: *"- Building a product / - Listening to developers / - Consulting."*
 - **"Anything Else?" near the close.** *"Did I miss something? Is there something on your top 5 list that I did not mention?"*
@@ -124,10 +153,12 @@ Warm, slightly goofy, occasionally folksy. Humor lives in the asides:
 ## Drafting checklist
 
 - [ ] Opens with one sentence restating the title or stating intent. No "Introduction" header.
-- [ ] Contractions present and natural. If absent, draft is in the wrong (2026) register.
+- [ ] **No contractions.** Full forms throughout.
 - [ ] Paragraphs 1–3 lines; one sentence per line is fine.
 - [ ] Pick a register: `## Goals` (tutorial), three-bullet spine (essay), or H2-as-question (concept). Use its scaffolding.
-- [ ] At least one "Let's" transition per major section.
+- [ ] **No "Let's."** Transitions are declarative sentences.
+- [ ] One sentence per line; declarative fragments carry the emphasis.
+- [ ] Opinions flagged early and often ("For me," "I think," "My recommendation").
 - [ ] Italics for single-word emphasis; bold reserved for one must-do callout.
 - [ ] Opinions flagged ("I think," "For me," "From my experience").
 - [ ] At least one moment of warmth: an aside, "(haha)," "freakin' cool," a genuine "Thank you!", or a small emoji.


### PR DESCRIPTION
All 13 published posts now match one measured register, plus a correction to the voice guide they are measured against.

## Why the guide changed first

`docs/gtm/voice.md` had two headline claims backwards. It called contractions normal and named "Let's" the **signature move**. Measured across every 2026 post in `~/repos/brianflove/src/content/posts/`, both are **zero** — the A2UI post contains one apostrophe in 2,252 words, and it is the possessive "Google's". Opinion flags are frequent instead (nine in one post).

The guide now documents the measured 2026 register as governing at the sentence level, marks the superseded 2012–2024 claims as historical rather than deleting them, and keeps that era's structural scaffolding (Goals blocks, H2-as-question, Conclusion, closing invitation), which still applies.

## The register applied

- No contractions — full forms throughout
- No "Let's" — declarative transitions instead, varied rather than templated
- One sentence per line where the emphasis lands
- Opinions flagged ("For me, …", "I think …", "My recommendation is simple:") — only where the text already took a position; no new claims invented
- No emoji (one green heart removed from the HVTrust post)
- No fabricated first-person anecdotes

## Scope guarantees

Prose only. Verified mechanically across all 13 posts:

| Check | Result |
|---|---|
| Contractions in prose | 0 |
| "Let's" in prose | 0 |
| Emoji | 0 |
| Heading lines changed | none |
| Frontmatter changed | none |
| Code blocks / comments changed | none |
| Links changed | none |
| Word delta | +0.4% to +2.7% |

**Headings are deliberately frozen** even where they carry the old voice (`## Let's wire it up`, `## What doesn't AG-UI give you?`). Heading text becomes the anchor URL and those anchors rank independently — `#how-ag-ui-events-become-signals` alone drew 32 impressions. Two headings reading in the old voice is the price of not breaking live ranking URLs.

## Verification

- `npx vitest run` in apps/website: **348/348 pass**
- Dev server: all 13 post URLs return 200, clean MDX compile, zero errors in the log

One commit per post, so any individual post can be reverted without unpicking the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)