### PR TITLE
feat(website): homepage punch list — hero merge, FAQ copy, FeatureBlock rows everywhere

### DIFF
--- a/apps/website/src/app/ag-ui/page.tsx
+++ b/apps/website/src/app/ag-ui/page.tsx
@@ -59,16 +59,10 @@ export default async function AgUiPage() {
         eyebrow="Runtime choice"
         headline="Pick a backend. Keep the UI."
         body="The AG-UI protocol decouples your agent runtime from your front-end. @threadplane/ag-ui wraps any AG-UI AbstractAgent into the runtime-neutral Agent contract that @threadplane/chat consumes — so the same Angular components ship against eight different runtimes."
-        bullets={[
-          'Stream from Python, .NET, or TypeScript backends — same chat primitives',
-          'Swap runtimes without rewriting the UI layer',
-          'Protocol-first: tool calls, state deltas, citations all standardized',
-          'Future runtimes that ship AG-UI work day-one',
-        ]}
-        supportingCards={[
-          { title: 'LangGraph', description: 'Python or TS via AG-UI.' },
-          { title: 'Mastra', description: 'TypeScript-native.' },
-          { title: 'CrewAI / AG2', description: 'Multi-agent crews.' },
+        rows={[
+          { claim: 'Stream from Python, .NET, or TypeScript', api: 'AG-UI protocol' },
+          { claim: 'Tool calls, state deltas, citations — standardized', api: 'protocol events' },
+          { claim: 'New AG-UI runtimes work day one', api: 'no adapter needed' },
         ]}
         cta={{ label: 'Browse the AG-UI protocol', href: 'https://github.com/ag-ui-protocol/ag-ui' }}
         visual={<BackendsGrid />}
@@ -79,16 +73,10 @@ export default async function AgUiPage() {
         eyebrow="Same primitives"
         headline="Drop-in for everything @threadplane/chat ships."
         body="provideAgent registers an AG-UI client and exposes the same Agent contract that @threadplane/langgraph provides. Chat rendering, status, tool calls, generative UI, and citations use the same Angular primitives; durable checkpointed threads and history depend on the backend protocol, so use @threadplane/langgraph when you need the native LangGraph thread API."
-        bullets={[
-          'provideAgent + injectAgent — same names across adapters',
-          'Shared Agent contract: messages() / status() / reload()',
-          'Same A2UI surface, themes, and citations rendering',
-          'MockAgentTransport works the same way for tests',
-        ]}
-        supportingCards={[
-          { title: 'provideAgent', description: 'AG-UI wiring.' },
-          { title: 'injectAgent()', description: 'No-args helper.' },
-          { title: '@threadplane/chat', description: 'Same components.' },
+        rows={[
+          { claim: 'Same names across adapters', api: 'provideAgent + injectAgent' },
+          { claim: 'Same components, themes, citations', api: '@threadplane/chat' },
+          { claim: 'Same deterministic testing', api: 'MockAgentTransport' },
         ]}
         cta={{ label: 'API reference', href: '/docs/langgraph/api/inject-agent' }}
         visualLeft

--- a/apps/website/src/app/chat/page.tsx
+++ b/apps/website/src/app/chat/page.tsx
@@ -51,16 +51,10 @@ export default async function ChatPage() {
         eyebrow="Compositions"
         headline="Opinionated shells, swappable parts."
         body="chat-timeline is a drop-in conversation surface that handles streaming, tool calls, interrupts, branching, and time-travel. chat-debug ships devtools alongside — tool-call inspector, message replay, thread history."
-        bullets={[
-          'chat-timeline — drop-in production surface',
-          'chat-debug — devtools alongside, ship-ready',
-          'Sidenav + history search palette',
-          'Themable via CSS vars or component overrides',
-        ]}
-        supportingCards={[
-          { title: 'chat-timeline', description: 'The conversation surface.' },
-          { title: 'chat-debug', description: 'Tool-call devtools.' },
-          { title: 'sidenav', description: 'Thread navigation.' },
+        rows={[
+          { claim: 'A drop-in production conversation surface', api: 'chat-timeline' },
+          { claim: 'Devtools beside it, ship-ready', api: 'chat-debug' },
+          { claim: 'Thread navigation and history search', api: 'sidenav + palette' },
         ]}
         cta={{ label: 'See @threadplane/chat docs', href: '/docs/chat/getting-started/introduction' }}
         visual={
@@ -90,16 +84,10 @@ export default async function ChatPage() {
         eyebrow="Headless"
         headline="Or skip the shell — use the primitives."
         body="If you have a design system, use the headless primitives directly. They're the same building blocks the compositions are made of — bring your own DOM, keep our state machine."
-        bullets={[
-          'Primitives stay unstyled',
-          'Bring your own design tokens',
-          'Compose with the streaming agent contract',
-          'No two-way coupling to the chat shell',
-        ]}
-        supportingCards={[
-          { title: 'message primitives', description: 'Streaming-aware atoms.' },
-          { title: 'tool primitives', description: 'Tool-call lifecycle.' },
-          { title: 'interrupt primitive', description: 'Approval gate.' },
+        rows={[
+          { claim: 'Unstyled primitives, your design tokens', api: 'message + tool primitives' },
+          { claim: 'The approval gate as a component', api: 'interrupt primitive' },
+          { claim: 'Composes against the streaming contract', api: 'Agent contract' },
         ]}
         cta={{ label: 'Headless API', href: '/docs/chat/api/provide-chat' }}
         visualLeft

--- a/apps/website/src/app/langgraph/page.tsx
+++ b/apps/website/src/app/langgraph/page.tsx
@@ -52,16 +52,10 @@ export default async function LangGraphPage() {
         eyebrow="Providers"
         headline="Drop it into app.config.ts. Done."
         body="provideAgent wires LangGraph into Angular's DI container. From any component, injectAgent() returns a signal-based handle for messages, status, errors, and interrupts."
-        bullets={[
-          'provideAgent — wire it once in app.config.ts',
-          'injectAgent() returns a typed signal-based handle',
-          'OnPush tested',
-          'Test transports for deterministic specs',
-        ]}
-        supportingCards={[
-          { title: 'provideAgent', description: 'LangGraph wiring.' },
-          { title: 'injectAgent()', description: 'No-args helper.' },
-          { title: 'MockAgentTransport', description: 'Deterministic tests.' },
+        rows={[
+          { claim: 'Wire it once in app.config.ts', api: 'provideAgent' },
+          { claim: 'A typed, signal-based handle, no args', api: 'injectAgent()' },
+          { claim: 'Deterministic tests without a backend', api: 'MockAgentTransport' },
         ]}
         cta={{ label: 'API reference', href: '/docs/langgraph/api/inject-agent' }}
         visual={
@@ -94,16 +88,10 @@ export class ChatComponent {
         eyebrow="Signals"
         headline="Reactive without RxJS gymnastics."
         body="Every agent surface is exposed as a signal — message stream, tool progress, interrupts, errors, status. Compose with the rest of your Angular reactivity story. No subscriptions to leak."
-        bullets={[
-          'messages() / status() / error() / reload()',
-          'interrupt() for human-in-the-loop gates',
-          'Branch / history / time-travel built in',
-          'Computed signals integrate cleanly',
-        ]}
-        supportingCards={[
-          { title: 'messages()', description: 'Streaming message list.' },
-          { title: 'interrupt()', description: 'Approval-gate signal.' },
-          { title: 'reload()', description: 'Recover from errors.' },
+        rows={[
+          { claim: 'messages(), status(), error() — live signals', api: 'signal-native handle' },
+          { claim: 'Human-in-the-loop gates', api: 'interrupt()' },
+          { claim: 'Branch, history, time-travel built in', api: 'checkpoints' },
         ]}
         cta={{ label: 'Read the streaming guide', href: '/docs/langgraph/guides/streaming' }}
         visualLeft

--- a/apps/website/src/app/pilot-to-prod/page.tsx
+++ b/apps/website/src/app/pilot-to-prod/page.tsx
@@ -52,16 +52,10 @@ export default function PilotToProdPage() {
         eyebrow="Week 1–2 · Discover"
         headline="Map your stack. Pick the work that earns its keep."
         body="We don't start with the model. We start with the workflow — the meeting where someone says 'this would be a great use of AI' and the friction that's stopping it from shipping."
-        bullets={[
-          'Audit existing Angular surfaces + agent-eligible workflows',
-          'Identify the 1–2 highest-leverage agents to build first',
-          'Lock down auth, data residency, observability constraints',
-          'Decide LangGraph vs AG-UI adapter strategy',
-        ]}
-        supportingCards={[
-          { title: 'Workshops', description: 'On-site or remote with your team.' },
-          { title: 'Stack audit', description: 'Existing Angular + backend review.' },
-          { title: 'Roadmap', description: 'Concrete scope for build phase.' },
+        rows={[
+          { claim: 'Audit your surfaces and agent-eligible workflows', api: 'stack audit' },
+          { claim: 'Pick the one or two agents that earn their keep', api: 'roadmap' },
+          { claim: 'Auth, residency, observability locked early', api: 'workshops' },
         ]}
         cta={{ label: 'See sample roadmap', href: '#whitepaper-block' }}
         visual={
@@ -93,16 +87,10 @@ export default function PilotToProdPage() {
         eyebrow="Week 3–5 · Build"
         headline="Ship a working agent on your real data."
         body="Working code, not slideware. We integrate against your real backend, your real auth, and your real Angular app — paired with your engineers, not behind a curtain."
-        bullets={[
-          'Real LangGraph or AG-UI backend (yours or ours, your call)',
-          'Streaming chat surface using @threadplane/chat compositions',
-          'Generative UI for the workflows that benefit from it',
-          'Daily syncs · weekly demo to stakeholders',
-        ]}
-        supportingCards={[
-          { title: 'Pair programming', description: 'Your engineers drive.' },
-          { title: 'Open repo', description: 'You own the source from day one.' },
-          { title: 'Weekly demo', description: 'Stakeholder transparency throughout.' },
+        rows={[
+          { claim: 'A working agent on your real data', api: 'your repo, your engineers' },
+          { claim: 'Streaming surface from the chat compositions', api: '@threadplane/chat' },
+          { claim: 'Weekly demos to stakeholders', api: 'open progress' },
         ]}
         cta={{ label: 'See @threadplane/chat', href: '/chat' }}
         visualLeft
@@ -125,17 +113,10 @@ export default function PilotToProdPage() {
         eyebrow="Week 6–7 · Harden"
         headline="Production-ready, not demo-ready."
         body="Observability, error boundaries, fallback strategies, deploy paths, on-call runbook. The stuff that makes the difference between a demo and an app you can leave running on a Friday afternoon."
-        bullets={[
-          'Observability — tracing, metrics, error budgets',
-          'Error/fallback strategy across every agent surface',
-          'CI/CD integration with your existing pipeline',
-          'Load + chaos testing patterns',
-          'On-call runbook handed to your team',
-        ]}
-        supportingCards={[
-          { title: 'Tracing', description: 'OpenTelemetry hooks.' },
-          { title: 'Fallback API', description: 'Per-component readiness.' },
-          { title: 'Runbook', description: 'Yours forever.' },
+        rows={[
+          { claim: 'Tracing, metrics, error budgets', api: 'OpenTelemetry hooks' },
+          { claim: 'Fallbacks across every agent surface', api: 'readiness + fallback' },
+          { claim: 'Load tested, on-call ready', api: 'runbook, yours' },
         ]}
         cta={{ label: 'Production patterns', href: '/docs/langgraph/guides/deployment' }}
         visual={

--- a/apps/website/src/app/render/page.tsx
+++ b/apps/website/src/app/render/page.tsx
@@ -49,16 +49,10 @@ export default async function RenderPage() {
         eyebrow="Schemas"
         headline="One spec. Your components."
         body="The agent emits structured UI as JSON. @threadplane/render maps each spec node to one of your Angular components — so the design system stays yours, and the agent gets to assemble it."
-        bullets={[
-          'Vercel json-render adapter',
-          'Google A2UI protocol',
-          'Component registry — declare once, use everywhere',
-          'Server schema, client validation',
-        ]}
-        supportingCards={[
-          { title: 'json-render', description: 'Vercel adapter.' },
-          { title: 'A2UI v1', description: 'Google A2UI protocol.' },
-          { title: 'registry', description: 'Spec → component.' },
+        rows={[
+          { claim: 'One spec, rendered by components you own', api: 'component registry' },
+          { claim: 'Both protocols spoken', api: 'json-render + A2UI' },
+          { claim: 'Schema on the server, validation in the client', api: 'validated specs' },
         ]}
         cta={{ label: 'See @threadplane/render docs', href: '/docs/render/getting-started/introduction' }}
         visual={
@@ -93,16 +87,10 @@ export default async function RenderPage() {
         eyebrow="Fallbacks"
         headline="Readiness gate + per-component fallback."
         body="When the agent emits a spec your registry doesn't know how to render, @threadplane/render falls back gracefully — and surfaces it to your observability layer. No mystery white screens."
-        bullets={[
-          'Per-component fallback API',
-          'Readiness gate holds renders until safe',
-          'Telemetry hook for render events',
-          'Streaming partial renders supported',
-        ]}
-        supportingCards={[
-          { title: 'fallback views', description: 'Per-component recovery.' },
-          { title: 'readiness gate', description: 'Hold until safe.' },
-          { title: 'render events', description: 'Telemetry surface.' },
+        rows={[
+          { claim: 'Unknown components degrade, not crash', api: 'fallback API' },
+          { claim: 'Renders hold until the surface is real', api: 'readiness gate' },
+          { claim: 'Partial renders while streaming', api: 'streaming specs' },
         ]}
         cta={{ label: 'Fallback patterns', href: '/docs/render/guides/registry' }}
         visualLeft

--- a/apps/website/src/components/landing/FeatureBlock.spec.tsx
+++ b/apps/website/src/components/landing/FeatureBlock.spec.tsx
@@ -24,21 +24,7 @@ describe('FeatureBlock', () => {
     expect(screen.getByText('Your design system, not a chat widget')).toBeTruthy();
     expect(screen.getByText('@threadplane/render')).toBeTruthy();
     expect(container.querySelector('.feature-block-card-row')).toBeNull();
-    expect(container.querySelector('.feature-block-bullets')).toBeNull();
+    expect(container.querySelectorAll('.feature-block-row')).toHaveLength(2);
     expect(container.querySelector('.feature-block-rail')).toBeTruthy();
-  });
-
-  it('bullets variant (the five non-home pages) still renders bullets and cards', () => {
-    const { container } = render(
-      <FeatureBlock
-        {...base}
-        bullets={['First bullet', 'Second bullet']}
-        supportingCards={[{ title: 'chat-timeline', description: 'Drop-in surface.' }]}
-      />,
-    );
-    expect(screen.getByText('First bullet')).toBeTruthy();
-    expect(screen.getByText('chat-timeline')).toBeTruthy();
-    expect(container.querySelector('.feature-block-rows')).toBeNull();
-    expect(container.querySelector('.feature-block-rail')).toBeNull();
   });
 });

--- a/apps/website/src/components/landing/FeatureBlock.tsx
+++ b/apps/website/src/components/landing/FeatureBlock.tsx
@@ -3,7 +3,6 @@ import Link from 'next/link';
 import { Container } from '../ui/Container';
 import { Section } from '../ui/Section';
 import { Eyebrow } from '../ui/Eyebrow';
-import { Card } from '../ui/Card';
 
 export interface FeatureRow {
   claim: string;
@@ -15,14 +14,10 @@ export interface FeatureBlockProps {
   headline: string;
   body: ReactNode;
   /**
-   * Rows structure (homepage, spec 2026-08-31): claim left, mono API right,
-   * in the Yes wall's row grammar. Renders the rail eyebrow and NO cards.
-   * Mutually exclusive with bullets/supportingCards.
+   * Rows structure: claim left, mono API right, in the Yes wall's row
+   * grammar. Renders the rail eyebrow.
    */
-  rows?: FeatureRow[];
-  /** Legacy structure — the five non-home consumers. */
-  bullets?: string[];
-  supportingCards?: { title: string; description: string }[];
+  rows: FeatureRow[];
   cta: { label: string; href: string };
   visual: ReactNode;
   /** If true, visual on the left; text on the right. Used to alternate sections. */
@@ -38,8 +33,6 @@ export function FeatureBlock({
   headline,
   body,
   rows,
-  bullets,
-  supportingCards,
   cta,
   visual,
   visualLeft = false,
@@ -53,55 +46,24 @@ export function FeatureBlock({
         <div className="feature-block-grid" data-visual-left={visualLeft || undefined}>
           {/* Text column */}
           <div className="feature-block-text">
-            {rows ? (
-              <div className="feature-block-rail">
-                <Eyebrow tone="accent" className="feature-block-eyebrow">{eyebrow}</Eyebrow>
-                <span className="feature-block-rail-line" aria-hidden="true" />
-              </div>
-            ) : (
+            <div className="feature-block-rail">
               <Eyebrow tone="accent" className="feature-block-eyebrow">{eyebrow}</Eyebrow>
-            )}
+              <span className="feature-block-rail-line" aria-hidden="true" />
+            </div>
             <h2 id={headingId} className="feature-block-heading">
               {headline}
             </h2>
             <p className="feature-block-body">
               {body}
             </p>
-            {rows ? (
-              <div className="feature-block-rows">
-                {rows.map((row) => (
-                  <div className="feature-block-row" key={row.claim}>
-                    <span className="feature-block-row-claim">{row.claim}</span>
-                    <span className="feature-block-row-api">{row.api}</span>
-                  </div>
-                ))}
-              </div>
-            ) : (
-              <>
-                <ul className="feature-block-bullets">
-                  {(bullets ?? []).map((b) => (
-                    <li key={b} className="feature-block-bullet">
-                      <span aria-hidden="true" className="feature-block-bullet-check">
-                        ✓
-                      </span>
-                      <span>{b}</span>
-                    </li>
-                  ))}
-                </ul>
-                <div className="feature-block-card-row">
-                  {(supportingCards ?? []).map((sc) => (
-                    <Card key={sc.title} padding="md" surface="tinted">
-                      <div className="feature-block-card-title">
-                        {sc.title}
-                      </div>
-                      <div className="feature-block-card-desc">
-                        {sc.description}
-                      </div>
-                    </Card>
-                  ))}
+            <div className="feature-block-rows">
+              {rows.map((row) => (
+                <div className="feature-block-row" key={row.claim}>
+                  <span className="feature-block-row-claim">{row.claim}</span>
+                  <span className="feature-block-row-api">{row.api}</span>
                 </div>
-              </>
-            )}
+              ))}
+            </div>
 
             <Link href={cta.href} className="feature-block-cta">
               {cta.label} →

--- a/apps/website/src/components/landing/Hero.spec.tsx
+++ b/apps/website/src/components/landing/Hero.spec.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, within } from '@testing-library/react';
-import { HERO_CHIPS, HERO_SUBHEAD, POSITIONING_PROOF_POINTS } from '../../lib/positioning';
+import { HERO_CAPABILITIES, HERO_SUBHEAD } from '../../lib/positioning';
 
 const trackMock = vi.hoisted(() => vi.fn());
 const writeTextMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
@@ -26,9 +26,6 @@ vi.mock('../ui/Eyebrow', () => ({
 }));
 vi.mock('../ui/BrowserFrame', () => ({
   BrowserFrame: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-}));
-vi.mock('../ui/Pill', () => ({
-  Pill: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
 }));
 vi.mock('../ui/Button', () => ({
   Button: ({ children, href, onClick }: { children: React.ReactNode; href?: string; onClick?: () => void }) =>
@@ -53,15 +50,12 @@ describe('Hero', () => {
       .toBe('Ship production agent UIs in Angular.');
     const subhead = document.querySelector('.hero-subhead');
     expect(subhead?.textContent).toBe(HERO_SUBHEAD);
-    const chipRow = screen.getByRole('list', { name: 'Capabilities' });
-    for (const chip of HERO_CHIPS) {
-      expect(within(chipRow).getByText(chip)).toBeTruthy();
+    const row = screen.getByRole('list', { name: 'Capabilities' });
+    for (const cap of HERO_CAPABILITIES) {
+      const link = within(row).getByRole('link', { name: cap.label });
+      expect(link.getAttribute('href')).toBe(cap.href);
     }
-    for (const proofPoint of POSITIONING_PROOF_POINTS) {
-      // 'LangGraph + AG-UI' appears both as a chip and as a proof pill label,
-      // so use getAllByText rather than getByText (which throws on multiple matches).
-      expect(screen.getAllByText(proofPoint.label).length).toBeGreaterThanOrEqual(1);
-    }
+    expect(document.querySelector('.hero-proof-row')).toBeNull();
   });
 
   it('primary CTA copies the install command and fires cta_id=hero_install', async () => {

--- a/apps/website/src/components/landing/Hero.tsx
+++ b/apps/website/src/components/landing/Hero.tsx
@@ -6,10 +6,9 @@ import { Section } from '../ui/Section';
 import { Eyebrow } from '../ui/Eyebrow';
 import { Button } from '../ui/Button';
 import { BrowserFrame } from '../ui/BrowserFrame';
-import { Pill } from '../ui/Pill';
 import { track } from '../../lib/analytics/client';
 import { analyticsEvents } from '../../lib/analytics/events';
-import { HERO_CHIPS, POSITIONING_PROOF_POINTS } from '../../lib/positioning';
+import { HERO_CAPABILITIES } from '../../lib/positioning';
 
 const INSTALL_COMMAND = 'npm install @threadplane/chat @threadplane/langgraph';
 const COPY_FEEDBACK_MS = 1500;
@@ -84,35 +83,27 @@ export function Hero() {
               </span>
             </p>
             <ul className="hero-chip-row" role="list" aria-label="Capabilities">
-              {HERO_CHIPS.map((chip) => (
-                <li key={chip} className="hero-chip">
-                  {chip}
+              {HERO_CAPABILITIES.map((cap) => (
+                <li key={cap.label}>
+                  <a
+                    className="hero-chip"
+                    href={cap.href}
+                    onClick={() =>
+                      track(analyticsEvents.marketingCtaClick, {
+                        cta_id: 'hero_proof_pill',
+                        track: 'developer',
+                        surface: 'home',
+                      })
+                    }
+                  >
+                    {cap.label}
+                  </a>
                 </li>
               ))}
             </ul>
             <div className="hero-cta-row">
               <PrimaryInstallButton />
               <SecondaryTalkButton />
-            </div>
-            <div className="hero-proof-row">
-              {POSITIONING_PROOF_POINTS.map((proofPoint, index) => (
-                <a
-                  key={proofPoint.label}
-                  href={proofPoint.href}
-                  onClick={() =>
-                    track(analyticsEvents.marketingCtaClick, {
-                      cta_id: 'hero_proof_pill',
-                      track: 'developer',
-                      surface: 'home',
-                    })
-                  }
-                  className="hero-proof-link"
-                >
-                  <Pill variant={index === 0 ? 'accent' : 'neutral'} className="hero-proof-pill">
-                    {proofPoint.label}
-                  </Pill>
-                </a>
-              ))}
             </div>
             <p className="hero-caption">
               Not another backend agent runtime. Keep LangGraph, Genkit, Mastra, CrewAI, or your own service. Threadplane solves the Angular UI layer.

--- a/apps/website/src/components/landing/HomeFAQ.tsx
+++ b/apps/website/src/components/landing/HomeFAQ.tsx
@@ -6,7 +6,7 @@ import { FAQ, type FAQItem } from '../ui/FAQ';
 const ITEMS: FAQItem[] = [
   {
     q: 'How is this different from using AG-UI directly?',
-    a: 'AG-UI is a protocol rather than a complete Angular UI layer. Threadplane gives Angular teams the production surface around compatible runtimes: headless chat, durable threads, interrupts, subagents, planning, memory, generative UI, and runtime adapters.',
+    a: 'AG-UI is a protocol rather than a complete Angular UI layer. Threadplane is the production surface built on the runtimes that speak it — the chat, threads, interrupts, and generative UI your Angular app actually ships.',
   },
   {
     q: 'Which adapter should I use — @threadplane/langgraph or @threadplane/ag-ui?',

--- a/apps/website/src/lib/positioning.ts
+++ b/apps/website/src/lib/positioning.ts
@@ -4,14 +4,23 @@ export const LONG_SUBHEAD =
   'The fullstack agentic Angular framework for LangGraph and AG-UI-compatible agents: durable threads, interrupts, subagents, planning, memory, and generative UI using Vercel json-render and Google A2UI.';
 export const HERO_SUBHEAD = `The streaming demo takes an afternoon. Everything after it takes six months. Threadplane is the Angular layer that closes the gap — and it keeps your backend exactly where it is.`;
 
-/** Capability nouns, demoted from the subheadline to chips (spec change F). */
-export const HERO_CHIPS: readonly string[] = [
-  'durable threads',
-  'interrupts',
-  'subagents',
-  'planning + memory',
-  'generative UI',
-  'LangGraph + AG-UI',
+export interface HeroCapability {
+  readonly label: string;
+  readonly href: string;
+}
+
+/**
+ * The hero's single capability row (spec 2026-08-31): chip casing, proof-pill
+ * hrefs, rendered as links. POSITIONING_PROOF_POINTS still feeds the OG image
+ * and metadata keywords — do not fold these together.
+ */
+export const HERO_CAPABILITIES: readonly HeroCapability[] = [
+  { label: 'durable threads', href: '/docs/langgraph/guides/persistence' },
+  { label: 'interrupts', href: '/docs/langgraph/guides/interrupts' },
+  { label: 'subagents', href: '/docs/langgraph/guides/subgraphs' },
+  { label: 'planning + memory', href: '/docs/langgraph/guides/memory' },
+  { label: 'generative UI', href: '/docs/render/concepts/json-render-vs-a2ui' },
+  { label: 'LangGraph + AG-UI', href: '/docs/choosing-an-adapter' },
 ];
 export interface PositioningProofPoint {
   readonly label: string;

--- a/apps/website/src/styles/landing.css
+++ b/apps/website/src/styles/landing.css
@@ -67,6 +67,9 @@
   margin: 0 0 28px;
   max-width: 54ch;
 }
+.hero-chip-row li {
+  display: inline-flex;
+}
 .hero-chip {
   font-family: var(--font-mono);
   font-size: 11.5px;
@@ -75,14 +78,24 @@
   border-radius: var(--radius-full);
   padding: 5px 11px;
   white-space: nowrap;
+  text-decoration: none;
+  display: inline-block;
 }
-/* On phones the chip row and the proof-pill row stack as two near-identical
- * pill lists in one viewport; the pills are links and carry the same nouns,
- * so the decorative chips yield. */
+/* Invisible tap-area extension (parity with the deleted proof pills):
+ * the chip renders ~29px tall; padding lifts the touch target toward the
+ * 44px ideal without shifting layout. */
 @media (max-width: 640px) {
-  .hero-chip-row {
-    display: none;
+  .hero-chip {
+    padding-top: 9px;
+    padding-bottom: 9px;
+    margin-top: -4px;
+    margin-bottom: -4px;
   }
+}
+.hero-chip:hover,
+.hero-chip:focus-visible {
+  border-color: var(--color-accent-border-hover);
+  color: var(--color-text-primary);
 }
 
 .hero-cta-row {
@@ -90,21 +103,6 @@
   gap: 12px;
   margin-bottom: 24px;
   flex-wrap: wrap;
-}
-.hero-proof-row {
-  display: flex;
-  gap: 8px;
-  align-items: center;
-  flex-wrap: wrap;
-  margin-bottom: 12px;
-}
-.hero-proof-link {
-  text-decoration: none;
-  /* Invisible tap-area extension: the pill renders ~27px tall; the padding
-   * lifts the touch target past the 24px WCAG floor toward the 44px ideal. */
-  display: inline-block;
-  padding: 6px 0;
-  margin: -6px 0;
 }
 .hero-caption {
   margin: 0;
@@ -152,28 +150,6 @@
     gap: 40px !important;
   }
 }
-.hero-proof-pill {
-  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease, color 160ms ease, box-shadow 160ms ease;
-  will-change: transform;
-}
-.hero-proof-link:hover > .hero-proof-pill,
-.hero-proof-link:focus-visible > .hero-proof-pill {
-  transform: translateY(-1px);
-  background: var(--color-accent-surface) !important;
-  border-color: var(--color-accent-border) !important;
-  color: var(--color-accent) !important;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
-}
-.hero-proof-link:active > .hero-proof-pill {
-  transform: translateY(0);
-  box-shadow: none;
-}
-@media (prefers-reduced-motion: reduce) {
-  .hero-proof-pill { transition: none; }
-  .hero-proof-link:hover > .hero-proof-pill,
-  .hero-proof-link:focus-visible > .hero-proof-pill { transform: none; }
-}
-
 /* FeatureBlock — components/landing/FeatureBlock.tsx */
 .feature-block-grid {
   display: grid;
@@ -213,57 +189,6 @@
   color: var(--color-text-secondary);
   margin: 0;
   margin-bottom: 24px;
-}
-.feature-block-bullets {
-  list-style: none;
-  padding: 0;
-  margin: 0 0 32px 0;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-.feature-block-bullet {
-  display: flex;
-  align-items: flex-start;
-  gap: 10px;
-  font-family: var(--font-inter);
-  font-size: var(--text-body);
-  line-height: var(--text-body--line-height);
-  color: var(--color-text-primary);
-}
-.feature-block-bullet-check {
-  flex: 0 0 18px;
-  height: 18px;
-  margin-top: 4px;
-  border-radius: var(--radius-full);
-  background: var(--color-accent-surface);
-  border: 1px solid var(--color-accent-border);
-  color: var(--color-accent);
-  font-size: 11px;
-  font-weight: 700;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  line-height: 1;
-}
-.feature-block-card-row {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(min(140px, 100%), 1fr));
-  gap: 8px;
-  margin-bottom: 24px;
-}
-.feature-block-card-title {
-  font-family: var(--font-mono);
-  font-size: 12px;
-  font-weight: 700;
-  color: var(--color-accent);
-  margin-bottom: 4px;
-}
-.feature-block-card-desc {
-  font-family: var(--font-inter);
-  font-size: var(--text-caption);
-  line-height: var(--text-caption--line-height);
-  color: var(--color-text-secondary);
 }
 .feature-block-cta {
   font-family: var(--font-inter);

--- a/docs/superpowers/plans/2026-08-31-homepage-punch-list.md
+++ b/docs/superpowers/plans/2026-08-31-homepage-punch-list.md
@@ -1,0 +1,368 @@
+# Homepage Punch List Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Merge the hero's two noun rows into one linked capability row, de-litany the first FAQ answer, and migrate all five non-home pages to `FeatureBlock` rows so the legacy bullets+cards path can be deleted — per `docs/superpowers/specs/2026-08-31-homepage-punch-list-design.md`.
+
+**Architecture:** Next.js 16 / React 19; UNLAYERED CSS in `apps/website/src/styles/landing.css` (no inline styles, no `@layer`). `POSITIONING_PROOF_POINTS` survives (OG image + site-metadata consume it); only Hero's usage is removed. After Task 3 no consumer passes `bullets`/`supportingCards`, so Task 4 deletes that path and makes `rows` required.
+
+**Test command:** `cd apps/website && npx vitest run --config vite.config.mts`
+**Branch:** `blove/homepage-punch-list` (spec committed). Expected starting HEAD: `0243298d` or descendant — verify before starting.
+
+---
+
+### Task 1: Hero — one linked capability row
+
+**Files:**
+- Modify: `apps/website/src/lib/positioning.ts`
+- Modify: `apps/website/src/components/landing/Hero.tsx`
+- Modify: `apps/website/src/components/landing/Hero.spec.tsx`
+- Modify: `apps/website/src/styles/landing.css`
+
+- [ ] **Step 1: Update Hero.spec.tsx FIRST (failing)**
+
+Replace the locked-copy test's chip and proof-point loops (and their imports)
+with one assertion block; keep the H1/subhead/`HERO_SUBHEAD` assertions and
+the CTA/analytics tests untouched:
+
+```tsx
+    const row = screen.getByRole('list', { name: 'Capabilities' });
+    for (const cap of HERO_CAPABILITIES) {
+      const link = within(row).getByRole('link', { name: cap.label });
+      expect(link.getAttribute('href')).toBe(cap.href);
+    }
+    expect(document.querySelector('.hero-proof-row')).toBeNull();
+```
+
+Import `HERO_CAPABILITIES` from `../../lib/positioning`; drop the
+`HERO_CHIPS` and `POSITIONING_PROOF_POINTS` spec imports if now unused.
+
+- [ ] **Step 2: Run to verify FAIL**
+
+Run: `cd apps/website && npx vitest run --config vite.config.mts src/components/landing/Hero.spec.tsx`
+Expected: FAIL — `HERO_CAPABILITIES` not exported.
+
+- [ ] **Step 3: positioning.ts**
+
+Delete the `HERO_CHIPS` export. Keep `POSITIONING_PROOF_POINTS` and its
+interface untouched. Add:
+
+```ts
+export interface HeroCapability {
+  readonly label: string;
+  readonly href: string;
+}
+
+/**
+ * The hero's single capability row (spec 2026-08-31): chip casing, proof-pill
+ * hrefs, rendered as links. POSITIONING_PROOF_POINTS still feeds the OG image
+ * and metadata keywords — do not fold these together.
+ */
+export const HERO_CAPABILITIES: readonly HeroCapability[] = [
+  { label: 'durable threads', href: '/docs/langgraph/guides/persistence' },
+  { label: 'interrupts', href: '/docs/langgraph/guides/interrupts' },
+  { label: 'subagents', href: '/docs/langgraph/guides/subgraphs' },
+  { label: 'planning + memory', href: '/docs/langgraph/guides/memory' },
+  { label: 'generative UI', href: '/docs/render/concepts/json-render-vs-a2ui' },
+  { label: 'LangGraph + AG-UI', href: '/docs/choosing-an-adapter' },
+];
+```
+
+- [ ] **Step 4: Hero.tsx**
+
+Change the positioning import to `{ HERO_CAPABILITIES }` (keep other imports
+as used; remove the `Pill` import if now unused — check). Replace the
+`hero-chip-row` `<ul>` with:
+
+```tsx
+            <ul className="hero-chip-row" role="list" aria-label="Capabilities">
+              {HERO_CAPABILITIES.map((cap) => (
+                <li key={cap.label}>
+                  <a
+                    className="hero-chip"
+                    href={cap.href}
+                    onClick={() =>
+                      track(analyticsEvents.marketingCtaClick, {
+                        cta_id: 'hero_proof_pill',
+                        track: 'developer',
+                        surface: 'home',
+                      })
+                    }
+                  >
+                    {cap.label}
+                  </a>
+                </li>
+              ))}
+            </ul>
+```
+
+Delete the whole `hero-proof-row` div (the `POSITIONING_PROOF_POINTS.map`
+block). Keep `hero-caption` and everything else.
+
+- [ ] **Step 5: landing.css**
+
+- `.hero-chip` becomes a link: add `text-decoration: none; display: inline-block;`
+  and a hover/focus state:
+
+```css
+.hero-chip:hover,
+.hero-chip:focus-visible {
+  border-color: var(--color-accent-border-hover);
+  color: var(--color-text-primary);
+}
+```
+
+- Delete the `@media (max-width: 640px) { .hero-chip-row { display: none; } }`
+  block (and its comment) — the row now shows on mobile.
+- Delete `.hero-proof-row`, `.hero-proof-link` (including its tap-target
+  padding block), and every `.hero-proof-pill` rule (grep
+  `hero-proof` in landing.css — remove all hits).
+- The `<li>` wrappers are new: add `.hero-chip-row li { display: inline-flex; }`
+  so the flex layout is unchanged. (NOT `display: contents` — that strips the
+  list-item boxes and can break list semantics in AT, the same trap the
+  `list-style: none` role fix guards against.)
+
+- [ ] **Step 6: Run hero spec, then whole suite**
+
+Run: `cd apps/website && npx vitest run --config vite.config.mts src/components/landing/Hero.spec.tsx`
+Expected: PASS. Then the full suite — `site-metadata.spec.ts` still asserts
+`POSITIONING_PROOF_POINTS` (unchanged export) and must stay green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/website/src
+git commit -m "feat(website): hero capability row — chips become the links"
+```
+
+---
+
+### Task 2: FAQ first answer
+
+**Files:**
+- Modify: `apps/website/src/components/landing/HomeFAQ.tsx`
+
+- [ ] **Step 1: Replace the first item's `a` string with EXACTLY:**
+
+```
+AG-UI is a protocol rather than a complete Angular UI layer. Threadplane is the production surface built on the runtimes that speak it — the chat, threads, interrupts, and generative UI your Angular app actually ships.
+```
+
+- [ ] **Step 2: Verify nothing asserts the old string**
+
+Run: `grep -rn 'production surface around compatible runtimes' apps/website/src apps/website/e2e`
+Expected: no matches after the edit.
+
+- [ ] **Step 3: Suite, then commit**
+
+Run: `cd apps/website && npx vitest run --config vite.config.mts` → PASS.
+
+```bash
+git add apps/website/src/components/landing/HomeFAQ.tsx
+git commit -m "copy(website): de-litany the first FAQ answer"
+```
+
+---
+
+### Task 3: Migrate the five pages to rows
+
+**Files:**
+- Modify: `apps/website/src/app/langgraph/page.tsx`
+- Modify: `apps/website/src/app/chat/page.tsx`
+- Modify: `apps/website/src/app/ag-ui/page.tsx`
+- Modify: `apps/website/src/app/render/page.tsx`
+- Modify: `apps/website/src/app/pilot-to-prod/page.tsx`
+
+- [ ] **Step 1: Convert each block**
+
+For every `<FeatureBlock>` on the five pages: DELETE its `bullets={[...]}` and
+`supportingCards={[...]}` props and ADD the `rows` prop below. Headlines,
+bodies, eyebrows, ctas, visuals, ids, comments all stay untouched. Rows
+verbatim from the spec:
+
+`/langgraph` block 1 (eyebrow "Providers"):
+```tsx
+        rows={[
+          { claim: 'Wire it once in app.config.ts', api: 'provideAgent' },
+          { claim: 'A typed, signal-based handle, no args', api: 'injectAgent()' },
+          { claim: 'Deterministic tests without a backend', api: 'MockAgentTransport' },
+        ]}
+```
+
+`/langgraph` block 2 (eyebrow "Signals"):
+```tsx
+        rows={[
+          { claim: 'messages(), status(), error() — live signals', api: 'signal-native handle' },
+          { claim: 'Human-in-the-loop gates', api: 'interrupt()' },
+          { claim: 'Branch, history, time-travel built in', api: 'checkpoints' },
+        ]}
+```
+
+`/chat` block 1 (eyebrow "Compositions"):
+```tsx
+        rows={[
+          { claim: 'A drop-in production conversation surface', api: 'chat-timeline' },
+          { claim: 'Devtools beside it, ship-ready', api: 'chat-debug' },
+          { claim: 'Thread navigation and history search', api: 'sidenav + palette' },
+        ]}
+```
+
+`/chat` block 2 (eyebrow "Headless"):
+```tsx
+        rows={[
+          { claim: 'Unstyled primitives, your design tokens', api: 'message + tool primitives' },
+          { claim: 'The approval gate as a component', api: 'interrupt primitive' },
+          { claim: 'Composes against the streaming contract', api: 'Agent contract' },
+        ]}
+```
+
+`/ag-ui` block 1 (eyebrow "Runtime choice"):
+```tsx
+        rows={[
+          { claim: 'Stream from Python, .NET, or TypeScript', api: 'AG-UI protocol' },
+          { claim: 'Tool calls, state deltas, citations — standardized', api: 'protocol events' },
+          { claim: 'New AG-UI runtimes work day one', api: 'no adapter needed' },
+        ]}
+```
+
+`/ag-ui` block 2 (eyebrow "Same primitives"):
+```tsx
+        rows={[
+          { claim: 'Same names across adapters', api: 'provideAgent + injectAgent' },
+          { claim: 'Same components, themes, citations', api: '@threadplane/chat' },
+          { claim: 'Same deterministic testing', api: 'MockAgentTransport' },
+        ]}
+```
+
+`/render` block 1 (eyebrow "Schemas"):
+```tsx
+        rows={[
+          { claim: 'One spec, rendered by components you own', api: 'component registry' },
+          { claim: 'Both protocols spoken', api: 'json-render + A2UI' },
+          { claim: 'Schema on the server, validation in the client', api: 'validated specs' },
+        ]}
+```
+
+`/render` block 2 (eyebrow "Fallbacks"):
+```tsx
+        rows={[
+          { claim: 'Unknown components degrade, not crash', api: 'fallback API' },
+          { claim: 'Renders hold until the surface is real', api: 'readiness gate' },
+          { claim: 'Partial renders while streaming', api: 'streaming specs' },
+        ]}
+```
+
+`/pilot-to-prod` block 1 (eyebrow "Week 1–2 · Discover"):
+```tsx
+        rows={[
+          { claim: 'Audit your surfaces and agent-eligible workflows', api: 'stack audit' },
+          { claim: 'Pick the one or two agents that earn their keep', api: 'roadmap' },
+          { claim: 'Auth, residency, observability locked early', api: 'workshops' },
+        ]}
+```
+
+`/pilot-to-prod` block 2 (eyebrow "Week 3–5 · Build"):
+```tsx
+        rows={[
+          { claim: 'A working agent on your real data', api: 'your repo, your engineers' },
+          { claim: 'Streaming surface from the chat compositions', api: '@threadplane/chat' },
+          { claim: 'Weekly demos to stakeholders', api: 'open progress' },
+        ]}
+```
+
+`/pilot-to-prod` block 3 (eyebrow "Week 6–7 · Harden"):
+```tsx
+        rows={[
+          { claim: 'Tracing, metrics, error budgets', api: 'OpenTelemetry hooks' },
+          { claim: 'Fallbacks across every agent surface', api: 'readiness + fallback' },
+          { claim: 'Load tested, on-call ready', api: 'runbook, yours' },
+        ]}
+```
+
+- [ ] **Step 2: Verify zero legacy usages remain**
+
+Run: `grep -rn 'bullets=\|supportingCards=' apps/website/src`
+Expected: no matches anywhere.
+
+- [ ] **Step 3: Suite, then commit**
+
+Run: `cd apps/website && npx vitest run --config vite.config.mts` → PASS (no
+page spec asserts the removed bullet strings — verified at plan time; if one
+fails, update ONLY the stale assertion and report it).
+
+```bash
+git add apps/website/src/app
+git commit -m "feat(website): migrate five pages to FeatureBlock rows"
+```
+
+---
+
+### Task 4: Delete the legacy path — `rows` becomes required
+
+**Files:**
+- Modify: `apps/website/src/components/landing/FeatureBlock.tsx`
+- Modify: `apps/website/src/components/landing/FeatureBlock.spec.tsx`
+- Modify: `apps/website/src/styles/landing.css`
+
+- [ ] **Step 1: Update the spec FIRST**
+
+In `FeatureBlock.spec.tsx`: delete the `'bullets variant …'` test entirely.
+In the rows test, drop the now-meaningless
+`expect(container.querySelector('.feature-block-bullets')).toBeNull();`
+assertion (the class won't exist) but KEEP the card-row-null and rail-present
+assertions. Add to the rows test:
+
+```tsx
+    expect(container.querySelectorAll('.feature-block-row')).toHaveLength(2);
+```
+
+- [ ] **Step 2: FeatureBlock.tsx**
+
+- Interface: `rows: FeatureRow[];` (required); DELETE `bullets` and
+  `supportingCards` and their doc comments; update the `rows` doc comment to
+  drop "Mutually exclusive…".
+- Destructuring: remove `bullets`, `supportingCards`.
+- JSX: the `rows ?` ternaries collapse — the rail eyebrow and the
+  `.feature-block-rows` block render unconditionally; the bullets `<ul>`,
+  the card row, and the `<>` fragment are deleted.
+- Remove the now-unused `Card` import.
+
+- [ ] **Step 3: landing.css**
+
+Delete `.feature-block-bullets`, `.feature-block-bullet`,
+`.feature-block-bullet-check`, `.feature-block-card-row`,
+`.feature-block-card-title`, `.feature-block-card-desc` rules (grep
+`feature-block-bullet\|feature-block-card` — remove all hits; nothing else).
+
+- [ ] **Step 4: Type-check the whole app compiles (the five pages must satisfy required `rows`)**
+
+Run: `cd apps/website && npx vitest run --config vite.config.mts` → PASS.
+Then from repo root: `npx nx build website --configuration=production` → success.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/website/src
+git commit -m "refactor(website): delete FeatureBlock legacy bullets+cards path"
+```
+
+---
+
+### Task 5: Verification gate
+
+- [ ] **Step 1:** Full suite → paste summary. Prod build → exit 0.
+- [ ] **Step 2:** Visual pass (Browser pane, `website-dev`): homepage hero at
+  1440px and 375px — ONE capability row, links hover, visible on mobile, no
+  horizontal scroll (measure via DOM at emulated width; hidden-pane
+  screenshots lie). `/langgraph` and `/pilot-to-prod` at 1440px — rows render,
+  no empty bullet/card scaffolding, rail kickers present.
+- [ ] **Step 3:** Click-through sanity: the six hero links resolve (fetch each
+  href against the dev server, expect 200).
+- [ ] **Step 4:** Commit any fixes; stop. No push/PR — separate decision.
+
+## Deviations that require stopping
+
+- Any consumer of `HERO_CHIPS` outside Hero + spec (grep first).
+- Any page spec failing on removed bullet strings in a way that isn't a
+  one-line assertion update.
+- A hero capability href 404ing against the dev server.

--- a/docs/superpowers/specs/2026-08-31-homepage-punch-list-design.md
+++ b/docs/superpowers/specs/2026-08-31-homepage-punch-list-design.md
@@ -1,0 +1,141 @@
+# Homepage punch list — hero merge, FAQ litany, FeatureBlock migration
+
+**Date:** 2026-08-31
+**Status:** Design — awaiting review. No code written.
+**Branch:** `blove/homepage-punch-list`
+
+## Problem
+
+Three follow-ups recorded across the shipped redesign arcs (#885/#886/#890):
+the hero renders two near-identical noun rows on desktop; the first FAQ answer
+still ends in an eight-noun litany; and `FeatureBlock` carries two content
+structures because five non-home pages still use the legacy bullets+cards
+shape — including an unguarded hole where a caller passing neither structure
+renders empty scaffolding.
+
+## Change 1 — hero: one row, chips become links
+
+`HERO_CHIPS` (decorative, hidden on mobile) and `POSITIONING_PROOF_POINTS`
+(linked pills) merge into one export in `positioning.ts`:
+
+```ts
+export interface HeroCapability {
+  readonly label: string;
+  readonly href: string;
+}
+
+export const HERO_CAPABILITIES: readonly HeroCapability[] = [
+  { label: 'durable threads', href: '/docs/langgraph/guides/persistence' },
+  { label: 'interrupts', href: '/docs/langgraph/guides/interrupts' },
+  { label: 'subagents', href: '/docs/langgraph/guides/subgraphs' },
+  { label: 'planning + memory', href: '/docs/langgraph/guides/memory' },
+  { label: 'generative UI', href: '/docs/render/concepts/json-render-vs-a2ui' },
+  { label: 'LangGraph + AG-UI', href: '/docs/choosing-an-adapter' },
+];
+```
+
+Labels take the chips' lowercase casing; hrefs come from the pills. The
+"generative UI" slot absorbs the pills' json-render + A2UI href — that page
+is what the label means.
+
+Rendering: the chip row's visual (mono, hairline border, `--radius-full`)
+becomes a row of `<a>` links firing the existing `hero_proof_pill` analytics
+id (funnel continuity). The `max-width: 640px` hide is removed — one row
+earns its mobile place. The old `hero-proof-row` markup, its pill styling,
+and `HERO_CHIPS` are deleted. `POSITIONING_PROOF_POINTS` SURVIVES — it also
+feeds the OG image (`app/opengraph-image.tsx`) and `site-metadata.ts`
+keywords, verified at design time; only Hero's usage of it is removed. `Hero.spec` asserts the six links (label + href) within the
+labelled row and drops the two-row logic.
+
+Also delete the `hero-caption` italic paragraph? **No** — out of scope; only
+the two noun rows are in play.
+
+## Change 2 — FAQ first answer
+
+Replace:
+> "…Threadplane gives Angular teams the production surface around compatible
+> runtimes: headless chat, durable threads, interrupts, subagents, planning,
+> memory, generative UI, and runtime adapters."
+
+with:
+> "AG-UI is a protocol rather than a complete Angular UI layer. Threadplane
+> is the production surface built on the runtimes that speak it — the chat,
+> threads, interrupts, and generative UI your Angular app actually ships."
+
+## Change 3 — migrate all five pages to rows, delete the legacy path
+
+All eleven remaining `FeatureBlock`s convert to `rows`. Headlines and bodies
+on those pages are NOT rewritten — only bullets+cards collapse into three
+rows each. Then the legacy path dies: `bullets`/`supportingCards` props,
+their JSX branch, `.feature-block-bullets`/`.feature-block-bullet*`/
+`.feature-block-card-*` CSS, and the `Card` import are deleted; `rows`
+becomes REQUIRED; the rail eyebrow becomes the only header form. The
+`FeatureBlock.spec` legacy-variant test is replaced by a test that TS
+requires `rows` (compile-level; runtime test asserts rows render).
+
+Row rule: no verbatim mono-tail repeats WITHIN a page (cross-page repeats
+fine). Tails name real public surfaces or, on /pilot-to-prod, engagement
+deliverables.
+
+### The 33 rows (approved copy; refine wording, keep claims and tails)
+
+**/langgraph · Providers** — Wire it once in app.config.ts → `provideAgent` ·
+A typed, signal-based handle, no args → `injectAgent()` · Deterministic tests
+without a backend → `MockAgentTransport`
+
+**/langgraph · Signals** — messages(), status(), error() — live signals →
+`signal-native handle` · Human-in-the-loop gates → `interrupt()` · Branch,
+history, time-travel built in → `checkpoints`
+
+**/chat · Compositions** — A drop-in production conversation surface →
+`chat-timeline` · Devtools beside it, ship-ready → `chat-debug` · Thread
+navigation and history search → `sidenav + palette`
+
+**/chat · Headless** — Unstyled primitives, your design tokens →
+`message + tool primitives` · The approval gate as a component →
+`interrupt primitive` · Composes against the streaming contract →
+`Agent contract`
+
+**/ag-ui · Runtime choice** — Stream from Python, .NET, or TypeScript →
+`AG-UI protocol` · Tool calls, state deltas, citations — standardized →
+`protocol events` · New AG-UI runtimes work day one → `no adapter needed`
+
+**/ag-ui · Same primitives** — Same names across adapters →
+`provideAgent + injectAgent` · Same components, themes, citations →
+`@threadplane/chat` · Same deterministic testing → `MockAgentTransport`
+
+**/render · Schemas** — One spec, rendered by components you own →
+`component registry` · Both protocols spoken → `json-render + A2UI` · Schema
+on the server, validation in the client → `validated specs`
+
+**/render · Fallbacks** — Unknown components degrade, not crash →
+`fallback API` · Renders hold until the surface is real → `readiness gate` ·
+Partial renders while streaming → `streaming specs`
+
+**/pilot-to-prod · Discover** — Audit your surfaces and agent-eligible
+workflows → `stack audit` · Pick the one or two agents that earn their keep →
+`roadmap` · Auth, residency, observability locked early → `workshops`
+
+**/pilot-to-prod · Build** — A working agent on your real data →
+`your repo, your engineers` · Streaming surface from the chat compositions →
+`@threadplane/chat` · Weekly demos to stakeholders → `open progress`
+
+**/pilot-to-prod · Harden** — Tracing, metrics, error budgets →
+`OpenTelemetry hooks` · Fallbacks across every agent surface →
+`readiness + fallback` · Load tested, on-call ready → `runbook, yours`
+
+## Testing
+
+- Hero spec: six capability links with hrefs, scoped to the labelled row;
+  no `hero-proof-row` remains.
+- FeatureBlock spec: rows required; render asserted.
+- Each migrated page's existing page spec must stay green; any asserting old
+  bullet/card strings gets updated (grep before assuming none).
+- Full suite + prod build + visual pass (homepage hero at 375px — the row now
+  shows on mobile; one migrated page, e.g. /langgraph, at both widths).
+
+## Out of scope
+
+Headline/body rewrites on the five pages; PilotBlock/WhitePaperBlock/
+Promises/RecentArticles passes; the SHORT_POSITIONING_DESCRIPTION meta string
+(it is a meta description, not rendered copy).


### PR DESCRIPTION
## Summary

Recreates #895 (closed accidentally by a premature branch deletion — same commits, now with main merged in). Per `docs/superpowers/specs/2026-08-31-homepage-punch-list-design.md`:

- **Hero: one capability row** — chip styling, pill hrefs, same `hero_proof_pill` analytics id; shows on mobile with tap-area padding; duplicate pill row deleted. `POSITIONING_PROOF_POINTS` survives for the OG image.
- **FAQ de-litany** — the first answer's eight-noun inventory becomes an argument.
- **All five non-home pages migrate to `FeatureBlock` rows** — 33 rows in the claim→API grammar; headlines/bodies untouched.
- **Legacy path deleted** — `rows` required; bullets/cards JSX + CSS gone (net −197 lines).

Note: 7 `PageActions.spec.tsx` failures visible in this branch's test run are **pre-existing on main** (verified on a pristine origin/main worktree; broke in #892 and landed because only Vercel gates merges). Tracked separately; this PR's own files are all green.

## Test Plan
- [x] `nx test website` — all failures accounted for as pre-existing main breakage; every file this PR touches is green (42 files / 358 tests before merging main; 361 passing post-merge with the 7 pre-existing failures isolated to PageActions)
- [x] `nx build website --configuration=production` — green
- [x] All six hero hrefs fetch 200; visual pass at 1440px + 375px
- [x] `/langgraph` + `/pilot-to-prod` render rows, zero legacy scaffolding

🤖 Generated with [Claude Code](https://claude.com/claude-code)