### PR TITLE
Unify Docs and Cockpit sidebar control planes

### DIFF
--- a/apps/cockpit/src/app/cockpit.css
+++ b/apps/cockpit/src/app/cockpit.css
@@ -346,3 +346,341 @@ pre.shiki {
   color: var(--ds-text-muted);
   font-size: 0.875rem;
 }
+
+/* Unified sidebar control plane */
+.cockpit-shell {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+}
+@media (min-width: 48rem) {
+  .cockpit-shell { grid-template-columns: 328px minmax(0, 1fr); }
+}
+.cockpit-control-plane {
+  display: grid;
+  grid-template-columns: 56px minmax(0, 272px);
+  height: 100%;
+  min-width: 0;
+  color: var(--ds-text-secondary);
+  background: var(--ds-surface);
+}
+.cockpit-control-plane [data-control-plane-rail] {
+  min-width: 0;
+  padding: 10px 6px;
+  border-right: 1px solid var(--ds-border);
+  background: var(--ds-surface-tinted);
+  display: flex;
+  flex-direction: column;
+}
+.cockpit-control-plane [data-control-plane-rail-group] {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.cockpit-control-plane [data-control-plane-rail-group="utilities"] { margin-top: auto; }
+.cockpit-control-plane-utility-anchor { display: contents; }
+.cockpit-control-plane [data-control-plane-rail-item] {
+  position: relative;
+  min-height: 48px;
+  padding: 6px 2px;
+  border: 0;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  color: var(--ds-text-muted);
+  background: transparent;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease;
+}
+.cockpit-control-plane [data-control-plane-rail-item]:hover {
+  color: var(--ds-text-primary);
+  background: var(--ds-surface);
+}
+.cockpit-control-plane [data-control-plane-rail-item][data-control-plane-active] {
+  color: var(--ds-accent);
+  background: var(--ds-accent-surface);
+}
+.cockpit-control-plane [data-control-plane-rail-label] {
+  font-size: 10px;
+  line-height: 1;
+  font-weight: 600;
+}
+.cockpit-control-plane [data-control-plane-pane] {
+  min-width: 0;
+  overflow-y: auto;
+  border-right: 1px solid var(--ds-border-strong);
+}
+[data-cockpit-context-content] {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 12px 10px 20px;
+}
+[data-cockpit-context-content] [data-control-plane-section] { padding: 3px 0; }
+[data-cockpit-context-content] [data-control-plane-section-trigger] {
+  width: 100%;
+  min-height: 34px;
+  padding: 6px 8px;
+  border: 0;
+  border-radius: 7px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: var(--ds-text-muted);
+  background: transparent;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 600;
+  text-align: left;
+}
+[data-cockpit-context-content] [data-control-plane-section-trigger]:hover {
+  color: var(--ds-text-primary);
+  background: var(--ds-surface-tinted);
+}
+[data-cockpit-context-content] [data-control-plane-section-chevron] {
+  flex: none;
+  transition: transform 150ms ease;
+}
+[data-cockpit-context-content] [data-control-plane-section-trigger][aria-expanded="true"] [data-control-plane-section-chevron] {
+  transform: rotate(90deg);
+}
+[data-cockpit-context-content] [data-control-plane-section-heading] {
+  margin: 0;
+  padding: 8px;
+  color: var(--ds-text-muted);
+  font-size: 12px;
+  line-height: 1.2;
+  font-weight: 600;
+}
+[data-cockpit-context-content] [data-control-plane-section-content] { padding: 2px 0 8px; }
+.cockpit-control-plane-scope {
+  margin: 0 8px;
+  padding: 10px;
+  border-radius: 8px;
+  background: var(--ds-surface-tinted);
+  display: grid;
+  gap: 3px;
+  color: var(--ds-text-muted);
+  font-size: 11px;
+}
+.cockpit-control-plane-scope strong {
+  color: var(--ds-text-primary);
+  font-size: 13px;
+  font-weight: 600;
+}
+.cockpit-nav-group-label {
+  color: var(--ds-text-secondary);
+  font-size: 12px;
+  font-weight: 600;
+}
+[data-cockpit-context-content] [aria-label^="Collapse"],
+[data-cockpit-context-content] [aria-label^="Expand"] {
+  border-radius: 7px;
+  min-height: 32px;
+}
+[data-cockpit-context-content] [aria-label^="Collapse"]:hover,
+[data-cockpit-context-content] [aria-label^="Expand"]:hover { background: var(--ds-surface-tinted) !important; }
+.cockpit-nav-item {
+  padding: 7px 9px;
+  margin: 1px 8px;
+  border-radius: 7px;
+  font-size: 13px;
+}
+[data-cockpit-context-content] [data-control-plane-environment-list] {
+  display: grid;
+  gap: 2px;
+  margin: 0 8px;
+}
+[data-cockpit-context-content] [data-control-plane-environment-row] {
+  min-height: 32px;
+  padding: 6px 8px;
+  border-radius: 7px;
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+}
+[data-cockpit-context-content] [data-control-plane-environment-row]:hover { background: var(--ds-surface-tinted); }
+[data-cockpit-context-content] [data-control-plane-environment-row] dt { color: var(--ds-text-muted); }
+[data-cockpit-context-content] [data-control-plane-environment-row] dd {
+  margin: 0;
+  color: var(--ds-text-primary);
+  font-family: var(--ds-font-mono);
+  font-size: 10px;
+}
+[data-cockpit-context-content] [data-control-plane-environment-icon] {
+  display: inline-flex;
+  color: var(--ds-text-muted);
+}
+[data-cockpit-context-content] [data-control-plane-action-bar] {
+  display: flex;
+  gap: 4px;
+  margin: 0 8px;
+}
+[data-cockpit-context-content] [data-control-plane-action] {
+  position: relative;
+  width: 34px;
+  height: 34px;
+  border: 0;
+  border-radius: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--ds-text-muted);
+  background: transparent;
+}
+[data-cockpit-context-content] [data-control-plane-action]:hover {
+  color: var(--ds-text-primary);
+  background: var(--ds-surface-tinted);
+}
+.cockpit-control-plane [data-control-plane-tooltip] {
+  position: absolute;
+  z-index: 60;
+  padding: 5px 7px;
+  border-radius: 6px;
+  color: var(--ds-surface);
+  background: var(--ds-text-primary);
+  box-shadow: var(--ds-shadow-sm);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 120ms ease, visibility 120ms ease;
+}
+.cockpit-control-plane [data-control-plane-rail-item] [data-control-plane-tooltip] {
+  left: calc(100% + 8px);
+  top: 50%;
+  transform: translateY(-50%);
+}
+.cockpit-control-plane [data-control-plane-action] [data-control-plane-tooltip] {
+  left: 50%;
+  bottom: calc(100% + 6px);
+  transform: translateX(-50%);
+}
+.cockpit-control-plane [data-control-plane-rail-item]:is(:hover, :focus-visible) [data-control-plane-tooltip],
+.cockpit-control-plane [data-control-plane-action]:is(:hover, :focus-visible) [data-control-plane-tooltip] {
+  opacity: 1;
+  visibility: visible;
+}
+.cockpit-control-plane [data-control-plane-utility-panel] { padding: 14px 12px; }
+.cockpit-control-plane [data-control-plane-utility-header] {
+  min-height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.cockpit-control-plane [data-control-plane-utility-header] h2 {
+  margin: 0;
+  color: var(--ds-text-primary);
+  font-size: 14px;
+  font-weight: 600;
+}
+.cockpit-control-plane [data-control-plane-utility-header] button,
+.cockpit-control-plane-theme {
+  width: 34px;
+  height: 34px;
+  border: 0;
+  border-radius: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--ds-text-muted);
+  background: transparent;
+  cursor: pointer;
+}
+.cockpit-control-plane [data-control-plane-utility-header] button:hover,
+.cockpit-control-plane-theme:hover { background: var(--ds-surface-tinted); color: var(--ds-text-primary); }
+.cockpit-control-plane-setting {
+  min-height: 48px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--ds-border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  color: var(--ds-text-muted);
+  font-size: 12px;
+}
+.cockpit-control-plane button:focus-visible,
+.cockpit-control-plane a:focus-visible,
+.cockpit-mobile-control-plane button:focus-visible,
+.cockpit-mobile-control-plane a:focus-visible {
+  outline: 2px solid var(--ds-accent);
+  outline-offset: 2px;
+}
+
+/* Adaptive mobile drawer */
+.cockpit-mobile-control-plane {
+  background: color-mix(in srgb, var(--ds-text-primary) 18%, transparent);
+  opacity: 1;
+  transition: opacity 150ms ease;
+}
+.cockpit-mobile-control-plane[data-state="closing"] { opacity: 0; }
+.cockpit-mobile-control-plane-panel {
+  width: 100%;
+  max-width: 360px;
+  height: 100%;
+  min-width: 0;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  background: var(--ds-surface);
+  transform: translateY(0);
+  transition: transform 200ms ease-out;
+}
+.cockpit-mobile-control-plane[data-state="closing"] .cockpit-mobile-control-plane-panel {
+  transform: translateY(8px);
+}
+.cockpit-mobile-control-plane-header {
+  min-height: 48px;
+  padding: 8px 12px 8px 16px;
+  border-bottom: 1px solid var(--ds-border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: var(--ds-text-secondary);
+  font-size: 13px;
+  font-weight: 600;
+}
+.cockpit-mobile-control-plane-header button {
+  width: 40px;
+  height: 40px;
+  border: 0;
+  border-radius: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--ds-text-muted);
+  background: transparent;
+}
+.cockpit-control-plane[data-mobile] {
+  grid-template-columns: 56px minmax(0, 1fr);
+  min-height: 0;
+}
+.cockpit-control-plane[data-mobile] [data-control-plane-pane] { border-right: 0; }
+@media (pointer: coarse) {
+  .cockpit-control-plane [data-control-plane-rail-item],
+  .cockpit-control-plane [data-control-plane-section-trigger],
+  .cockpit-control-plane [data-control-plane-action],
+  .cockpit-nav-item,
+  .cockpit-mobile-control-plane-header button { min-height: 44px; }
+  .cockpit-control-plane [data-control-plane-action] {
+    width: 44px;
+    height: 44px;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .cockpit-control-plane *,
+  .cockpit-mobile-control-plane,
+  .cockpit-mobile-control-plane-panel {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+  }
+}

--- a/apps/cockpit/src/components/cockpit-shell.spec.tsx
+++ b/apps/cockpit/src/components/cockpit-shell.spec.tsx
@@ -1,0 +1,87 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { CONTROL_PLANE_STORAGE_KEY, ThemeProvider } from '@threadplane/ui-react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { getCockpitPageModel } from '../lib/cockpit-page';
+import { CockpitShell } from './cockpit-shell';
+
+const model = getCockpitPageModel();
+const contentBundle = {
+  codeFiles: {},
+  promptFiles: {},
+  runtimeUrl: null,
+  docSections: [],
+  narrativeDocs: [],
+};
+
+const seedMode = (activeMode: 'Run' | 'Code' | 'Docs' | 'API') => {
+  window.localStorage.setItem(CONTROL_PLANE_STORAGE_KEY, JSON.stringify({
+    version: 1,
+    docs: { expanded: { Learn: true, Environment: false } },
+    cockpit: { activeMode, expanded: { Capability: true, Environment: true } },
+  }));
+};
+
+const renderShell = () => render(
+  <ThemeProvider theme="light">
+    <CockpitShell
+      navigationTree={model.navigationTree}
+      presentation={model.presentation}
+      entryTitle={model.entry.title}
+      contentBundle={contentBundle}
+    />
+  </ThemeProvider>,
+);
+
+describe('CockpitShell control-plane mode state', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.history.replaceState({}, '', '/');
+  });
+
+  afterEach(() => {
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('initializes from the saved Cockpit mode after hydration', async () => {
+    seedMode('Docs');
+    renderShell();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Docs' }).getAttribute('aria-pressed')).toBe('true');
+    });
+    expect(screen.getByRole('region', { name: 'Docs mode' })).toBeTruthy();
+  });
+
+  it('consumes a valid mode query once and persists it over the saved mode', async () => {
+    seedMode('Docs');
+    window.history.replaceState({}, '', '/?mode=code&keep=1');
+    renderShell();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Code' }).getAttribute('aria-pressed')).toBe('true');
+    });
+    expect(window.location.search).toBe('?keep=1');
+    expect(JSON.parse(window.localStorage.getItem(CONTROL_PLANE_STORAGE_KEY) ?? '{}').cockpit.activeMode).toBe('Code');
+  });
+
+  it('ignores invalid mode queries and uses the saved mode', async () => {
+    seedMode('API');
+    window.history.replaceState({}, '', '/?mode=preview');
+    renderShell();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'API' }).getAttribute('aria-pressed')).toBe('true');
+    });
+  });
+
+  it('keeps Run mounted while another mode is selected', async () => {
+    renderShell();
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Run' })).toBeTruthy());
+    fireEvent.click(screen.getByRole('button', { name: 'Code' }));
+
+    expect(screen.getByRole('region', { name: 'Run mode' })).toBeTruthy();
+    expect(screen.getByRole('region', { name: 'Code mode' })).toBeTruthy();
+  });
+});

--- a/apps/cockpit/src/components/cockpit-shell.tsx
+++ b/apps/cockpit/src/components/cockpit-shell.tsx
@@ -1,19 +1,23 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { cockpitManifest } from '@threadplane/cockpit-registry';
+import { Menu } from 'lucide-react';
+import {
+  parseControlPlaneMode,
+  useControlPlanePreferences,
+  type ControlPlaneMode,
+} from '@threadplane/ui-react';
 import type { ContentBundle } from '../lib/content-bundle';
 import type { CapabilityPresentation, NavigationProduct } from '../lib/route-resolution';
+import { PRODUCT_LABELS } from '../lib/navigation-labels';
 import { CodeMode } from './code-mode/code-mode';
 import { ApiMode } from './api-mode/api-mode';
 import { NarrativeDocs } from './narrative-docs/narrative-docs';
-import { ModeSwitcher } from './modes/mode-switcher';
 import { RunMode } from './run-mode/run-mode';
-import { CockpitSidebar } from './sidebar/cockpit-sidebar';
 import { MobileNavOverlay } from './mobile-nav-overlay';
+import { CockpitControlPlane } from './control-plane/cockpit-control-plane';
 
