### PR TITLE
feat(ag-ui): upgrade @ag-ui/* to 0.0.59 and send protocol-standard top-level resume

### DIFF
--- a/libs/ag-ui/fixtures/runtime-transcripts/strands-resume.request.json
+++ b/libs/ag-ui/fixtures/runtime-transcripts/strands-resume.request.json
@@ -1,0 +1,24 @@
+{
+  "threadId": "th-int-555800",
+  "runId": "run-2",
+  "messages": [
+    {
+      "id": "u-b176b0c0",
+      "role": "user",
+      "content": "Schedule a meeting with Dana about the Q3 roadmap."
+    }
+  ],
+  "tools": [],
+  "context": [],
+  "state": {},
+  "forwardedProps": {},
+  "resume": [
+    {
+      "interruptId": "v1:tool_call:call_A9ckGX1LrvO82OhqZinzDsom:340a4daa-b874-5aad-8309-a63b92d507dd",
+      "status": "resolved",
+      "payload": {
+        "chosen_label": "Tuesday 10:00"
+      }
+    }
+  ]
+}

--- a/libs/ag-ui/src/lib/reducer.ts
+++ b/libs/ag-ui/src/lib/reducer.ts
@@ -521,8 +521,14 @@ function randomId(): string {
   return Math.random().toString(36).slice(2);
 }
 
-/** Loosely-typed RUN_FINISHED outcome (protocol-standard since AG-UI added
- *  run outcomes; @ag-ui/client@0.0.52 parses it through intact). */
+/** Loosely-typed RUN_FINISHED outcome. @ag-ui/core@0.0.59 ships the strict
+ *  RunFinishedInterruptOutcomeSchema / InterruptSchema for this shape, but
+ *  the reducer deliberately keeps this tolerant hand-rolled view: a strict
+ *  parse would silently DROP an interrupt whose entries deviate from the
+ *  schema (extra keys on the strict outcome object, a missing `reason`),
+ *  while the contract here is to preserve every entry verbatim under
+ *  `value.interrupts` for resume to address. Validation strictness would be
+ *  a behavior change, not a simplification. */
 interface RunFinishedOutcome {
   type?: string;
   interrupts?: unknown;

--- a/libs/ag-ui/src/lib/to-agent.resume-wire.spec.ts
+++ b/libs/ag-ui/src/lib/to-agent.resume-wire.spec.ts
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: MIT
+//
+// Wire-level resume tests against the REAL @ag-ui/client HttpAgent (0.0.59).
+//
+// The stub-based specs in to-agent.resume.spec.ts assert what the adapter
+// hands to runAgent(); these specs assert what actually leaves over HTTP —
+// prepareRunAgentInput assembly included. That distinction is the whole
+// story of this upgrade: on 0.0.52 prepareRunAgentInput dropped a top-level
+// `resume` at assembly, so the parameter-level shape never reached the wire.
+//
+// Each test replays a REAL captured interrupt transcript (fixtures/
+// runtime-transcripts/, 2026-08-31 runtime-portability spikes) through the
+// real client, submits a resume, and compares the serialized request body
+// against the request MEASURED to work for that runtime. Fixture payloads
+// are verbatim from the wire — do not edit them.
+//
+// Byte-equality caveats (each documented at the assertion):
+// - `runId` is minted per run by the client (uuid v4); the spike drivers
+//   used fixed ids. Excluded from equality, asserted to be a string.
+// - `messages` are the client's accumulated thread (set by the interrupt
+//   run's MESSAGES_SNAPSHOT), so the resume request legitimately resends the
+//   assistant tool-call message too; the spike drivers resent only the user
+//   message. The user message is asserted byte-equal (its id is
+//   deterministic — the snapshot assigned it); the array as a whole is not.
+// Every other top-level field is compared byte-for-byte.
+import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { HttpAgent } from '@ag-ui/client';
+import { toAgent } from './to-agent';
+
+const FIXTURES_DIR = join(__dirname, '../../fixtures/runtime-transcripts');
+
+/** Build a text/event-stream Response from a fixture's `data:` lines
+ *  (non-data lines, such as maf-hitl-resume.sse's `__request__` header line,
+ *  are capture metadata and not part of the SSE stream).
+ *
+ *  The events' TOP-LEVEL `threadId`/`runId` are re-stamped with the ids of
+ *  the request being answered — exactly what the real servers do (they echo
+ *  the ids the client sent; the spike drivers picked their own run ids,
+ *  while the 0.0.59 client mints a uuid per run). Payloads are otherwise
+ *  verbatim from the capture. */
+function sseResponseFromFixture(name: string, request: Record<string, unknown>): Response {
+  const raw = readFileSync(join(FIXTURES_DIR, name), 'utf8');
+  const body = raw
+    .split('\n')
+    .filter((line) => line.startsWith('data:'))
+    .map((line) => {
+      const event = JSON.parse(line.slice('data:'.length)) as Record<string, unknown>;
+      if ('threadId' in event) event['threadId'] = request['threadId'];
+      if ('runId' in event) event['runId'] = request['runId'];
+      return `data: ${JSON.stringify(event)}`;
+    })
+    .join('\n\n') + '\n\n';
+  return new Response(body, {
+    status: 200,
+    headers: { 'content-type': 'text/event-stream' },
+  });
+}
+
+/** SYNTHETIC minimal success run for the resume response — these tests are
+ *  about the outgoing resume REQUEST; the response just has to be a valid
+ *  stream so the run settles. */
+function syntheticSuccessResponse(request: Record<string, unknown>): Response {
+  const { threadId, runId } = request;
+  const body = [
+    `data: ${JSON.stringify({ type: 'RUN_STARTED', threadId, runId })}`,
+    `data: ${JSON.stringify({ type: 'RUN_FINISHED', threadId, runId })}`,
+  ].join('\n\n') + '\n\n';
+  return new Response(body, {
+    status: 200,
+    headers: { 'content-type': 'text/event-stream' },
+  });
+}
+
+function readCapturedRequest(name: string): Record<string, unknown> {
+  const raw = readFileSync(join(FIXTURES_DIR, name), 'utf8');
+  if (name.endsWith('.request.json')) return JSON.parse(raw) as Record<string, unknown>;
+  const firstLine = raw.split('\n', 1)[0];
+  return (JSON.parse(firstLine) as { __request__: Record<string, unknown> }).__request__;
+}
+
+interface WireHarness {
+  agent: ReturnType<typeof toAgent>;
+  source: HttpAgent;
+  bodies: () => Array<Record<string, unknown>>;
+}
+
+/** Real HttpAgent whose fetch is fed queued fixture responses; every request
+ *  body is recorded for wire-shape assertions. */
+function wireHarness(
+  threadId: string,
+  responses: Array<(request: Record<string, unknown>) => Response>,
+): WireHarness {
+  const bodies: Array<Record<string, unknown>> = [];
+  let call = 0;
+  const fetchMock = vi.fn(async (_url: unknown, init?: { body?: unknown }) => {
+    const request = JSON.parse(String(init?.body)) as Record<string, unknown>;
+    bodies.push(request);
+    const next = responses[call] ?? responses[responses.length - 1];
+    call += 1;
+    return next(request);
+  });
+  const source = new HttpAgent({
+    url: 'http://spike.invalid/agent',
+    threadId,
+    fetch: fetchMock as unknown as ConstructorParameters<typeof HttpAgent>[0]['fetch'],
+  });
+  return { agent: toAgent(source), source, bodies: () => bodies };
+}
+
+describe('AWS Strands resume over the wire (0.0.59 top-level resume array)', () => {
+  it('serializes the measured working request', async () => {
+    const { agent, source, bodies } = wireHarness('th-int-555800', [
+      (request) => sseResponseFromFixture('strands-interrupt.sse', request),
+      (request) => syntheticSuccessResponse(request),
+    ]);
+
+    await agent.submit({ message: 'Schedule a meeting with Dana about the Q3 roadmap.' });
+    expect(agent.interrupt!()).toBeDefined();
+    // 0.0.59 client-side ledger recorded the RUN_FINISHED interrupt outcome.
+    expect(source.pendingInterrupts).toHaveLength(1);
+
+    await agent.submit({ resume: { chosen_label: 'Tuesday 10:00' } });
+    expect(agent.error()).toBeUndefined();
+
+    const measured = readCapturedRequest('strands-resume.request.json');
+    expect(bodies()).toHaveLength(2);
+    const body = bodies()[1];
+
+    // Byte-equality on everything except the documented volatile fields.
+    const { runId: measuredRunId, messages: measuredMessages, ...measuredRest } = measured;
+    const { runId, messages, ...rest } = body as {
+      runId: unknown; messages: Array<Record<string, unknown>>;
+    } & Record<string, unknown>;
+    expect(rest).toEqual(measuredRest);
+    // runId: client-minted uuid per run; the spike driver sent 'run-2'.
+    expect(typeof runId).toBe('string');
+    expect(runId).not.toBe(measuredRunId);
+    // messages[0]: the user message, byte-equal — id included, because the
+    // interrupt run's MESSAGES_SNAPSHOT assigned it deterministically. The
+    // client also resends the snapshot's assistant tool-call message, which
+    // the spike driver omitted; Strands keys resume on the top-level resume
+    // array (measured), not on the resent messages.
+    expect(messages[0]).toEqual((measuredMessages as unknown[])[0]);
+  });
+
+  it('lets a plain submit abandon the interrupt without tripping the 0.0.59 pending-interrupt gate', async () => {
+    const { agent, source, bodies } = wireHarness('th-int-555800', [
+      (request) => sseResponseFromFixture('strands-interrupt.sse', request),
+      (request) => syntheticSuccessResponse(request),
+    ]);
+
+    await agent.submit({ message: 'Schedule a meeting with Dana about the Q3 roadmap.' });
+    expect(source.pendingInterrupts).toHaveLength(1);
+
+    // Pre-0.0.59 semantics: a plain message after an interrupt just runs.
+    // Without the adapter clearing the ledger, 0.0.59's onInitialize throws
+    // AGUIError before any request is sent.
+    await agent.submit({ message: 'Never mind, cancel that.' });
+    expect(agent.error()).toBeUndefined();
+    expect(bodies()).toHaveLength(2);
+    expect(bodies()[1]['resume']).toBeUndefined();
+  });
+});
+
+describe('Microsoft Agent Framework resume over the wire', () => {
+  it('serializes top-level resume entries addressing the measured pending interrupt', async () => {
+    const { agent, source, bodies } = wireHarness('thread-06-hitl-interrupt', [
+      (request) => sseResponseFromFixture('maf-hitl-interrupt.sse', request),
+      (request) => syntheticSuccessResponse(request),
+    ]);
+
+    await agent.submit({ message: 'Plan the task: build a birdhouse.' });
+    expect(agent.interrupt!()).toBeDefined();
+    expect(source.pendingInterrupts).toHaveLength(1);
+
+    await agent.submit({ resume: { approved: true } });
+    expect(agent.error()).toBeUndefined();
+
+    expect(bodies()).toHaveLength(2);
+    const body = bodies()[1];
+    const measured = readCapturedRequest('maf-hitl-resume.sse');
+
+    // The measured working request carried the entries under the
+    // pre-standard forwardedProps.command.resume location keyed `id`. The
+    // bridge reads the protocol-standard top-level field FIRST
+    // (_extract_resume_payload checks input.resume before
+    // forwardedProps.command.resume) and accepts `interruptId`, so the wire
+    // moves to the standard location; identity, status, and payload are
+    // asserted against the measured entries.
+    const measuredEntries = (
+      measured['forwardedProps'] as { command: { resume: Array<Record<string, unknown>> } }
+    ).command.resume;
+    expect(body['resume']).toEqual(
+      measuredEntries.map(({ id, ...restEntry }) => ({ interruptId: id, ...restEntry })),
+    );
+    expect(body['forwardedProps']).toEqual({});
+    expect(body['threadId']).toBe(measured['threadId']);
+  });
+});
+
+describe('Mastra resume over the wire (forwardedProps shape preserved)', () => {
+  // Mastra emits BOTH the CUSTOM on_interrupt convention (first) and the
+  // RUN_FINISHED interrupt outcome — so on 0.0.59 the client ledger records
+  // a pending interrupt even though the measured working resume rides
+  // forwardedProps.command with NO top-level resume. The adapter must clear
+  // the ledger and reproduce the 0.0.52-measured request byte-for-byte.
+  it('reproduces the measured forwardedProps request with no top-level resume', async () => {
+    const { agent, source, bodies } = wireHarness('thread-hitl-1', [
+      (request) => sseResponseFromFixture('mastra-reinterrupt.sse', request),
+      (request) => syntheticSuccessResponse(request),
+    ]);
+
+    await agent.submit({ message: 'Schedule a meeting with Dana about the Q4 roadmap.' });
+    expect(agent.interrupt!()).toBeDefined();
+    expect(source.pendingInterrupts).toHaveLength(1);
+
+    await agent.submit({ resume: { chosen_time: '2026-09-01T10:00' } });
+    expect(agent.error()).toBeUndefined();
+
+    expect(bodies()).toHaveLength(2);
+    const body = bodies()[1];
+    const measured = readCapturedRequest('mastra-resume-correct.request.json');
+    expect(body['forwardedProps']).toEqual(measured['forwardedProps']);
+    expect(body['resume']).toBeUndefined();
+    expect(body['threadId']).toBe(measured['threadId']);
+  });
+});

--- a/libs/ag-ui/src/lib/to-agent.resume.spec.ts
+++ b/libs/ag-ui/src/lib/to-agent.resume.spec.ts
@@ -72,9 +72,15 @@ async function replayInterruptRun(
   expect(agent.interrupt!()).toBeDefined();
 }
 
-function lastRunAgentArg(stub: StubAgent): { forwardedProps?: Record<string, unknown> } {
+function lastRunAgentArg(stub: StubAgent): {
+  forwardedProps?: Record<string, unknown>;
+  resume?: Array<Record<string, unknown>>;
+} {
   const calls = stub.runAgent.mock.calls as unknown as ReadonlyArray<ReadonlyArray<unknown>>;
-  return calls[calls.length - 1][0] as { forwardedProps?: Record<string, unknown> };
+  return calls[calls.length - 1][0] as {
+    forwardedProps?: Record<string, unknown>;
+    resume?: Array<Record<string, unknown>>;
+  };
 }
 
 describe('submit({ resume }) — LangGraph wire shape is unchanged', () => {
@@ -134,11 +140,15 @@ describe('submit({ resume }) — Mastra transcript round-trip', () => {
 
 describe('submit({ resume }) — Microsoft Agent Framework transcript round-trip', () => {
   // Inbound: spike-maf/transcripts/06-hitl-interrupt.sse (RUN_FINISHED
-  // interrupt outcome). Expected outbound: the measured working request
-  // captured on the __request__ line of spike-maf/transcripts/
-  // 08-hitl-resume.sse — one structured { id, status, payload } entry per
-  // pending interrupt under command.resume.
-  it('reproduces the measured structured per-interrupt command.resume entries', async () => {
+  // interrupt outcome). Outbound since @ag-ui/client@0.0.59: the
+  // protocol-standard TOP-LEVEL resume array. The measured working request
+  // (maf-hitl-resume.sse __request__ line) carried the same entries under the
+  // pre-standard forwardedProps.command.resume location keyed `id`; the
+  // Microsoft bridge reads the top-level field FIRST (_extract_resume_payload
+  // checks input.resume before forwardedProps.command.resume) and accepts
+  // `interruptId` keys, so identity/status/payload are asserted against the
+  // measured entries with only the documented id → interruptId key rename.
+  it('addresses the measured pending interrupt via top-level resume entries', async () => {
     const stub = new StubAgent();
     const agent = toAgent(stub as unknown as AbstractAgent);
     await replayInterruptRun(
@@ -148,46 +158,53 @@ describe('submit({ resume }) — Microsoft Agent Framework transcript round-trip
     await agent.submit({ resume: { approved: true } });
 
     const measured = readCapturedRequest('maf-hitl-resume.sse');
-    expect(lastRunAgentArg(stub).forwardedProps).toEqual(measured['forwardedProps']);
-    expect(lastRunAgentArg(stub).forwardedProps).toEqual({
-      command: {
-        resume: [{
-          id: 'call_VlNsrwdW5hhp2G8Ufp6i8ueQ',
-          status: 'resolved',
-          payload: { approved: true },
-        }],
-      },
-    });
+    const measuredEntries = (
+      (measured['forwardedProps'] as { command: { resume: Array<Record<string, unknown>> } })
+    ).command.resume;
+    const sent = lastRunAgentArg(stub);
+    expect(sent.resume).toEqual(
+      measuredEntries.map(({ id, ...rest }) => ({ interruptId: id, ...rest })),
+    );
+    expect(sent.resume).toEqual([{
+      interruptId: 'call_VlNsrwdW5hhp2G8Ufp6i8ueQ',
+      status: 'resolved',
+      payload: { approved: true },
+    }]);
+    // The legacy forwardedProps location is NOT double-sent.
+    expect(sent.forwardedProps).toBeUndefined();
   });
 });
 
 describe('submit({ resume }) — AWS Strands interrupt outcome', () => {
-  // Inbound: spike-strands/transcripts/interrupt_phase1.sse. The outcome
-  // entry's id must ride back so the backend can address the pending
-  // interrupt. (The Strands spike resumed via the protocol-standard TOP-LEVEL
-  // resume array, which RunAgentInputSchema@0.0.52 cannot send — adopting it
-  // is an explicit follow-up; forwardedProps carries the same identity today.)
-  it('carries the interrupt id in structured entries with the resume payload', async () => {
+  // Inbound: spike-strands/transcripts/interrupt_phase1.sse. Outbound: the
+  // protocol-standard TOP-LEVEL resume array — byte-for-byte the `resume`
+  // field of the measured working request (strands-resume.request.json,
+  // captured as interrupt_phase2_resume in the spike). Strands reads ONLY
+  // this location (it received forwardedProps as {} in every capture), which
+  // is why 0.0.52 — whose prepareRunAgentInput dropped top-level resume at
+  // assembly — could not resume Strands at all.
+  it('sends the measured top-level resume array', async () => {
     const stub = new StubAgent();
     const agent = toAgent(stub as unknown as AbstractAgent);
     await replayInterruptRun(stub, agent, 'strands-interrupt.sse', 'run-1');
 
     await agent.submit({ resume: { chosen_label: 'Tuesday 10:00' } });
 
-    expect(lastRunAgentArg(stub).forwardedProps).toEqual({
-      command: {
-        resume: [{
-          id: 'v1:tool_call:call_A9ckGX1LrvO82OhqZinzDsom:340a4daa-b874-5aad-8309-a63b92d507dd',
-          status: 'resolved',
-          payload: { chosen_label: 'Tuesday 10:00' },
-        }],
-      },
-    });
+    const measured = readCapturedRequest('strands-resume.request.json');
+    const sent = lastRunAgentArg(stub);
+    expect(sent.resume).toEqual(measured['resume']);
+    expect(sent.resume).toEqual([{
+      interruptId: 'v1:tool_call:call_A9ckGX1LrvO82OhqZinzDsom:340a4daa-b874-5aad-8309-a63b92d507dd',
+      status: 'resolved',
+      payload: { chosen_label: 'Tuesday 10:00' },
+    }]);
+    expect(sent.forwardedProps).toBeUndefined();
   });
 
   // SYNTHETIC: no transcript covers a caller that authors its own structured
-  // entries; those must pass through untouched rather than be re-wrapped.
-  it('passes caller-authored structured entries through untouched', async () => {
+  // entries; those ride the top-level resume array normalized to the
+  // protocol's ResumeEntry shape (interruptId-keyed entries are unchanged).
+  it('passes caller-authored interruptId-keyed entries through unchanged', async () => {
     const stub = new StubAgent();
     const agent = toAgent(stub as unknown as AbstractAgent);
     await replayInterruptRun(stub, agent, 'strands-interrupt.sse', 'run-1');
@@ -199,8 +216,27 @@ describe('submit({ resume }) — AWS Strands interrupt outcome', () => {
     }];
     await agent.submit({ resume: structured });
 
-    expect(lastRunAgentArg(stub).forwardedProps).toEqual({
-      command: { resume: structured },
+    expect(lastRunAgentArg(stub)).toEqual({ resume: structured });
+  });
+
+  // SYNTHETIC: entries authored with the pre-standard `id` key are renamed to
+  // the protocol's `interruptId`; other fields ride along unchanged.
+  it('normalizes caller-authored id-keyed entries to ResumeEntry', async () => {
+    const stub = new StubAgent();
+    const agent = toAgent(stub as unknown as AbstractAgent);
+    await replayInterruptRun(stub, agent, 'strands-interrupt.sse', 'run-1');
+
+    await agent.submit({
+      resume: [{ id: 'interrupt-1', payload: { ok: true }, metadata: { via: 'test' } }],
+    });
+
+    expect(lastRunAgentArg(stub)).toEqual({
+      resume: [{
+        interruptId: 'interrupt-1',
+        status: 'resolved',
+        payload: { ok: true },
+        metadata: { via: 'test' },
+      }],
     });
   });
 });

--- a/libs/ag-ui/src/lib/to-agent.ts
+++ b/libs/ag-ui/src/lib/to-agent.ts
@@ -2,6 +2,7 @@
 import { computed, signal, type Signal } from '@angular/core';
 import { Subject } from 'rxjs';
 import type { AbstractAgent } from '@ag-ui/client';
+import type { ResumeEntry } from '@ag-ui/core';
 import {
   completeDelivery,
   staticDelivery,
@@ -269,6 +270,20 @@ export function toAgent(source: AbstractAgent, options: ToAgentOptions = {}): Ag
     const runParameters = parameters === undefined && tools.length === 0
       ? undefined
       : { ...parameters, ...(tools.length > 0 ? { tools } : {}) };
+    // @ag-ui/client@0.0.59 records RUN_FINISHED interrupt outcomes on
+    // source.pendingInterrupts and REFUSES the next runAgent() unless a
+    // `resume` entry addresses every pending id (AGUIError thrown in
+    // onInitialize). The adapter's own interrupt signal governs resume flow:
+    // when this run resolves the interrupt through forwardedProps (Mastra,
+    // LangGraph — their measured wire shapes carry no top-level resume) or is
+    // a plain submit that abandons the interrupt (the pre-0.0.59 semantics),
+    // clear the client-side ledger so the run is sent exactly as before.
+    if (runParameters?.resume === undefined) {
+      const pending = (source as { pendingInterrupts?: unknown }).pendingInterrupts;
+      if (Array.isArray(pending) && pending.length > 0) {
+        (source as { pendingInterrupts: unknown[] }).pendingInterrupts = [];
+      }
+    }
     try {
       await source.runAgent(runParameters);
       settleTransportClose(run);
@@ -398,15 +413,15 @@ export function toAgent(source: AbstractAgent, options: ToAgentOptions = {}): Ag
     submit: async (input: AgentSubmitInput, _opts?: AgentSubmitOptions) => {
       if (input.resume !== undefined) {
         // Resume path: clear the pending interrupt and replay the run with the
-        // resume payload forwarded via AG-UI's forwardedProps mechanism. The
-        // wire shape is derived from the identifying fields the inbound
-        // interrupt carried — see buildResumeForwardedProps.
+        // resume payload. The wire mechanism (protocol-standard top-level
+        // `resume` array vs forwardedProps) is derived from how the inbound
+        // interrupt arrived — see buildResumeRunParameters.
         applyStatePatch(input.state);
         const pendingInterrupt = store.interrupt();
         store.interrupt.set(undefined);
         await executeRun(
           'resume',
-          { forwardedProps: buildResumeForwardedProps(input.resume, pendingInterrupt) },
+          buildResumeRunParameters(input.resume, pendingInterrupt),
           true,
         );
         return;
@@ -491,70 +506,78 @@ export function toAgent(source: AbstractAgent, options: ToAgentOptions = {}): Ag
 }
 
 /**
- * Build the outgoing forwardedProps for a `submit({ resume })`.
+ * Build the outgoing run parameters for a `submit({ resume })`.
  *
- * The shape is keyed on the identifying fields the pending interrupt carried
- * on the way IN, so each runtime finds the resume payload where it reads it
- * (all measured against the 2026-08-31 runtime-portability spike captures):
+ * The wire mechanism is keyed on how the pending interrupt arrived, so each
+ * runtime finds the resume payload where it reads it (all measured against
+ * the 2026-08-31 runtime-portability spike captures):
  *
  * - LangGraph (CUSTOM on_interrupt with an opaque payload — no identifying
- *   fields): exactly `{ command: { resume } }`, byte-for-byte the historical
- *   shape. Backward compatibility here is non-negotiable.
+ *   fields): exactly `{ forwardedProps: { command: { resume } } }`,
+ *   byte-for-byte the historical shape. Backward compatibility here is
+ *   non-negotiable.
  * - Mastra (CUSTOM on_interrupt payload carrying `toolCallId` + `runId`):
- *   `{ command: { resume, interruptEvent: { toolCallId, runId } } }` — the
- *   measured working request (fixtures/runtime-transcripts/
- *   mastra-resume-correct.request.json).
- * - Protocol-standard RUN_FINISHED interrupt outcome (Microsoft Agent
- *   Framework, AWS Strands — stored by the reducer as
- *   `{ interrupts: [...], runId }`): one structured entry per pending
- *   interrupt, `{ command: { resume: [{ id, status: 'resolved', payload }] } }`
- *   — the measured working request (fixtures/runtime-transcripts/
- *   maf-hitl-resume.sse, `__request__` line). A caller that already provides
- *   entry-shaped `resume` values is passed through untouched.
- *
- * Adopting the protocol-standard TOP-LEVEL `resume` array is an explicit
- * follow-up: RunAgentInputSchema@0.0.52 has no such field, while
- * `forwardedProps` is a schema field every runtime reads today.
+ *   `{ forwardedProps: { command: { resume, interruptEvent: { toolCallId,
+ *   runId } } } }` — the measured working request (fixtures/
+ *   runtime-transcripts/mastra-resume-correct.request.json), byte-for-byte
+ *   unchanged.
+ * - Protocol-standard RUN_FINISHED interrupt outcome (AWS Strands, Microsoft
+ *   Agent Framework — stored by the reducer as `{ interrupts: [...], runId }`):
+ *   the protocol-standard TOP-LEVEL `resume` array, one
+ *   `{ interruptId, status: 'resolved', payload }` entry per pending
+ *   interrupt. RunAgentInputSchema@0.0.59 carries the field and
+ *   prepareRunAgentInput serializes it (0.0.52 dropped it at assembly, which
+ *   made Strands resume unsendable — the reason for the 0.0.59 upgrade).
+ *   Strands reads exactly this shape (fixtures/runtime-transcripts/
+ *   strands-resume.request.json, measured working); the Microsoft bridge
+ *   reads the top-level field FIRST (`_extract_resume_payload` in
+ *   agent_framework_ag_ui checks `input.resume` before
+ *   forwardedProps.command.resume) and accepts `interruptId` entries. A
+ *   caller that already provides entry-shaped `resume` values has them
+ *   normalized to `ResumeEntry` (`id` → `interruptId`) and sent top-level.
  */
-function buildResumeForwardedProps(
+function buildResumeRunParameters(
   resume: unknown,
   interrupt: AgentInterrupt | undefined,
-): Record<string, unknown> {
+): { resume: ResumeEntry[] } | { forwardedProps: Record<string, unknown> } {
   const value = interrupt?.value;
   if (isRecord(value)) {
     if (typeof value['toolCallId'] === 'string') {
       return {
-        command: {
-          resume,
-          interruptEvent: {
-            toolCallId: value['toolCallId'],
-            ...(typeof value['runId'] === 'string' ? { runId: value['runId'] } : {}),
+        forwardedProps: {
+          command: {
+            resume,
+            interruptEvent: {
+              toolCallId: value['toolCallId'],
+              ...(typeof value['runId'] === 'string' ? { runId: value['runId'] } : {}),
+            },
           },
         },
       };
     }
     if (Array.isArray(value['interrupts'])) {
+      if (isStructuredResume(resume)) {
+        return { resume: (resume as Record<string, unknown>[]).map(toResumeEntry) };
+      }
       const entries = (value['interrupts'] as unknown[])
         .filter(isRecord)
         .filter((entry) => typeof entry['id'] === 'string');
-      if (entries.length > 0 && !isStructuredResume(resume)) {
+      if (entries.length > 0) {
         return {
-          command: {
-            resume: entries.map((entry) => ({
-              id: entry['id'],
-              status: 'resolved',
-              payload: resume,
-            })),
-          },
+          resume: entries.map((entry) => ({
+            interruptId: entry['id'] as string,
+            status: 'resolved' as const,
+            payload: resume,
+          })),
         };
       }
     }
   }
-  return { command: { resume } };
+  return { forwardedProps: { command: { resume } } };
 }
 
 /** True when the caller already provided per-interrupt entries
- *  (`[{ id | interruptId, ... }]`) — forwarded untouched in that case. */
+ *  (`[{ id | interruptId, ... }]`). */
 function isStructuredResume(resume: unknown): boolean {
   return Array.isArray(resume)
     && resume.length > 0
@@ -562,6 +585,18 @@ function isStructuredResume(resume: unknown): boolean {
       isRecord(entry)
       && (typeof entry['id'] === 'string' || typeof entry['interruptId'] === 'string'),
     );
+}
+
+/** Normalize a caller-authored entry to the protocol's ResumeEntry shape:
+ *  `id` becomes `interruptId`, status defaults to 'resolved', every other
+ *  field (payload, metadata, …) rides along unchanged. */
+function toResumeEntry(entry: Record<string, unknown>): ResumeEntry {
+  const { id, interruptId, status, ...rest } = entry;
+  return {
+    interruptId: (typeof interruptId === 'string' ? interruptId : id) as string,
+    status: status === 'cancelled' ? 'cancelled' : 'resolved',
+    ...rest,
+  } as ResumeEntry;
 }
 
 function isRecord(v: unknown): v is Record<string, unknown> {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "marketing/metrics"
       ],
       "dependencies": {
-        "@ag-ui/client": "^0.0.52",
+        "@ag-ui/client": "^0.0.59",
         "@angular/cdk": "~21.1.0",
         "@angular/common": "~21.1.0",
         "@angular/compiler": "~21.1.0",
@@ -399,13 +399,13 @@
       "dev": true
     },
     "node_modules/@ag-ui/client": {
-      "version": "0.0.52",
-      "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.52.tgz",
-      "integrity": "sha512-U407VvDDwR5qs8TiyN1qY38x87qMWc2n0epw8iA5aa1qwzCKBBDgg3Fkm4JogQf0X4jwNsz8HUbIZrBB56mrpg==",
+      "version": "0.0.59",
+      "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.59.tgz",
+      "integrity": "sha512-d7++r8sBAq6z9G/D/WKrMznQ1Mdvew14pCqOVATReFIvl06mCi1BPqTwmos3zCDGAIiSgcvxc/8m472rYQgFFQ==",
       "dependencies": {
-        "@ag-ui/core": "0.0.52",
-        "@ag-ui/encoder": "0.0.52",
-        "@ag-ui/proto": "0.0.52",
+        "@ag-ui/core": "0.0.59",
+        "@ag-ui/encoder": "0.0.59",
+        "@ag-ui/proto": "0.0.59",
         "@types/uuid": "^10.0.0",
         "compare-versions": "^6.1.1",
         "fast-json-patch": "^3.1.1",
@@ -429,20 +429,20 @@
       }
     },
     "node_modules/@ag-ui/core": {
-      "version": "0.0.52",
-      "resolved": "https://registry.npmjs.org/@ag-ui/core/-/core-0.0.52.tgz",
-      "integrity": "sha512-Xo0bUaNV56EqylzcrAuhUkQX7et7+SZIrqZZtEByGwEq/I1EHny6ZMkWHLkKR7UNi0FJZwJyhKYmKJS3B2SEgA==",
+      "version": "0.0.59",
+      "resolved": "https://registry.npmjs.org/@ag-ui/core/-/core-0.0.59.tgz",
+      "integrity": "sha512-hDgy4ipTqXieT8YG8Mr917Y+FD/f11VK1GefZ5CwTDCuNqS/oTwjJ5l/DZkicThgS8hQW/Y7wPylPBMBJ8BkUg==",
       "dependencies": {
         "zod": "^3.22.4"
       }
     },
     "node_modules/@ag-ui/encoder": {
-      "version": "0.0.52",
-      "resolved": "https://registry.npmjs.org/@ag-ui/encoder/-/encoder-0.0.52.tgz",
-      "integrity": "sha512-6GVDTb1dv2rjap7VVnmXYypDutZi6nrsTcdfxoP6ryDG5ynlXtmmS+FSDAt62JbIMD5CtEE963xNCb6d1iXw9g==",
+      "version": "0.0.59",
+      "resolved": "https://registry.npmjs.org/@ag-ui/encoder/-/encoder-0.0.59.tgz",
+      "integrity": "sha512-wQCzBsStyZMm8nzhTdTx1G0B1C8yv5rbzZLnz1ka/l5LcJEsK3KTounU8CR9l+7QtcpOUUDJKd0xAbyI6gNcSw==",
       "dependencies": {
-        "@ag-ui/core": "0.0.52",
-        "@ag-ui/proto": "0.0.52"
+        "@ag-ui/core": "0.0.59",
+        "@ag-ui/proto": "0.0.59"
       }
     },
     "node_modules/@ag-ui/langgraph": {
@@ -464,11 +464,11 @@
       }
     },
     "node_modules/@ag-ui/proto": {
-      "version": "0.0.52",
-      "resolved": "https://registry.npmjs.org/@ag-ui/proto/-/proto-0.0.52.tgz",
-      "integrity": "sha512-+iCGzNUNL50YIoThVmsolWPjG4MJidl+R9k8QAGVwErEfHRtQ64KFyrdpeOXNVuWtM3SViJqPSgFyv7eGVS63A==",
+      "version": "0.0.59",
+      "resolved": "https://registry.npmjs.org/@ag-ui/proto/-/proto-0.0.59.tgz",
+      "integrity": "sha512-X+uvDaegLEHw5kJu8tv2eSqHH8ouat+JCfFokGV1uuMquY8qCEQSlGsM7xzexwX9fujuxgHOWumg5kJDqa0+RA==",
       "dependencies": {
-        "@ag-ui/core": "0.0.52",
+        "@ag-ui/core": "0.0.59",
         "@bufbuild/protobuf": "^2.2.5",
         "@protobuf-ts/protoc": "^2.11.1"
       }

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "marketing/metrics"
   ],
   "dependencies": {
-    "@ag-ui/client": "^0.0.52",
+    "@ag-ui/client": "^0.0.59",
     "@angular/cdk": "~21.1.0",
     "@angular/common": "~21.1.0",
     "@angular/compiler": "~21.1.0",


### PR DESCRIPTION
Phase 2 Step 1.5 of the runtime-portability effort (plan: docs/superpowers/plans/2026-08-31-runtime-portability-matrix.md on blove/runtime-matrix-plan). Stacked on #889 (which stacks on #888).

## Why

On @ag-ui/client@0.0.52, `prepareRunAgentInput` builds a hardcoded object literal — a top-level `resume` field is dropped at input assembly, before serialization. AWS Strands reads ONLY the protocol-standard top-level `resume` array (measured: it received `forwardedProps` as `{}` and keyed resume on top-level `interruptId` entries), so Strands resume was unsendable on 0.0.52. 0.0.59 adds `resume` to `RunAgentInputSchema` with a conditional spread in `prepareRunAgentInput`, plus `InterruptSchema` / `RunFinishedInterruptOutcomeSchema` and client-side `pendingInterrupts` tracking.

## What

**Dep bump (surgical lockfile edit, not regenerated)**: @ag-ui/core, client, proto, encoder → 0.0.59 (they pin each other exactly and must move together). `npm ci` resolves cleanly; `npm ls` shows a single deduped 0.0.59 for each; @ag-ui/langgraph@0.0.41 peers (`>=0.0.42`) satisfied.

**Resume builder branches on interrupt provenance**:
- RUN_FINISHED interrupt outcome (Strands, Microsoft Agent Framework) → protocol-standard TOP-LEVEL `resume` array, `{ interruptId, status: 'resolved', payload }` per pending interrupt. Byte-equal to the measured working Strands request (new fixture `strands-resume.request.json`). The Microsoft bridge reads the top-level field first (`_extract_resume_payload` checks `input.resume` before `forwardedProps.command.resume`) and accepts `interruptId` keys.
- CUSTOM on_interrupt (LangGraph opaque payload; Mastra toolCallId/runId) → forwardedProps shapes stay byte-for-byte unchanged against the measured captures.

**0.0.59 pending-interrupt gate handled**: the client now refuses a run when `pendingInterrupts` aren't addressed by `resume` entries. The adapter clears the ledger for runs that carry no resume entries, so Mastra's forwardedProps resume (it double-signals with a RUN_FINISHED outcome) and plain submits that abandon an interrupt keep their pre-0.0.59 behavior.

**Schemas**: adopted the official `ResumeEntry` type in the adapter. The reducer deliberately keeps its tolerant hand-rolled outcome view — the strict `RunFinishedInterruptOutcomeSchema`/`InterruptSchema` parse would drop near-miss entries the contract preserves verbatim (documented inline).

**New wire-level spec** (`to-agent.resume-wire.spec.ts`): drives the REAL 0.0.59 `HttpAgent` with a mocked fetch, replays the captured interrupt transcripts, and asserts the serialized request bodies against the measured working requests. Strands is full-body byte-equality except two documented volatile fields (client-minted `runId`; `messages` legitimately resent from the interrupt run's MESSAGES_SNAPSHOT where the spike driver resent only the user message — the user message itself IS asserted byte-equal).

Explicit non-goal: no SUBAGENT_* handling — no measured runtime emits those events.

## Verification

- `nx test ag-ui`: 229/229 (12 files) green; `nx test chat` green; `nx build ag-ui` + `ag-ui:type-tests` + lint green (warnings only).
- All Step 1 transcript-replay fixtures pass on 0.0.59 UNMODIFIED (pre-change baseline run: 224/224 — zero behavioral drift in the committed captures).
- `nx e2e examples-ag-ui-angular` (aimock replay through the real client stack): 37/37 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
