### PR TITLE
feat(cockpit): per-topic framework adapters in the AG-UI deployment generator

### DIFF
--- a/apps/cockpit/scripts/capability-registry.ts
+++ b/apps/cockpit/scripts/capability-registry.ts
@@ -2,9 +2,25 @@
  * Single source of truth for all cockpit capability examples.
  * Used by serve, build, test, and deploy scripts.
  */
+/**
+ * Backend framework of an AG-UI-served capability (products 'ag-ui' and
+ * 'runtimes'). Selects the framework adapter in
+ * scripts/generate-ag-ui-deployment-config.ts: the bridge import, the
+ * per-topic module contract (`src/graph.py` exposing `graph` for LangGraph
+ * vs `src/agent.py` exposing `agent` for Microsoft Agent Framework), and
+ * the FastAPI mount call. Omitted means 'langgraph'.
+ */
+export type CapabilityFramework = 'langgraph' | 'microsoft-agent-framework';
+
 export interface Capability {
   id: string;
-  product: 'langgraph' | 'deep-agents' | 'render' | 'chat' | 'ag-ui';
+  /**
+   * 'runtimes' is the one-capability-many-runtimes axis
+   * (cockpit/runtimes/<runtime>/): non-LangGraph AG-UI backends measured
+   * against the same neutral Agent contract. Like 'ag-ui' caps, they are
+   * served by the aggregated deployments/ag-ui-dev FastAPI app.
+   */
+  product: 'langgraph' | 'deep-agents' | 'render' | 'chat' | 'ag-ui' | 'runtimes';
   topic: string;
   angularProject: string;
   port: number;
@@ -13,6 +29,8 @@ export interface Capability {
   pythonDir?: string;
   /** Optional — see pythonDir. */
   graphName?: string;
+  /** AG-UI backend framework; defaults to 'langgraph' when omitted. */
+  framework?: CapabilityFramework;
 }
 
 export const capabilities: readonly Capability[] = [

--- a/apps/cockpit/scripts/serve-example.ts
+++ b/apps/cockpit/scripts/serve-example.ts
@@ -9,7 +9,7 @@ export const COCKPIT_RUNTIME_ENV = { NEXT_PUBLIC_COCKPIT_RUNTIME_BASE_URL: '' } 
 export function backendCommand(cap: Capability): string | null {
   if (!cap.pythonDir) return null;
   const enter = `cd ${cap.pythonDir} && source $HOME/.local/bin/env 2>/dev/null; uv sync`;
-  if (cap.product === 'ag-ui') {
+  if (cap.product === 'ag-ui' || cap.product === 'runtimes') {
     return `${enter} && uv run uvicorn src.server:app --port ${cap.pythonPort}`;
   }
   return `${enter} && uv run langgraph dev --port ${cap.pythonPort} --no-browser`;

--- a/deployments/ag-ui-dev/deps/client_tools/prompts/client-tools.md
+++ b/deployments/ag-ui-dev/deps/client_tools/prompts/client-tools.md
@@ -8,6 +8,11 @@ three client tools — call the right one and do not answer in prose first:
 - When the user asks to *show* or *display* a weather card, call `weather_card`
   with the location and plausible readings (temperatureF, conditions, humidity,
   windMph). After it renders, briefly confirm.
+- When the user asks for a quiet or terminal weather snapshot, call
+  `weather_snapshot` with the location and plausible readings. Do not summarize
+  afterwards; the rendered card is the final response.
+- When the user asks to test stopping a slow browser tool, call
+  `slow_status_check` with a short label.
 - When the user asks to book or reserve something, call `confirm_booking` with a
   one-line `summary` of what they're booking. After the user responds, confirm
   if they accepted or acknowledge if they cancelled.

--- a/scripts/generate-ag-ui-deployment-config.spec.ts
+++ b/scripts/generate-ag-ui-deployment-config.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, beforeEach } from 'vitest';
 import { mkdtempSync, rmSync, existsSync, readFileSync, statSync } from 'fs';
 import { tmpdir } from 'os';
 import { join, resolve } from 'path';
-import { generateAgUiDeployment } from './generate-ag-ui-deployment-config';
+import { buildServerPy, generateAgUiDeployment, type AgUiTopic } from './generate-ag-ui-deployment-config';
 
 const REPO_ROOT = resolve(__dirname, '..');
 
@@ -72,6 +72,19 @@ describe('generateAgUiDeployment', () => {
     expect(reqs).not.toMatch(/^-e \./m);
   });
 
+  it('matches the committed deployments/ag-ui-dev artifacts byte-for-byte (drift check)', () => {
+    // The deploy-ag-ui workflow regenerates and fails on `git diff` drift.
+    // This is the same guarantee, runnable locally without touching the
+    // committed artifacts.
+    generateAgUiDeployment({ repoRoot: REPO_ROOT, outDir });
+    const committedDir = join(REPO_ROOT, 'deployments/ag-ui-dev');
+    for (const file of ['server.py', 'requirements.txt']) {
+      expect(readFileSync(join(outDir, file), 'utf8')).toBe(
+        readFileSync(join(committedDir, file), 'utf8'),
+      );
+    }
+  });
+
   it('produces byte-identical output across runs (idempotent)', () => {
     generateAgUiDeployment({ repoRoot: REPO_ROOT, outDir });
     const firstServer = readFileSync(join(outDir, 'server.py'), 'utf8');
@@ -79,5 +92,54 @@ describe('generateAgUiDeployment', () => {
     generateAgUiDeployment({ repoRoot: REPO_ROOT, outDir });
     expect(readFileSync(join(outDir, 'server.py'), 'utf8')).toBe(firstServer);
     expect(readFileSync(join(outDir, 'requirements.txt'), 'utf8')).toBe(firstReqs);
+  });
+});
+
+describe('buildServerPy framework adapters', () => {
+  const lg = (topic: string): AgUiTopic => ({ topic, pythonDir: `x/${topic}/python`, framework: 'langgraph' });
+  const maf = (topic: string): AgUiTopic => ({
+    topic,
+    pythonDir: `x/${topic}/python`,
+    framework: 'microsoft-agent-framework',
+  });
+
+  it('langgraph topics import graph and mount via LangGraphAgent, with no MAF bridge import', () => {
+    const server = buildServerPy([lg('interrupts')]);
+    expect(server).toContain('from ag_ui_langgraph import add_langgraph_fastapi_endpoint, LangGraphAgent');
+    expect(server).toContain('from deps.interrupts.src.graph import graph as interrupts_graph');
+    expect(server).toContain('LangGraphAgent(name="interrupts", graph=interrupts_graph)');
+    expect(server).not.toContain('agent_framework_ag_ui');
+  });
+
+  it('microsoft-agent-framework topics import agent and mount the agent object directly', () => {
+    const server = buildServerPy([maf('microsoft-agent-framework')]);
+    expect(server).toContain('from agent_framework_ag_ui import add_agent_framework_fastapi_endpoint');
+    expect(server).toContain(
+      'from deps.microsoft_agent_framework.src.agent import agent as microsoft_agent_framework_agent',
+    );
+    expect(server).toContain(
+      'add_agent_framework_fastapi_endpoint(\n' +
+        '    app,\n' +
+        '    microsoft_agent_framework_agent,\n' +
+        '    path="/agent/microsoft-agent-framework",\n' +
+        ')',
+    );
+    // No LangGraph machinery when no langgraph topic is present.
+    expect(server).not.toContain('ag_ui_langgraph');
+    expect(server).not.toContain('LangGraphAgent');
+  });
+
+  it('mixed sets emit both bridge imports (langgraph first) and per-topic mounts', () => {
+    const server = buildServerPy([lg('interrupts'), maf('microsoft-agent-framework')]);
+    const lgImport = server.indexOf('from ag_ui_langgraph import');
+    const mafImport = server.indexOf('from agent_framework_ag_ui import');
+    expect(lgImport).toBeGreaterThan(-1);
+    expect(mafImport).toBeGreaterThan(lgImport);
+    expect(server).toContain('path="/agent/interrupts"');
+    expect(server).toContain('path="/agent/microsoft-agent-framework"');
+    // Framework routing is per-topic: the langgraph topic must not be
+    // mounted through the MAF bridge or vice versa.
+    expect(server).toContain('LangGraphAgent(name="interrupts"');
+    expect(server).not.toContain('LangGraphAgent(name="microsoft-agent-framework"');
   });
 });

--- a/scripts/generate-ag-ui-deployment-config.ts
+++ b/scripts/generate-ag-ui-deployment-config.ts
@@ -1,6 +1,6 @@
 import { cpSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { resolve } from 'path';
-import { capabilities } from '../apps/cockpit/scripts/capability-registry';
+import { capabilities, type CapabilityFramework } from '../apps/cockpit/scripts/capability-registry';
 
 const GENERATED_HEADER = '# GENERATED — do not edit. Source: scripts/generate-ag-ui-deployment-config.ts';
 
@@ -9,10 +9,61 @@ export interface GenerateOptions {
   outDir: string;
 }
 
-interface AgUiTopic {
+export interface AgUiTopic {
   topic: string;
   pythonDir: string;
+  framework: CapabilityFramework;
 }
+
+/**
+ * Per-framework adapter: how a topic's staged module is imported and mounted
+ * on the aggregated FastAPI app. Adding a runtime means adding one entry here
+ * plus a `framework` discriminator on its registry capability — nothing else
+ * in the generator is framework-aware.
+ *
+ * Module contract per framework:
+ * - langgraph: `deps/<mod>/src/graph.py` exposes a compiled `graph`; mounted
+ *   via ag-ui-langgraph's LangGraphAgent wrapper.
+ * - microsoft-agent-framework: `deps/<mod>/src/agent.py` exposes an `agent`
+ *   object (agent_framework Agent / AgentFrameworkAgent); the bridge mounts
+ *   the agent object directly — there is no wrapper class.
+ */
+interface FrameworkAdapter {
+  /** Module-level import line for the framework's AG-UI bridge package. */
+  bridgeImport: string;
+  /** Per-topic import of the staged module's exported object. */
+  topicImport(mod: string): string;
+  /** Per-topic FastAPI mount block. */
+  mount(topic: string, mod: string): string;
+}
+
+/**
+ * Declaration order is emission order for bridge imports in server.py:
+ * langgraph stays first so a langgraph-only registry generates byte-identical
+ * output to the pre-adapter generator.
+ */
+const FRAMEWORK_ADAPTERS: Record<CapabilityFramework, FrameworkAdapter> = {
+  langgraph: {
+    bridgeImport: 'from ag_ui_langgraph import add_langgraph_fastapi_endpoint, LangGraphAgent',
+    topicImport: (mod) => `from deps.${mod}.src.graph import graph as ${mod}_graph`,
+    mount: (topic, mod) =>
+      `add_langgraph_fastapi_endpoint(\n` +
+      `    app,\n` +
+      `    LangGraphAgent(name="${topic}", graph=${mod}_graph),\n` +
+      `    path="/agent/${topic}",\n` +
+      `)`,
+  },
+  'microsoft-agent-framework': {
+    bridgeImport: 'from agent_framework_ag_ui import add_agent_framework_fastapi_endpoint',
+    topicImport: (mod) => `from deps.${mod}.src.agent import agent as ${mod}_agent`,
+    mount: (topic, mod) =>
+      `add_agent_framework_fastapi_endpoint(\n` +
+      `    app,\n` +
+      `    ${mod}_agent,\n` +
+      `    path="/agent/${topic}",\n` +
+      `)`,
+  },
+};
 
 /**
  * A topic is a URL slug and may contain hyphens (e.g. `tool-views`,
@@ -27,8 +78,14 @@ function pyModule(topic: string): string {
 
 function collectTopics(): AgUiTopic[] {
   const topics = capabilities
-    .filter((c) => c.product === 'ag-ui' && c.pythonDir)
-    .map<AgUiTopic>((c) => ({ topic: c.topic, pythonDir: c.pythonDir! }));
+    // 'ag-ui' and 'runtimes' products are both AG-UI-served FastAPI backends
+    // aggregated into the single ag-ui-dev deployment.
+    .filter((c) => (c.product === 'ag-ui' || c.product === 'runtimes') && c.pythonDir)
+    .map<AgUiTopic>((c) => ({
+      topic: c.topic,
+      pythonDir: c.pythonDir!,
+      framework: c.framework ?? 'langgraph',
+    }));
   topics.sort((a, b) => a.topic.localeCompare(b.topic));
   if (topics.length === 0) {
     throw new Error('No ag-ui topics with pythonDir found in capability registry');
@@ -58,19 +115,18 @@ function stageDeps(repoRoot: string, outDir: string, topics: AgUiTopic[]): void 
   }
 }
 
-function buildServerPy(topics: AgUiTopic[]): string {
+export function buildServerPy(topics: AgUiTopic[]): string {
+  const usedFrameworks = (Object.keys(FRAMEWORK_ADAPTERS) as CapabilityFramework[]).filter(
+    (framework) => topics.some((t) => t.framework === framework),
+  );
+  const bridgeImports = usedFrameworks
+    .map((framework) => FRAMEWORK_ADAPTERS[framework].bridgeImport)
+    .join('\n');
   const imports = topics
-    .map((t) => `from deps.${pyModule(t.topic)}.src.graph import graph as ${pyModule(t.topic)}_graph`)
+    .map((t) => FRAMEWORK_ADAPTERS[t.framework].topicImport(pyModule(t.topic)))
     .join('\n');
   const mounts = topics
-    .map(
-      (t) =>
-        `add_langgraph_fastapi_endpoint(\n` +
-        `    app,\n` +
-        `    LangGraphAgent(name="${t.topic}", graph=${pyModule(t.topic)}_graph),\n` +
-        `    path="/agent/${t.topic}",\n` +
-        `)`,
-    )
+    .map((t) => FRAMEWORK_ADAPTERS[t.framework].mount(t.topic, pyModule(t.topic)))
     .join('\n');
   return `${GENERATED_HEADER}
 # Multi-topic AG-UI FastAPI server. Aggregates each cockpit/ag-ui/*/python topic
@@ -79,7 +135,7 @@ function buildServerPy(topics: AgUiTopic[]): string {
 import os
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
-from ag_ui_langgraph import add_langgraph_fastapi_endpoint, LangGraphAgent
+${bridgeImports}
 
 ${imports}
 

--- a/scripts/generate-shared-deployment-config.ts
+++ b/scripts/generate-shared-deployment-config.ts
@@ -64,9 +64,9 @@ rmSync(stagedDependenciesDir, { recursive: true, force: true });
 mkdirSync(stagedDependenciesDir, { recursive: true });
 
 for (const capability of capabilities) {
-  if (!capability.pythonDir || capability.product === 'ag-ui') {
-    // No-Python caps have nothing to deploy. ag-ui caps DO have a pythonDir
-    // (uvicorn ag-ui-langgraph FastAPI apps) but deploy to Railway via
+  if (!capability.pythonDir || capability.product === 'ag-ui' || capability.product === 'runtimes') {
+    // No-Python caps have nothing to deploy. ag-ui and runtimes caps DO have
+    // a pythonDir (uvicorn AG-UI FastAPI apps) but deploy to Railway via
     // generate-ag-ui-deployment-config.ts — they ship no langgraph.json.
     continue;
   }


### PR DESCRIPTION
## Summary

Phase 2 / Step 2 (slice 1) of the runtime-portability effort: generalize `scripts/generate-ag-ui-deployment-config.ts` from hardcoded LangGraph to **per-topic framework adapters**, so a non-LangGraph AG-UI backend (first up: Microsoft Agent Framework) can join the aggregated `deployments/ag-ui-dev` Railway deployment. No behavior change with the current registry — this PR is independently revertable and lands no new example.

### Registry (type-only)

- New optional discriminator on `Capability`: `framework?: 'langgraph' | 'microsoft-agent-framework'` (default `'langgraph'`; no existing entry touched).
- New `'runtimes'` product for the upcoming one-capability-many-runtimes axis (`cockpit/runtimes/<runtime>/`). Zero entries use it yet.

### Generator

- `FRAMEWORK_ADAPTERS` maps framework → `{ bridge import, per-topic module import, FastAPI mount block }` in one place:
  - `langgraph`: `from deps.<mod>.src.graph import graph …` + `add_langgraph_fastapi_endpoint(app, LangGraphAgent(...), path=…)` — emitted bytes unchanged.
  - `microsoft-agent-framework`: `from deps.<mod>.src.agent import agent …` + `add_agent_framework_fastapi_endpoint(app, <agent object>, path=…)` (the MAF bridge mounts an agent object directly; there is no wrapper class).
- Bridge imports are emitted only for frameworks actually in use, langgraph first, so a langgraph-only registry generates byte-identical output.
- `requirements.txt` assembly is untouched: per-topic direct deps still come from each topic's uv-exported `requirements.txt` (`# via cockpit-*`), which makes per-framework deps work for free once a `cockpit-…`-named MAF example lands.
- `generate-shared-deployment-config.ts` and `serve-example.ts` treat `'runtimes'` like `'ag-ui'` (uvicorn AG-UI backends; excluded from the LangGraph shared deployment).

### Byte-identical proof

With this PR applied, `npx tsx scripts/generate-ag-ui-deployment-config.ts` followed by `git diff --stat -- deployments/ag-ui-dev/` is **clean** — same guarantee the `deploy-ag-ui` workflow drift check enforces.

One caveat surfaced while proving it: `deployments/ag-ui-dev/deps/client_tools/prompts/client-tools.md` was already stale on `main` (source prompt updated in 622b07cd without regenerating). The first commit regenerates that one file verbatim; it is pre-existing drift, not an effect of the adapter change (`server.py` / `requirements.txt` were byte-identical before it).

### Tests

- `scripts/generate-ag-ui-deployment-config.spec.ts`: new adapter-branching tests (langgraph-only, MAF-only, mixed) + a committed-artifact byte-equality test mirroring the CI drift check. All 12 tests green.
- Note: the root `scripts/*.spec.ts` generator specs are not wired into any Nx test target today (cockpit/website vitest includes are project-relative); they were run locally via an ad-hoc vitest config. `apps/cockpit` vitest suite (183 tests, includes registry consumers) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