-const PRIMARY_MODES = ['Run', 'Code', 'Docs', 'API'] as const;
-type PrimaryMode = (typeof PRIMARY_MODES)[number];
 
 interface CockpitShellProps {
   navigationTree: NavigationProduct[];
@@ -28,45 +32,52 @@ const toLabel = (value: string) =>
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(' ');
 
-function MenuIcon() {
-  return (
-    <svg aria-hidden="true" width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5">
-      <path d="M3 5h14M3 10h14M3 15h14" />
-    </svg>
-  );
-}
-
 export function CockpitShell({
   navigationTree,
   presentation,
   entryTitle,
   contentBundle,
 }: CockpitShellProps) {
-  const [isHydrated, setIsHydrated] = useState(false);
-  const [activeMode, setActiveMode] = useState<PrimaryMode>('Run');
+  const preferences = useControlPlanePreferences('cockpit');
+  const queryHandled = useRef(false);
+  const mobileTriggerRef = useRef<HTMLButtonElement>(null);
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const isCapability = presentation.kind === 'capability';
   const codeAssetPaths = isCapability ? presentation.codeAssetPaths : [];
   const backendAssetPaths = isCapability ? (presentation.backendAssetPaths ?? []) : [];
   const entry = presentation.entry;
-  const contextLabel = `${toLabel(entry.product)} / ${toLabel(entry.section)} / ${entry.topic}`;
+  const contextLabel = `${PRODUCT_LABELS[entry.product] ?? toLabel(entry.product)} / ${toLabel(entry.section)} / ${toLabel(entry.topic)}`;
 
   useEffect(() => {
-    setIsHydrated(true);
-  }, []);
+    if (!preferences.hydrated || queryHandled.current) return;
+    queryHandled.current = true;
+    const url = new URL(window.location.href);
+    const rawMode = url.searchParams.get('mode');
+    const requestedMode = parseControlPlaneMode(rawMode);
+    if (requestedMode) preferences.setActiveMode(requestedMode);
+    if (rawMode !== null) {
+      url.searchParams.delete('mode');
+      window.history.replaceState(window.history.state, '', `${url.pathname}${url.search}${url.hash}`);
+    }
+  }, [preferences]);
+
+  const activeMode: ControlPlaneMode = preferences.activeMode;
 
   return (
     <main
       aria-label="Cockpit shell"
-      className="grid md:grid-cols-[16rem_minmax(0,1fr)] h-screen overflow-hidden"
-      data-hydrated={isHydrated ? 'true' : 'false'}
+      className="cockpit-shell h-screen overflow-hidden"
+      data-hydrated={preferences.hydrated ? 'true' : 'false'}
     >
       {/* Desktop sidebar — hidden on mobile */}
-      <div className="hidden md:block overflow-y-auto">
-        <CockpitSidebar
+      <div className="hidden md:block min-h-0 overflow-hidden">
+        <CockpitControlPlane
           navigationTree={navigationTree}
           manifest={cockpitManifest}
           entry={entry}
+          activeMode={activeMode}
+          onModeChange={preferences.setActiveMode}
+          runtimeUrl={contentBundle.runtimeUrl}
         />
       </div>
 
@@ -75,8 +86,12 @@ export function CockpitShell({
         navigationTree={navigationTree}
         manifest={cockpitManifest}
         entry={entry}
+        activeMode={activeMode}
+        onModeChange={preferences.setActiveMode}
+        runtimeUrl={contentBundle.runtimeUrl}
         isOpen={isSidebarOpen}
         onClose={() => setIsSidebarOpen(false)}
+        triggerRef={mobileTriggerRef}
       />
 
       <section className="grid grid-rows-[auto_1fr] grid-cols-[minmax(0,1fr)] overflow-hidden bg-[var(--ds-surface)]">
@@ -85,23 +100,16 @@ export function CockpitShell({
         >
           <div className="flex items-center gap-3 min-w-0">
             <button
+              ref={mobileTriggerRef}
               className="md:hidden"
               onClick={() => setIsSidebarOpen(true)}
               aria-label={isSidebarOpen ? 'Close navigation' : 'Open navigation'}
               aria-expanded={isSidebarOpen}
               style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--ds-text-secondary)' }}
             >
-              <MenuIcon />
+              <Menu size={20} strokeWidth={2} aria-hidden="true" />
             </button>
             <p className="hidden md:block text-[var(--ds-text-muted)] font-mono text-xs truncate">{contextLabel}</p>
-          </div>
-          <div className="shrink-0 overflow-x-auto">
-            <ModeSwitcher
-              modes={PRIMARY_MODES}
-              activeMode={activeMode}
-              onChange={setActiveMode}
-              capability={entry.topic}
-            />
           </div>
         </header>
 

--- a/apps/cockpit/src/components/control-plane/cockpit-control-plane.spec.tsx
+++ b/apps/cockpit/src/components/control-plane/cockpit-control-plane.spec.tsx
@@ -1,0 +1,130 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { cockpitManifest } from '@threadplane/cockpit-registry';
+import { ThemeProvider } from '@threadplane/ui-react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildNavigationTree } from '../../lib/route-resolution';
+import { CockpitControlPlane } from './cockpit-control-plane';
+
+const { track } = vi.hoisted(() => ({ track: vi.fn() }));
+vi.mock('../../lib/analytics/client', () => ({ track }));
+
+const entry = cockpitManifest.find(
+  (candidate) =>
+    candidate.product === 'langgraph' &&
+    candidate.section === 'core-capabilities' &&
+    candidate.topic === 'streaming' &&
+    candidate.language === 'python',
+)!;
+
+const renderControlPlane = (
+  overrides: Partial<React.ComponentProps<typeof CockpitControlPlane>> = {},
+) => {
+  const onModeChange = vi.fn();
+  render(
+    <ThemeProvider theme="light">
+      <CockpitControlPlane
+        navigationTree={buildNavigationTree(cockpitManifest)}
+        manifest={cockpitManifest}
+        entry={entry}
+        activeMode="Run"
+        onModeChange={onModeChange}
+        runtimeUrl="https://runtime.example.test"
+        {...overrides}
+      />
+    </ThemeProvider>,
+  );
+  return { onModeChange };
+};
+
+describe('CockpitControlPlane', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    track.mockClear();
+  });
+
+  it('renders labeled primary modes and truthful context', () => {
+    renderControlPlane();
+
+    const rail = screen.getByRole('navigation', { name: 'Cockpit modes' });
+    expect(within(rail).getAllByRole('button').slice(0, 4).map((button) => button.textContent)).toEqual([
+      'Docs',
+      'Run',
+      'Code',
+      'API',
+    ]);
+    for (const mode of ['Run', 'Code', 'Docs', 'API']) {
+      expect(screen.getByRole('button', { name: mode })).toBeTruthy();
+    }
+    expect(screen.getByRole('button', { name: 'Run' }).getAttribute('aria-pressed')).toBe('true');
+    const settings = screen.getByRole('button', { name: 'Settings' });
+    const settingsTooltip = screen.getByRole('tooltip', { name: 'Settings' });
+    expect(settings.getAttribute('aria-describedby')).toBe(settingsTooltip.id);
+    expect(screen.queryByRole('button', { name: 'Activity' })).toBeNull();
+
+    const pane = screen.getByRole('complementary', { name: 'Cockpit context' });
+    expect(within(pane).getByRole('heading', { name: 'Scope' })).toBeTruthy();
+    expect(pane.textContent).toContain('LangGraph');
+    expect(pane.textContent).toContain('Streaming');
+    expect(within(pane).getByRole('button', { name: 'Capability' })).toBeTruthy();
+    expect(within(pane).getByRole('button', { name: 'Environment' })).toBeTruthy();
+    expect(within(pane).getByRole('link', { name: 'Open runtime' }).getAttribute('href')).toBe(
+      'https://runtime.example.test',
+    );
+    expect(within(pane).queryByText('Theme')).toBeNull();
+  });
+
+  it('switches modes, clears utilities, and preserves mode analytics', () => {
+    const { onModeChange } = renderControlPlane();
+    fireEvent.click(screen.getByRole('button', { name: 'Settings' }));
+    expect(screen.getByRole('heading', { name: 'Settings' })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Code' }));
+
+    expect(onModeChange).toHaveBeenCalledWith('Code');
+    expect(screen.queryByRole('heading', { name: 'Settings' })).toBeNull();
+    expect(track).toHaveBeenCalledWith('cockpit:mode_switched', {
+      capability: 'streaming',
+      from_mode: 'run',
+      to_mode: 'code',
+    });
+  });
+
+  it('keeps language and theme controls inside the Settings utility', () => {
+    renderControlPlane();
+    expect(screen.queryByRole('button', { name: 'Python' })).toBeNull();
+
+    const settings = screen.getByRole('button', { name: 'Settings' });
+    fireEvent.click(settings);
+
+    const heading = screen.getByRole('heading', { name: 'Settings' });
+    expect(document.activeElement).toBe(heading);
+    expect(screen.getByRole('button', { name: 'Python' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Switch to dark theme' })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Capability' })).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close Settings' }));
+    expect(document.activeElement).toBe(settings);
+  });
+
+  it('keeps Settings open when Escape dismisses the nested language menu', () => {
+    renderControlPlane();
+    fireEvent.click(screen.getByRole('button', { name: 'Settings' }));
+    const language = screen.getByRole('button', { name: 'Python' });
+    fireEvent.click(language);
+    expect(screen.getByRole('menu', { name: 'Language picker' })).toBeTruthy();
+
+    fireEvent.keyDown(language, { key: 'Escape' });
+
+    expect(screen.getByRole('heading', { name: 'Settings' })).toBeTruthy();
+    expect(screen.queryByRole('menu', { name: 'Language picker' })).toBeNull();
+    expect(document.activeElement).toBe(language);
+  });
+
+  it('omits the runtime action when no runtime exists', () => {
+    renderControlPlane({ runtimeUrl: null });
+    expect(screen.queryByRole('link', { name: 'Open runtime' })).toBeNull();
+    expect(screen.queryByText('Runtime')).toBeNull();
+  });
+});

--- a/apps/cockpit/src/components/control-plane/cockpit-control-plane.tsx
+++ b/apps/cockpit/src/components/control-plane/cockpit-control-plane.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import React, { useRef, useState } from 'react';
+import type { CockpitManifestEntry } from '@threadplane/cockpit-registry';
+import {
+  BookOpen,
+  Braces,
+  Code2,
+  Play,
+  Settings,
+} from 'lucide-react';
+import {
+  ControlPlanePane,
+  ControlPlaneRail,
+  ControlPlaneRailItem,
+  ControlPlaneUtilityPanel,
+  ThemeToggle,
+  useControlPlanePreferences,
+  type ControlPlaneMode,
+} from '@threadplane/ui-react';
+import type { NavigationProduct } from '../../lib/route-resolution';
+import { track } from '../../lib/analytics/client';
+import { CockpitSidebar } from '../sidebar/cockpit-sidebar';
+import { LanguagePicker } from '../sidebar/language-picker';
+
+const MODES: Array<{
+  label: ControlPlaneMode;
+  icon: typeof Play;
+  analytics: 'run' | 'code' | 'docs' | 'api';
+}> = [
+  { label: 'Docs', icon: BookOpen, analytics: 'docs' },
+  { label: 'Run', icon: Play, analytics: 'run' },
+  { label: 'Code', icon: Code2, analytics: 'code' },
+  { label: 'API', icon: Braces, analytics: 'api' },
+];
+
+export interface CockpitControlPlaneProps {
+  navigationTree: NavigationProduct[];
+  manifest: CockpitManifestEntry[];
+  entry: CockpitManifestEntry;
+  activeMode: ControlPlaneMode;
+  onModeChange: (mode: ControlPlaneMode) => void;
+  runtimeUrl: string | null;
+  mobile?: boolean;
+  onNavigate?: () => void;
+}
+
+export function CockpitControlPlane({
+  navigationTree,
+  manifest,
+  entry,
+  activeMode,
+  onModeChange,
+  runtimeUrl,
+  mobile = false,
+  onNavigate,
+}: CockpitControlPlaneProps) {
+  const preferences = useControlPlanePreferences('cockpit');
+  const [activeUtility, setActiveUtility] = useState<'settings' | null>(null);
+  const settingsRef = useRef<HTMLSpanElement>(null);
+
+  const closeSettings = () => {
+    settingsRef.current?.querySelector('button')?.focus();
+    setActiveUtility(null);
+  };
+
+  const selectMode = (mode: ControlPlaneMode) => {
+    setActiveUtility(null);
+    if (mode !== activeMode) {
+      track('cockpit:mode_switched', {
+        capability: entry.topic,
+        from_mode: MODES.find((candidate) => candidate.label === activeMode)?.analytics,
+        to_mode: MODES.find((candidate) => candidate.label === mode)?.analytics,
+      });
+    }
+    onModeChange(mode);
+  };
+
+  return (
+    <div
+      className="cockpit-control-plane"
+      data-cockpit-control-plane
+      data-mobile={mobile || undefined}
+    >
+      <ControlPlaneRail
+        label="Cockpit modes"
+        primary={MODES.map(({ label, icon: Icon }) => (
+          <ControlPlaneRailItem
+            key={label}
+            label={label}
+            icon={<Icon size={18} aria-hidden="true" />}
+            active={activeUtility === null && label === activeMode}
+            onSelect={() => selectMode(label)}
+          />
+        ))}
+        utilities={
+          <span ref={settingsRef} className="cockpit-control-plane-utility-anchor">
+            <ControlPlaneRailItem
+              label="Settings"
+              icon={<Settings size={18} aria-hidden="true" />}
+              iconOnly
+              active={activeUtility === 'settings'}
+              onSelect={() => setActiveUtility((current) => current === 'settings' ? null : 'settings')}
+            />
+          </span>
+        }
+      />
+
+      <ControlPlanePane label="Cockpit context">
+        {activeUtility === 'settings' ? (
+          <ControlPlaneUtilityPanel title="Settings" onClose={closeSettings}>
+            <div className="cockpit-control-plane-setting">
+              <span>Language</span>
+              <LanguagePicker manifest={manifest} entry={entry} />
+            </div>
+            <div className="cockpit-control-plane-setting">
+              <span>Theme</span>
+              <ThemeToggle className="cockpit-control-plane-theme" />
+            </div>
+          </ControlPlaneUtilityPanel>
+        ) : (
+          <CockpitSidebar
+            navigationTree={navigationTree}
+            entry={entry}
+            runtimeUrl={runtimeUrl}
+            expanded={preferences.expanded}
+            onExpandedChange={preferences.setExpanded}
+            onNavigate={onNavigate}
+          />
+        )}
+      </ControlPlanePane>
+    </div>
+  );
+}

--- a/apps/cockpit/src/components/mobile-nav-overlay.spec.tsx
+++ b/apps/cockpit/src/components/mobile-nav-overlay.spec.tsx
@@ -1,131 +1,96 @@
-import React from 'react';
-import { renderToStaticMarkup } from 'react-dom/server';
-import { describe, expect, it } from 'vitest';
+/** @vitest-environment jsdom */
+import React, { createRef } from 'react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { cockpitManifest } from '@threadplane/cockpit-registry';
+import { ThemeProvider } from '@threadplane/ui-react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { buildNavigationTree } from '../lib/route-resolution';
 import { MobileNavOverlay } from './mobile-nav-overlay';
 
 const tree = buildNavigationTree(cockpitManifest);
 const entry = cockpitManifest.find(
-  (e) =>
-    e.product === 'render' &&
-    e.section === 'core-capabilities' &&
-    e.topic === 'spec-rendering' &&
-    e.language === 'python'
+  (candidate) =>
+    candidate.product === 'render' &&
+    candidate.section === 'core-capabilities' &&
+    candidate.topic === 'spec-rendering' &&
+    candidate.language === 'python',
 )!;
 
+const renderOverlay = (overrides: Partial<React.ComponentProps<typeof MobileNavOverlay>> = {}) => {
+  const onClose = vi.fn();
+  const onModeChange = vi.fn();
+  const triggerRef = createRef<HTMLButtonElement>();
+  render(
+    <ThemeProvider theme="light">
+      <button ref={triggerRef}>Shell trigger</button>
+      <MobileNavOverlay
+        navigationTree={tree}
+        manifest={cockpitManifest}
+        entry={entry}
+        activeMode="Run"
+        onModeChange={onModeChange}
+        runtimeUrl={null}
+        isOpen
+        onClose={onClose}
+        triggerRef={triggerRef}
+        {...overrides}
+      />
+    </ThemeProvider>,
+  );
+  return { onClose, onModeChange, triggerRef };
+};
+
 describe('MobileNavOverlay', () => {
+  beforeEach(() => window.localStorage.clear());
+
   it('renders nothing when closed', () => {
-    const html = renderToStaticMarkup(
-      <MobileNavOverlay
-        navigationTree={tree}
-        manifest={cockpitManifest}
-        entry={entry}
-        isOpen={false}
-        onClose={() => {}}
-      />
-    );
-    expect(html).toBe('');
+    renderOverlay({ isOpen: false });
+    expect(screen.queryByRole('dialog')).toBeNull();
   });
 
-  it('renders all four product groups when open', () => {
-    const html = renderToStaticMarkup(
-      <MobileNavOverlay
-        navigationTree={tree}
-        manifest={cockpitManifest}
-        entry={entry}
-        isOpen={true}
-        onClose={() => {}}
-      />
-    );
-    expect(html).toContain('LangGraph');
-    expect(html).toContain('Render');
-    expect(html).toContain('Chat');
-    expect(html).toContain('Deep Agents');
+  it('exposes every mode and capability through the adaptive drawer', () => {
+    renderOverlay();
+    const dialog = screen.getByRole('dialog', { name: 'Cockpit control plane' });
+    for (const mode of ['Run', 'Code', 'Docs', 'API']) {
+      expect(within(dialog).getByRole('button', { name: mode })).toBeTruthy();
+    }
+    expect(within(dialog).getByRole('link', { name: 'Spec Rendering' })).toBeTruthy();
+    expect(within(dialog).getByRole('button', { name: 'Settings' })).toBeTruthy();
+    expect(dialog.getAttribute('style') ?? '').not.toContain('width:');
   });
 
-  it('renders topic chips as links', () => {
-    const html = renderToStaticMarkup(
-      <MobileNavOverlay
-        navigationTree={tree}
-        manifest={cockpitManifest}
-        entry={entry}
-        isOpen={true}
-        onClose={() => {}}
-      />
-    );
-    expect(html).toContain('Streaming');
-    expect(html).toContain('Persistence');
-    expect(html).toContain('Messages');
-    expect(html).toContain('href="/');
+  it('replaces only the drawer body for Settings and restores utility focus', () => {
+    const result = renderOverlay();
+    const dialog = screen.getByRole('dialog', { name: 'Cockpit control plane' });
+    const settings = within(dialog).getByRole('button', { name: 'Settings' });
+    fireEvent.click(settings);
+
+    expect(within(dialog).getByRole('heading', { name: 'Settings' })).toBeTruthy();
+    expect(within(dialog).getByRole('button', { name: 'Run' })).toBeTruthy();
+    expect(within(dialog).queryByRole('button', { name: 'Capability' })).toBeNull();
+
+    fireEvent.keyDown(within(dialog).getByRole('heading', { name: 'Settings' }), {
+      key: 'Escape',
+    });
+
+    expect(result.onClose).not.toHaveBeenCalled();
+    expect(within(dialog).getByRole('button', { name: 'Capability' })).toBeTruthy();
+    expect(document.activeElement).toBe(settings);
   });
 
-  it('highlights the active entry chip', () => {
-    const html = renderToStaticMarkup(
-      <MobileNavOverlay
-        navigationTree={tree}
-        manifest={cockpitManifest}
-        entry={entry}
-        isOpen={true}
-        onClose={() => {}}
-      />
-    );
-    expect(html).toContain('aria-current="page"');
-  });
+  it('closes from Escape, backdrop, and close control and restores shell focus', () => {
+    const result = renderOverlay();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(result.onClose).toHaveBeenCalledTimes(1);
+    expect(document.activeElement).toBe(result.triggerRef.current);
 
-  it('strips product prefix from topic titles', () => {
-    const html = renderToStaticMarkup(
-      <MobileNavOverlay
-        navigationTree={tree}
-        manifest={cockpitManifest}
-        entry={entry}
-        isOpen={true}
-        onClose={() => {}}
-      />
-    );
-    expect(html).toContain('Spec Rendering');
-    expect(html).not.toContain('>Render Spec Rendering<');
-  });
+    result.onClose.mockClear();
+    const dialog = screen.getByRole('dialog', { name: 'Cockpit control plane' });
+    fireEvent.mouseDown(dialog);
+    expect(result.onClose).toHaveBeenCalledTimes(1);
 
-  it('filters out overview topics', () => {
-    const html = renderToStaticMarkup(
-      <MobileNavOverlay
-        navigationTree={tree}
-        manifest={cockpitManifest}
-        entry={entry}
-        isOpen={true}
-        onClose={() => {}}
-      />
-    );
-    // No chip should link to an overview topic (topic segment = "overview")
-    const hrefMatches = html.match(/href="[^"]+"/g) || [];
-    const overviewHrefs = hrefMatches.filter((h) => /\/overview\/overview\//.test(h));
-    expect(overviewHrefs).toHaveLength(0);
-  });
-
-  it('includes the language picker', () => {
-    const html = renderToStaticMarkup(
-      <MobileNavOverlay
-        navigationTree={tree}
-        manifest={cockpitManifest}
-        entry={entry}
-        isOpen={true}
-        onClose={() => {}}
-      />
-    );
-    expect(html).toContain('Python');
-  });
-
-  it('includes a close button', () => {
-    const html = renderToStaticMarkup(
-      <MobileNavOverlay
-        navigationTree={tree}
-        manifest={cockpitManifest}
-        entry={entry}
-        isOpen={true}
-        onClose={() => {}}
-      />
-    );
-    expect(html).toContain('aria-label="Close navigation"');
+    result.onClose.mockClear();
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Close navigation' }));
+    expect(result.onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/cockpit/src/components/mobile-nav-overlay.tsx
+++ b/apps/cockpit/src/components/mobile-nav-overlay.tsx
@@ -1,46 +1,49 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState, type RefObject } from 'react';
 import type { CockpitManifestEntry } from '@threadplane/cockpit-registry';
+import { X } from 'lucide-react';
+import type { ControlPlaneMode } from '@threadplane/ui-react';
 import type { NavigationProduct } from '../lib/route-resolution';
-import { toCockpitPath } from '../lib/route-resolution';
-import { PRODUCT_LABELS, stripProductPrefix } from '../lib/navigation-labels';
-import { LanguagePicker } from './sidebar/language-picker';
-
-function CloseIcon() {
-  return (
-    <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
-      <path d="M18 6L6 18M6 6l12 12" />
-    </svg>
-  );
-}
+import { CockpitControlPlane } from './control-plane/cockpit-control-plane';
 
 interface MobileNavOverlayProps {
   navigationTree: NavigationProduct[];
   manifest: CockpitManifestEntry[];
   entry: CockpitManifestEntry;
+  activeMode: ControlPlaneMode;
+  onModeChange: (mode: ControlPlaneMode) => void;
+  runtimeUrl: string | null;
   isOpen: boolean;
   onClose: () => void;
+  triggerRef?: RefObject<HTMLButtonElement | null>;
 }
 
 export function MobileNavOverlay({
   navigationTree,
   manifest,
   entry,
+  activeMode,
+  onModeChange,
+  runtimeUrl,
   isOpen,
   onClose,
+  triggerRef,
 }: MobileNavOverlayProps) {
   const [state, setState] = useState<'closed' | 'open' | 'closing'>(
-    isOpen ? 'open' : 'closed'
+    isOpen ? 'open' : 'closed',
   );
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  const requestClose = useCallback(() => {
+    onClose();
+    triggerRef?.current?.focus();
+  }, [onClose, triggerRef]);
 
   useEffect(() => {
-    if (isOpen) {
-      setState('open');
-    } else if (state === 'open') {
-      setState('closing');
-    }
-  }, [isOpen]);
+    if (isOpen) setState('open');
+    else if (state === 'open') setState('closing');
+  }, [isOpen, state]);
 
   useEffect(() => {
     if (state !== 'closing') return;
@@ -49,124 +52,73 @@ export function MobileNavOverlay({
   }, [state]);
 
   useEffect(() => {
-    if (state !== 'open') return;
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
+    if (state !== 'open') return undefined;
+    document.body.style.overflow = 'hidden';
+    const dialog = dialogRef.current;
+    const focusable = () => Array.from(dialog?.querySelectorAll<HTMLElement>(
+      'a[href], button:not(:disabled), [tabindex]:not([tabindex="-1"])',
+    ) ?? []);
+    focusable()[0]?.focus();
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        requestClose();
+        return;
+      }
+      if (event.key !== 'Tab') return;
+      const items = focusable();
+      const first = items[0];
+      const last = items.at(-1);
+      if (!first || !last) return;
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
     };
     document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [state, onClose]);
+    return () => {
+      document.body.style.overflow = '';
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [requestClose, state]);
 
   if (state === 'closed') return null;
 
   return (
     <div
+      ref={dialogRef}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Cockpit control plane"
       data-state={state}
-      className="fixed inset-0 z-50 md:hidden flex flex-col"
-      style={{
-        background: 'var(--ds-surface)',
-        boxShadow: 'var(--ds-shadow-lg)',
-        opacity: state === 'open' ? 1 : 0,
-        transform: state === 'open' ? 'translateY(0)' : 'translateY(8px)',
-        transition: state === 'open'
-          ? 'opacity 200ms ease-out, transform 200ms ease-out'
-          : 'opacity 150ms ease-in, transform 150ms ease-in',
+      className="cockpit-mobile-control-plane fixed inset-0 z-50 md:hidden"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) requestClose();
       }}
     >
-      {/* Header */}
-      <header
-        className="flex items-center justify-between px-4 py-3 border-b border-[var(--ds-border)]"
-      >
-        <p
-          className="font-mono text-xs font-semibold uppercase tracking-wide"
-          style={{ color: 'var(--ds-text-muted)' }}
-        >
-          Cockpit
-        </p>
-        <div className="flex items-center gap-3">
-          <LanguagePicker manifest={manifest} entry={entry} />
-          <button
-            type="button"
-            onClick={onClose}
-            aria-label="Close navigation"
-            className="p-2 -m-2"
-            style={{
-              background: 'none',
-              border: 'none',
-              cursor: 'pointer',
-              color: 'var(--ds-text-muted)',
-            }}
-          >
-            <CloseIcon />
+      <div className="cockpit-mobile-control-plane-panel">
+        <header className="cockpit-mobile-control-plane-header">
+          <span>Cockpit</span>
+          <button type="button" onClick={requestClose} aria-label="Close navigation">
+            <X size={20} strokeWidth={2} aria-hidden="true" />
           </button>
-        </div>
-      </header>
-
-      {/* Scrollable product cards */}
-      <div className="flex-1 overflow-y-auto px-4 py-3" style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-        {navigationTree.map((product) => {
-          const label = PRODUCT_LABELS[product.product] ?? product.product;
-          const topics = product.sections.flatMap((section) =>
-            section.entries.filter((e) => e.topic !== 'overview')
-          );
-
-          if (topics.length === 0) return null;
-
-          return (
-            <div
-              key={product.product}
-              style={{
-                background: 'var(--ds-surface-tinted)',
-                border: '1px solid var(--ds-border)',
-                borderRadius: 10,
-                padding: 12,
-              }}
-            >
-              <p
-                style={{
-                  fontFamily: 'var(--ds-font-mono)',
-                  fontSize: '0.7rem',
-                  fontWeight: 600,
-                  textTransform: 'uppercase',
-                  letterSpacing: '0.05em',
-                  color: 'var(--ds-accent)',
-                  marginBottom: 8,
-                }}
-              >
-                {label}
-              </p>
-              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
-                {topics.map((topicEntry) => {
-                  const isActive =
-                    topicEntry.product === entry.product &&
-                    topicEntry.section === entry.section &&
-                    topicEntry.topic === entry.topic &&
-                    topicEntry.page === entry.page;
-
-                  return (
-                    <a
-                      key={`${topicEntry.product}-${topicEntry.topic}`}
-                      href={toCockpitPath(topicEntry)}
-                      aria-current={isActive ? 'page' : undefined}
-                      style={{
-                        padding: '4px 10px',
-                        borderRadius: 20,
-                        fontSize: '0.8rem',
-                        textDecoration: 'none',
-                        transition: 'all 0.15s',
-                        background: isActive ? 'var(--ds-accent-surface)' : 'rgba(0, 0, 0, 0.04)',
-                        color: isActive ? 'var(--ds-accent)' : 'var(--ds-text-secondary)',
-                        border: isActive ? '1px solid var(--ds-accent-border)' : '1px solid transparent',
-                      }}
-                    >
-                      {stripProductPrefix(topicEntry.title)}
-                    </a>
-                  );
-                })}
-              </div>
-            </div>
-          );
-        })}
+        </header>
+        <CockpitControlPlane
+          navigationTree={navigationTree}
+          manifest={manifest}
+          entry={entry}
+          activeMode={activeMode}
+          onModeChange={(mode) => {
+            onModeChange(mode);
+            requestClose();
+          }}
+          runtimeUrl={runtimeUrl}
+          mobile
+          onNavigate={requestClose}
+        />
       </div>
     </div>
   );

--- a/apps/cockpit/src/components/pane-rendering.spec.tsx
+++ b/apps/cockpit/src/components/pane-rendering.spec.tsx
@@ -69,7 +69,8 @@ describe('refreshed shell structure', () => {
     );
 
     expect(html).toContain('aria-label="Cockpit shell"');
-    expect(html).toContain('aria-label="Cockpit sidebar"');
+    expect(html).toContain('aria-label="Cockpit modes"');
+    expect(html).toContain('aria-label="Cockpit context"');
     expect(html).toContain('aria-label="Code mode"');
     expect(html).toContain('page.tsx');
     expect(html).toContain('index.ts');

--- a/apps/cockpit/src/components/sidebar/cockpit-sidebar.spec.tsx
+++ b/apps/cockpit/src/components/sidebar/cockpit-sidebar.spec.tsx
@@ -19,7 +19,7 @@ describe('CockpitSidebar', () => {
       <CockpitSidebar
         entry={entry}
         navigationTree={buildNavigationTree(cockpitManifest)}
-        manifest={cockpitManifest}
+        runtimeUrl="https://runtime.example.test"
       />
     );
 
@@ -28,7 +28,10 @@ describe('CockpitSidebar', () => {
     // Title is stripped of product prefix: "LangGraph Streaming" → "Streaming"
     expect(html).toContain('Streaming');
     expect(html).toContain('aria-current="page"');
-    expect(html).not.toContain('<select');
+    expect(html).toContain('Scope');
+    expect(html).toContain('Environment');
     expect(html).toContain('Python');
+    expect(html).toContain('aria-label="Open runtime"');
+    expect(html).not.toContain('Theme');
   });
 });

--- a/apps/cockpit/src/components/sidebar/cockpit-sidebar.tsx
+++ b/apps/cockpit/src/components/sidebar/cockpit-sidebar.tsx
@@ -1,43 +1,84 @@
 import React from 'react';
-import { ThemeToggle } from '@threadplane/ui-react';
-import type {
-  CockpitManifestEntry,
-} from '@threadplane/cockpit-registry';
+import { Boxes, Code2, ExternalLink, Package } from 'lucide-react';
+import {
+  ControlPlaneActionBar,
+  ControlPlaneEnvironmentList,
+  ControlPlaneIconButton,
+  ControlPlaneSection,
+} from '@threadplane/ui-react';
+import type { CockpitManifestEntry } from '@threadplane/cockpit-registry';
 import type { NavigationProduct } from '../../lib/route-resolution';
-import { Logo } from '../branding/logo';
-import { LanguagePicker } from './language-picker';
+import { PRODUCT_LABELS, stripProductPrefix } from '../../lib/navigation-labels';
 import { NavigationGroups } from './navigation-groups';
 
 interface CockpitSidebarProps {
   navigationTree: NavigationProduct[];
-  manifest: CockpitManifestEntry[];
   entry: CockpitManifestEntry;
+  runtimeUrl: string | null;
+  expanded?: Record<string, boolean>;
+  onExpandedChange?: (key: string, open: boolean) => void;
+  onNavigate?: () => void;
 }
 
 export function CockpitSidebar({
   navigationTree,
-  manifest,
   entry,
+  runtimeUrl,
+  expanded = {},
+  onExpandedChange,
+  onNavigate,
 }: CockpitSidebarProps) {
+  const product = PRODUCT_LABELS[entry.product] ?? entry.product;
+
   return (
-    <aside
-      aria-label="Cockpit sidebar"
-      className="flex flex-col gap-4 py-6 px-0 border-r border-[var(--ds-border-strong)] bg-[var(--ds-surface-tinted)] overflow-y-auto"
-      style={{
-        position: 'sticky',
-        top: 0,
-        minHeight: '100vh',
-      }}
-    >
-      <header className="flex items-center justify-between px-4">
-        <Logo />
-        <LanguagePicker manifest={manifest} entry={entry} />
-      </header>
-      <NavigationGroups tree={navigationTree} currentEntry={entry} />
-      <div className="mt-auto border-t border-[var(--ds-border)] px-4 py-3 flex items-center justify-between">
-        <span className="text-xs text-[var(--ds-text-muted)]">Theme</span>
-        <ThemeToggle className="rounded-md p-1.5 text-[var(--ds-text-secondary)] hover:bg-[var(--ds-surface-tinted)] hover:text-[var(--ds-text-primary)] transition-colors" />
-      </div>
-    </aside>
+    <div data-cockpit-context-content>
+      <ControlPlaneSection title="Scope" collapsible={false}>
+        <div className="cockpit-control-plane-scope">
+          <span>{product}</span>
+          <span>{entry.section.split('-').map((part) => `${part[0]?.toUpperCase()}${part.slice(1)}`).join(' ')}</span>
+          <strong>{stripProductPrefix(entry.title)}</strong>
+        </div>
+      </ControlPlaneSection>
+
+      <ControlPlaneSection
+        title="Capability"
+        open={expanded.Capability ?? true}
+        onOpenChange={(open) => onExpandedChange?.('Capability', open)}
+      >
+        <NavigationGroups
+          tree={navigationTree}
+          currentEntry={entry}
+          expanded={expanded}
+          onExpandedChange={onExpandedChange}
+          onNavigate={onNavigate}
+        />
+      </ControlPlaneSection>
+
+      <ControlPlaneSection
+        title="Environment"
+        open={expanded.Environment ?? true}
+        onOpenChange={(open) => onExpandedChange?.('Environment', open)}
+      >
+        <ControlPlaneEnvironmentList rows={[
+          { label: 'Product', value: product, icon: <Boxes size={15} aria-hidden="true" /> },
+          { label: 'Language', value: entry.language === 'typescript' ? 'TypeScript' : 'Python', icon: <Code2 size={15} aria-hidden="true" /> },
+          ...(runtimeUrl ? [{ label: 'Runtime', value: 'Available', icon: <Package size={15} aria-hidden="true" /> }] : []),
+        ]} />
+      </ControlPlaneSection>
+
+      {runtimeUrl ? (
+        <ControlPlaneSection title="Actions" collapsible={false}>
+          <ControlPlaneActionBar label="Cockpit actions">
+            <ControlPlaneIconButton
+              label="Open runtime"
+              icon={<ExternalLink size={16} aria-hidden="true" />}
+              href={runtimeUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+            />
+          </ControlPlaneActionBar>
+        </ControlPlaneSection>
+      ) : null}
+    </div>
   );
 }

--- a/apps/cockpit/src/components/sidebar/language-picker.tsx
+++ b/apps/cockpit/src/components/sidebar/language-picker.tsx
@@ -21,6 +21,7 @@ interface LanguagePickerProps {
 export function LanguagePicker({ manifest, entry }: LanguagePickerProps) {
   const [isOpen, setIsOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
   const currentLabel =
     LANGUAGE_OPTIONS.find(({ language }) => language === entry.language)?.label ?? entry.language;
 
@@ -29,20 +30,27 @@ export function LanguagePicker({ manifest, entry }: LanguagePickerProps) {
     const handleClick = (e: MouseEvent) => {
       if (ref.current && !ref.current.contains(e.target as Node)) setIsOpen(false);
     };
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setIsOpen(false);
-    };
     document.addEventListener('mousedown', handleClick);
-    document.addEventListener('keydown', handleKeyDown);
     return () => {
       document.removeEventListener('mousedown', handleClick);
-      document.removeEventListener('keydown', handleKeyDown);
     };
   }, [isOpen]);
 
   return (
-    <div ref={ref} style={{ position: 'relative' }}>
+    <div
+      ref={ref}
+      style={{ position: 'relative' }}
+      onKeyDown={(event) => {
+        if (!isOpen || event.key !== 'Escape') return;
+        event.preventDefault();
+        event.stopPropagation();
+        event.nativeEvent.stopImmediatePropagation();
+        setIsOpen(false);
+        triggerRef.current?.focus();
+      }}
+    >
       <button
+        ref={triggerRef}
         type="button"
         aria-haspopup="menu"
         aria-expanded={isOpen}

--- a/apps/cockpit/src/components/sidebar/navigation-groups.spec.tsx
+++ b/apps/cockpit/src/components/sidebar/navigation-groups.spec.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { act } from 'react';
 import { createRoot } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
 
 vi.mock('../../lib/analytics/client', () => ({ track: vi.fn() }));
 
@@ -67,5 +68,47 @@ describe('NavigationGroups capability link instrumentation', () => {
         from_capability: 'streaming',
       }),
     );
+  });
+
+  it('uses sentence-case headings and modern chevrons', () => {
+    const currentEntry = cockpitManifest.find(
+      (candidate) => candidate.topic === 'streaming' && candidate.language === 'python',
+    )!;
+    const html = renderToStaticMarkup(
+      <NavigationGroups
+        tree={buildNavigationTree(cockpitManifest)}
+        currentEntry={currentEntry}
+      />,
+    );
+
+    expect(html).toContain('cockpit-nav-group-label');
+    expect(html).toContain('lucide-chevron-right');
+    expect(html).not.toContain('text-transform:uppercase');
+  });
+
+  it('uses one labeled navigation landmark and connected disclosures', () => {
+    container = document.createElement('div');
+    document.body.append(container);
+    root = createRoot(container);
+    const currentEntry = cockpitManifest.find(
+      (candidate) => candidate.topic === 'streaming' && candidate.language === 'python',
+    )!;
+
+    act(() => {
+      root!.render(
+        <NavigationGroups
+          tree={buildNavigationTree(cockpitManifest)}
+          currentEntry={currentEntry}
+        />,
+      );
+    });
+
+    const landmarks = container.querySelectorAll('nav');
+    expect(landmarks).toHaveLength(1);
+    expect(landmarks[0]?.getAttribute('aria-label')).toBe('Cockpit navigation');
+    const disclosure = container.querySelector<HTMLButtonElement>('button[aria-expanded]');
+    const controlledId = disclosure?.getAttribute('aria-controls');
+    expect(controlledId).toBeTruthy();
+    expect(container.querySelector(`#${controlledId}`)).toBeTruthy();
   });
 });

--- a/apps/cockpit/src/components/sidebar/navigation-groups.tsx
+++ b/apps/cockpit/src/components/sidebar/navigation-groups.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useId } from 'react';
+import { ChevronRight } from 'lucide-react';
 import type { CockpitManifestEntry } from '@threadplane/cockpit-registry';
 import type { NavigationProduct } from '../../lib/route-resolution';
 import { toCockpitPath } from '../../lib/route-resolution';
@@ -10,23 +11,33 @@ import { track } from '../../lib/analytics/client';
 interface NavigationGroupsProps {
   tree: NavigationProduct[];
   currentEntry: CockpitManifestEntry;
+  expanded?: Record<string, boolean>;
+  onExpandedChange?: (key: string, open: boolean) => void;
+  onNavigate?: () => void;
 }
 
 function ProductGroup({
   product,
   currentEntry,
+  open,
+  onOpenChange,
+  onNavigate,
 }: {
   product: NavigationProduct;
   currentEntry: CockpitManifestEntry;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onNavigate?: () => void;
 }) {
-  const [open, setOpen] = useState(true);
   const label = PRODUCT_LABELS[product.product] ?? product.product;
+  const contentId = useId();
 
   return (
     <div style={{ marginBottom: 16 }}>
       <button
-        onClick={() => setOpen(!open)}
+        onClick={() => onOpenChange(!open)}
         aria-expanded={open}
+        aria-controls={contentId}
         aria-label={`${open ? 'Collapse' : 'Expand'} ${label}`}
         style={{
           width: '100%',
@@ -40,28 +51,19 @@ function ProductGroup({
           cursor: 'pointer',
         }}
       >
-        <span style={{
-          fontFamily: 'var(--ds-font-mono)',
-          fontSize: '0.7rem',
-          fontWeight: 600,
-          textTransform: 'uppercase',
-          letterSpacing: '0.05em',
-          color: 'var(--ds-accent)',
-        }}>
+        <span className="cockpit-nav-group-label">
           {label}
         </span>
         <span
           className={`cockpit-nav-caret${open ? ' cockpit-nav-caret--open' : ''}`}
           aria-hidden="true"
         >
-          <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M3.5 2.5 6.5 5 3.5 7.5" />
-          </svg>
+          <ChevronRight size={15} strokeWidth={2} aria-hidden="true" />
         </span>
       </button>
 
       {open && (
-        <nav style={{ display: 'flex', flexDirection: 'column', marginTop: 4 }}>
+        <div id={contentId} style={{ display: 'flex', flexDirection: 'column', marginTop: 4 }}>
           {product.sections.flatMap((section) =>
             section.entries
               .filter((entry) => entry.topic !== 'overview')
@@ -78,6 +80,7 @@ function ProductGroup({
                   href={toCockpitPath(entry)}
                   data-capability-link
                   onClick={() => {
+                    onNavigate?.();
                     track('cockpit:recipe_opened', {
                       capability: entry.topic,
                       category: entry.product,
@@ -92,18 +95,34 @@ function ProductGroup({
               );
             })
           )}
-        </nav>
+        </div>
       )}
     </div>
   );
 }
 
-export function NavigationGroups({ tree, currentEntry }: NavigationGroupsProps) {
+export function NavigationGroups({
+  tree,
+  currentEntry,
+  expanded = {},
+  onExpandedChange,
+  onNavigate,
+}: NavigationGroupsProps) {
   return (
     <nav aria-label="Cockpit navigation" style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-      {tree.map((product) => (
-        <ProductGroup key={product.product} product={product} currentEntry={currentEntry} />
-      ))}
+      {tree.map((product) => {
+        const key = `Capability:${product.product}`;
+        return (
+          <ProductGroup
+            key={product.product}
+            product={product}
+            currentEntry={currentEntry}
+            open={expanded[key] ?? true}
+            onOpenChange={(open) => onExpandedChange?.(key, open)}
+            onNavigate={onNavigate}
+          />
+        );
+      })}
     </nav>
   );
 }

--- a/apps/website/src/app/docs/[library]/[section]/[slug]/page.tsx
+++ b/apps/website/src/app/docs/[library]/[section]/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
-import { DocsSidebar } from '../../../../../components/docs/DocsSidebar';
+import { DocsControlPlane } from '../../../../../components/docs/DocsControlPlane';
 import { MdxRenderer } from '../../../../../components/docs/MdxRenderer';
 import { DocsSearch } from '../../../../../components/docs/DocsSearch';
 import { DocsBreadcrumb } from '../../../../../components/docs/DocsBreadcrumb';
@@ -61,6 +61,7 @@ export default async function DocsPage({ params }: DocsRouteProps) {
   if (!doc) notFound();
 
   const pathname = `/docs/${library}/${section}/${slug}`;
+  const headings = extractHeadings(doc.body);
 
   const articleData = techArticleJsonLd({
     title: doc.title,
@@ -89,7 +90,12 @@ export default async function DocsPage({ params }: DocsRouteProps) {
       <JsonLd data={articleData} />
       <JsonLd data={breadcrumbs} />
       <DocsSearch library={library as LibraryId} />
-      <DocsSidebar activeLibrary={library as LibraryId} activeSection={section} activeSlug={slug} />
+      <DocsControlPlane
+        activeLibrary={library as LibraryId}
+        activeSection={section}
+        activeSlug={slug}
+        pageTitle={doc.title}
+      />
       <div className="flex-1 flex min-w-0 docs-shell-body">
         <div className="flex-1 min-w-0">
           <div className="px-4 sm:px-6 md:px-12 pt-6">
@@ -97,7 +103,7 @@ export default async function DocsPage({ params }: DocsRouteProps) {
             <DocsPageHeader
               library={library as LibraryId}
               section={section}
-              actions={<PageActions library={library} section={section} slug={slug} />}
+              actions={<PageActions library={library} section={section} slug={slug} headings={headings} />}
             />
           </div>
           <article className="flex-1 py-8 px-4 sm:px-6 md:px-12 md:max-w-3xl overflow-x-hidden">
@@ -134,7 +140,7 @@ export default async function DocsPage({ params }: DocsRouteProps) {
             <DocsPrevNext library={library as LibraryId} section={section} slug={slug} />
           </div>
         </div>
-        <DocsTOC headings={extractHeadings(doc.body)} />
+        <DocsTOC headings={headings} />
       </div>
     </div>
   );

--- a/apps/website/src/components/docs/DocsControlPlane.spec.tsx
+++ b/apps/website/src/components/docs/DocsControlPlane.spec.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DocsControlPlane, DocsContextContent } from './DocsControlPlane';
+
+const push = vi.fn();
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/docs/langgraph/guides/streaming',
+  useRouter: () => ({ push }),
+}));
+
+beforeEach(() => {
+  window.localStorage.clear();
+  push.mockClear();
+});
+
+describe('DocsControlPlane', () => {
+  it('renders the stable labeled mode rail with deterministic Cockpit links', () => {
+    render(
+      <DocsControlPlane
+        activeLibrary="langgraph"
+        activeSection="guides"
+        activeSlug="streaming"
+        pageTitle="Streaming"
+      />,
+    );
+
+    const rail = screen.getByRole('navigation', { name: 'Docs modes' });
+    expect(rail).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'Docs' }).getAttribute('aria-current')).toBe('page');
+    expect(screen.getByRole('link', { name: 'Run' }).getAttribute('href')).toContain('/langgraph/core-capabilities/streaming/overview/python?mode=run');
+    expect(screen.getByRole('link', { name: 'Code' }).getAttribute('href')).toContain('mode=code');
+    expect(screen.getByRole('link', { name: 'API' }).getAttribute('href')).toContain('mode=api');
+    expect(screen.queryByRole('button', { name: 'Activity' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Settings' })).toBeNull();
+  });
+
+  it('shows truthful scope and collapsed environment defaults', async () => {
+    render(
+      <DocsControlPlane
+        activeLibrary="langgraph"
+        activeSection="guides"
+        activeSlug="streaming"
+        pageTitle="Streaming"
+      />,
+    );
+
+    const scope = screen.getByRole('heading', { name: 'Scope' }).closest('section');
+    if (!scope) throw new Error('Expected Scope section');
+    expect(within(scope).getByText('LangGraph')).toBeTruthy();
+    expect(within(scope).getByText('Guides')).toBeTruthy();
+    expect(within(scope).getByText('Streaming')).toBeTruthy();
+    const environment = screen.getByRole('button', { name: 'Environment' });
+    expect(environment.getAttribute('aria-expanded')).toBe('false');
+    fireEvent.click(environment);
+    expect(screen.getByText('Angular')).toBeTruthy();
+    expect(screen.getByText('npm')).toBeTruthy();
+    await waitFor(() => expect(window.localStorage.getItem('threadplane:control-plane:v1')).toContain('Environment'));
+  });
+
+  it('keeps search as a real icon action', () => {
+    const listener = vi.fn();
+    document.addEventListener('keydown', listener);
+    render(
+      <DocsControlPlane
+        activeLibrary="langgraph"
+        activeSection="guides"
+        activeSlug="streaming"
+        pageTitle="Streaming"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Search docs' }));
+    expect(listener).toHaveBeenCalledWith(expect.objectContaining({ key: 'k', metaKey: true }));
+    document.removeEventListener('keydown', listener);
+  });
+
+  it('connects nested Learn disclosures to their controlled content', () => {
+    render(
+      <DocsControlPlane
+        activeLibrary="langgraph"
+        activeSection="guides"
+        activeSlug="streaming"
+        pageTitle="Streaming"
+      />,
+    );
+
+    const guides = screen.getByRole('button', { name: 'Guides' });
+    const controlledId = guides.getAttribute('aria-controls');
+    expect(controlledId).toBeTruthy();
+    if (!controlledId) throw new Error('Expected Guides to control its page links');
+    expect(document.getElementById(controlledId)).toBeTruthy();
+  });
+
+  it('supports keyboard entry and dismissal for the library menu', () => {
+    render(
+      <DocsControlPlane
+        activeLibrary="langgraph"
+        activeSection="guides"
+        activeSlug="streaming"
+        pageTitle="Streaming"
+      />,
+    );
+
+    const trigger = screen.getByRole('button', { name: 'LangGraph' });
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' });
+    const firstItem = screen.getByRole('menuitem', { name: /LangGraph/ });
+    expect(document.activeElement).toBe(firstItem);
+
+    fireEvent.keyDown(firstItem, { key: 'Escape' });
+    expect(screen.queryByRole('menu')).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+  });
+});
+
+describe('DocsContextContent', () => {
+  it('reuses the same sentence-case navigation content for mobile', () => {
+    render(
+      <DocsContextContent
+        activeLibrary="render"
+        activeSection="guides"
+        activeSlug="specs"
+        pageTitle="Specs & Elements"
+        mobile
+      />,
+    );
+
+    expect(screen.getByRole('heading', { name: 'Scope' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Learn' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Environment' })).toBeTruthy();
+    expect(screen.getByRole('toolbar', { name: 'Docs actions' })).toBeTruthy();
+  });
+});

--- a/apps/website/src/components/docs/DocsControlPlane.tsx
+++ b/apps/website/src/components/docs/DocsControlPlane.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import {
+  Blocks,
+  BookOpen,
+  Braces,
+  Code2,
+  ExternalLink,
+  Package,
+  Play,
+  Search,
+} from 'lucide-react';
+import {
+  ControlPlaneActionBar,
+  ControlPlaneEnvironmentList,
+  ControlPlaneIconButton,
+  ControlPlanePane,
+  ControlPlaneRail,
+  ControlPlaneRailItem,
+  ControlPlaneSection,
+  useControlPlanePreferences,
+} from '@threadplane/ui-react';
+import {
+  getDocsSection,
+  getLibraryConfig,
+  type LibraryId,
+} from '../../lib/docs-config';
+import { buildCockpitModeHref } from '../../lib/cockpit-links';
+import { DocsNavigation } from './DocsSidebar';
+
+export interface DocsControlPlaneProps {
+  activeLibrary: LibraryId;
+  activeSection: string;
+  activeSlug: string;
+  pageTitle: string;
+}
+
+const dispatchSearch = () =>
+  document.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', metaKey: true }));
+
+export function DocsContextContent({
+  activeLibrary,
+  activeSection,
+  activeSlug,
+  pageTitle,
+  mobile = false,
+  onNavigate,
+}: DocsControlPlaneProps & { mobile?: boolean; onNavigate?: () => void }) {
+  const preferences = useControlPlanePreferences('docs');
+  const library = getLibraryConfig(activeLibrary);
+  const section = getDocsSection(activeLibrary, activeSection);
+  const openSearch = () => {
+    if (!mobile) {
+      dispatchSearch();
+      return;
+    }
+    onNavigate?.();
+    window.setTimeout(dispatchSearch, 0);
+  };
+  const environmentRows = [
+    { label: 'Library', value: library?.title ?? activeLibrary, icon: <Package size={15} aria-hidden="true" /> },
+    { label: 'Framework', value: 'Angular', icon: <Blocks size={15} aria-hidden="true" /> },
+    { label: 'Package manager', value: 'npm', icon: <Code2 size={15} aria-hidden="true" /> },
+  ];
+
+  return (
+    <div data-docs-control-plane-context data-mobile={mobile || undefined}>
+      <ControlPlaneSection title="Scope" collapsible={false}>
+        <div className="docs-control-plane-scope">
+          <span>{library?.title ?? activeLibrary}</span>
+          <span>{section?.title ?? activeSection}</span>
+          <strong>{pageTitle}</strong>
+        </div>
+      </ControlPlaneSection>
+
+      <ControlPlaneSection
+        title="Learn"
+        open={preferences.expanded.Learn ?? true}
+        onOpenChange={(open) => preferences.setExpanded('Learn', open)}
+      >
+        <DocsNavigation
+          activeLibrary={activeLibrary}
+          activeSection={activeSection}
+          activeSlug={activeSlug}
+          expanded={preferences.expanded}
+          onExpandedChange={preferences.setExpanded}
+          onNavigate={onNavigate}
+        />
+      </ControlPlaneSection>
+
+      <ControlPlaneSection
+        title="Environment"
+        open={preferences.expanded.Environment ?? false}
+        onOpenChange={(open) => preferences.setExpanded('Environment', open)}
+      >
+        <ControlPlaneEnvironmentList rows={environmentRows} />
+      </ControlPlaneSection>
+
+      <ControlPlaneSection title="Actions" collapsible={false}>
+        <ControlPlaneActionBar label="Docs actions">
+          <ControlPlaneIconButton
+            label="Search docs"
+            icon={<Search size={16} aria-hidden="true" />}
+            onClick={openSearch}
+          />
+          {library?.demoUrl ? (
+            <ControlPlaneIconButton
+              label={library.demoLabel ?? 'Open live demo'}
+              icon={<ExternalLink size={16} aria-hidden="true" />}
+              href={library.demoUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+            />
+          ) : null}
+        </ControlPlaneActionBar>
+      </ControlPlaneSection>
+    </div>
+  );
+}
+
+export function DocsControlPlane(props: DocsControlPlaneProps) {
+  const identity = {
+    library: props.activeLibrary,
+    section: props.activeSection,
+    slug: props.activeSlug,
+  };
+  const currentPath = `/docs/${props.activeLibrary}/${props.activeSection}/${props.activeSlug}`;
+
+  return (
+    <div className="docs-control-plane" data-docs-control-plane>
+      <ControlPlaneRail
+        label="Docs modes"
+        primary={
+          <>
+            <ControlPlaneRailItem
+              label="Docs"
+              icon={<BookOpen size={18} aria-hidden="true" />}
+              href={currentPath}
+              active
+            />
+            <ControlPlaneRailItem
+              label="Run"
+              icon={<Play size={18} aria-hidden="true" />}
+              href={buildCockpitModeHref(identity, 'Run')}
+            />
+            <ControlPlaneRailItem
+              label="Code"
+              icon={<Code2 size={18} aria-hidden="true" />}
+              href={buildCockpitModeHref(identity, 'Code')}
+            />
+            <ControlPlaneRailItem
+              label="API"
+              icon={<Braces size={18} aria-hidden="true" />}
+              href={buildCockpitModeHref(identity, 'API')}
+            />
+          </>
+        }
+      />
+      <ControlPlanePane label="Docs context">
+        <DocsContextContent {...props} />
+      </ControlPlanePane>
+    </div>
+  );
+}

--- a/apps/website/src/components/docs/DocsSidebar.tsx
+++ b/apps/website/src/components/docs/DocsSidebar.tsx
@@ -1,241 +1,318 @@
 'use client';
-import { useState, useRef, useEffect } from 'react';
+
+import {
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type ComponentType,
+  type KeyboardEvent,
+} from 'react';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
-import { docsConfig, getLibraryConfig, specialDocsPages, type DocsSection, type LibraryId } from '../../lib/docs-config';
+import {
+  Blocks,
+  BookOpen,
+  Boxes,
+  Braces,
+  ChevronDown,
+  Circle,
+  FileCode2,
+  Lightbulb,
+  Rocket,
+} from 'lucide-react';
+import {
+  docsConfig,
+  getLibraryConfig,
+  specialDocsPages,
+  type DocsSection,
+  type LibraryId,
+} from '../../lib/docs-config';
 import { LibraryMark } from './LibraryMark';
 
-interface Props {
+export interface DocsNavigationProps {
   activeLibrary: LibraryId;
   activeSection: string;
   activeSlug: string;
+  expanded?: Record<string, boolean>;
+  onExpandedChange?: (key: string, open: boolean) => void;
+  onNavigate?: () => void;
 }
 
-function LibraryDropdown({ activeLibrary }: { activeLibrary: LibraryId }) {
+function LibraryDropdown({
+  activeLibrary,
+  onNavigate,
+}: {
+  activeLibrary: LibraryId;
+  onNavigate?: () => void;
+}) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const initialFocusRef = useRef(0);
+  const menuId = useId();
   const router = useRouter();
 
   useEffect(() => {
-    const handler = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    const handler = (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) setOpen(false);
     };
     document.addEventListener('mousedown', handler);
     return () => document.removeEventListener('mousedown', handler);
   }, []);
 
-  const currentLib = getLibraryConfig(activeLibrary);
+  useEffect(() => {
+    if (!open) return;
+    const items = menuRef.current?.querySelectorAll<HTMLButtonElement>('[role="menuitem"]');
+    items?.[initialFocusRef.current]?.focus();
+  }, [open]);
+
+  const openMenu = (initialIndex: number) => {
+    initialFocusRef.current = initialIndex;
+    setOpen(true);
+  };
+
+  const closeMenu = (restoreFocus = false) => {
+    setOpen(false);
+    if (restoreFocus) triggerRef.current?.focus();
+  };
+
+  const onMenuKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    const items = Array.from(
+      menuRef.current?.querySelectorAll<HTMLButtonElement>('[role="menuitem"]') ?? [],
+    );
+    const current = Math.max(0, items.indexOf(document.activeElement as HTMLButtonElement));
+    const nextIndex =
+      event.key === 'Home'
+        ? 0
+        : event.key === 'End'
+          ? items.length - 1
+          : event.key === 'ArrowDown'
+            ? (current + 1) % items.length
+            : event.key === 'ArrowUp'
+              ? (current - 1 + items.length) % items.length
+              : -1;
+    if (nextIndex >= 0) {
+      event.preventDefault();
+      items[nextIndex]?.focus();
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      event.stopPropagation();
+      event.nativeEvent.stopImmediatePropagation();
+      closeMenu(true);
+    } else if (event.key === 'Tab') {
+      closeMenu();
+    }
+  };
+
+  const currentLibrary = getLibraryConfig(activeLibrary);
 
   return (
-    <div ref={ref} className="relative px-4 mb-4">
+    <div ref={ref} className="docs-sidebar-library">
       <button
-        onClick={() => setOpen(!open)}
-        className="w-full text-left px-3 py-2 rounded-lg text-sm flex items-center justify-between docs-sidebar-lib-trigger"
+        ref={triggerRef}
+        type="button"
+        onClick={() => {
+          if (open) closeMenu(true);
+          else openMenu(0);
+        }}
+        onKeyDown={(event) => {
+          if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+            event.preventDefault();
+            openMenu(event.key === 'ArrowDown' ? 0 : docsConfig.length - 1);
+          }
+        }}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-controls={menuId}
+        className="docs-sidebar-lib-trigger"
       >
         <span className="docs-sidebar-lib-trigger-inner">
           <LibraryMark library={activeLibrary} size={20} />
           <span className="docs-sidebar-lib-trigger-label">
-            {currentLib?.title ?? activeLibrary}
+            {currentLibrary?.title ?? activeLibrary}
           </span>
         </span>
-        <span className="docs-sidebar-lib-caret" data-open={open ? '' : undefined}>
-          &#9662;
-        </span>
+        <ChevronDown size={16} strokeWidth={2} aria-hidden="true" data-open={open || undefined} />
       </button>
 
-      {open && (
-        <div className="absolute left-4 right-4 mt-1 rounded-lg overflow-hidden z-10 docs-sidebar-lib-menu">
-          {docsConfig.map((lib) => (
+      {open ? (
+        <div
+          ref={menuRef}
+          id={menuId}
+          role="menu"
+          className="docs-sidebar-lib-menu"
+          onKeyDown={onMenuKeyDown}
+        >
+          {docsConfig.map((library) => (
             <button
-              key={lib.id}
+              type="button"
+              role="menuitem"
+              tabIndex={-1}
+              key={library.id}
               onClick={() => {
-                setOpen(false);
-                router.push(`/docs/${lib.id}/getting-started/introduction`);
+                closeMenu();
+                onNavigate?.();
+                router.push(`/docs/${library.id}/getting-started/introduction`);
               }}
-              className="w-full text-left px-3 py-2.5 text-sm flex items-start gap-2.5 docs-sidebar-lib-item"
-              data-active={lib.id === activeLibrary || undefined}
+              className="docs-sidebar-lib-item"
+              data-active={library.id === activeLibrary || undefined}
             >
               <span className="docs-sidebar-lib-item-icon">
-                <LibraryMark library={lib.id} size={20} />
+                <LibraryMark library={library.id} size={20} />
               </span>
-              <span className="flex flex-col docs-sidebar-lib-item-text">
+              <span className="docs-sidebar-lib-item-text">
                 <span
                   className="docs-sidebar-lib-item-title"
-                  data-active={lib.id === activeLibrary || undefined}
+                  data-active={library.id === activeLibrary || undefined}
                 >
-                  {lib.title}
+                  {library.title}
                 </span>
-                <span className="docs-sidebar-lib-item-desc">
-                  {lib.description}
-                </span>
+                <span className="docs-sidebar-lib-item-desc">{library.description}</span>
               </span>
             </button>
           ))}
         </div>
-      )}
+      ) : null}
     </div>
   );
 }
 
-/** Small consistent-stroke glyphs keyed by section id (premium-polish pass). */
-function SectionGlyph({ id }: { id: string }) {
-  const common = {
-    width: 15,
-    height: 15,
-    viewBox: '0 0 16 16',
-    fill: 'none',
-    stroke: 'currentColor',
-    strokeWidth: 1.5,
-    strokeLinecap: 'round' as const,
-    strokeLinejoin: 'round' as const,
-    'aria-hidden': true,
-  };
-  switch (id) {
-    case 'getting-started':
-      return (
-        <svg {...common}><path d="M3 13c0-3 1-6.5 5-10 4 3.5 5 7 5 10l-2.5-2h-5L3 13Z" /><circle cx="8" cy="7" r="1.4" /></svg>
-      );
-    case 'guides':
-      return (
-        <svg {...common}><path d="M2.5 3.5A1.5 1.5 0 014 2h4v11H4a1.5 1.5 0 00-1.5 1.5V3.5Z" /><path d="M13.5 3.5A1.5 1.5 0 0012 2H8v11h4a1.5 1.5 0 011.5 1.5V3.5Z" /></svg>
-      );
-    case 'concepts':
-      return (
-        <svg {...common}><path d="M8 2a4.5 4.5 0 00-2.5 8.2c.6.5 1 1.1 1 1.8h3c0-.7.4-1.3 1-1.8A4.5 4.5 0 008 2Z" /><path d="M6.5 14h3" /></svg>
-      );
-    case 'components':
-      return (
-        <svg {...common}><rect x="2" y="2" width="5" height="5" rx="1" /><rect x="9" y="2" width="5" height="5" rx="1" /><rect x="2" y="9" width="5" height="5" rx="1" /><rect x="9" y="9" width="5" height="5" rx="1" /></svg>
-      );
-    case 'a2ui':
-      return (
-        <svg {...common}><rect x="2" y="2.5" width="12" height="11" rx="1.5" /><path d="M4.5 5.5h7" /><path d="M4.5 8h4" /><path d="M4.5 10.5h5.5" /></svg>
-      );
-    case 'api':
-    case 'reference':
-      return (
-        <svg {...common}><path d="M5.5 3.5 2 8l3.5 4.5" /><path d="M10.5 3.5 14 8l-3.5 4.5" /></svg>
-      );
-    default:
-      return (
-        <svg {...common}><circle cx="8" cy="8" r="2" /></svg>
-      );
-  }
-}
+const SECTION_ICONS: Record<string, ComponentType<{ size?: number; 'aria-hidden'?: boolean }>> = {
+  'getting-started': Rocket,
+  guides: BookOpen,
+  concepts: Lightbulb,
+  components: Boxes,
+  a2ui: Blocks,
+  api: Braces,
+  reference: FileCode2,
+};
 
 function SectionGroup({
   section,
   activeLibrary,
   activeSection,
   activeSlug,
+  open,
+  onOpenChange,
+  onNavigate,
 }: {
   section: DocsSection;
   activeLibrary: LibraryId;
   activeSection: string;
   activeSlug: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onNavigate?: () => void;
 }) {
-  const [open, setOpen] = useState(true);
+  const SectionIcon = SECTION_ICONS[section.id] ?? Circle;
+  const contentId = useId();
 
   return (
     <div className="docs-sidebar-section">
       <button
-        onClick={() => setOpen(!open)}
-        className="w-full text-left px-4 py-1.5 flex items-center justify-between docs-sidebar-section-toggle"
+        type="button"
+        onClick={() => onOpenChange(!open)}
+        aria-expanded={open}
+        aria-controls={contentId}
+        className="docs-sidebar-section-toggle"
       >
         <span className="docs-sidebar-section-labelrow">
-          <span className="docs-sidebar-section-glyph"><SectionGlyph id={section.id} /></span>
-          <span
-            className="font-mono text-xs uppercase tracking-wider docs-sidebar-section-label"
-            data-tone={section.color}
-          >
-            {section.title}
-          </span>
+          <SectionIcon size={16} aria-hidden={true} />
+          <span className="docs-sidebar-section-label">{section.title}</span>
         </span>
-        <span className="docs-sidebar-section-caret" data-open={open ? '' : undefined}>
-          &#9662;
-        </span>
+        <ChevronDown
+          size={16}
+          strokeWidth={2}
+          aria-hidden="true"
+          className="docs-sidebar-section-caret"
+          data-open={open || undefined}
+        />
       </button>
 
-      {open && (
-        <nav className="flex flex-col mt-1">
+      {open ? (
+        <nav
+          id={contentId}
+          aria-label={`${section.title} pages`}
+          className="docs-sidebar-section-links"
+        >
           {section.pages.map((page) => {
             const isActive = page.section === activeSection && page.slug === activeSlug;
             return (
               <Link
                 key={`${page.section}/${page.slug}`}
                 href={`/docs/${activeLibrary}/${page.section}/${page.slug}`}
+                onClick={onNavigate}
                 data-docs-navlink
                 data-active={isActive || undefined}
-                className="px-4 py-1.5 text-sm mx-2 rounded-md transition-all docs-sidebar-section-link"
+                aria-current={isActive ? 'page' : undefined}
+                className="docs-sidebar-section-link"
               >
                 {page.title}
               </Link>
             );
           })}
         </nav>
-      )}
+      ) : null}
     </div>
   );
 }
 
-export function DocsSidebar({ activeLibrary, activeSection, activeSlug }: Props) {
-  const libConfig = getLibraryConfig(activeLibrary);
+export function DocsNavigation({
+  activeLibrary,
+  activeSection,
+  activeSlug,
+  expanded = {},
+  onExpandedChange,
+  onNavigate,
+}: DocsNavigationProps) {
+  const library = getLibraryConfig(activeLibrary);
   const pathname = usePathname();
 
   return (
-    <aside className="w-64 shrink-0 py-6 overflow-y-auto hidden lg:block docs-sidebar">
-      {/* Search trigger */}
-      <div className="px-4 mb-4">
-        <button
-          className="w-full text-left px-3 py-2 rounded-lg text-sm flex items-center justify-between docs-sidebar-search-trigger"
-          onClick={() => document.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', metaKey: true }))}
-        >
-          <span className="docs-sidebar-search-inner">
-            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" aria-hidden="true">
-              <circle cx="7" cy="7" r="4.5" />
-              <path d="M10.5 10.5L14 14" />
-            </svg>
-            <span className="docs-sidebar-search-label">Search docs...</span>
-          </span>
-          <kbd className="docs-sidebar-search-kbd">⌘K</kbd>
-        </button>
-      </div>
-
-      <nav className="flex flex-col mb-4">
+    <div data-docs-navigation>
+      <nav aria-label="Featured documentation" className="docs-sidebar-top-links">
         {specialDocsPages.map((page) => (
           <Link
             key={page.path}
             href={page.path}
+            onClick={onNavigate}
             data-docs-navlink
             data-active={pathname === page.path || undefined}
-            className="px-4 py-1.5 text-sm mx-2 rounded-md transition-all docs-sidebar-top-link"
+            aria-current={pathname === page.path ? 'page' : undefined}
+            className="docs-sidebar-top-link"
           >
             {page.title}
           </Link>
         ))}
       </nav>
 
-      <LibraryDropdown activeLibrary={activeLibrary} />
+      <LibraryDropdown activeLibrary={activeLibrary} onNavigate={onNavigate} />
 
-      {libConfig?.demoUrl && (
-        <div className="px-4 mb-4">
-          <a href={libConfig.demoUrl} target="_blank" rel="noopener noreferrer"
-            className="w-full text-left px-3 py-2 rounded-lg text-sm flex items-center justify-between docs-sidebar-demo-link">
-            <span>{libConfig.demoLabel ?? 'Live demo'}</span>
-            <span aria-hidden="true">↗</span>
-          </a>
-        </div>
-      )}
+      {library?.sections.map((section) => {
+        const key = `Learn:${activeLibrary}:${section.id}`;
+        return (
+          <SectionGroup
+            key={section.id}
+            section={section}
+            activeLibrary={activeLibrary}
+            activeSection={activeSection}
+            activeSlug={activeSlug}
+            open={expanded[key] ?? true}
+            onOpenChange={(open) => onExpandedChange?.(key, open)}
+            onNavigate={onNavigate}
+          />
+        );
+      })}
+    </div>
+  );
+}
 
-      {libConfig?.sections.map((section) => (
-        <SectionGroup
-          key={section.id}
-          section={section}
-          activeLibrary={activeLibrary}
-          activeSection={activeSection}
-          activeSlug={activeSlug}
-        />
-      ))}
+export function DocsSidebar(props: DocsNavigationProps) {
+  return (
+    <aside className="docs-sidebar">
+      <DocsNavigation {...props} />
     </aside>
   );
 }

--- a/apps/website/src/components/docs/DocsTOC.tsx
+++ b/apps/website/src/components/docs/DocsTOC.tsx
@@ -41,8 +41,8 @@ export function DocsTOC({ headings }: { headings: DocHeading[] }) {
   if (headings.length === 0) return null;
 
   return (
-    <aside className="hidden xl:block w-56 shrink-0 py-8 pl-8 pr-6 docs-toc">
-      <p className="font-mono text-xs uppercase tracking-wider mb-3 docs-toc-label">On this page</p>
+    <aside id="docs-on-this-page" tabIndex={-1} className="hidden xl:block w-56 shrink-0 py-8 pl-8 pr-6 docs-toc">
+      <p className="mb-3 docs-toc-label">On this page</p>
       <nav className="flex flex-col gap-0.5 docs-toc-nav">
         {headings.map((h) => (
           <a

--- a/apps/website/src/components/docs/PageActions.spec.tsx
+++ b/apps/website/src/components/docs/PageActions.spec.tsx
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 // @vitest-environment jsdom
 import React from 'react';
-import { describe, expect, it, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const trackMock = vi.hoisted(() => vi.fn());
 const writeTextMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
@@ -19,9 +19,21 @@ beforeEach(() => {
   Object.assign(globalThis, { fetch: fetchMock });
 });
 
+const headings = [
+  { id: 'overview', text: 'Overview', level: 2 as const },
+  { id: 'details', text: 'Details', level: 3 as const },
+];
+
 async function renderActions() {
   const { PageActions } = await import('./PageActions');
-  render(<PageActions library="langgraph" section="guides" slug="streaming" />);
+  render(
+    <PageActions
+      library="langgraph"
+      section="guides"
+      slug="streaming"
+      headings={headings}
+    />,
+  );
 }
 
 async function open() {
@@ -30,16 +42,79 @@ async function open() {
 }
 
 describe('PageActions', () => {
-  it('copies the raw markdown from the route and fires analytics', async () => {
-    // Split-button redesign: copy is the labeled PRIMARY segment, not a menu item.
+  it('uses one ellipsis trigger and keeps utilities inside its menu', async () => {
     await renderActions();
-    fireEvent.click(screen.getByRole('button', { name: /copy page as markdown/i }));
+    expect(screen.getByRole('button', { name: /page actions/i })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /copy page as markdown/i })).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: /page actions/i }));
+    expect(screen.getAllByRole('menuitem').map((item) => item.textContent?.trim())).toEqual([
+      'On this page',
+      'Copy page as Markdown',
+      'Open in ChatGPT',
+      'View as Markdown',
+      'Edit on GitHub',
+    ]);
+  });
+
+  it('copies raw Markdown from the route and fires analytics', async () => {
+    await open();
+    fireEvent.click(screen.getByRole('menuitem', { name: /copy page as markdown/i }));
     await waitFor(() => expect(writeTextMock).toHaveBeenCalledWith('# Streaming\n\nbody'));
     expect(fetchMock).toHaveBeenCalledWith('/api/markdown/langgraph/guides/streaming');
     expect(trackMock).toHaveBeenCalledWith(
       'docs:copy_code_click',
       expect.objectContaining({ surface: 'docs', cta_id: 'copy_page_markdown' }),
     );
+    expect(screen.getByRole('menuitem', { name: /copied/i })).toBeTruthy();
+  });
+
+  it('keeps the menu usable and never reports success after copy failure', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 503 });
+    await open();
+    fireEvent.click(screen.getByRole('menuitem', { name: /copy page as markdown/i }));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(screen.queryByRole('menuitem', { name: /copied/i })).toBeNull();
+    expect(screen.getByRole('menuitem', { name: /copy page as markdown/i })).toBeTruthy();
+  });
+
+  it('focuses the wide table of contents from On this page', async () => {
+    const toc = document.createElement('aside');
+    toc.id = 'docs-on-this-page';
+    toc.tabIndex = -1;
+    Object.defineProperty(toc, 'getClientRects', { value: () => [{ width: 100 }] });
+    document.body.append(toc);
+    await open();
+
+    fireEvent.click(screen.getByRole('menuitem', { name: /on this page/i }));
+    expect(document.activeElement).toBe(toc);
+    expect(screen.queryByRole('menu')).toBeNull();
+    toc.remove();
+  });
+
+  it('reveals heading links in the menu when the wide TOC is unavailable', async () => {
+    await open();
+    fireEvent.click(screen.getByRole('menuitem', { name: /on this page/i }));
+    expect(screen.getByRole('menuitem', { name: 'Overview' }).getAttribute('href')).toBe('#overview');
+    expect(screen.getByRole('menuitem', { name: 'Details' }).getAttribute('href')).toBe('#details');
+  });
+
+  it('supports menu keyboard navigation and restores trigger focus on Escape', async () => {
+    await open();
+    const items = screen.getAllByRole('menuitem');
+    const last = items.at(-1);
+    if (!last) throw new Error('Expected page action items');
+    await waitFor(() => expect(document.activeElement).toBe(items[0]));
+    fireEvent.keyDown(items[0], { key: 'End' });
+    expect(document.activeElement).toBe(last);
+    fireEvent.keyDown(last, { key: 'Home' });
+    expect(document.activeElement).toBe(items[0]);
+    fireEvent.keyDown(items[0], { key: 'ArrowUp' });
+    expect(document.activeElement).toBe(last);
+    fireEvent.keyDown(last, { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(items[0]);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    await waitFor(() => expect(document.activeElement).toBe(screen.getByRole('button', { name: /page actions/i })));
   });
 
   it('links to ChatGPT with the page URL and to GitHub edit', async () => {

--- a/apps/website/src/components/docs/PageActions.tsx
+++ b/apps/website/src/components/docs/PageActions.tsx
@@ -1,7 +1,18 @@
 'use client';
-import { useEffect, useRef, useState } from 'react';
+
+import { useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from 'react';
+import {
+  Bot,
+  Check,
+  Copy,
+  Ellipsis,
+  FileText,
+  ListTree,
+  SquarePen,
+} from 'lucide-react';
 import { analyticsEvents } from '../../lib/analytics/events';
 import { track } from '../../lib/analytics/client';
+import type { DocHeading } from '../../lib/extract-headings';
 import { SITE_ORIGIN } from '../../lib/site-origin';
 
 const GITHUB_EDIT_BASE =
@@ -11,78 +22,63 @@ interface Props {
   library: string;
   section: string;
   slug: string;
+  headings: DocHeading[];
 }
 
-function CopyIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-      <rect x="5" y="5" width="9" height="9" rx="1.5" />
-      <path d="M11 5V3.5A1.5 1.5 0 009.5 2h-6A1.5 1.5 0 002 3.5v6A1.5 1.5 0 003.5 11H5" />
-    </svg>
-  );
-}
-
-function CheckIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-      <path d="M3 8.5l3.5 3.5L13 5" />
-    </svg>
-  );
-}
-
-function ChevronIcon() {
-  return (
-    <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-      <path d="M4 6.5l4 4 4-4" />
-    </svg>
-  );
-}
-
-/**
- * "Copy page" split button (docs premium-polish pass). The primary segment
- * copies the page's raw Markdown — the single most useful docs action in the
- * LLM era, previously buried behind an unlabeled "⋯" menu. The chevron opens
- * the secondary actions. Menu a11y (first-item focus, arrow roving, Escape,
- * focus restore) carried over from the a11y pass (#865).
- */
-export function PageActions({ library, section, slug }: Props) {
+export function PageActions({ library, section, slug, headings }: Props) {
   const [open, setOpen] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [showHeadings, setShowHeadings] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+  const copiedTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const restoreTriggerFocus = useRef(true);
+
+  const closeMenu = () => {
+    setOpen(false);
+    setShowHeadings(false);
+  };
 
   useEffect(() => {
     if (!open) return undefined;
-    const items = menuRef.current?.querySelectorAll<HTMLElement>('[role="menuitem"]');
-    items?.[0]?.focus();
-    const onDown = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    menuRef.current?.querySelector<HTMLElement>('[role="menuitem"]')?.focus();
+    const onDown = (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) closeMenu();
     };
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setOpen(false);
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') closeMenu();
     };
     document.addEventListener('mousedown', onDown);
     document.addEventListener('keydown', onKey);
     return () => {
       document.removeEventListener('mousedown', onDown);
       document.removeEventListener('keydown', onKey);
-      triggerRef.current?.focus();
+      if (restoreTriggerFocus.current) triggerRef.current?.focus();
     };
   }, [open]);
 
-  const onMenuKeyDown = (e: React.KeyboardEvent) => {
-    const items = [...(menuRef.current?.querySelectorAll<HTMLElement>('[role="menuitem"]') ?? [])];
+  useEffect(
+    () => () => {
+      if (copiedTimer.current) clearTimeout(copiedTimer.current);
+    },
+    [],
+  );
+
+  const onMenuKeyDown = (event: ReactKeyboardEvent) => {
+    const items = Array.from(
+      menuRef.current?.querySelectorAll<HTMLElement>('[role="menuitem"]') ?? [],
+    );
     if (items.length === 0) return;
-    const i = items.indexOf(document.activeElement as HTMLElement);
-    const move = (n: number) => {
-      e.preventDefault();
-      items[(n + items.length) % items.length].focus();
+    const current = Math.max(0, items.indexOf(document.activeElement as HTMLElement));
+    const move = (index: number) => {
+      event.preventDefault();
+      items[(index + items.length) % items.length]?.focus();
     };
-    if (e.key === 'ArrowDown') move(i + 1);
-    if (e.key === 'ArrowUp') move(i - 1);
-    if (e.key === 'Home') move(0);
-    if (e.key === 'End') move(items.length - 1);
+    if (event.key === 'ArrowDown') move(current + 1);
+    if (event.key === 'ArrowUp') move(current - 1);
+    if (event.key === 'Home') move(0);
+    if (event.key === 'End') move(items.length - 1);
   };
 
   const path = `${library}/${section}/${slug}`;
@@ -95,43 +91,49 @@ export function PageActions({ library, section, slug }: Props) {
 
   const copyMarkdown = async () => {
     try {
-      const res = await fetch(markdownUrl);
-      if (!res.ok) throw new Error(String(res.status));
-      const text = await res.text();
-      await navigator.clipboard.writeText(text);
-      track(analyticsEvents.docsCopyCodeClick, { surface: 'docs', cta_id: 'copy_page_markdown' });
+      const response = await fetch(markdownUrl);
+      if (!response.ok) throw new Error(String(response.status));
+      await navigator.clipboard.writeText(await response.text());
+      track(analyticsEvents.docsCopyCodeClick, {
+        surface: 'docs',
+        cta_id: 'copy_page_markdown',
+      });
       setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      if (copiedTimer.current) clearTimeout(copiedTimer.current);
+      copiedTimer.current = setTimeout(() => setCopied(false), 2000);
     } catch {
-      // network/clipboard failure — silently ignore
+      setCopied(false);
     }
+  };
+
+  const openOnThisPage = () => {
+    const toc = document.getElementById('docs-on-this-page');
+    if (toc && toc.getClientRects().length > 0) {
+      restoreTriggerFocus.current = false;
+      closeMenu();
+      toc.focus();
+      return;
+    }
+    setShowHeadings(true);
   };
 
   return (
     <div ref={ref} className="docs-page-actions">
-      <div className="docs-copy-split">
-        <button
-          type="button"
-          aria-label="Copy page as Markdown"
-          onClick={copyMarkdown}
-          className="docs-copy-primary"
-          data-copied={copied || undefined}
-        >
-          {copied ? <CheckIcon /> : <CopyIcon />}
-          <span>{copied ? 'Copied' : 'Copy page'}</span>
-        </button>
-        <button
-          type="button"
-          ref={triggerRef}
-          aria-label="Page actions"
-          aria-haspopup="menu"
-          aria-expanded={open}
-          onClick={() => setOpen((o) => !o)}
-          className="docs-copy-more"
-        >
-          <ChevronIcon />
-        </button>
-      </div>
+      <button
+        type="button"
+        ref={triggerRef}
+        aria-label="Page actions"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => {
+          restoreTriggerFocus.current = true;
+          setOpen((current) => !current);
+          if (open) setShowHeadings(false);
+        }}
+        className="docs-page-actions-trigger"
+      >
+        <Ellipsis size={18} strokeWidth={2} aria-hidden="true" />
+      </button>
       {open ? (
         <div
           role="menu"
@@ -139,35 +141,73 @@ export function PageActions({ library, section, slug }: Props) {
           onKeyDown={onMenuKeyDown}
           className="docs-page-actions-menu"
         >
+          <button
+            type="button"
+            role="menuitem"
+            onClick={openOnThisPage}
+            className="docs-page-actions-item"
+          >
+            <ListTree size={16} aria-hidden="true" />
+            <span>On this page</span>
+          </button>
+          {showHeadings ? (
+            <div className="docs-page-actions-headings">
+              {headings.map((heading) => (
+                <a
+                  key={heading.id}
+                  role="menuitem"
+                  href={`#${heading.id}`}
+                  data-level={heading.level}
+                  onClick={closeMenu}
+                  className="docs-page-actions-heading"
+                >
+                  {heading.text}
+                </a>
+              ))}
+            </div>
+          ) : null}
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => void copyMarkdown()}
+            className="docs-page-actions-item"
+          >
+            {copied ? <Check size={16} aria-hidden="true" /> : <Copy size={16} aria-hidden="true" />}
+            <span>{copied ? 'Copied' : 'Copy page as Markdown'}</span>
+          </button>
+          <div className="docs-page-actions-separator" role="separator" />
           <a
             role="menuitem"
             href={chatgptUrl}
             target="_blank"
             rel="noopener noreferrer"
-            onClick={() => setOpen(false)}
+            onClick={closeMenu}
             className="docs-page-actions-item"
           >
-            Open in ChatGPT
+            <Bot size={16} aria-hidden="true" />
+            <span>Open in ChatGPT</span>
           </a>
           <a
             role="menuitem"
             href={markdownUrl}
             target="_blank"
             rel="noopener noreferrer"
-            onClick={() => setOpen(false)}
+            onClick={closeMenu}
             className="docs-page-actions-item"
           >
-            View as Markdown
+            <FileText size={16} aria-hidden="true" />
+            <span>View as Markdown</span>
           </a>
           <a
             role="menuitem"
             href={githubUrl}
             target="_blank"
             rel="noopener noreferrer"
-            onClick={() => setOpen(false)}
+            onClick={closeMenu}
             className="docs-page-actions-item"
           >
-            Edit on GitHub
+            <SquarePen size={16} aria-hidden="true" />
+            <span>Edit on GitHub</span>
           </a>
         </div>
       ) : null}

--- a/apps/website/src/components/shared/Nav.spec.tsx
+++ b/apps/website/src/components/shared/Nav.spec.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Nav } from './Nav';
+
+const { trackCtaClick } = vi.hoisted(() => ({
+  trackCtaClick: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/docs/langgraph/guides/streaming',
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock('../../lib/analytics/client', () => ({
+  trackCtaClick,
+  trackExternalLinkClick: vi.fn(),
+}));
+
+describe('Docs mobile navigation', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    trackCtaClick.mockClear();
+  });
+
+  it('uses the existing header trigger for the control-plane Docs drawer', () => {
+    render(<Nav />);
+    const trigger = screen.getByRole('button', { name: 'Open menu' });
+    fireEvent.click(trigger);
+
+    expect(screen.getByRole('dialog', { name: 'Mobile navigation' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Docs' }).getAttribute('data-active')).not.toBeNull();
+    expect(screen.getByRole('heading', { name: 'Scope' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Learn' })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Settings' })).toBeNull();
+    expect(within(screen.getByRole('dialog')).getByRole('button', { name: 'Close menu' })).toBeTruthy();
+  });
+
+  it('closes from the global control inside the dialog and restores trigger focus', async () => {
+    render(<Nav />);
+    const trigger = screen.getByRole('button', { name: 'Open menu' });
+    fireEvent.click(trigger);
+    const dialog = screen.getByRole('dialog', { name: 'Mobile navigation' });
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Close menu' }));
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it('closes on Escape and restores focus to the sole trigger', async () => {
+    render(<Nav />);
+    const trigger = screen.getByRole('button', { name: 'Open menu' });
+    fireEvent.click(trigger);
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it('keeps the drawer open when Escape dismisses the nested library menu', () => {
+    render(<Nav />);
+    fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+    const dialog = screen.getByRole('dialog', { name: 'Mobile navigation' });
+    const libraryTrigger = within(dialog).getByRole('button', { name: 'LangGraph' });
+    fireEvent.click(libraryTrigger);
+
+    fireEvent.keyDown(within(dialog).getByRole('menuitem', { name: /LangGraph/ }), {
+      key: 'Escape',
+    });
+
+    expect(screen.getByRole('dialog', { name: 'Mobile navigation' })).toBeTruthy();
+    expect(screen.queryByRole('menu')).toBeNull();
+    expect(document.activeElement).toBe(libraryTrigger);
+  });
+
+  it('closes the drawer before dispatching mobile search', async () => {
+    const searchListener = vi.fn();
+    document.addEventListener('keydown', searchListener);
+    render(<Nav />);
+    fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Search docs' }));
+
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Mobile navigation' })).toBeNull());
+    await waitFor(() => expect(searchListener).toHaveBeenCalledWith(
+      expect.objectContaining({ key: 'k', metaKey: true }),
+    ));
+    document.removeEventListener('keydown', searchListener);
+  });
+
+  it('preserves the Site tab alongside the Docs control plane', () => {
+    render(<Nav />);
+    fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Site' }));
+
+    const dialog = screen.getByRole('dialog', { name: 'Mobile navigation' });
+    expect(within(dialog).getByRole('link', { name: 'Pricing' })).toBeTruthy();
+    expect(screen.queryByRole('heading', { name: 'Scope' })).toBeNull();
+  });
+
+  it('preserves page-level analytics for Docs links', () => {
+    render(<Nav />);
+    fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+
+    const dialog = screen.getByRole('dialog', { name: 'Mobile navigation' });
+    fireEvent.click(within(dialog).getByRole('link', { name: 'Streaming' }));
+
+    expect(trackCtaClick).toHaveBeenCalledWith({
+      surface: 'mobile_nav',
+      destination_url: '/docs/langgraph/guides/streaming',
+      cta_id: 'mobile_nav_docs_page',
+      cta_text: 'Streaming',
+      library: 'langgraph',
+    });
+  });
+});

--- a/apps/website/src/components/shared/Nav.tsx
+++ b/apps/website/src/components/shared/Nav.tsx
@@ -1,13 +1,14 @@
 'use client';
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { tokens } from '@threadplane/design-tokens';
-import { docsConfig, specialDocsPages } from '../../lib/docs-config';
+import { findDocsPage, getLibraryConfig, type LibraryId } from '../../lib/docs-config';
 import { trackCtaClick, trackExternalLinkClick } from '../../lib/analytics/client';
+import type { AnalyticsLibrary } from '../../lib/analytics/events';
 import { LogoMark } from '../ui/LogoMark';
 import { Button } from '../ui/Button';
 import { DEMOS, demoCtaSuffix } from '../../lib/demos';
+import { DocsContextContent } from '../docs/DocsControlPlane';
 
 const links = [
   { label: 'Pilot to Prod', href: '/pilot-to-prod', external: false },
@@ -15,6 +16,18 @@ const links = [
   { label: 'Pricing', href: '/pricing', external: false },
   { label: 'Examples', href: 'https://cockpit.threadplane.ai', external: true },
 ];
+
+const toAnalyticsLibrary = (library: LibraryId): AnalyticsLibrary => {
+  switch (library) {
+    case 'langgraph':
+    case 'render':
+    case 'chat':
+    case 'ag-ui':
+      return library;
+    default:
+      return 'unknown';
+  }
+};
 
 function GitHubIcon() {
   return (
@@ -82,7 +95,14 @@ export function Nav() {
   const activeLibrary = isDocsPage && pathParts.length >= 2 ? pathParts[1] : '';
   const activeSection = isDocsPage && pathParts.length >= 3 ? pathParts[2] : '';
   const activeSlug = isDocsPage && pathParts.length >= 4 ? pathParts[3] : '';
-  const initialMobileLibrary = docsConfig.find((lib) => lib.id === activeLibrary)?.id ?? 'langgraph';
+  const docsLibrary = (getLibraryConfig(activeLibrary)?.id ?? 'langgraph') as LibraryId;
+  const docsPageTitle = findDocsPage(activeLibrary, activeSection, activeSlug)?.title ?? 'Documentation';
+  const mobileTriggerRef = useRef<HTMLButtonElement>(null);
+  const mobileDialogRef = useRef<HTMLDivElement>(null);
+  const closeMobileMenu = useCallback(() => {
+    setOpen(false);
+    mobileTriggerRef.current?.focus();
+  }, []);
 
   const [mobileTab, setMobileTab] = useState<'site' | 'docs'>(isDocsPage ? 'docs' : 'site');
 
@@ -95,23 +115,38 @@ export function Nav() {
     }
     return () => { document.body.style.overflow = ''; };
   }, [open]);
-  const [mobileLibrary, setMobileLibrary] = useState(initialMobileLibrary);
-  const [openSections, setOpenSections] = useState<Set<string>>(() => new Set(activeSection ? [activeSection] : []));
-
   useEffect(() => {
-    const nextLibrary = docsConfig.find((lib) => lib.id === activeLibrary)?.id;
-    if (nextLibrary) setMobileLibrary(nextLibrary);
-  }, [activeLibrary]);
+    if (!open) return undefined;
+    const dialog = mobileDialogRef.current;
+    const focusable = () => Array.from(
+      dialog?.querySelectorAll<HTMLElement>(
+        'a[href], button:not(:disabled), [tabindex]:not([tabindex="-1"])',
+      ) ?? [],
+    );
+    focusable()[0]?.focus();
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        closeMobileMenu();
+        return;
+      }
+      if (event.key !== 'Tab') return;
+      const items = focusable();
+      const first = items[0];
+      const last = items.at(-1);
+      if (!first || !last) return;
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [closeMobileMenu, open]);
 
-  const toggleSection = (id: string) => {
-    setOpenSections(prev => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id); else next.add(id);
-      return next;
-    });
-  };
-
-  const currentLib = docsConfig.find(lib => lib.id === mobileLibrary);
   const trackNavLink = (label: string, href: string, external: boolean, surface: 'nav' | 'mobile_nav') => {
     const slug = label.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_|_$/g, '');
     const ctaId: `nav_${string}` | `mobile_nav_${string}` =
@@ -179,9 +214,13 @@ export function Nav() {
 
         {/* Mobile hamburger */}
         <button
+          ref={mobileTriggerRef}
           className="lg:hidden inline-flex items-center justify-center nav-hamburger"
           onClick={() => { setOpen(!open); if (!open) setMobileTab(isDocsPage ? 'docs' : 'site'); }}
-          aria-label={open ? 'Close menu' : 'Open menu'}>
+          aria-expanded={open}
+          aria-hidden={open || undefined}
+          tabIndex={open ? -1 : 0}
+          aria-label="Open menu">
           {open ? <CloseIcon /> : <MenuIcon />}
         </button>
       </div>
@@ -190,8 +229,22 @@ export function Nav() {
 
     {/* Mobile full-screen overlay — rendered outside nav to avoid stacking context issues */}
     {open && (
-      <div className="lg:hidden fixed left-0 right-0 bottom-0 nav-mobile-overlay">
+      <div
+        ref={mobileDialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Mobile navigation"
+        className="lg:hidden fixed left-0 right-0 bottom-0 nav-mobile-overlay"
+      >
           <div className="nav-mobile-overlay-inner">
+            <button
+              type="button"
+              className="nav-mobile-dialog-close"
+              aria-label="Close menu"
+              onClick={closeMobileMenu}
+            >
+              <CloseIcon />
+            </button>
 
             {/* Primary tabs — only on docs pages */}
             {isDocsPage && (
@@ -201,118 +254,32 @@ export function Nav() {
               </div>
             )}
 
-            {/* Library sub-tabs — only when Docs tab active */}
-            {isDocsPage && mobileTab === 'docs' && (
-              <div className="nav-msubtabs-wrap">
-                <div className="nav-mobile-list">
-                  {specialDocsPages.map((page) => {
-                    const isActive = pathname === page.path;
-                    return (
-                      <Link
-                        key={page.path}
-                        href={page.path}
-                        onClick={() => {
-                          trackCtaClick({
-                            surface: 'mobile_nav',
-                            destination_url: page.path,
-                            cta_id: 'mobile_nav_docs_page',
-                            cta_text: page.title,
-                            library: 'unknown',
-                          });
-                          setOpen(false);
-                        }}
-                        className="nav-mobile-item nav-mobile-item--strong"
-                        data-active={isActive || undefined}
-                      >
-                        {page.title}
-                      </Link>
-                    );
-                  })}
-                </div>
-                <div className="nav-msubtabs">
-                  {docsConfig.map(lib => (
-                    <button key={lib.id} onClick={() => setMobileLibrary(lib.id)} className="nav-msubtab" data-active={mobileLibrary === lib.id || undefined}>
-                      {lib.title}
-                    </button>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {/* Docs content */}
-            {(mobileTab === 'docs' && isDocsPage && currentLib) && (
-              <div className="nav-mobile-content-list">
-                {/* Docs search was ⌘K-only, with its trigger in the
-                    desktop-only sidebar — phones had no way in (findings §7).
-                    DocsSearch is mounted on every docs page and listens for
-                    the same synthetic keydown the sidebar trigger sends. */}
-                <button
-                  type="button"
-                  className="nav-mobile-item nav-mobile-search"
-                  onClick={() => {
-                    setOpen(false);
-                    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', metaKey: true }));
-                  }}
-                >
-                  Search docs…
-                </button>
-                {currentLib.demoUrl && (
-                  <a href={currentLib.demoUrl} target="_blank" rel="noopener noreferrer"
-                    onClick={() => {
-                      const demoUrl = currentLib.demoUrl;
-                      if (!demoUrl) return;
-                      trackExternalLinkClick(demoUrl, { surface: 'mobile_nav', cta_id: `mobile_nav_docs_demo_${currentLib.id}`, cta_text: currentLib.demoLabel ?? 'Live demo' });
-                      setOpen(false);
-                    }}
-                    className="nav-mobile-demo-link">
-                    <span>{currentLib.demoLabel ?? 'Live demo'}</span><span aria-hidden="true">↗</span>
-                  </a>
-                )}
-                {currentLib.sections.map((section) => {
-                  return (
-                    <div key={section.id}>
-                      <button
-                        onClick={() => toggleSection(section.id)}
-                        className="nav-mobile-section-toggle"
-                      >
-                        {section.title}
-                        <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke={tokens.colors.textMuted} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
-                          className="nav-mobile-chevron" data-open={openSections.has(section.id) || undefined}>
-                          <path d="M5 7.5l5 5 5-5" />
-                        </svg>
-                      </button>
-                      {openSections.has(section.id) && (
-                        <nav className="nav-mobile-list">
-                          {section.pages.map((page) => {
-                            const isActive = page.section === activeSection && page.slug === activeSlug && mobileLibrary === activeLibrary;
-                            return (
-                              <Link
-                                key={`${currentLib.id}/${page.section}/${page.slug}`}
-                                href={`/docs/${currentLib.id}/${page.section}/${page.slug}`}
-                                onClick={() => {
-                                  trackCtaClick({
-                                    surface: 'mobile_nav',
-                                    destination_url: `/docs/${currentLib.id}/${page.section}/${page.slug}`,
-                                    cta_id: 'mobile_nav_docs_page',
-                                    cta_text: page.title,
-                                    library: currentLib.id === 'langgraph' || currentLib.id === 'render' || currentLib.id === 'chat' || currentLib.id === 'ag-ui' ? currentLib.id : 'unknown',
-                                  });
-                                  setOpen(false);
-                                }}
-                                className="nav-mobile-item"
-                                data-active={isActive || undefined}
-                              >
-                                {page.title}
-                              </Link>
-                            );
-                          })}
-                        </nav>
-                      )}
-                    </div>
+            {mobileTab === 'docs' && isDocsPage ? (
+              <div
+                onClickCapture={(event) => {
+                  const link = (event.target as HTMLElement).closest<HTMLAnchorElement>(
+                    'a[data-docs-navlink]',
                   );
-                })}
+                  if (!link) return;
+                  trackCtaClick({
+                    surface: 'mobile_nav',
+                    destination_url: link.getAttribute('href') ?? link.href,
+                    cta_id: 'mobile_nav_docs_page',
+                    cta_text: link.textContent?.trim() ?? 'Docs page',
+                    library: toAnalyticsLibrary(docsLibrary),
+                  });
+                }}
+              >
+                <DocsContextContent
+                  activeLibrary={docsLibrary}
+                  activeSection={activeSection || 'getting-started'}
+                  activeSlug={activeSlug || 'introduction'}
+                  pageTitle={docsPageTitle}
+                  mobile
+                  onNavigate={() => setOpen(false)}
+                />
               </div>
-            )}
+            ) : null}
 
             {/* Site content */}
             {(mobileTab === 'site' || !isDocsPage) && (

--- a/apps/website/src/lib/cockpit-links.spec.ts
+++ b/apps/website/src/lib/cockpit-links.spec.ts
@@ -1,0 +1,84 @@
+import { cockpitManifest } from '@threadplane/cockpit-registry';
+import { describe, expect, it } from 'vitest';
+import {
+  buildCockpitModeHref,
+  docsCockpitMappings,
+  resolveCockpitIdentity,
+} from './cockpit-links';
+
+describe('Docs-to-Cockpit links', () => {
+  it('contains the exhaustive first-iteration mapping set', () => {
+    expect(docsCockpitMappings).toEqual({
+      'langgraph/guides/streaming': {
+        product: 'langgraph', section: 'core-capabilities', topic: 'streaming', page: 'overview', language: 'python',
+      },
+      'langgraph/guides/deployment': {
+        product: 'langgraph', section: 'core-capabilities', topic: 'deployment-runtime', page: 'overview', language: 'python',
+      },
+      'render/guides/specs': {
+        product: 'render', section: 'core-capabilities', topic: 'spec-rendering', page: 'overview', language: 'python',
+      },
+      'render/guides/registry': {
+        product: 'render', section: 'core-capabilities', topic: 'registry', page: 'overview', language: 'python',
+      },
+      'chat/guides/generative-ui': {
+        product: 'chat', section: 'core-capabilities', topic: 'generative-ui', page: 'overview', language: 'python',
+      },
+    });
+  });
+
+  it('resolves only explicit mappings', () => {
+    expect(resolveCockpitIdentity('render', 'guides', 'specs')?.topic).toBe('spec-rendering');
+    expect(resolveCockpitIdentity('langgraph', 'api', 'inject-agent')).toBeNull();
+    expect(resolveCockpitIdentity('docs', 'special', 'choosing-an-adapter')).toBeNull();
+  });
+
+  it('targets a mapped capability and appends the requested mode', () => {
+    expect(
+      buildCockpitModeHref(
+        { library: 'langgraph', section: 'guides', slug: 'deployment' },
+        'Code',
+        'https://local-cockpit.example/base',
+      ),
+    ).toBe(
+      'https://local-cockpit.example/langgraph/core-capabilities/deployment-runtime/overview/python?mode=code',
+    );
+  });
+
+  it('uses Cockpit home for unsupported pages without guessing', () => {
+    expect(
+      buildCockpitModeHref(
+        { library: 'langgraph', section: 'api', slug: 'inject-agent' },
+        'API',
+        'https://cockpit.example',
+      ),
+    ).toBe('https://cockpit.example/?mode=api');
+  });
+
+  it('uses the configured public Cockpit origin by default', () => {
+    const original = process.env.NEXT_PUBLIC_COCKPIT_BASE_URL;
+    process.env.NEXT_PUBLIC_COCKPIT_BASE_URL = 'https://configured-cockpit.example';
+    try {
+      expect(
+        buildCockpitModeHref(
+          { library: 'chat', section: 'guides', slug: 'generative-ui' },
+          'Run',
+        ),
+      ).toContain('https://configured-cockpit.example/chat/core-capabilities/generative-ui/overview/python?mode=run');
+    } finally {
+      process.env.NEXT_PUBLIC_COCKPIT_BASE_URL = original;
+    }
+  });
+
+  it('keeps every mapped target aligned with the Cockpit manifest', () => {
+    for (const target of Object.values(docsCockpitMappings)) {
+      expect(cockpitManifest.some((entry) =>
+        entry.product === target.product &&
+        entry.section === target.section &&
+        entry.topic === target.topic &&
+        entry.page === target.page &&
+        entry.language === target.language,
+      )).toBe(true);
+    }
+  });
+});

--- a/apps/website/src/lib/cockpit-links.ts
+++ b/apps/website/src/lib/cockpit-links.ts
@@ -1,0 +1,72 @@
+import type { CockpitManifestIdentity } from '@threadplane/cockpit-registry';
+import type { ControlPlaneMode } from '@threadplane/ui-react';
+
+export interface DocsIdentity {
+  library: string;
+  section: string;
+  slug: string;
+}
+
+export const docsCockpitMappings = {
+  'langgraph/guides/streaming': {
+    product: 'langgraph',
+    section: 'core-capabilities',
+    topic: 'streaming',
+    page: 'overview',
+    language: 'python',
+  },
+  'langgraph/guides/deployment': {
+    product: 'langgraph',
+    section: 'core-capabilities',
+    topic: 'deployment-runtime',
+    page: 'overview',
+    language: 'python',
+  },
+  'render/guides/specs': {
+    product: 'render',
+    section: 'core-capabilities',
+    topic: 'spec-rendering',
+    page: 'overview',
+    language: 'python',
+  },
+  'render/guides/registry': {
+    product: 'render',
+    section: 'core-capabilities',
+    topic: 'registry',
+    page: 'overview',
+    language: 'python',
+  },
+  'chat/guides/generative-ui': {
+    product: 'chat',
+    section: 'core-capabilities',
+    topic: 'generative-ui',
+    page: 'overview',
+    language: 'python',
+  },
+} satisfies Record<string, CockpitManifestIdentity>;
+
+const docsKey = (library: string, section: string, slug: string) =>
+  `${library}/${section}/${slug}`;
+
+export const resolveCockpitIdentity = (
+  library: string,
+  section: string,
+  slug: string,
+): CockpitManifestIdentity | null =>
+  docsCockpitMappings[
+    docsKey(library, section, slug) as keyof typeof docsCockpitMappings
+  ] ?? null;
+
+const cockpitPath = (target: CockpitManifestIdentity) =>
+  `/${target.product}/${target.section}/${target.topic}/${target.page}/${target.language}`;
+
+export const buildCockpitModeHref = (
+  identity: DocsIdentity,
+  mode: Exclude<ControlPlaneMode, 'Docs'>,
+  baseUrl = process.env.NEXT_PUBLIC_COCKPIT_BASE_URL ?? 'https://cockpit.threadplane.ai',
+): string => {
+  const target = resolveCockpitIdentity(identity.library, identity.section, identity.slug);
+  const url = new URL(target ? cockpitPath(target) : '/', baseUrl);
+  url.searchParams.set('mode', mode.toLowerCase());
+  return url.toString();
+};

--- a/apps/website/src/styles/chrome.css
+++ b/apps/website/src/styles/chrome.css
@@ -142,6 +142,7 @@
   padding: 12px;
   margin: -12px;
 }
+.nav-hamburger[aria-hidden="true"] { visibility: hidden; }
 .nav-mobile-overlay {
   top: calc(var(--nav-h) - 1px);
   z-index: 9999;
@@ -157,6 +158,23 @@
   flex-direction: column;
   gap: 16px;
   min-height: 100%;
+}
+.nav-mobile-dialog-close {
+  width: 44px;
+  height: 44px;
+  margin: -6px -8px -6px auto;
+  border: 0;
+  border-radius: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-primary);
+  background: transparent;
+  cursor: pointer;
+}
+.nav-mobile-dialog-close:hover,
+.nav-mobile-dialog-close:focus-visible {
+  background: var(--color-surface-dim);
 }
 .nav-mtabs {
   display: flex;

--- a/apps/website/src/styles/docs.css
+++ b/apps/website/src/styles/docs.css
@@ -1051,81 +1051,6 @@
 .docs-page-actions {
   position: relative;
 }
-/* "Copy page" split button (premium-polish pass) — the primary docs action,
- * labeled and visible instead of hidden behind an unlabeled trigger. */
-.docs-copy-split {
-  display: inline-flex;
-  align-items: stretch;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  background: var(--color-surface);
-  box-shadow: var(--shadow-sm);
-  /* No overflow: hidden — the segments' ::after hit-areas (44px touch
-   * targets, findings §7) must extend past the box. Radius is applied
-   * per segment instead. */
-}
-.docs-copy-primary {
-  position: relative;
-  border-radius: calc(var(--radius-md) - 1px) 0 0 calc(var(--radius-md) - 1px);
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  padding: 7px 12px;
-  font-family: var(--font-inter);
-  font-size: 13px;
-  font-weight: 500;
-  color: var(--color-text-secondary);
-  background: transparent;
-  border: none;
-  cursor: pointer;
-  transition: background 120ms ease, color 120ms ease;
-}
-.docs-copy-primary:hover {
-  background: var(--color-surface-dim);
-  color: var(--color-text-primary);
-}
-.docs-copy-primary[data-copied] {
-  color: var(--color-render-green);
-}
-.docs-copy-more {
-  position: relative;
-  border-radius: 0 calc(var(--radius-md) - 1px) calc(var(--radius-md) - 1px) 0;
-  display: inline-flex;
-  align-items: center;
-  padding: 0 8px;
-  color: var(--color-text-muted);
-  background: transparent;
-  border: none;
-  border-left: 1px solid var(--color-border);
-  cursor: pointer;
-  transition: background 120ms ease, color 120ms ease;
-}
-/* 44px touch targets without visual growth: extend each segment's hit
- * area vertically, and the chevron's to the right (it sits at the box
- * edge and is only ~29px wide). The segments split the shared border. */
-.docs-copy-primary::after,
-.docs-copy-more::after {
-  content: '';
-  position: absolute;
-  left: 0;
-  right: 0;
-  top: -6px;
-  bottom: -6px;
-}
-.docs-copy-more::after {
-  right: -15px;
-}
-.docs-copy-more:hover,
-.docs-copy-more[aria-expanded='true'] {
-  background: var(--color-surface-dim);
-  color: var(--color-text-primary);
-}
-.docs-copy-primary:focus-visible,
-.docs-copy-more:focus-visible {
-  outline: none;
-  box-shadow: var(--shadow-focus);
-  border-radius: var(--radius-sm);
-}
 .docs-page-actions-menu {
   position: absolute;
   top: calc(100% + 6px);
@@ -1653,4 +1578,409 @@
   align-items: center;
   gap: 8px;
   min-width: 0;
+}
+
+/* Unified sidebar control plane */
+.docs-control-plane {
+  display: none;
+  position: sticky;
+  top: var(--nav-h);
+  align-self: flex-start;
+  width: 328px;
+  height: calc(100vh - var(--nav-h));
+  flex: 0 0 328px;
+  border-right: 1px solid var(--color-border);
+  background: var(--color-surface);
+}
+@media (min-width: 64rem) {
+  .docs-control-plane { display: flex; }
+}
+.docs-control-plane [data-control-plane-rail] {
+  width: 56px;
+  flex: 0 0 56px;
+  padding: 10px 6px;
+  border-right: 1px solid var(--color-border);
+  background: var(--color-surface-dim);
+  display: flex;
+  flex-direction: column;
+}
+.docs-control-plane [data-control-plane-rail-group] {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.docs-control-plane [data-control-plane-rail-group="utilities"] { margin-top: auto; }
+.docs-control-plane [data-control-plane-rail-item] {
+  position: relative;
+  min-height: 48px;
+  padding: 6px 2px;
+  border: 0;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  color: var(--color-text-muted);
+  background: transparent;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease;
+}
+.docs-control-plane [data-control-plane-rail-item]:hover {
+  color: var(--color-text-primary);
+  background: var(--color-surface);
+}
+.docs-control-plane [data-control-plane-rail-item][data-control-plane-active] {
+  color: var(--color-accent);
+  background: var(--color-accent-surface);
+}
+.docs-control-plane [data-control-plane-rail-label] {
+  font-family: var(--font-inter);
+  font-size: 10px;
+  line-height: 1;
+  font-weight: 600;
+}
+.docs-control-plane [data-control-plane-pane] {
+  width: 272px;
+  min-width: 0;
+  overflow-y: auto;
+}
+[data-docs-control-plane-context] {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 12px 10px 20px;
+}
+[data-docs-control-plane-context] [data-control-plane-section] {
+  padding: 3px 0;
+}
+[data-docs-control-plane-context] [data-control-plane-section-trigger] {
+  width: 100%;
+  min-height: 34px;
+  padding: 6px 8px;
+  border: 0;
+  border-radius: 7px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: var(--color-text-muted);
+  background: transparent;
+  cursor: pointer;
+  font-family: var(--font-inter);
+  font-size: 12px;
+  font-weight: 600;
+  text-align: left;
+}
+[data-docs-control-plane-context] [data-control-plane-section-trigger]:hover {
+  color: var(--color-text-primary);
+  background: var(--color-surface-dim);
+}
+[data-docs-control-plane-context] [data-control-plane-section-trigger] [data-control-plane-section-chevron] {
+  flex: none;
+  transition: transform 150ms ease;
+  transform: rotate(0deg);
+}
+[data-docs-control-plane-context] [data-control-plane-section-trigger][aria-expanded="true"] [data-control-plane-section-chevron] {
+  transform: rotate(90deg);
+}
+[data-docs-control-plane-context] [data-control-plane-section-heading] {
+  margin: 0;
+  padding: 8px;
+  color: var(--color-text-muted);
+  font-family: var(--font-inter);
+  font-size: 12px;
+  line-height: 1.2;
+  font-weight: 600;
+}
+[data-docs-control-plane-context] [data-control-plane-section-content] {
+  padding: 2px 0 8px;
+}
+.docs-control-plane-scope {
+  margin: 0 8px;
+  padding: 10px;
+  border-radius: 8px;
+  background: var(--color-surface-dim);
+  display: grid;
+  gap: 3px;
+  color: var(--color-text-muted);
+  font-family: var(--font-inter);
+  font-size: 11px;
+}
+.docs-control-plane-scope strong {
+  color: var(--color-text-primary);
+  font-size: 13px;
+  font-weight: 600;
+}
+.docs-sidebar-library { position: relative; margin: 2px 8px 10px; }
+.docs-sidebar-lib-trigger {
+  width: 100%;
+  min-height: 38px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.docs-sidebar-lib-trigger-label {
+  font-family: var(--font-inter);
+  font-size: 13px;
+}
+.docs-sidebar-lib-trigger > svg { transition: transform 150ms ease; }
+.docs-sidebar-lib-trigger > svg[data-open] { transform: rotate(180deg); }
+.docs-sidebar-lib-menu {
+  position: absolute;
+  inset-inline: 0;
+  top: calc(100% + 4px);
+  z-index: 30;
+  overflow: hidden;
+  border-radius: 9px;
+}
+.docs-sidebar-lib-item {
+  width: 100%;
+  padding: 9px 10px;
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+  text-align: left;
+}
+.docs-sidebar-lib-item-title { font-family: var(--font-inter); }
+.docs-sidebar-top-links,
+.docs-sidebar-section-links { display: flex; flex-direction: column; }
+.docs-sidebar-top-links { margin: 0 8px 8px; }
+.docs-sidebar-top-link,
+.docs-sidebar-section-link {
+  margin: 1px 0;
+  padding: 7px 9px;
+  border-radius: 7px;
+  font-family: var(--font-inter);
+  font-size: 13px;
+  line-height: 1.35;
+  text-decoration: none;
+}
+.docs-sidebar-section { margin: 0 0 3px; }
+.docs-sidebar-section-toggle {
+  width: calc(100% - 16px);
+  min-height: 34px;
+  margin: 0 8px;
+  padding: 6px 8px;
+  border-radius: 7px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: var(--color-text-muted);
+  font-family: var(--font-inter);
+  font-size: 12px;
+  font-weight: 600;
+}
+.docs-sidebar-section-toggle:hover {
+  color: var(--color-text-primary);
+  background: var(--color-surface-dim);
+}
+.docs-sidebar-section-label { color: inherit; font-weight: inherit; }
+.docs-sidebar-section-caret { transform: rotate(-90deg); }
+.docs-sidebar-section-caret[data-open] { transform: rotate(0deg); }
+.docs-sidebar-section-links { margin: 1px 8px 6px; }
+[data-docs-control-plane-context] [data-control-plane-environment-list] {
+  display: grid;
+  gap: 2px;
+  margin: 0 8px;
+}
+[data-docs-control-plane-context] [data-control-plane-environment-row] {
+  min-height: 32px;
+  padding: 6px 8px;
+  border-radius: 7px;
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-inter);
+  font-size: 11px;
+}
+[data-docs-control-plane-context] [data-control-plane-environment-row]:hover {
+  background: var(--color-surface-dim);
+}
+[data-docs-control-plane-context] [data-control-plane-environment-row] dt { color: var(--color-text-muted); }
+[data-docs-control-plane-context] [data-control-plane-environment-row] dd {
+  margin: 0;
+  color: var(--color-text-primary);
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+[data-docs-control-plane-context] [data-control-plane-environment-icon] {
+  display: inline-flex;
+  color: var(--color-text-muted);
+}
+[data-docs-control-plane-context] [data-control-plane-action-bar] {
+  display: flex;
+  gap: 4px;
+  margin: 0 8px;
+}
+[data-docs-control-plane-context] [data-control-plane-action] {
+  position: relative;
+  width: 34px;
+  height: 34px;
+  padding: 0;
+  border: 0;
+  border-radius: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-muted);
+  background: transparent;
+  cursor: pointer;
+}
+[data-docs-control-plane-context] [data-control-plane-action]:hover {
+  color: var(--color-text-primary);
+  background: var(--color-surface-dim);
+}
+.docs-control-plane [data-control-plane-tooltip],
+[data-docs-control-plane-context] [data-control-plane-tooltip] {
+  position: absolute;
+  z-index: 60;
+  padding: 5px 7px;
+  border-radius: 6px;
+  color: var(--color-surface);
+  background: var(--color-text-primary);
+  box-shadow: var(--shadow-sm);
+  font-family: var(--font-inter);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 120ms ease, visibility 120ms ease;
+}
+.docs-control-plane [data-control-plane-rail-item] [data-control-plane-tooltip] {
+  left: calc(100% + 8px);
+  top: 50%;
+  transform: translateY(-50%);
+}
+[data-docs-control-plane-context] [data-control-plane-action] [data-control-plane-tooltip] {
+  left: 50%;
+  bottom: calc(100% + 6px);
+  transform: translateX(-50%);
+}
+.docs-control-plane [data-control-plane-rail-item]:is(:hover, :focus-visible) [data-control-plane-tooltip],
+[data-docs-control-plane-context] [data-control-plane-action]:is(:hover, :focus-visible) [data-control-plane-tooltip] {
+  opacity: 1;
+  visibility: visible;
+}
+[data-docs-control-plane-context][data-mobile] {
+  height: 100%;
+  overflow-y: auto;
+  padding: 10px 12px 24px;
+}
+@media (prefers-reduced-motion: reduce) {
+  .docs-control-plane *,
+  [data-docs-control-plane-context] *,
+  .docs-page-actions * {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+  }
+}
+
+/* Docs table of contents: complete rounded active/hover surfaces. */
+.docs-toc:focus { outline: none; }
+.docs-toc-label {
+  font-family: var(--font-inter);
+  font-size: 12px;
+  font-weight: 600;
+}
+.docs-toc-nav { border-left: 0; gap: 2px; }
+.docs-toc-link,
+.docs-toc-link[data-level="3"] {
+  margin: 0;
+  padding: 5px 8px;
+  border: 0;
+  border-radius: 7px;
+}
+.docs-toc-link:hover { background: var(--color-surface-dim); }
+.docs-toc-link[data-active] {
+  border: 0;
+  background: var(--color-accent-surface);
+}
+
+/* Page utility overflow */
+.docs-page-actions-trigger {
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  border: 0;
+  border-radius: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-muted);
+  background: transparent;
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease;
+}
+.docs-page-actions-trigger:hover,
+.docs-page-actions-trigger[aria-expanded="true"] {
+  color: var(--color-text-primary);
+  background: var(--color-surface-dim);
+}
+.docs-page-actions-menu {
+  top: calc(100% + 7px);
+  min-width: 224px;
+  padding: 5px;
+  border-radius: 10px;
+  box-shadow: var(--shadow-lg);
+}
+.docs-page-actions-item {
+  min-height: 36px;
+  padding: 8px 10px;
+  border-radius: 7px;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+}
+.docs-page-actions-separator {
+  height: 1px;
+  margin: 4px 6px;
+  background: var(--color-border);
+}
+.docs-page-actions-headings {
+  max-height: 220px;
+  margin: 0 4px 4px 26px;
+  padding-left: 7px;
+  border-left: 1px solid var(--color-border);
+  overflow-y: auto;
+}
+.docs-page-actions-heading {
+  min-height: 32px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  color: var(--color-text-secondary);
+  font-family: var(--font-inter);
+  font-size: 12px;
+  text-decoration: none;
+}
+.docs-page-actions-heading[data-level="3"] { padding-left: 16px; color: var(--color-text-muted); }
+.docs-page-actions-heading:hover,
+.docs-page-actions-heading:focus-visible { background: var(--color-surface-dim); }
+.docs-page-actions-trigger:focus-visible,
+[data-docs-control-plane-context] button:focus-visible,
+[data-docs-control-plane-context] a:focus-visible,
+.docs-control-plane [data-control-plane-rail-item]:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
+}
+@media (pointer: coarse) {
+  [data-docs-control-plane-context][data-mobile] button,
+  [data-docs-control-plane-context][data-mobile] a,
+  [data-docs-control-plane-context] [data-control-plane-action],
+  .docs-page-actions-trigger,
+  .docs-page-actions-item,
+  .docs-page-actions-heading { min-height: 44px; }
+  [data-docs-control-plane-context] [data-control-plane-action] {
+    width: 44px;
+    height: 44px;
+  }
 }

--- a/apps/website/tsconfig.json
+++ b/apps/website/tsconfig.json
@@ -24,6 +24,7 @@
       "@threadplane/cockpit-registry": ["../../libs/cockpit-registry/src/index.ts"],
       "@threadplane/cockpit-shell": ["../../libs/cockpit-shell/src/index.ts"],
       "@threadplane/design-tokens": ["../../libs/design-tokens/src/index.ts"],
+      "@threadplane/ui-react": ["../../libs/ui-react/src/index.ts"],
       "@threadplane/telemetry/shared": [
         "../../libs/telemetry/src/shared/public-api.ts"
       ],

--- a/docs/superpowers/specs/2026-08-30-unified-sidebar-control-plane-design.md
+++ b/docs/superpowers/specs/2026-08-30-unified-sidebar-control-plane-design.md
@@ -1,0 +1,439 @@
+# Unified sidebar control plane for Docs and Cockpit
+
+## Status
+
+Approved through interactive design review on 2026-08-30. This document is the implementation contract for the first production iteration.
+
+## Summary
+
+Replace the separate Docs navigation sidebar and Cockpit navigation-plus-header-mode-switcher with one shared sidebar model: a compact activity rail plus a contextual control pane.
+
+The rail selects the kind of work. The context pane governs the current library, capability, environment, and available actions. The main area remains the place where reading, running, coding, and API inspection happen.
+
+The implementation must feel like one Threadplane control plane across both applications without pretending that Docs and Cockpit have identical data or capabilities. Shared React primitives own structure and accessibility; app adapters provide truthful data, navigation, actions, and token mappings.
+
+## Problem
+
+The current sidebars are navigation-only and diverge in important ways:
+
+- Docs has a 16rem library-and-page navigator, a separate right-side table of contents, and page actions in a split Copy button.
+- Cockpit has a 16rem product navigator, while Run, Code, Docs, and API live in a separate header mode switcher.
+- Section headings use uppercase monospaced styling that is louder and less readable than the surrounding interface.
+- Several icons and chevrons are one-off inline SVGs with inconsistent weight.
+- Page-level utilities compete with content instead of living in a quiet overflow menu.
+- The UI has no stable place to expose scope, environment, activity, and settings as the product grows.
+
+This creates two product grammars for the same workflow and makes each new control fight for space in an arbitrary toolbar or navigation list.
+
+## Research synthesis
+
+The design is grounded in these findings:
+
+- A control plane exposes current scope, consequential state, and high-frequency controls; it does not absorb the detailed work surface.
+- Stable mode rails reduce relocation cost when the contextual pane changes.
+- Adaptive navigation should preserve the primary workspace at narrow widths rather than permanently consuming most of the viewport.
+- Sidebar hierarchies should remain shallow, use disclosure controls with accurate state, and preserve keyboard and target-size requirements.
+- Composable sidebar infrastructure is useful, but the product must still define its own information architecture and state model.
+
+Primary references:
+
+- [WezTerm vertical tabs pull request](https://github.com/wezterm/wezterm/pull/7679) — a useful implementation signal for resizable vertical navigation, but not by itself a complete control-plane model.
+- [shadcn/ui Sidebar](https://ui.shadcn.com/docs/components/base/sidebar) — composable rail, group, action, badge, and collapse primitives.
+- [Microsoft NavigationView](https://learn.microsoft.com/en-us/windows/apps/design/controls/navigationview) — adaptive pane modes and compact navigation behavior.
+- [Apple Human Interface Guidelines: Sidebars](https://developer.apple.com/design/human-interface-guidelines/sidebars) — sidebar hierarchy and content-preservation guidance.
+- [WAI-ARIA disclosure pattern](https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/) — expanded-state and keyboard semantics.
+- [WAI-ARIA toolbar pattern](https://www.w3.org/WAI/ARIA/apg/patterns/toolbar/) — grouped command semantics.
+- [WCAG 2.2 target size minimum](https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html) — pointer target requirements.
+
+## Goals
+
+1. Establish one recognizable control-plane grammar across Docs and Cockpit.
+2. Put Docs, Run, Code, and API in a stable primary rail.
+3. Put current scope, contextual navigation, environment, and actions in the adjacent pane.
+4. Keep the main workspace visually calm and as wide as practical.
+5. Use modern, consistent icons and stronger chevrons.
+6. Replace uppercase monospaced section headings with minimal sentence-case labels.
+7. Use complete rounded hover and active backgrounds; do not use decorative left-edge rails or partial rounded borders.
+8. Consolidate page utilities, including On this page and Copy page, into a polished three-dot overflow menu.
+9. Preserve existing routes, content sources, analytics, runtime iframe continuity, and accessible keyboard behavior.
+10. Provide an adaptive mobile presentation without forcing the full desktop pane to remain open.
+
+## Non-goals
+
+- A backend activity/event service.
+- Invented deployment health, branch, last-run, or connectivity data.
+- User-reorderable sidebar modules.
+- Arbitrarily nestable navigation trees.
+- A new global command palette.
+- Changes to cockpit manifest route shapes or docs content taxonomy.
+- Rebuilding the Docs content renderer, Cockpit mode panes, or runtime examples.
+- Replacing the existing design-token systems.
+
+## Design principles
+
+### The sidebar governs; the workspace performs
+
+The sidebar owns choices that affect the whole workspace: mode, scope, capability, environment, and commands. Long-form documentation, code, runtime interaction, logs, and API details stay in the main workspace.
+
+### No inert or fictional controls
+
+Rail utilities and environment rows render only when an adapter supplies a real destination, value, or handler. Missing data is omitted rather than filled with plausible-looking placeholder state.
+
+### Context-sensitive defaults with remembered intent
+
+Docs defaults to Docs mode and a collapsed Environment section. Cockpit defaults to Run mode and an expanded Environment section. After the user changes a mode or disclosure state, the shell remembers that choice independently for each surface.
+
+### Labels where comprehension matters; icons where commands are familiar
+
+Primary modes and navigation rows keep visible labels. Quick actions and the bottom Activity/Settings utilities are icon-only with accessible names and tooltips. Icons never carry meaning without a programmatic label.
+
+## Information architecture
+
+### Activity rail
+
+Primary modes, top to bottom:
+
+1. Docs
+2. Run
+3. Code
+4. API
+
+Global utilities, anchored at the bottom and visually separated from primary modes:
+
+- Activity — icon-only. It opens a current-session view when a surface supplies real activity data. If no adapter is available, the item is omitted rather than disabled.
+- Settings — icon-only. It opens the surface's existing preferences, including theme and language where available. If a surface has no real preference controls, the item is omitted under the same rule as Activity.
+
+The rail remains stable while the context pane and main workspace change.
+
+Activity and Settings are utility panels, not routes or popovers. Selecting one temporarily replaces the context pane's Scope/Learn/Environment/Actions content while leaving the rail and main workspace unchanged. The selected utility uses `aria-pressed="true"` and the normal fully rounded active background. Utility selection is ephemeral and is not written to preferences.
+
+Each utility panel has a visible title and close button. It closes when the user presses Escape, activates its rail item again, activates any primary mode, or uses the close button. Closing restores the ordinary contextual pane and returns focus to the invoking rail item when dismissal came from Escape or the close button.
+
+When a narrow layout keeps the compact rail, the same behavior applies inside the focus-trapped control-plane drawer. When the compact rail is omitted, the drawer renders each adapter-supplied utility in an icon-only toolbar anchored below its ordinary navigation content. Selecting a utility replaces only the drawer body and keeps that utility toolbar mounted. Escape or the utility panel's close button restores the ordinary drawer body and returns focus to the invoking utility button. Closing the entire drawer through its global close button or backdrop returns focus to the external mobile navigation trigger. Docs supplies neither Activity nor Settings in the first iteration because the website has no real activity source or preference controls; the utility toolbar is therefore omitted there. Cockpit supplies Settings and omits Activity.
+
+Representative behavior:
+
+- In desktop Cockpit, Settings replaces the capability pane with Language and Appearance controls while Run remains visible and mounted in the main workspace.
+- At 320–360px in Cockpit, Settings opens in the control-plane drawer and receives initial focus at its heading or first control. Closing only Settings restores the ordinary drawer and focuses the Settings utility button; closing the whole drawer focuses the external mobile navigation trigger.
+
+### Context pane
+
+The context pane contains, in order:
+
+1. **Scope** — current library/product, capability or page, framework, and language when applicable.
+2. **Learn** in Docs or **Capability** in Cockpit — contextual navigation.
+3. **Environment** — truthful configuration and runtime facts supplied by the surface adapter.
+4. **Actions** — a compact icon-only command strip. It renders only handlers that exist for the current context.
+5. Footer utilities such as search and theme when they are not active rail destinations.
+
+### Environment rows
+
+The shared component accepts labeled rows but does not define their values.
+
+Docs may provide:
+
+- Package/library name.
+- Framework compatibility derived from repository configuration.
+- Package-manager convention.
+- Live demo destination when configured.
+
+Cockpit may provide:
+
+- Current product, capability, page, and language from the manifest entry.
+- Runtime target derived from `contentBundle.runtimeUrl`.
+- Framework or backend language from manifest/content metadata.
+
+The first iteration must not label a deployment Healthy, show a branch, or show a last-run time unless the application can prove that value.
+
+## Surface behavior
+
+### Docs
+
+- The Docs rail item is active.
+- Run, Code, and API are cross-surface links, not mutable local Docs modes. They link to an explicitly mapped Cockpit capability when one exists. When no mapping exists, they link to the Cockpit home route rather than guessing.
+- Docs-to-Cockpit links append a validated mode query (`?mode=run`, `?mode=code`, or `?mode=api`). Cockpit treats that explicit query as a one-time navigation instruction: after hydration it overrides the stored Cockpit mode, becomes the current persisted Cockpit mode, and is removed from the URL with `history.replaceState` so refreshes use the normal saved preference. Missing or invalid mode queries fall back to the saved Cockpit preference and then to Run.
+- The website constructs links from `NEXT_PUBLIC_COCKPIT_BASE_URL`, defaulting to `https://cockpit.threadplane.ai` in production. Local development can point the website at a local Cockpit origin. Cross-origin state is handed off only through the validated URL query; Docs never attempts to read or write Cockpit localStorage.
+- Scope uses the active library, section, and page.
+- Learn renders the existing docs configuration and preserves section disclosure.
+- Environment defaults collapsed.
+- Actions contains control-plane commands only, such as Open demo when a configured destination exists. Page-reading and page-editing utilities do not appear here.
+- Activity and Settings are omitted in the first iteration because the website currently supplies neither real session activity nor a functional theme/preferences system. Do not reuse Cockpit's ThemeToggle: it depends on Cockpit's theme provider and `/api/theme` route, neither of which exists in the website.
+- Search remains available through the existing command-K behavior.
+- The existing right-side table of contents remains on wide screens for scanability.
+- Page actions change from a Copy split button to one borderless ellipsis trigger. Its menu contains:
+  - On this page. On wide screens this focuses the existing table of contents; on narrower screens it reveals the heading list within the menu.
+  - Copy page as Markdown.
+  - Open in ChatGPT.
+  - View as Markdown.
+  - Edit on GitHub.
+- Menu keyboard behavior preserves first-item focus, arrow navigation, Home/End, Escape, outside click, and focus restoration.
+
+#### Deterministic Docs-to-Cockpit mapping
+
+Create a typed, explicit `docsCockpitMappings` record in `apps/website/src/lib/cockpit-links.ts`, keyed by the complete Docs identity `${library}/${section}/${slug}`. Each value is a complete Cockpit identity: product, section, topic, page, and language. Link generation may validate that identity against `cockpitManifest`, which is already available to the website through `@threadplane/cockpit-registry`, but it must not infer a topic from string similarity.
+
+Complete first-iteration mapping set:
+
+| Docs identity | Cockpit identity | Case |
+| --- | --- | --- |
+| `langgraph/guides/streaming` | `langgraph/core-capabilities/streaming/overview/python` | Exact topic name |
+| `langgraph/guides/deployment` | `langgraph/core-capabilities/deployment-runtime/overview/python` | Explicit rename |
+| `render/guides/specs` | `render/core-capabilities/spec-rendering/overview/python` | Explicit rename |
+| `render/guides/registry` | `render/core-capabilities/registry/overview/python` | Exact topic name |
+| `chat/guides/generative-ui` | `chat/core-capabilities/generative-ui/overview/python` | Exact topic name |
+| `langgraph/api/inject-agent` | no entry | Unsupported; use Cockpit home |
+| `docs/choosing-an-adapter` | no entry | Special page; use Cockpit home |
+
+The five non-empty rows above are the exhaustive approved mapping record for the first iteration. Every other Docs identity, including the two unsupported examples shown, uses Cockpit home. Adding a Cockpit capability does not implicitly create a Docs mapping, and adding a Docs page does not silently inherit one. Unit tests cover every record target plus renamed and unsupported examples.
+
+### Cockpit
+
+- Run, Code, Docs, and API move from the header switcher into the rail.
+- The active mode continues to control the existing pane-rendering logic. Run remains mounted while hidden so iframe state is preserved.
+- Scope uses the current manifest entry and language.
+- Capability renders the current navigation tree.
+- Environment defaults expanded.
+- Actions render only real commands. The first iteration may include opening the runtime in a new tab, refreshing the runtime iframe through an explicit shell callback, or copying a current prompt when the corresponding data and handler exist.
+- Settings hosts the existing LanguagePicker and ThemeToggle rather than duplicating them elsewhere.
+- Activity can expose only real current-session facts already available to the shell. A fabricated event feed is out of scope.
+- Cockpit owns `activeUtility: 'Activity' | 'Settings' | null` as transient component state. Opening a utility does not change or unmount the active primary mode. Selecting a primary mode clears `activeUtility` before applying the mode change.
+
+## Visual design
+
+### Typography
+
+- Section labels use Inter, sentence case, medium weight, and muted neutral color.
+- Approved labels are Scope, Learn/Capability, Environment, and Actions.
+- Remove uppercase transformation, wide tracking, and monospaced section headings.
+- Monospace remains appropriate for code, package identifiers, keyboard shortcuts, and aligned environment values.
+
+### Icons
+
+- Add `lucide-react` and use one outline icon family across rail modes, navigation metadata, environment facts, actions, search, theme, overflow menus, and disclosure controls.
+- Default icon sizes are 16px in rows/actions and 18px in the primary rail.
+- Use a consistent stroke weight through the library defaults; do not mix thin one-off chevrons with heavier mode icons.
+- Decorative icons are `aria-hidden`. Icon-only buttons have `aria-label` and a tooltip.
+
+### Active and hover states
+
+- Dense navigation and action targets use the existing small/medium radius, approximately 6–8px depending on the surface token.
+- The background covers the complete target rectangle.
+- No left-edge accent border, pseudo-element rail, or half-rounded active shape.
+- Active state combines accent text, a subtle accent surface, and `aria-current` or pressed/selected semantics.
+- Hover uses the surface-dim token and must not shift layout.
+
+### Page overflow menu
+
+- Borderless 34–36px ellipsis trigger with a rounded hover/expanded background.
+- Opaque tokenized popover, 8–10px radius, compact shadow, and 36px minimum menu rows.
+- Every row has a consistent 16px icon and visible label.
+- Group related reading actions before external/editing actions when a separator improves scanning.
+
+## Shared architecture
+
+Create structural primitives in `@threadplane/ui-react`:
+
+- `ControlPlaneRail`
+- `ControlPlaneRailItem`
+- `ControlPlanePane`
+- `ControlPlaneSection`
+- `ControlPlaneEnvironmentList`
+- `ControlPlaneActionBar`
+- `ControlPlaneIconButton`
+- `useControlPlanePreferences`
+
+These primitives own:
+
+- Semantic structure and ARIA attributes.
+- Disclosure behavior.
+- Keyboard and focus behavior for rail items and icon toolbars.
+- Local preference persistence.
+- Stable data attributes/class names for styling.
+
+They do not own:
+
+- Next.js routing.
+- Docs config or cockpit manifest interpretation.
+- Analytics event names.
+- Runtime health determination.
+- Application color tokens.
+
+Each application supplies an adapter and app-specific CSS token mapping. Shared components expose stable `data-control-plane-*` hooks so the two apps share geometry and behavior without forcing their distinct `--color-*` and `--ds-*` token namespaces into one package.
+
+## State and persistence
+
+Use one versioned localStorage record:
+
+```ts
+interface ControlPlanePreferencesV1 {
+  version: 1;
+  docs: {
+    expanded: Record<string, boolean>;
+  };
+  cockpit: {
+    activeMode: 'Docs' | 'Run' | 'Code' | 'API';
+    expanded: Record<string, boolean>;
+  };
+}
+```
+
+Defaults:
+
+- Docs: Docs is always the local active destination; Environment collapsed.
+- Cockpit: `activeMode = 'Run'`, Environment expanded.
+- Learn/Capability expanded on both surfaces.
+
+Requirements:
+
+- Read storage only after hydration.
+- Validate the stored version and values before use.
+- Fall back silently to defaults for missing, invalid, or blocked storage.
+- Persist only user changes, not every render.
+- Keep Docs and Cockpit preferences independent.
+- Do not persist utility-panel selection. Docs has no persisted `activeMode` because its non-Docs rail items navigate to Cockpit rather than changing a local pane.
+
+## Responsive behavior
+
+### Desktop
+
+- Use rail + context pane + main workspace.
+- Target approximately 54–58px for the rail and 256–280px for the context pane.
+- The context pane can scroll independently; the main workspace retains its current scroll model.
+- Do not add the right-side width cost of a second permanent control pane. The existing wide-screen Docs table of contents is retained because it is page-local reading navigation, not control-plane chrome.
+
+### Narrow screens
+
+- Preserve the compact rail only where the viewport can still provide compliant targets and readable content.
+- The context pane becomes an overlay/drawer instead of permanently pushing the workspace below or beside it.
+- Cockpit may reuse and restyle its existing MobileNavOverlay.
+- Docs must reuse its existing global `Nav` mobile trigger and Site/Docs overlay rather than adding a second trigger. The Docs tab is recomposed from the same context content as the desktop control plane and uses the same headings, icons, and rounded states while preserving Site navigation and existing mobile analytics.
+- The main workspace must not horizontally overflow at 320px.
+
+## Accessibility
+
+- Rail is a labeled navigation landmark.
+- Active destination uses `aria-current="page"` for navigation or `aria-pressed`/tab semantics for local mode changes.
+- Disclosure buttons expose `aria-expanded` and `aria-controls`.
+- Icon-only controls have accessible names and focusable tooltips; essential meaning is not hover-only.
+- Touch targets are approximately 44px on coarse pointers.
+- Overflow menus preserve current keyboard behavior and visible focus rings.
+- Motion respects `prefers-reduced-motion`.
+- Color is never the only active-state signal.
+
+## Error handling
+
+- Invalid persisted preferences fall back to surface defaults.
+- Missing Cockpit mappings send the user to the Cockpit home route; no guessed path is generated.
+- Missing environment values and action handlers are omitted.
+- Copy failures keep the menu usable and do not show a false success state.
+- External links use `noopener noreferrer`.
+- A runtime refresh action is rendered only when the Run pane exposes a safe callback.
+
+## Analytics
+
+Preserve existing analytics and add events only for new decisions that matter:
+
+- Cockpit mode changes continue emitting `cockpit:mode_switched`.
+- Existing recipe-open and code-copy events remain unchanged.
+- Docs Copy page continues emitting the current docs copy event.
+- New rail utility events may be added only if product analysis has a concrete consumer; do not emit generic click noise.
+
+## Testing strategy
+
+### Shared UI library
+
+- Rail active semantics and labels.
+- Icon-only accessible names.
+- Disclosure toggle behavior.
+- per-surface defaults and independent preference persistence.
+- invalid storage fallback.
+- Activity item omission when no adapter exists.
+
+### Docs
+
+- Active library/page rendering through the adapter.
+- Environment collapsed by default and remembered after interaction.
+- full rounded active/hover hooks without left-border classes.
+- PageActions is one ellipsis trigger, contains On this page and Copy page, and preserves keyboard navigation/focus restoration.
+- deterministic Cockpit mapping and safe fallback behavior.
+- mode query handoff uses the configured Cockpit base URL and does not depend on cross-origin storage.
+- narrow layout has no horizontal overflow.
+
+### Cockpit
+
+- rail mode changes render the correct existing pane.
+- Run iframe stays mounted across mode changes.
+- Environment expanded by default and remembered independently from Docs.
+- LanguagePicker and ThemeToggle remain reachable through Settings.
+- navigation analytics continue firing.
+- mobile overlay retains focus and close behavior.
+
+### Visual and integration verification
+
+- `npx nx test ui-react`
+- `npx nx lint ui-react`
+- `npx nx build ui-react`
+- `npx nx test website`
+- `npx nx lint website`
+- `npx nx build website`
+- `npx nx test cockpit`
+- `npx nx build cockpit`
+- Relevant website and cockpit Playwright coverage at desktop and 320–360px.
+- Regenerate public agent context only if the final change alters public product guidance, not merely shell presentation.
+
+## File-level change map
+
+Expected additions:
+
+- `libs/ui-react/src/lib/control-plane/control-plane.tsx`
+- `libs/ui-react/src/lib/control-plane/control-plane-icons.tsx`
+- `libs/ui-react/src/lib/control-plane/control-plane-preferences.ts`
+- `libs/ui-react/src/lib/control-plane/control-plane.spec.tsx`
+- `libs/ui-react/src/lib/control-plane/control-plane-preferences.spec.ts`
+- `apps/website/src/components/docs/docs-control-plane.tsx`
+- `apps/website/src/lib/cockpit-links.ts`
+- `apps/cockpit/src/components/control-plane/cockpit-control-plane.tsx`
+
+Expected modifications:
+
+- `libs/ui-react/src/index.ts`
+- `libs/ui-react/package.json`
+- root `package.json` and `package-lock.json` for `lucide-react`
+- `apps/website/src/components/docs/DocsSidebar.tsx`
+- `apps/website/src/components/docs/PageActions.tsx`
+- `apps/website/src/components/docs/PageActions.spec.tsx`
+- `apps/website/src/components/docs/DocsTOC.tsx`
+- `apps/website/src/app/docs/[library]/[section]/[slug]/page.tsx`
+- `apps/website/src/styles/docs.css`
+- `apps/cockpit/src/components/cockpit-shell.tsx`
+- `apps/cockpit/src/components/sidebar/cockpit-sidebar.tsx`
+- `apps/cockpit/src/components/sidebar/navigation-groups.tsx`
+- `apps/cockpit/src/components/mobile-nav-overlay.tsx`
+- `apps/cockpit/src/app/cockpit.css`
+- Existing Cockpit sidebar, mode, mobile, and pane-rendering tests.
+
+The implementation plan may reduce this file list after inspecting the cleanest existing boundaries, but it must preserve the shared-primitive/app-adapter split.
+
+## Delivery and merge policy
+
+- Work on `blove/sidebar-control-plane`.
+- Use focused commits; do not make mid-task checkpoint commits.
+- Open a pull request after fresh project-scoped verification.
+- Wait for required CI checks and review feedback.
+- Merge only when required checks are green and the branch is mergeable.
+- Do not bypass protections or merge with pending/failing required checks.
+
+## Acceptance criteria
+
+1. Docs and Cockpit visibly share the same rail + contextual-pane grammar on desktop.
+2. Docs defaults to Docs with Environment collapsed; Cockpit defaults to Run with Environment expanded.
+3. Docs disclosure state and Cockpit mode/disclosure state persist safely and independently; explicit cross-surface mode links override Cockpit state once through a validated query.
+4. Primary modes stay labeled; adapter-supplied Activity and Settings items are icon-only with tooltips and accessible names. Docs omits both utilities in the first iteration, and Cockpit exposes Settings only.
+5. Section headings are sentence-case Inter labels, not uppercase mono.
+6. Modern icons and consistent chevrons replace ad hoc glyphs in the changed surfaces.
+7. Active/hover backgrounds are fully rounded and have no decorative left rail.
+8. Quick actions are compact icon-only controls and render only real handlers.
+9. Docs page utilities, including On this page and Copy page, live in the ellipsis menu.
+10. Existing Cockpit pane behavior, Docs routing, analytics, and mobile accessibility remain intact.
+11. Relevant Nx tests, lint, builds, and browser checks pass before the PR is merged.
+12. Activity and Settings use a defined replacement-pane interaction with correct dismissal, focus restoration, and narrow-screen drawer behavior.

--- a/libs/ui-react/package.json
+++ b/libs/ui-react/package.json
@@ -16,5 +16,8 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
+  "dependencies": {
+    "lucide-react": "^1.38.0"
+  },
   "private": true
 }

--- a/libs/ui-react/src/index.ts
+++ b/libs/ui-react/src/index.ts
@@ -5,3 +5,29 @@ export { ThemeProvider, useTheme, type ThemeProviderProps } from './lib/theme-co
 export { ThemedFrame, type ThemedFrameProps } from './lib/themed-frame';
 export { useEmbeddedTheme } from './lib/use-embedded-theme';
 export { ThemeToggle } from './lib/theme-toggle';
+export {
+  ControlPlaneActionBar,
+  ControlPlaneEnvironmentList,
+  ControlPlaneIconButton,
+  ControlPlanePane,
+  ControlPlaneRail,
+  ControlPlaneRailItem,
+  ControlPlaneSection,
+  ControlPlaneUtilityPanel,
+  type ControlPlaneEnvironmentRow,
+  type ControlPlaneIconButtonProps,
+  type ControlPlanePaneProps,
+  type ControlPlaneRailItemProps,
+  type ControlPlaneRailProps,
+  type ControlPlaneSectionProps,
+} from './lib/control-plane/control-plane';
+export {
+  CONTROL_PLANE_STORAGE_KEY,
+  parseControlPlaneMode,
+  readControlPlanePreferences,
+  useControlPlanePreferences,
+  writeControlPlanePreferences,
+  type ControlPlaneMode,
+  type ControlPlanePreferencesV1,
+  type ControlPlaneSurface,
+} from './lib/control-plane/control-plane-preferences';

--- a/libs/ui-react/src/lib/control-plane/control-plane-preferences.spec.ts
+++ b/libs/ui-react/src/lib/control-plane/control-plane-preferences.spec.ts
@@ -1,0 +1,169 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  CONTROL_PLANE_STORAGE_KEY,
+  parseControlPlaneMode,
+  readControlPlanePreferences,
+  useControlPlanePreferences,
+  writeControlPlanePreferences,
+} from './control-plane-preferences';
+
+describe('control-plane preferences', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('uses surface-specific defaults when storage is empty', () => {
+    const preferences = readControlPlanePreferences(window.localStorage);
+
+    expect(preferences).toEqual({
+      version: 1,
+      docs: { expanded: { Learn: true, Environment: false } },
+      cockpit: {
+        activeMode: 'Run',
+        expanded: { Capability: true, Environment: true },
+      },
+    });
+  });
+
+  it('validates persisted values and falls back only for invalid fields', () => {
+    window.localStorage.setItem(
+      CONTROL_PLANE_STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        docs: { expanded: { Learn: false, Environment: 'yes' } },
+        cockpit: {
+          activeMode: 'Preview',
+          expanded: { Capability: false, Environment: true, Extra: 'no' },
+        },
+      }),
+    );
+
+    expect(readControlPlanePreferences(window.localStorage)).toEqual({
+      version: 1,
+      docs: { expanded: { Learn: false, Environment: false } },
+      cockpit: {
+        activeMode: 'Run',
+        expanded: { Capability: false, Environment: true },
+      },
+    });
+  });
+
+  it('falls back silently when storage access is blocked', () => {
+    const blocked = {
+      getItem: () => {
+        throw new DOMException('blocked');
+      },
+      setItem: () => {
+        throw new DOMException('blocked');
+      },
+    };
+
+    expect(() => readControlPlanePreferences(blocked)).not.toThrow();
+    expect(() =>
+      writeControlPlanePreferences(blocked, readControlPlanePreferences(blocked)),
+    ).not.toThrow();
+  });
+
+  it('falls back silently when the browser storage getter is blocked', async () => {
+    const descriptor = Object.getOwnPropertyDescriptor(window, 'localStorage');
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      get: () => {
+        throw new DOMException('blocked', 'SecurityError');
+      },
+    });
+
+    try {
+      const { result } = renderHook(() => useControlPlanePreferences('cockpit'));
+      await waitFor(() => expect(result.current.hydrated).toBe(true));
+      expect(result.current.activeMode).toBe('Run');
+      expect(() => act(() => result.current.setActiveMode('Code'))).not.toThrow();
+      expect(result.current.activeMode).toBe('Code');
+    } finally {
+      if (descriptor) Object.defineProperty(window, 'localStorage', descriptor);
+    }
+  });
+
+  it('parses only supported cross-surface mode values', () => {
+    expect(parseControlPlaneMode('run')).toBe('Run');
+    expect(parseControlPlaneMode('CODE')).toBe('Code');
+    expect(parseControlPlaneMode('Docs')).toBe('Docs');
+    expect(parseControlPlaneMode('api')).toBe('API');
+    expect(parseControlPlaneMode('preview')).toBeNull();
+    expect(parseControlPlaneMode(null)).toBeNull();
+  });
+
+  it('hydrates Cockpit mode and persists mode changes without erasing Docs', async () => {
+    window.localStorage.setItem(
+      CONTROL_PLANE_STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        docs: { expanded: { Learn: false, Environment: true } },
+        cockpit: {
+          activeMode: 'Code',
+          expanded: { Capability: true, Environment: false },
+        },
+      }),
+    );
+
+    const { result } = renderHook(() => useControlPlanePreferences('cockpit'));
+    await waitFor(() => expect(result.current.hydrated).toBe(true));
+    expect(result.current.activeMode).toBe('Code');
+
+    act(() => result.current.setActiveMode('API'));
+
+    const stored = window.localStorage.getItem(CONTROL_PLANE_STORAGE_KEY);
+    expect(stored).not.toBeNull();
+    expect(JSON.parse(stored ?? '{}')).toEqual({
+      version: 1,
+      docs: { expanded: { Learn: false, Environment: true } },
+      cockpit: {
+        activeMode: 'API',
+        expanded: { Capability: true, Environment: false },
+      },
+    });
+  });
+
+  it('keeps Docs active and persists only its disclosure state', async () => {
+    const { result } = renderHook(() => useControlPlanePreferences('docs'));
+    await waitFor(() => expect(result.current.hydrated).toBe(true));
+
+    act(() => result.current.setActiveMode('Code'));
+    act(() => result.current.setExpanded('Environment', true));
+
+    expect(result.current.activeMode).toBe('Docs');
+    expect(result.current.expanded.Environment).toBe(true);
+    const stored = window.localStorage.getItem(CONTROL_PLANE_STORAGE_KEY);
+    expect(stored).not.toBeNull();
+    expect(JSON.parse(stored ?? '{}')).toEqual({
+      version: 1,
+      docs: { expanded: { Learn: true, Environment: true } },
+      cockpit: {
+        activeMode: 'Run',
+        expanded: { Capability: true, Environment: true },
+      },
+    });
+  });
+
+  it('merges writes from concurrent hook instances without reverting newer preferences', async () => {
+    const shell = renderHook(() => useControlPlanePreferences('cockpit'));
+    const pane = renderHook(() => useControlPlanePreferences('cockpit'));
+    await waitFor(() => {
+      expect(shell.result.current.hydrated).toBe(true);
+      expect(pane.result.current.hydrated).toBe(true);
+    });
+
+    act(() => shell.result.current.setActiveMode('Code'));
+    act(() => pane.result.current.setExpanded('Environment', false));
+
+    expect(JSON.parse(window.localStorage.getItem(CONTROL_PLANE_STORAGE_KEY) ?? '{}')).toEqual({
+      version: 1,
+      docs: { expanded: { Learn: true, Environment: false } },
+      cockpit: {
+        activeMode: 'Code',
+        expanded: { Capability: true, Environment: false },
+      },
+    });
+  });
+});

--- a/libs/ui-react/src/lib/control-plane/control-plane-preferences.ts
+++ b/libs/ui-react/src/lib/control-plane/control-plane-preferences.ts
@@ -1,0 +1,179 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export type ControlPlaneMode = 'Docs' | 'Run' | 'Code' | 'API';
+export type ControlPlaneSurface = 'docs' | 'cockpit';
+
+export interface ControlPlanePreferencesV1 {
+  version: 1;
+  docs: {
+    expanded: Record<string, boolean>;
+  };
+  cockpit: {
+    activeMode: ControlPlaneMode;
+    expanded: Record<string, boolean>;
+  };
+}
+
+export const CONTROL_PLANE_STORAGE_KEY = 'threadplane:control-plane:v1';
+
+const DEFAULT_PREFERENCES: ControlPlanePreferencesV1 = {
+  version: 1,
+  docs: { expanded: { Learn: true, Environment: false } },
+  cockpit: {
+    activeMode: 'Run',
+    expanded: { Capability: true, Environment: true },
+  },
+};
+
+const MODES: readonly ControlPlaneMode[] = ['Docs', 'Run', 'Code', 'API'];
+
+const cloneDefaults = (): ControlPlanePreferencesV1 => ({
+  version: 1,
+  docs: { expanded: { ...DEFAULT_PREFERENCES.docs.expanded } },
+  cockpit: {
+    activeMode: DEFAULT_PREFERENCES.cockpit.activeMode,
+    expanded: { ...DEFAULT_PREFERENCES.cockpit.expanded },
+  },
+});
+
+const getBrowserStorage = (): Storage | null => {
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const booleanRecord = (
+  value: unknown,
+  defaults: Record<string, boolean>,
+): Record<string, boolean> => {
+  const result = { ...defaults };
+  if (!isRecord(value)) return result;
+  for (const [key, candidate] of Object.entries(value)) {
+    if (typeof candidate === 'boolean') result[key] = candidate;
+  }
+  return result;
+};
+
+const isMode = (value: unknown): value is ControlPlaneMode =>
+  typeof value === 'string' && MODES.includes(value as ControlPlaneMode);
+
+export const parseControlPlaneMode = (value: string | null): ControlPlaneMode | null => {
+  if (!value) return null;
+  const normalized = value.toLowerCase();
+  return MODES.find((mode) => mode.toLowerCase() === normalized) ?? null;
+};
+
+export const readControlPlanePreferences = (
+  storage: Pick<Storage, 'getItem'>,
+): ControlPlanePreferencesV1 => {
+  const defaults = cloneDefaults();
+  try {
+    const raw = storage.getItem(CONTROL_PLANE_STORAGE_KEY);
+    if (!raw) return defaults;
+    const parsed: unknown = JSON.parse(raw);
+    if (!isRecord(parsed) || parsed.version !== 1) return defaults;
+
+    const docs = isRecord(parsed.docs) ? parsed.docs : {};
+    const cockpit = isRecord(parsed.cockpit) ? parsed.cockpit : {};
+    return {
+      version: 1,
+      docs: {
+        expanded: booleanRecord(docs.expanded, defaults.docs.expanded),
+      },
+      cockpit: {
+        activeMode: isMode(cockpit.activeMode)
+          ? cockpit.activeMode
+          : defaults.cockpit.activeMode,
+        expanded: booleanRecord(cockpit.expanded, defaults.cockpit.expanded),
+      },
+    };
+  } catch {
+    return defaults;
+  }
+};
+
+export const writeControlPlanePreferences = (
+  storage: Pick<Storage, 'setItem'>,
+  value: ControlPlanePreferencesV1,
+): void => {
+  try {
+    storage.setItem(CONTROL_PLANE_STORAGE_KEY, JSON.stringify(value));
+  } catch {
+    // Preferences are progressive enhancement; blocked storage is non-fatal.
+  }
+};
+
+export function useControlPlanePreferences(surface: ControlPlaneSurface) {
+  const [preferences, setPreferences] = useState<ControlPlanePreferencesV1>(cloneDefaults);
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    const storage = getBrowserStorage();
+    setPreferences(storage ? readControlPlanePreferences(storage) : cloneDefaults());
+    setHydrated(true);
+  }, []);
+
+  const update = useCallback(
+    (recipe: (current: ControlPlanePreferencesV1) => ControlPlanePreferencesV1) => {
+      setPreferences((current) => {
+        const storage = getBrowserStorage();
+        const base = hydrated && storage
+          ? readControlPlanePreferences(storage)
+          : current;
+        const next = recipe(base);
+        if (hydrated && storage) writeControlPlanePreferences(storage, next);
+        return next;
+      });
+    },
+    [hydrated],
+  );
+
+  const setActiveMode = useCallback(
+    (activeMode: ControlPlaneMode) => {
+      if (surface === 'docs') return;
+      update((current) => ({
+        ...current,
+        cockpit: { ...current.cockpit, activeMode },
+      }));
+    },
+    [surface, update],
+  );
+
+  const setExpanded = useCallback(
+    (section: string, open: boolean) => {
+      update((current) =>
+        surface === 'docs'
+          ? {
+              ...current,
+              docs: {
+                ...current.docs,
+                expanded: { ...current.docs.expanded, [section]: open },
+              },
+            }
+          : {
+              ...current,
+              cockpit: {
+                ...current.cockpit,
+                expanded: { ...current.cockpit.expanded, [section]: open },
+              },
+            },
+      );
+    },
+    [surface, update],
+  );
+
+  return {
+    hydrated,
+    activeMode: surface === 'docs' ? ('Docs' as const) : preferences.cockpit.activeMode,
+    expanded: preferences[surface].expanded,
+    setActiveMode,
+    setExpanded,
+  };
+}

--- a/libs/ui-react/src/lib/control-plane/control-plane.spec.tsx
+++ b/libs/ui-react/src/lib/control-plane/control-plane.spec.tsx
@@ -1,0 +1,153 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  ControlPlaneActionBar,
+  ControlPlaneEnvironmentList,
+  ControlPlaneIconButton,
+  ControlPlanePane,
+  ControlPlaneRail,
+  ControlPlaneRailItem,
+  ControlPlaneSection,
+  ControlPlaneUtilityPanel,
+} from './control-plane';
+
+const Icon = () => <svg aria-hidden="true" data-testid="icon" />;
+
+describe('control-plane structure', () => {
+  it('renders labeled primary navigation and optional utilities', () => {
+    render(
+      <ControlPlaneRail
+        label="Workspace modes"
+        primary={
+          <ControlPlaneRailItem
+            label="Docs"
+            icon={<Icon />}
+            href="/docs"
+            active
+          />
+        }
+        utilities={
+          <ControlPlaneRailItem
+            label="Settings"
+            icon={<Icon />}
+            onSelect={vi.fn()}
+            iconOnly
+          />
+        }
+      />,
+    );
+
+    expect(screen.getByRole('navigation', { name: 'Workspace modes' })).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'Docs' }).getAttribute('aria-current')).toBe('page');
+    expect(screen.getByText('Docs')).toBeTruthy();
+    const settings = screen.getByRole('button', { name: 'Settings' });
+    const tooltip = screen.getByRole('tooltip', { name: 'Settings' });
+    expect(settings.getAttribute('aria-describedby')).toBe(tooltip.id);
+    expect(document.querySelector('[data-control-plane-rail-label]')?.textContent).not.toBe('Settings');
+  });
+
+  it('uses pressed semantics for active local mode and utility buttons', () => {
+    render(
+      <ControlPlaneRailItem label="Run" icon={<Icon />} active onSelect={vi.fn()} />,
+    );
+    expect(screen.getByRole('button', { name: 'Run' }).getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('renders a labeled contextual pane and environment facts', () => {
+    render(
+      <ControlPlanePane label="Docs context">
+        <ControlPlaneEnvironmentList
+          rows={[
+            { label: 'Framework', value: 'Angular' },
+            { label: 'Package manager', value: 'npm' },
+          ]}
+        />
+      </ControlPlanePane>,
+    );
+
+    expect(screen.getByRole('complementary', { name: 'Docs context' })).toBeTruthy();
+    expect(screen.getByText('Framework').tagName).toBe('DT');
+    expect(screen.getByText('Angular').tagName).toBe('DD');
+  });
+
+  it('exposes controlled disclosure state and toggles it', () => {
+    const onOpenChange = vi.fn();
+    render(
+      <ControlPlaneSection title="Environment" open onOpenChange={onOpenChange}>
+        <p>Angular</p>
+      </ControlPlaneSection>,
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Environment' });
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    expect(trigger.getAttribute('aria-controls')).toBeTruthy();
+    expect(trigger.querySelector('svg[data-control-plane-chevron]')).toBeTruthy();
+    fireEvent.click(trigger);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(screen.getByText('Angular')).toBeTruthy();
+  });
+});
+
+describe('control-plane actions', () => {
+  it('uses a labeled toolbar with accessible icon buttons', () => {
+    render(
+      <ControlPlaneActionBar label="Quick actions">
+        <ControlPlaneIconButton label="Search" icon={<Icon />} onClick={vi.fn()} />
+        <ControlPlaneIconButton label="Open runtime" icon={<Icon />} onClick={vi.fn()} />
+      </ControlPlaneActionBar>,
+    );
+
+    expect(screen.getByRole('toolbar', { name: 'Quick actions' })).toBeTruthy();
+    const search = screen.getByRole('button', { name: 'Search' });
+    const tooltip = screen.getByRole('tooltip', { name: 'Search' });
+    expect(search.getAttribute('aria-describedby')).toBe(tooltip.id);
+    expect(search.tabIndex).toBe(0);
+    expect(screen.getByRole('button', { name: 'Open runtime' }).tabIndex).toBe(-1);
+  });
+
+  it('supports wrapping arrow navigation and Home/End while skipping disabled actions', () => {
+    render(
+      <ControlPlaneActionBar label="Quick actions">
+        <ControlPlaneIconButton label="First" icon={<Icon />} onClick={vi.fn()} />
+        <ControlPlaneIconButton label="Disabled" icon={<Icon />} onClick={vi.fn()} disabled />
+        <ControlPlaneIconButton label="Last" icon={<Icon />} onClick={vi.fn()} />
+      </ControlPlaneActionBar>,
+    );
+
+    const first = screen.getByRole('button', { name: 'First' });
+    const last = screen.getByRole('button', { name: 'Last' });
+    first.focus();
+    fireEvent.keyDown(first, { key: 'ArrowLeft' });
+    expect(document.activeElement).toBe(last);
+    fireEvent.keyDown(last, { key: 'Home' });
+    expect(document.activeElement).toBe(first);
+    fireEvent.keyDown(first, { key: 'End' });
+    expect(document.activeElement).toBe(last);
+    fireEvent.keyDown(last, { key: 'ArrowRight' });
+    expect(document.activeElement).toBe(first);
+  });
+});
+
+describe('ControlPlaneUtilityPanel', () => {
+  it('renders a title and closes from its button or Escape', () => {
+    const onClose = vi.fn();
+    const { rerender } = render(
+      <ControlPlaneUtilityPanel title="Settings" onClose={onClose}>
+        Preferences
+      </ControlPlaneUtilityPanel>,
+    );
+
+    expect(screen.getByRole('heading', { name: 'Settings' })).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Close Settings' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <ControlPlaneUtilityPanel title="Settings" onClose={onClose}>
+        Preferences
+      </ControlPlaneUtilityPanel>,
+    );
+    fireEvent.keyDown(screen.getByRole('heading', { name: 'Settings' }), { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+});

--- a/libs/ui-react/src/lib/control-plane/control-plane.tsx
+++ b/libs/ui-react/src/lib/control-plane/control-plane.tsx
@@ -1,0 +1,363 @@
+'use client';
+
+import {
+  Children,
+  cloneElement,
+  isValidElement,
+  useEffect,
+  useId,
+  useRef,
+  type KeyboardEvent,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
+import { ChevronRight, X } from 'lucide-react';
+
+type CommonProps = {
+  className?: string;
+};
+
+export interface ControlPlaneRailProps extends CommonProps {
+  label: string;
+  primary: ReactNode;
+  utilities?: ReactNode;
+}
+
+export function ControlPlaneRail({
+  label,
+  primary,
+  utilities,
+  className,
+}: ControlPlaneRailProps) {
+  return (
+    <nav aria-label={label} className={className} data-control-plane-rail>
+      <div data-control-plane-rail-group="primary">{primary}</div>
+      {utilities ? (
+        <div data-control-plane-rail-group="utilities">{utilities}</div>
+      ) : null}
+    </nav>
+  );
+}
+
+export interface ControlPlaneRailItemProps extends CommonProps {
+  label: string;
+  icon: ReactNode;
+  active?: boolean;
+  href?: string;
+  onSelect?: () => void;
+  iconOnly?: boolean;
+  target?: string;
+  rel?: string;
+}
+
+export function ControlPlaneRailItem({
+  label,
+  icon,
+  active = false,
+  href,
+  onSelect,
+  iconOnly = false,
+  className,
+  target,
+  rel,
+}: ControlPlaneRailItemProps) {
+  const tooltipId = useId();
+  const content = (
+    <>
+      <span data-control-plane-rail-icon>{icon}</span>
+      {iconOnly ? null : <span data-control-plane-rail-label>{label}</span>}
+      {iconOnly ? (
+        <span id={tooltipId} role="tooltip" data-control-plane-tooltip>
+          {label}
+        </span>
+      ) : null}
+    </>
+  );
+  const shared = {
+    className,
+    'data-control-plane-rail-item': true,
+    'data-control-plane-active': active || undefined,
+    'aria-label': iconOnly ? label : undefined,
+    'aria-describedby': iconOnly ? tooltipId : undefined,
+  } as const;
+
+  if (href) {
+    return (
+      <a
+        {...shared}
+        href={href}
+        target={target}
+        rel={rel}
+        aria-current={active ? 'page' : undefined}
+        onClick={onSelect}
+      >
+        {content}
+      </a>
+    );
+  }
+
+  return (
+    <button
+      {...shared}
+      type="button"
+      aria-pressed={active}
+      onClick={onSelect}
+    >
+      {content}
+    </button>
+  );
+}
+
+export interface ControlPlanePaneProps extends CommonProps {
+  label: string;
+  children: ReactNode;
+}
+
+export function ControlPlanePane({ label, children, className }: ControlPlanePaneProps) {
+  return (
+    <aside
+      aria-label={label}
+      className={className}
+      data-control-plane-pane
+    >
+      {children}
+    </aside>
+  );
+}
+
+export interface ControlPlaneSectionProps extends CommonProps {
+  title: string;
+  icon?: ReactNode;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  children: ReactNode;
+  collapsible?: boolean;
+}
+
+export function ControlPlaneSection({
+  title,
+  icon,
+  open = true,
+  onOpenChange,
+  children,
+  className,
+  collapsible = true,
+}: ControlPlaneSectionProps) {
+  const id = useId();
+  return (
+    <section className={className} data-control-plane-section>
+      {collapsible ? (
+        <button
+          type="button"
+          aria-expanded={open}
+          aria-controls={id}
+          onClick={() => onOpenChange?.(!open)}
+          data-control-plane-section-trigger
+        >
+          <span data-control-plane-section-title>
+            {icon ? <span data-control-plane-section-icon>{icon}</span> : null}
+            {title}
+          </span>
+          <ChevronRight
+            size={16}
+            strokeWidth={2}
+            aria-hidden="true"
+            data-control-plane-chevron
+            data-control-plane-section-chevron
+          />
+        </button>
+      ) : (
+        <h2 data-control-plane-section-heading>
+          {icon ? <span data-control-plane-section-icon>{icon}</span> : null}
+          {title}
+        </h2>
+      )}
+      {open ? (
+        <div id={id} data-control-plane-section-content>
+          {children}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+export interface ControlPlaneEnvironmentRow {
+  label: string;
+  value: ReactNode;
+  icon?: ReactNode;
+}
+
+export function ControlPlaneEnvironmentList({
+  rows,
+  className,
+}: CommonProps & { rows: ControlPlaneEnvironmentRow[] }) {
+  return (
+    <dl className={className} data-control-plane-environment-list>
+      {rows.map((row) => (
+        <div key={row.label} data-control-plane-environment-row>
+          {row.icon ? <span data-control-plane-environment-icon>{row.icon}</span> : null}
+          <dt>{row.label}</dt>
+          <dd>{row.value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+type ToolbarChildProps = { tabIndex?: number; disabled?: boolean };
+
+export function ControlPlaneActionBar({
+  label,
+  children,
+  className,
+}: CommonProps & { label: string; children: ReactNode }) {
+  const ref = useRef<HTMLDivElement>(null);
+  let assignedTabStop = false;
+  const items = Children.map(children, (child) => {
+    if (!isValidElement<ToolbarChildProps>(child)) return child;
+    const enabled = !child.props.disabled;
+    const tabIndex = enabled && !assignedTabStop ? 0 : -1;
+    if (enabled) assignedTabStop = true;
+    return cloneElement(child as ReactElement<ToolbarChildProps>, { tabIndex });
+  });
+
+  const onKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) return;
+    const enabled = Array.from(
+      ref.current?.querySelectorAll<HTMLElement>(
+        '[data-control-plane-action]:not(:disabled):not([aria-disabled="true"])',
+      ) ?? [],
+    );
+    if (enabled.length === 0) return;
+    const current = Math.max(0, enabled.indexOf(document.activeElement as HTMLElement));
+    const nextIndex =
+      event.key === 'Home'
+        ? 0
+        : event.key === 'End'
+          ? enabled.length - 1
+          : event.key === 'ArrowRight'
+            ? (current + 1) % enabled.length
+            : (current - 1 + enabled.length) % enabled.length;
+    event.preventDefault();
+    enabled.forEach((item, index) => {
+      item.tabIndex = index === nextIndex ? 0 : -1;
+    });
+    enabled[nextIndex]?.focus();
+  };
+
+  return (
+    <div
+      ref={ref}
+      role="toolbar"
+      aria-label={label}
+      className={className}
+      data-control-plane-action-bar
+      onKeyDown={onKeyDown}
+    >
+      {items}
+    </div>
+  );
+}
+
+export interface ControlPlaneIconButtonProps extends CommonProps {
+  label: string;
+  icon: ReactNode;
+  onClick?: () => void;
+  href?: string;
+  disabled?: boolean;
+  tabIndex?: number;
+  target?: string;
+  rel?: string;
+}
+
+export function ControlPlaneIconButton({
+  label,
+  icon,
+  onClick,
+  href,
+  disabled = false,
+  tabIndex,
+  className,
+  target,
+  rel,
+}: ControlPlaneIconButtonProps) {
+  const tooltipId = useId();
+  const content = (
+    <>
+      {icon}
+      <span id={tooltipId} role="tooltip" data-control-plane-tooltip>
+        {label}
+      </span>
+    </>
+  );
+  const shared = {
+    'aria-label': label,
+    'aria-describedby': tooltipId,
+    className,
+    tabIndex,
+    'data-control-plane-action': true,
+  } as const;
+  if (href) {
+    return (
+      <a
+        {...shared}
+        href={href}
+        target={target}
+        rel={rel}
+        aria-disabled={disabled || undefined}
+        onClick={(event) => {
+          if (disabled) event.preventDefault();
+          else onClick?.();
+        }}
+      >
+        {content}
+      </a>
+    );
+  }
+  return (
+    <button
+      {...shared}
+      type="button"
+      disabled={disabled}
+      onClick={onClick}
+    >
+      {content}
+    </button>
+  );
+}
+
+export function ControlPlaneUtilityPanel({
+  title,
+  onClose,
+  children,
+  className,
+}: CommonProps & { title: string; onClose: () => void; children: ReactNode }) {
+  const titleId = useId();
+  const titleRef = useRef<HTMLHeadingElement>(null);
+  useEffect(() => {
+    titleRef.current?.focus();
+  }, []);
+
+  return (
+    <section
+      aria-labelledby={titleId}
+      className={className}
+      data-control-plane-utility-panel
+      onKeyDown={(event) => {
+        if (event.key !== 'Escape') return;
+        event.preventDefault();
+        event.stopPropagation();
+        event.nativeEvent.stopImmediatePropagation();
+        onClose();
+      }}
+    >
+      <header data-control-plane-utility-header>
+        <h2 ref={titleRef} id={titleId} tabIndex={-1}>{title}</h2>
+        <button type="button" aria-label={`Close ${title}`} onClick={onClose}>
+          <X size={18} strokeWidth={2} aria-hidden="true" />
+        </button>
+      </header>
+      <div data-control-plane-utility-content>{children}</div>
+    </section>
+  );
+}

--- a/libs/ui-react/tsconfig.json
+++ b/libs/ui-react/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "lib": ["es2022", "DOM", "DOM.Iterable"]
   },
   "files": [],
   "references": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "@upstash/ratelimit": "^2.0.5",
         "@upstash/redis": "^1.34.3",
         "gray-matter": "^4.0.3",
+        "lucide-react": "^1.38.0",
         "next": "~16.1.6",
         "next-mdx-remote": "^6.0.0",
         "react": "^19.0.0",
@@ -358,6 +359,9 @@
       "name": "@threadplane/ui-react",
       "version": "0.0.31",
       "license": "MIT",
+      "dependencies": {
+        "lucide-react": "^1.38.0"
+      },
       "peerDependencies": {
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -31884,6 +31888,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.38.0.tgz",
+      "integrity": "sha512-xZCyBd/wiVUDactoCc+42TjL0aB7EBOXsuX+tjz+W/sGzw2KhHpL1NOH3FIaVUcpimvUBpIYfz34Ofj9S5JEzQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lunr": {

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "@upstash/ratelimit": "^2.0.5",
     "@upstash/redis": "^1.34.3",
     "gray-matter": "^4.0.3",
+    "lucide-react": "^1.38.0",
     "next": "~16.1.6",
     "next-mdx-remote": "^6.0.0",
     "react": "^19.0.0",


### PR DESCRIPTION
## Summary

- introduce shared rail, context-pane, action, utility, and preference primitives
- refactor Docs and Cockpit around one stable Docs / Run / Code / API control plane
- add icon-led actions, modern Lucide icons, rounded interaction states, and a polished page-actions overflow menu
- preserve analytics, routing, runtime continuity, mobile focus behavior, and accessible nested interactions

## Verification

- npx nx test ui-react
- npx nx test website
- npx nx test cockpit
- npx nx lint ui-react
- npx nx build ui-react
- npx nx lint website
- npx nx build website
- npx nx build cockpit
- real-browser QA at desktop and 320px for Docs and Cockpit