### PR TITLE
feat(website): homepage lower half — ledgers, numerals, paper, intent-gated toast

### DIFF
--- a/apps/website/src/components/landing/DemoShowcase.tsx
+++ b/apps/website/src/components/landing/DemoShowcase.tsx
@@ -35,7 +35,10 @@ export function DemoShowcase() {
 
   return (
     <div className="demo-showcase">
-      <p className="demo-showcase__eyebrow">See it running</p>
+      <div className="demo-showcase__rail">
+        <p className="demo-showcase__eyebrow">See it running</p>
+        <span className="demo-showcase__rail-line" aria-hidden="true" />
+      </div>
       <h2 className="demo-showcase__heading">
         One chat UI. Two runtimes. Same code.
       </h2>

--- a/apps/website/src/components/landing/PilotBlock.tsx
+++ b/apps/website/src/components/landing/PilotBlock.tsx
@@ -2,20 +2,19 @@ import { Container } from '../ui/Container';
 import { Section } from '../ui/Section';
 import { Eyebrow } from '../ui/Eyebrow';
 import { Button } from '../ui/Button';
-import { Card } from '../ui/Card';
 
 const TIMELINE = [
-  { phase: '1', title: 'Discover', body: 'Map your stack, surfaces, and the agentic work that earns its keep.' },
-  { phase: '2', title: 'Build', body: 'Ship a working demo on your real data, in your real Angular app.' },
-  { phase: '3', title: 'Harden', body: 'Observability, error boundaries, deploy paths, on-call patterns.' },
-  { phase: '4', title: 'Train', body: 'Your team owns the stack. We leave you with a runbook, not a black box.' },
+  { phase: '01', title: 'Discover', body: 'Map your stack, surfaces, and the agentic work that earns its keep.' },
+  { phase: '02', title: 'Build', body: 'A working demo on your real data, in your real app.' },
+  { phase: '03', title: 'Harden', body: 'Observability, error boundaries, deploy paths, on-call patterns.' },
+  { phase: '04', title: 'Train', body: 'Your team owns the stack. We leave you with a runbook, not a black box.' },
 ];
 
 const OUTCOMES = [
-  'Working agent demo on your domain',
-  'Hardened production patterns (error/fallback/observability)',
-  'Deploy-ready integration with your CI/CD',
-  'Team trained on the framework + LangGraph',
+  { claim: 'A working agent demo on your domain', tail: 'your data' },
+  { claim: 'Hardened error, fallback, observability patterns', tail: 'production-ready' },
+  { claim: 'Deploy-ready integration', tail: 'your CI/CD' },
+  { claim: 'Team trained on the framework', tail: 'runbook, yours' },
 ];
 
 export function PilotBlock() {
@@ -24,23 +23,24 @@ export function PilotBlock() {
       <Container>
         <div className="pilot-block-grid">
           <div>
-            <Eyebrow tone="accent" className="pilot-eyebrow">For teams</Eyebrow>
+            <div className="pilot-rail">
+              <Eyebrow tone="accent" className="pilot-eyebrow">For teams</Eyebrow>
+              <span className="pilot-rail-line" aria-hidden="true" />
+            </div>
             <h2 id="pilot-heading" className="pilot-heading">
               Ship your first Angular agent in 8 weeks.
             </h2>
             <p className="pilot-subhead">
               Pilot-to-Prod is a concierge delivery — concrete outcomes, your engineers in the driver&apos;s seat, no lock-in.
             </p>
-            <ul className="pilot-outcomes">
+            <div className="pilot-rows">
               {OUTCOMES.map((o) => (
-                <li key={o} className="pilot-outcome">
-                  <span aria-hidden="true" className="pilot-outcome-check">
-                    ✓
-                  </span>
-                  <span>{o}</span>
-                </li>
+                <div className="pilot-row" key={o.claim}>
+                  <p className="pilot-row-claim">{o.claim}</p>
+                  <p className="pilot-row-tail">{o.tail}</p>
+                </div>
               ))}
-            </ul>
+            </div>
             <div className="pilot-cta-row">
               <Button variant="primary" size="lg" href="/pilot-to-prod">See the program</Button>
               <Button variant="secondary" size="lg" href="/pilot-to-prod#contact">Book a call</Button>
@@ -48,23 +48,15 @@ export function PilotBlock() {
           </div>
 
           {/* Timeline */}
-          <div className="pilot-timeline">
+          <div className="pilot-steps">
             {TIMELINE.map((t) => (
-              <Card key={t.phase} padding="md">
-                <div className="pilot-timeline-row">
-                  <div className="pilot-timeline-phase">
-                    {t.phase}
-                  </div>
-                  <div>
-                    <div className="pilot-timeline-title">
-                      {t.title}
-                    </div>
-                    <div className="pilot-timeline-body">
-                      {t.body}
-                    </div>
-                  </div>
+              <div className="pilot-step" key={t.phase}>
+                <span className="pilot-step-num" aria-hidden="true">{t.phase}</span>
+                <div>
+                  <div className="pilot-step-title">{t.title}</div>
+                  <div className="pilot-step-body">{t.body}</div>
                 </div>
-              </Card>
+              </div>
             ))}
           </div>
         </div>

--- a/apps/website/src/components/landing/Promises.tsx
+++ b/apps/website/src/components/landing/Promises.tsx
@@ -1,56 +1,37 @@
 import { Container } from '../ui/Container';
 import { Section } from '../ui/Section';
 import { Eyebrow } from '../ui/Eyebrow';
-import { Card } from '../ui/Card';
 
 const PROMISES = [
-  {
-    title: 'No runtime lock-in',
-    body: 'Every Threadplane package is MIT-licensed for commercial and noncommercial use.',
-  },
-  {
-    title: 'No abandoned majors',
-    body: 'We support Angular’s current and previous LTS versions.',
-  },
-  {
-    title: 'No required cloud',
-    body: 'Self-host LangGraph + your Angular app. Run it all in your VPC.',
-  },
-  {
-    title: 'No hidden telemetry',
-    body: 'Package installation is inert. Browser and Node events require an explicit application action.',
-  },
-  {
-    title: 'No model lock-in',
-    body: 'Adapters work with any LLM your runtime supports. Swap providers without changing Angular code.',
-  },
+  { no: 'No runtime lock-in', rest: 'every package is MIT, commercial or not.', tail: 'MIT, all packages' },
+  { no: 'No abandoned majors', rest: "Angular's current and previous LTS, always.", tail: 'support policy' },
+  { no: 'No required cloud', rest: 'run everything in your own VPC.', tail: 'self-host' },
+  { no: 'No hidden telemetry', rest: 'events require an explicit application action.', tail: 'installation is inert' },
+  { no: 'No model lock-in', rest: 'swap providers without touching Angular code.', tail: 'any LLM your runtime runs' },
 ];
 
 export function Promises() {
   return (
     <Section surface="canvas" ariaLabelledBy="promises-heading">
       <Container>
-        <div className="promises-intro">
+        <div className="promises-rail">
           <Eyebrow tone="accent" className="promises-eyebrow">
             Built on principles
           </Eyebrow>
-          <h2 id="promises-heading" className="promises-heading">
-            What we won&apos;t do.
-          </h2>
-          <p className="promises-subhead">
-            Honest commitments, not aspirations.
-          </p>
+          <span className="promises-rail-line" aria-hidden="true" />
+          <span className="promises-rail-aside">honest commitments, not aspirations</span>
         </div>
-        <div className="promises-grid">
+        <h2 id="promises-heading" className="promises-heading">
+          What we won&apos;t do.
+        </h2>
+        <div className="promises-rows">
           {PROMISES.map((p) => (
-            <Card key={p.title} padding="lg">
-              <h3 className="promises-card-title">
-                {p.title}
-              </h3>
-              <p className="promises-card-body">
-                {p.body}
+            <div className="promises-row" key={p.no}>
+              <p className="promises-row-claim">
+                <span className="marker-highlight">{p.no}</span> — {p.rest}
               </p>
-            </Card>
+              <p className="promises-row-tail">{p.tail}</p>
+            </div>
           ))}
         </div>
       </Container>

--- a/apps/website/src/components/landing/RecentArticles.tsx
+++ b/apps/website/src/components/landing/RecentArticles.tsx
@@ -17,10 +17,11 @@ export function RecentArticles() {
   return (
     <Section surface="canvas" ariaLabelledBy="recent-articles-heading">
       <Container>
-        <div className="recent-articles-header">
+        <div className="recent-articles-rail">
           <Eyebrow tone="accent" className="recent-articles-eyebrow">
             Blog
           </Eyebrow>
+          <span className="recent-articles-rail-line" aria-hidden="true" />
           <h2 id="recent-articles-heading" className="recent-articles-heading">
             Recent articles
           </h2>

--- a/apps/website/src/components/landing/WhitePaperBlock.spec.tsx
+++ b/apps/website/src/components/landing/WhitePaperBlock.spec.tsx
@@ -1,0 +1,32 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { WhitePaperBlock } from './WhitePaperBlock';
+
+const trackMock = vi.fn();
+vi.mock('../../lib/analytics/client', async (importOriginal) => {
+  const mod = await importOriginal<Record<string, unknown>>();
+  return {
+    ...mod,
+    track: (...args: unknown[]) => trackMock(...args),
+    trackWhitepaperDownloadClick: vi.fn(),
+  };
+});
+
+describe('WhitePaperBlock', () => {
+  beforeEach(() => {
+    trackMock.mockClear();
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
+  });
+
+  it('submits the email, fires signup analytics, and shows the done state', async () => {
+    render(<WhitePaperBlock />);
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'dev@example.com' },
+    });
+    fireEvent.submit(screen.getByRole('button', { name: /download/i }).closest('form')!);
+    await waitFor(() => expect(screen.getByText(/Check your inbox/i)).toBeTruthy());
+    const events = trackMock.mock.calls.map((c) => c[0]);
+    expect(events).toContain('marketing:whitepaper_signup_submit');
+    expect(events).toContain('marketing:whitepaper_signup_success');
+  });
+});

--- a/apps/website/src/components/landing/WhitePaperBlock.tsx
+++ b/apps/website/src/components/landing/WhitePaperBlock.tsx
@@ -4,14 +4,13 @@ import { Container } from '../ui/Container';
 import { Section } from '../ui/Section';
 import { Eyebrow } from '../ui/Eyebrow';
 import { Button } from '../ui/Button';
-import { BrowserFrame } from '../ui/BrowserFrame';
 import { analyticsEvents } from '../../lib/analytics/events';
 import { track, trackWhitepaperDownloadClick } from '../../lib/analytics/client';
 
-const BULLETS = [
-  'Six production-readiness dimensions for Angular AI',
-  'Concrete patterns — error boundaries, fallbacks, observability, deploy',
-  'No vendor pitch. Just what we learned shipping it.',
+const ROWS = [
+  { claim: 'Six production-readiness dimensions', tail: '18 pages' },
+  { claim: 'Error boundaries, fallbacks, observability, deploy', tail: 'concrete patterns' },
+  { claim: 'No vendor pitch — what we learned shipping it', tail: 'free' },
 ];
 
 type WhitepaperId = 'overview' | 'angular' | 'render' | 'chat';
@@ -71,18 +70,21 @@ export function WhitePaperBlock({ paper = 'overview' }: WhitePaperBlockProps = {
       <Container>
         <div className="wp-grid">
           <div>
-            <Eyebrow tone="accent" className="wp-eyebrow">Field report</Eyebrow>
+            <div className="wp-rail">
+              <Eyebrow tone="accent" className="wp-eyebrow">Field report</Eyebrow>
+              <span className="wp-rail-line" aria-hidden="true" />
+            </div>
             <h2 id="wp-heading" className="wp-heading">
               The last-mile gap in Angular AI.
             </h2>
-            <ul className="wp-bullets">
-              {BULLETS.map((b) => (
-                <li key={b} className="wp-bullet">
-                  <span aria-hidden="true" className="wp-bullet-dot" />
-                  <span>{b}</span>
-                </li>
+            <div className="wp-rows">
+              {ROWS.map((r) => (
+                <div key={r.claim} className="wp-row">
+                  <p className="wp-row-claim">{r.claim}</p>
+                  <p className="wp-row-tail">{r.tail}</p>
+                </div>
               ))}
-            </ul>
+            </div>
 
             {state === 'done' ? (
               <div className="wp-success">
@@ -157,30 +159,15 @@ export function WhitePaperBlock({ paper = 'overview' }: WhitePaperBlockProps = {
           </div>
 
           {/* Tilted whitepaper cover */}
-          <div className="wp-cover-wrap">
-            <BrowserFrame
-              url="angular-agent-readiness-guide.pdf"
-              rotate={-2}
-              elevation="lg"
-              maxWidth={420}
-            >
-              <div className="wp-cover">
-                <div>
-                  <div className="wp-cover-badge">
-                    Field report · 18 pages
-                  </div>
-                  <div className="wp-cover-title">
-                    From Prototype to Production
-                  </div>
-                  <div className="wp-cover-desc">
-                    Six production-readiness dimensions for Angular AI teams.
-                  </div>
-                </div>
-                <div className="wp-cover-footer">
-                  Threadplane
-                </div>
+          <div className="wp-cover-wrap" aria-hidden="true">
+            <div className="wp-paper">
+              <div>
+                <div className="wp-cover-badge">Field report · 18 pages</div>
+                <div className="wp-cover-title">From Prototype to Production</div>
+                <div className="wp-cover-desc">Six production-readiness dimensions for Angular AI teams.</div>
               </div>
-            </BrowserFrame>
+              <div className="wp-cover-footer">Threadplane</div>
+            </div>
           </div>
         </div>
       </Container>

--- a/apps/website/src/components/shared/AnnouncementToast.spec.tsx
+++ b/apps/website/src/components/shared/AnnouncementToast.spec.tsx
@@ -43,7 +43,7 @@ describe('AnnouncementToast', () => {
   it('appears once BOTH the timer and the 40% scroll threshold are met', () => {
     render(<AnnouncementToast />);
     act(() => vi.advanceTimersByTime(31_000));
-    act(() => setScroll(0.5));
+    act(() => setScroll(0.45));
     expect(document.querySelector('.toast-root')).toBeTruthy();
   });
 });

--- a/apps/website/src/components/shared/AnnouncementToast.spec.tsx
+++ b/apps/website/src/components/shared/AnnouncementToast.spec.tsx
@@ -1,0 +1,49 @@
+import { render, act, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { AnnouncementToast } from './AnnouncementToast';
+
+vi.mock('../../lib/analytics/client', () => ({
+  track: vi.fn(),
+  trackWhitepaperDownloadClick: vi.fn(),
+}));
+
+function setScroll(fraction: number) {
+  Object.defineProperty(document.documentElement, 'scrollHeight', {
+    value: 5000,
+    configurable: true,
+  });
+  Object.defineProperty(window, 'innerHeight', { value: 1000, configurable: true });
+  // The threshold denominator is the SCROLLABLE range (scrollHeight - innerHeight),
+  // not raw scrollHeight.
+  window.scrollY = fraction * (5000 - 1000);
+  fireEvent.scroll(window);
+}
+
+describe('AnnouncementToast', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    localStorage.clear();
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      cb(0);
+      return 0;
+    });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('stays hidden after the timer if the reader has not scrolled 40%', () => {
+    render(<AnnouncementToast />);
+    act(() => vi.advanceTimersByTime(31_000));
+    act(() => setScroll(0.1));
+    expect(document.querySelector('.toast-root')).toBeNull();
+  });
+
+  it('appears once BOTH the timer and the 40% scroll threshold are met', () => {
+    render(<AnnouncementToast />);
+    act(() => vi.advanceTimersByTime(31_000));
+    act(() => setScroll(0.5));
+    expect(document.querySelector('.toast-root')).toBeTruthy();
+  });
+});

--- a/apps/website/src/components/shared/AnnouncementToast.spec.tsx
+++ b/apps/website/src/components/shared/AnnouncementToast.spec.tsx
@@ -46,4 +46,15 @@ describe('AnnouncementToast', () => {
     act(() => setScroll(0.45));
     expect(document.querySelector('.toast-root')).toBeTruthy();
   });
+
+  it('stays dismissed: never reappears once the storage key is set', () => {
+    // STORAGE_KEY is not exported from the component; mirrored here from its
+    // literal construction: `dismissed-announcement-${ANNOUNCEMENT_DATE}`
+    // with ANNOUNCEMENT_DATE = '2026-04-07'.
+    localStorage.setItem('dismissed-announcement-2026-04-07', 'true');
+    render(<AnnouncementToast />);
+    act(() => vi.advanceTimersByTime(31_000));
+    act(() => setScroll(0.45));
+    expect(document.querySelector('.toast-root')).toBeNull();
+  });
 });

--- a/apps/website/src/components/shared/AnnouncementToast.tsx
+++ b/apps/website/src/components/shared/AnnouncementToast.tsx
@@ -21,15 +21,46 @@ export function AnnouncementToast() {
   const [email, setEmail] = useState('');
   const [submitting, setSubmitting] = useState(false);
 
+  const [timerDone, setTimerDone] = useState(false);
+  const [scrolledEnough, setScrolledEnough] = useState(false);
+
   useEffect(() => {
     try {
       if (localStorage.getItem(STORAGE_KEY) === 'true') return;
     } catch {
       return;
     }
-    const timer = setTimeout(() => setVisible(true), DELAY_MS);
+    const timer = setTimeout(() => setTimerDone(true), DELAY_MS);
     return () => clearTimeout(timer);
   }, []);
+
+  // Intent gate (spec 2026-08-31): the toast waits for BOTH the delay and a
+  // 40% scroll depth — it should meet readers who are reading, not arrivals.
+  useEffect(() => {
+    if (scrolledEnough) return undefined;
+    let raf = 0;
+    const check = () => {
+      raf = 0;
+      const doc = document.documentElement;
+      const denom = Math.max(1, doc.scrollHeight - window.innerHeight);
+      if (window.scrollY / denom >= 0.4) {
+        setScrolledEnough(true);
+      }
+    };
+    const onScroll = () => {
+      if (!raf) raf = requestAnimationFrame(check);
+    };
+    window.addEventListener('scroll', onScroll, { passive: true });
+    check();
+    return () => {
+      window.removeEventListener('scroll', onScroll);
+      if (raf) cancelAnimationFrame(raf);
+    };
+  }, [scrolledEnough]);
+
+  useEffect(() => {
+    if (timerDone && scrolledEnough) setVisible(true);
+  }, [timerDone, scrolledEnough]);
 
   useEffect(() => {
     if (visible) {

--- a/apps/website/src/styles/landing.css
+++ b/apps/website/src/styles/landing.css
@@ -634,6 +634,7 @@
   font-weight: 400;
   color: var(--color-text-muted);
   margin: 0;
+  text-transform: lowercase;
   white-space: nowrap;
 }
 .recent-articles-grid {

--- a/apps/website/src/styles/landing.css
+++ b/apps/website/src/styles/landing.css
@@ -525,10 +525,6 @@
 }
 
 /* Promises — components/landing/Promises.tsx */
-.promises-intro {
-  text-align: center;
-  margin-bottom: 56px;
-}
 .promises-eyebrow {
   margin-bottom: 16px;
 }
@@ -542,35 +538,58 @@
   margin-bottom: 12px;
   letter-spacing: -0.015em;
 }
-.promises-subhead {
-  font-family: var(--font-inter);
-  font-size: var(--text-body-lg);
-  line-height: var(--text-body-lg--line-height);
-  color: var(--color-text-secondary);
-  margin: 0;
+.promises-rail {
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
 }
-.promises-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(min(200px, 100%), 1fr));
-  gap: 16px;
-  max-width: 1100px;
-  margin: 0 auto;
+.promises-rail-line {
+  flex: 1;
+  height: 1px;
+  background: var(--color-border);
 }
-.promises-card-title {
-  font-family: var(--font-inter);
-  font-size: 17px;
-  line-height: 1.3;
-  font-weight: 600;
-  color: var(--color-text-primary);
-  margin: 0;
-  margin-bottom: 8px;
-}
-.promises-card-body {
+.promises-rail-aside {
   font-family: var(--font-inter);
   font-size: 14px;
-  line-height: var(--text-body--line-height);
-  color: var(--color-text-secondary);
+  font-style: italic;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+}
+.promises-rows {
+  margin-top: 22px;
+  border-top: 2px solid var(--color-text-primary);
+  max-width: 56ch;
+}
+.promises-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 16px;
+  align-items: baseline;
+  border-bottom: 1px solid var(--color-border);
+  padding: 11px 0;
+}
+.promises-row-claim {
+  font-family: var(--font-inter);
+  font-size: 15.5px;
+  line-height: 1.55;
+  color: var(--color-text-primary);
   margin: 0;
+}
+.promises-row-tail {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+  margin: 0;
+}
+@media (max-width: 640px) {
+  .promises-row {
+    grid-template-columns: 1fr;
+    gap: 2px;
+  }
+  .promises-rail-aside {
+    display: none;
+  }
 }
 
 /* RecentArticles — components/landing/RecentArticles.tsx */

--- a/apps/website/src/styles/landing.css
+++ b/apps/website/src/styles/landing.css
@@ -425,6 +425,16 @@
 .pilot-eyebrow {
   margin-bottom: 16px;
 }
+.pilot-rail {
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
+}
+.pilot-rail-line {
+  flex: 1;
+  height: 1px;
+  background: var(--color-border);
+}
 .pilot-heading {
   font-family: var(--font-garamond);
   font-size: var(--text-h2);
@@ -443,77 +453,72 @@
   margin: 0;
   margin-bottom: 24px;
 }
-.pilot-outcomes {
-  list-style: none;
-  padding: 0;
-  margin: 0 0 32px 0;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-.pilot-outcome {
-  display: flex;
-  align-items: flex-start;
-  gap: 10px;
-  font-family: var(--font-inter);
-  font-size: var(--text-body);
-  line-height: var(--text-body--line-height);
-  color: var(--color-text-primary);
-}
-.pilot-outcome-check {
-  flex: 0 0 18px;
-  height: 18px;
-  margin-top: 4px;
-  border-radius: var(--radius-full);
-  background: var(--color-accent);
-  color: var(--color-text-inverted);
-  font-size: 11px;
-  font-weight: 700;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  line-height: 1;
-}
 .pilot-cta-row {
   display: flex;
   gap: 12px;
   flex-wrap: wrap;
 }
-.pilot-timeline {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
+.pilot-rows {
+  margin: 18px 0 4px;
+  border-top: 2px solid var(--color-text-primary);
+  max-width: 44ch;
 }
-.pilot-timeline-row {
-  display: flex;
-  align-items: flex-start;
+.pilot-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
   gap: 16px;
+  align-items: baseline;
+  border-bottom: 1px solid var(--color-border);
+  padding: 9px 0;
 }
-.pilot-timeline-phase {
-  flex: 0 0 36px;
-  height: 36px;
-  border-radius: var(--radius-full);
-  background: var(--color-accent);
-  color: var(--color-text-inverted);
-  font-family: var(--font-mono);
-  font-size: 14px;
-  font-weight: 700;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
-.pilot-timeline-title {
+.pilot-row-claim {
   font-family: var(--font-inter);
-  font-size: 17px;
+  font-size: 15px;
+  line-height: 1.45;
+  color: var(--color-text-primary);
+  margin: 0;
+}
+.pilot-row-tail {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+  margin: 0;
+}
+.pilot-steps {
+  border-top: 2px solid var(--color-text-primary);
+}
+.pilot-step {
+  display: grid;
+  grid-template-columns: 64px 1fr;
+  gap: 16px;
+  align-items: start;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--color-border);
+}
+.pilot-step:last-child {
+  border-bottom: none;
+}
+.pilot-step-num {
+  font-family: var(--font-garamond);
+  font-size: 44px;
+  font-weight: 700;
+  line-height: 0.9;
+  letter-spacing: -0.03em;
+  color: var(--color-border);
+}
+.pilot-step-title {
+  font-family: var(--font-inter);
+  font-size: 15.5px;
   font-weight: 600;
   color: var(--color-text-primary);
-  margin-bottom: 4px;
 }
-.pilot-timeline-body {
+.pilot-step-body {
   font-family: var(--font-inter);
-  font-size: var(--text-body);
-  line-height: var(--text-body--line-height);
+  font-size: 14px;
+  line-height: 1.5;
   color: var(--color-text-secondary);
+  margin-top: 2px;
 }
 @media (max-width: 900px) {
   .pilot-block-grid {
@@ -521,6 +526,12 @@
      * the stacked column past the viewport (findings §2). */
     grid-template-columns: minmax(0, 1fr) !important;
     gap: 40px !important;
+  }
+}
+@media (max-width: 640px) {
+  .pilot-row {
+    grid-template-columns: 1fr;
+    gap: 2px;
   }
 }
 

--- a/apps/website/src/styles/landing.css
+++ b/apps/website/src/styles/landing.css
@@ -939,13 +939,6 @@
   max-width: 560px;
   margin: 0 0 20px;
 }
-/* Centered ragged text is fine at 2 lines on desktop but becomes a 6-line
- * ragged column on phones; left-align for readability. */
-@media (max-width: 640px) {
-  .demo-showcase__subhead {
-    text-align: left;
-  }
-}
 .demo-showcase__launch-btn {
   position: absolute;
   inset: 0;

--- a/apps/website/src/styles/landing.css
+++ b/apps/website/src/styles/landing.css
@@ -264,6 +264,16 @@
   gap: 64px;
   align-items: center;
 }
+.wp-rail {
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
+}
+.wp-rail-line {
+  flex: 1;
+  height: 1px;
+  background: var(--color-border);
+}
 .wp-eyebrow {
   margin-bottom: 16px;
 }
@@ -277,29 +287,38 @@
   margin-bottom: 20px;
   letter-spacing: -0.015em;
 }
-.wp-bullets {
-  list-style: none;
-  padding: 0;
-  margin: 0 0 24px 0;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
+.wp-rows {
+  margin: 18px 0 4px;
+  border-top: 2px solid var(--color-text-primary);
+  max-width: 42ch;
 }
-.wp-bullet {
-  display: flex;
-  align-items: flex-start;
-  gap: 10px;
+.wp-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 16px;
+  align-items: baseline;
+  border-bottom: 1px solid var(--color-border);
+  padding: 9px 0;
+}
+.wp-row-claim {
   font-family: var(--font-inter);
-  font-size: var(--text-body-lg);
-  line-height: var(--text-body-lg--line-height);
-  color: var(--color-text-secondary);
+  font-size: 15px;
+  line-height: 1.45;
+  color: var(--color-text-primary);
+  margin: 0;
 }
-.wp-bullet-dot {
-  flex: 0 0 6px;
-  height: 6px;
-  margin-top: 12px;
-  border-radius: var(--radius-full);
-  background: var(--color-accent);
+.wp-row-tail {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+  margin: 0;
+}
+@media (max-width: 640px) {
+  .wp-row {
+    grid-template-columns: 1fr;
+    gap: 2px;
+  }
 }
 .wp-success {
   font-family: var(--font-inter);
@@ -352,15 +371,19 @@
    * content's 392px inside a 280px track. */
   min-width: 0;
 }
-/* The frame is shrink-to-fit, so the cover's `100%` was indefinite and its
- * aspect-ratio kept deriving a fixed ~392px width from content height. A
- * definite width (capped by the frame's own inline maxWidth) lets the cover
- * track the viewport. Scoped to the stacked breakpoint: at desktop the grid
- * track is wider than the card, and an unconditional 100% would grow it. */
-@media (max-width: 640px) {
-  .wp-cover-wrap > [data-ui="browser-frame"] {
-    width: 100%;
-  }
+.wp-paper {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  min-height: 300px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 26px 24px;
+  transform: rotate(-1.2deg);
+  box-shadow:
+    0 2px 4px rgba(0, 0, 0, 0.05),
+    0 26px 52px -18px rgba(28, 28, 28, 0.28);
 }
 .wp-cover {
   /* aspect-ratio alone derives width from the content's height, which makes

--- a/apps/website/src/styles/landing.css
+++ b/apps/website/src/styles/landing.css
@@ -613,20 +613,28 @@
 }
 
 /* RecentArticles — components/landing/RecentArticles.tsx */
-.recent-articles-header {
+.recent-articles-rail {
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
   margin-bottom: 32px;
 }
+.recent-articles-rail-line {
+  flex: 1;
+  height: 1px;
+  background: var(--color-border);
+}
 .recent-articles-eyebrow {
-  margin-bottom: 16px;
+  margin-bottom: 0;
 }
 .recent-articles-heading {
-  font-family: var(--font-garamond);
-  font-size: var(--text-h2);
-  line-height: var(--text-h2--line-height);
-  font-weight: 700;
-  letter-spacing: -0.015em;
-  color: var(--color-text-primary);
+  font-family: var(--font-inter);
+  font-size: 14px;
+  font-style: italic;
+  font-weight: 400;
+  color: var(--color-text-muted);
   margin: 0;
+  white-space: nowrap;
 }
 .recent-articles-grid {
   display: grid;
@@ -894,7 +902,16 @@
 .demo-showcase {
   max-width: 760px;
   margin: 0 auto;
-  text-align: center;
+}
+.demo-showcase__rail {
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
+}
+.demo-showcase__rail-line {
+  flex: 1;
+  height: 1px;
+  background: var(--color-border);
 }
 .demo-showcase__eyebrow {
   font-family: var(--font-mono);
@@ -920,7 +937,7 @@
   line-height: var(--text-body-lg--line-height);
   color: var(--color-text-secondary);
   max-width: 560px;
-  margin: 0 auto 20px;
+  margin: 0 0 20px;
 }
 /* Centered ragged text is fine at 2 lines on desktop but becomes a 6-line
  * ragged column on phones; left-align for readability. */

--- a/apps/website/src/styles/landing.css
+++ b/apps/website/src/styles/landing.css
@@ -385,20 +385,6 @@
     0 2px 4px rgba(0, 0, 0, 0.05),
     0 26px 52px -18px rgba(28, 28, 28, 0.28);
 }
-.wp-cover {
-  /* aspect-ratio alone derives width from the content's height, which makes
-   * the cover a fixed ~392px regardless of container — the audit's 392px
-   * card forcing phones to clip. Pin the width; aspect-ratio then drives
-   * height, and content taller than the ratio still stretches it (min-height
-   * auto). */
-  width: min(100%, 392px);
-  aspect-ratio: 8.5 / 11;
-  background: linear-gradient(135deg, #fafbfc 0%, #eaf3ff 100%);
-  padding: 48px 36px;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-}
 .wp-cover-badge {
   font-family: var(--font-mono);
   font-size: 11px;

--- a/docs/superpowers/plans/2026-08-31-homepage-lower-half.md
+++ b/docs/superpowers/plans/2026-08-31-homepage-lower-half.md
@@ -1,0 +1,634 @@
+# Homepage Lower Half Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Apply the established design language to `Promises`, `PilotBlock`, `WhitePaperBlock`, `RecentArticles`, the `DemoShowcase` header, and intent-gate the sitewide `AnnouncementToast` — per `docs/superpowers/specs/2026-08-31-homepage-lower-half-design.md`.
+
+**Architecture:** Next.js 16 / React 19; UNLAYERED CSS in `apps/website/src/styles/landing.css` (toast styles in `chrome.css`); no inline styles, no `@layer`. All devices already exist: `.marker-highlight` (landing.css), the rows grammar (reference `.feature-block-rows` values), ghost numerals (reference `.yes-wall-group-numeral`, light variant), paper elevation (reference `.proof-strip-cell` shadows). Do NOT fork new header anatomies — reuse the feature blocks' railkick pattern (kicker + hairline span) where `SectionHeader` doesn't fit.
+
+**Test command:** `cd apps/website && npx vitest run --config vite.config.mts`
+**Known-red baseline:** 7 pre-existing failures in 4 docs-chrome files (main breakage, tracked separately). Green means: no NEW failures; all files this plan touches pass.
+**Branch:** `blove/homepage-lower-half`, expected starting HEAD `88587e92` or descendant.
+
+---
+
+### Task 1: Promises ledger
+
+**Files:**
+- Modify: `apps/website/src/components/landing/Promises.tsx`
+- Modify: `apps/website/src/styles/landing.css`
+
+- [ ] **Step 1: Restructure the component**
+
+Replace the PROMISES data and render with:
+
+```tsx
+const PROMISES = [
+  { no: 'No runtime lock-in', rest: 'every package is MIT, commercial or not.', tail: 'MIT, all packages' },
+  { no: 'No abandoned majors', rest: "Angular's current and previous LTS, always.", tail: 'support policy' },
+  { no: 'No required cloud', rest: 'run everything in your own VPC.', tail: 'self-host' },
+  { no: 'No hidden telemetry', rest: 'events require an explicit application action.', tail: 'installation is inert' },
+  { no: 'No model lock-in', rest: 'swap providers without touching Angular code.', tail: 'any LLM your runtime runs' },
+];
+```
+
+JSX inside `<Section surface="canvas" ariaLabelledBy="promises-heading">` + `Container`:
+
+```tsx
+        <div className="promises-rail">
+          <Eyebrow tone="accent" className="promises-eyebrow">
+            Built on principles
+          </Eyebrow>
+          <span className="promises-rail-line" aria-hidden="true" />
+          <span className="promises-rail-aside">honest commitments, not aspirations</span>
+        </div>
+        <h2 id="promises-heading" className="promises-heading">
+          What we won&apos;t do.
+        </h2>
+        <div className="promises-rows">
+          {PROMISES.map((p) => (
+            <div className="promises-row" key={p.no}>
+              <p className="promises-row-claim">
+                <span className="marker-highlight">{p.no}</span> — {p.rest}
+              </p>
+              <p className="promises-row-tail">{p.tail}</p>
+            </div>
+          ))}
+        </div>
+```
+
+The old `promises-intro`/`promises-subhead` markup and the Card grid go away;
+remove the `Card` import.
+
+- [ ] **Step 2: CSS**
+
+In `landing.css`, find the `/* Promises — ... */` block: delete the
+`promises-intro`, `promises-subhead`, `promises-grid`, `promises-card-title`,
+`promises-card-desc` (grep `promises-` for the full set) rules; keep/adjust
+`promises-eyebrow`, `promises-heading` (left-aligned now: remove any
+`text-align: center` and `margin: … auto`), and add:
+
+```css
+.promises-rail {
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
+}
+.promises-rail-line {
+  flex: 1;
+  height: 1px;
+  background: var(--color-border);
+}
+.promises-rail-aside {
+  font-family: var(--font-inter);
+  font-size: 14px;
+  font-style: italic;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+}
+.promises-rows {
+  margin-top: 22px;
+  border-top: 2px solid var(--color-text-primary);
+  max-width: 56ch;
+}
+.promises-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 16px;
+  align-items: baseline;
+  border-bottom: 1px solid var(--color-border-soft, var(--color-border));
+  padding: 11px 0;
+}
+.promises-row-claim {
+  font-family: var(--font-inter);
+  font-size: 15.5px;
+  line-height: 1.55;
+  color: var(--color-text-primary);
+  margin: 0;
+}
+.promises-row-tail {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+  margin: 0;
+}
+@media (max-width: 640px) {
+  .promises-row {
+    grid-template-columns: 1fr;
+    gap: 2px;
+  }
+  .promises-rail-aside {
+    display: none;
+  }
+}
+```
+
+(Write `border-bottom: 1px solid var(--color-border);` — the -soft var does
+not exist; shown only to flag the family.)
+
+- [ ] **Step 3: Suite + commit**
+
+Full suite: no new failures. Commit:
+```bash
+git add apps/website/src
+git commit -m "feat(website): Promises becomes a marker-swept ledger"
+```
+
+---
+
+### Task 2: PilotBlock rows + specimen numerals
+
+**Files:**
+- Modify: `apps/website/src/components/landing/PilotBlock.tsx`
+- Modify: `apps/website/src/styles/landing.css`
+
+- [ ] **Step 1: Component**
+
+Data:
+```tsx
+const TIMELINE = [
+  { phase: '01', title: 'Discover', body: 'Map your stack, surfaces, and the agentic work that earns its keep.' },
+  { phase: '02', title: 'Build', body: 'A working demo on your real data, in your real app.' },
+  { phase: '03', title: 'Harden', body: 'Observability, error boundaries, deploy paths, on-call patterns.' },
+  { phase: '04', title: 'Train', body: 'Your team owns the stack. We leave you with a runbook, not a black box.' },
+];
+const OUTCOMES = [
+  { claim: 'A working agent demo on your domain', tail: 'your data' },
+  { claim: 'Hardened error, fallback, observability patterns', tail: 'production-ready' },
+  { claim: 'Deploy-ready integration', tail: 'your CI/CD' },
+  { claim: 'Team trained on the framework', tail: 'runbook, yours' },
+];
+```
+
+Left column: eyebrow becomes the railkick pattern:
+```tsx
+            <div className="pilot-rail">
+              <Eyebrow tone="accent" className="pilot-eyebrow">For teams</Eyebrow>
+              <span className="pilot-rail-line" aria-hidden="true" />
+            </div>
+```
+Heading + subhead + CTA row unchanged. The `pilot-outcomes` `<ul>` becomes:
+```tsx
+            <div className="pilot-rows">
+              {OUTCOMES.map((o) => (
+                <div className="pilot-row" key={o.claim}>
+                  <p className="pilot-row-claim">{o.claim}</p>
+                  <p className="pilot-row-tail">{o.tail}</p>
+                </div>
+              ))}
+            </div>
+```
+
+Right column: the Card timeline becomes (remove the `Card` import):
+```tsx
+          <div className="pilot-steps">
+            {TIMELINE.map((t) => (
+              <div className="pilot-step" key={t.phase}>
+                <span className="pilot-step-num" aria-hidden="true">{t.phase}</span>
+                <div>
+                  <div className="pilot-step-title">{t.title}</div>
+                  <div className="pilot-step-body">{t.body}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+```
+
+- [ ] **Step 2: CSS**
+
+Delete the old `pilot-timeline*` and `pilot-outcome*` rules (grep `pilot-`
+for the block; keep `pilot-block-grid`, `pilot-eyebrow`, `pilot-heading`,
+`pilot-subhead`, `pilot-cta-row`). Add:
+
+```css
+.pilot-rail {
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
+}
+.pilot-rail-line {
+  flex: 1;
+  height: 1px;
+  background: var(--color-border);
+}
+.pilot-rows {
+  margin: 18px 0 4px;
+  border-top: 2px solid var(--color-text-primary);
+  max-width: 44ch;
+}
+.pilot-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 16px;
+  align-items: baseline;
+  border-bottom: 1px solid var(--color-border);
+  padding: 9px 0;
+}
+.pilot-row-claim {
+  font-family: var(--font-inter);
+  font-size: 15px;
+  line-height: 1.45;
+  color: var(--color-text-primary);
+  margin: 0;
+}
+.pilot-row-tail {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+  margin: 0;
+}
+.pilot-steps {
+  border-top: 2px solid var(--color-text-primary);
+}
+.pilot-step {
+  display: grid;
+  grid-template-columns: 64px 1fr;
+  gap: 16px;
+  align-items: start;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--color-border);
+}
+.pilot-step:last-child {
+  border-bottom: none;
+}
+.pilot-step-num {
+  font-family: var(--font-garamond);
+  font-size: 44px;
+  font-weight: 700;
+  line-height: 0.9;
+  letter-spacing: -0.03em;
+  color: var(--color-border);
+}
+.pilot-step-title {
+  font-family: var(--font-inter);
+  font-size: 15.5px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+.pilot-step-body {
+  font-family: var(--font-inter);
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--color-text-secondary);
+  margin-top: 2px;
+}
+@media (max-width: 640px) {
+  .pilot-row {
+    grid-template-columns: 1fr;
+    gap: 2px;
+  }
+}
+```
+
+If the old block had a mobile rule collapsing `pilot-block-grid`, keep it.
+
+- [ ] **Step 3: Suite + commit**
+
+```bash
+git add apps/website/src
+git commit -m "feat(website): PilotBlock rows and specimen-numeral timeline"
+```
+
+---
+
+### Task 3: WhitePaperBlock — rows + bare paper card + form spec
+
+**Files:**
+- Modify: `apps/website/src/components/landing/WhitePaperBlock.tsx`
+- Create: `apps/website/src/components/landing/WhitePaperBlock.spec.tsx`
+- Modify: `apps/website/src/styles/landing.css`
+
+- [ ] **Step 1: Write the form spec FIRST (it pins CURRENT behavior — must pass before AND after the visual change)**
+
+```tsx
+// apps/website/src/components/landing/WhitePaperBlock.spec.tsx
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { WhitePaperBlock } from './WhitePaperBlock';
+
+const trackMock = vi.fn();
+vi.mock('../../lib/analytics/client', async (importOriginal) => {
+  const mod = await importOriginal<Record<string, unknown>>();
+  return {
+    ...mod,
+    track: (...args: unknown[]) => trackMock(...args),
+    trackWhitepaperDownloadClick: vi.fn(),
+  };
+});
+
+describe('WhitePaperBlock', () => {
+  beforeEach(() => {
+    trackMock.mockClear();
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
+  });
+
+  it('submits the email, fires signup analytics, and shows the done state', async () => {
+    render(<WhitePaperBlock />);
+    fireEvent.change(screen.getByPlaceholderText(/email/i), {
+      target: { value: 'dev@example.com' },
+    });
+    fireEvent.submit(screen.getByRole('button', { name: /download/i }).closest('form')!);
+    await waitFor(() => expect(screen.getByText(/Check your inbox/i)).toBeTruthy());
+    const events = trackMock.mock.calls.map((c) => c[0]);
+    expect(events).toContain('marketing:whitepaper_signup_submit');
+    expect(events).toContain('marketing:whitepaper_signup_success');
+  });
+});
+```
+
+BEFORE writing: check the real event-name strings in
+`apps/website/src/lib/analytics/events.ts` (grep `whitepaper_signup`) and the
+real input placeholder / button label in the component — adapt the literals
+to what actually exists, then run the spec against the UNMODIFIED component.
+It must PASS. Paste the run line.
+
+- [ ] **Step 2: Rows + paper card**
+
+In `WhitePaperBlock.tsx`:
+- Eyebrow becomes the railkick pattern (same as Task 1/2:
+  `wp-rail` / `wp-rail-line`).
+- Replace the BULLETS array + `wp-bullets` list with rows:
+```tsx
+const ROWS = [
+  { claim: 'Six production-readiness dimensions', tail: '18 pages' },
+  { claim: 'Error boundaries, fallbacks, observability, deploy', tail: 'concrete patterns' },
+  { claim: 'No vendor pitch — what we learned shipping it', tail: 'free' },
+];
+```
+rendered as `wp-rows`/`wp-row`/`wp-row-claim`/`wp-row-tail` (same structure
+as Task 2's rows).
+- Replace the `BrowserFrame` wrapper of the cover with a bare paper card,
+  keeping the inner cover content EXACTLY as-is:
+```tsx
+          <div className="wp-cover-wrap" aria-hidden="true">
+            <div className="wp-paper">
+              <div>
+                <div className="wp-cover-badge">Field report · 18 pages</div>
+                <div className="wp-cover-title">From Prototype to Production</div>
+                <div className="wp-cover-desc">Six production-readiness dimensions for Angular AI teams.</div>
+              </div>
+              <div className="wp-cover-footer">Threadplane</div>
+            </div>
+          </div>
+```
+  Remove the `BrowserFrame` import if now unused in the file.
+- The form/states/fetch/analytics: untouched.
+
+- [ ] **Step 3: CSS**
+
+Delete `wp-bullets`/`wp-bullet`/`wp-bullet-dot` rules. Add (reusing Task 1/2
+row values — copy them; and treatment-D shadows):
+
+```css
+.wp-rail { display: flex; align-items: baseline; gap: 14px; }
+.wp-rail-line { flex: 1; height: 1px; background: var(--color-border); }
+.wp-rows { margin: 18px 0 4px; border-top: 2px solid var(--color-text-primary); max-width: 42ch; }
+.wp-row { display: grid; grid-template-columns: 1fr auto; gap: 16px; align-items: baseline; border-bottom: 1px solid var(--color-border); padding: 9px 0; }
+.wp-row-claim { font-family: var(--font-inter); font-size: 15px; line-height: 1.45; color: var(--color-text-primary); margin: 0; }
+.wp-row-tail { font-family: var(--font-mono); font-size: 11.5px; color: var(--color-text-muted); white-space: nowrap; margin: 0; }
+.wp-paper {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  min-height: 300px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 26px 24px;
+  transform: rotate(-1.2deg);
+  box-shadow:
+    0 2px 4px rgba(0, 0, 0, 0.05),
+    0 26px 52px -18px rgba(28, 28, 28, 0.28);
+}
+@media (max-width: 640px) {
+  .wp-row { grid-template-columns: 1fr; gap: 2px; }
+}
+```
+
+Check the existing `wp-cover`/`wp-cover-*` rules: keep the typography rules
+(`wp-cover-badge/title/desc/footer`); delete a `wp-cover` layout rule only if
+it referenced BrowserFrame internals — otherwise leave.
+
+- [ ] **Step 4: Re-run the form spec (must STILL pass) + full suite + commit**
+
+```bash
+git add apps/website/src
+git commit -m "feat(website): WhitePaperBlock rows and bare paper cover"
+```
+
+---
+
+### Task 4: Rail headers for RecentArticles + DemoShowcase
+
+**Files:**
+- Modify: `apps/website/src/components/landing/RecentArticles.tsx`
+- Modify: `apps/website/src/components/landing/DemoShowcase.tsx`
+- Modify: `apps/website/src/styles/landing.css`
+
+- [ ] **Step 1: RecentArticles**
+
+Header becomes:
+```tsx
+        <div className="recent-articles-rail">
+          <Eyebrow tone="accent" className="recent-articles-eyebrow">Blog</Eyebrow>
+          <span className="recent-articles-rail-line" aria-hidden="true" />
+          <h2 id="recent-articles-heading" className="recent-articles-heading">
+            Recent articles
+          </h2>
+        </div>
+```
+(the h2 moves INTO the rail as the right-side aside, styled italic muted —
+it keeps its id for the Section's ariaLabelledBy).
+
+- [ ] **Step 2: DemoShowcase**
+
+FIRST check `DemoShowcase.spec.tsx` for assertions on the header (grep
+'See it running' / eyebrow / heading in the spec). Convert the
+`demo-showcase__eyebrow` `<p>` into the railkick pattern
+(`demo-showcase__rail` wrapping the existing eyebrow p + a hairline span);
+heading and subhead keep their classes but the block left-aligns. Update any
+spec assertions that break, minimally.
+
+- [ ] **Step 3: CSS**
+
+```css
+.recent-articles-rail {
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
+}
+.recent-articles-rail-line { flex: 1; height: 1px; background: var(--color-border); }
+.recent-articles-heading {
+  font-family: var(--font-inter);
+  font-size: 14px;
+  font-style: italic;
+  font-weight: 400;
+  color: var(--color-text-muted);
+  margin: 0;
+  white-space: nowrap;
+}
+.demo-showcase__rail { display: flex; align-items: baseline; gap: 14px; }
+.demo-showcase__rail-line { flex: 1; height: 1px; background: var(--color-border); }
+```
+
+Adjust/remove the old centered rules: `recent-articles-header` (was likely
+centered), `demo-showcase__eyebrow` centering, `demo-showcase__heading`
+`text-align: center` → left, `demo-showcase__subhead` `margin: 0 auto` →
+`margin: 0` (keep its max-width). Grep those class names in landing.css and
+fix each centering declaration.
+
+- [ ] **Step 4: Suite (DemoShowcase spec green) + commit**
+
+```bash
+git add apps/website/src
+git commit -m "refactor(website): rail headers for RecentArticles and DemoShowcase"
+```
+
+---
+
+### Task 5: AnnouncementToast scroll gating
+
+**Files:**
+- Modify: `apps/website/src/components/shared/AnnouncementToast.tsx`
+- Create: `apps/website/src/components/shared/AnnouncementToast.spec.tsx`
+
+- [ ] **Step 1: Write the failing spec**
+
+```tsx
+// apps/website/src/components/shared/AnnouncementToast.spec.tsx
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { AnnouncementToast } from './AnnouncementToast';
+
+vi.mock('../../lib/analytics/client', () => ({
+  track: vi.fn(),
+  trackWhitepaperDownloadClick: vi.fn(),
+}));
+
+function setScroll(fraction: number) {
+  Object.defineProperty(document.documentElement, 'scrollHeight', {
+    value: 5000,
+    configurable: true,
+  });
+  Object.defineProperty(window, 'innerHeight', { value: 1000, configurable: true });
+  window.scrollY = fraction * 5000;
+  fireEvent.scroll(window);
+}
+
+describe('AnnouncementToast', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    localStorage.clear();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('stays hidden after the timer if the reader has not scrolled 40%', () => {
+    render(<AnnouncementToast />);
+    act(() => vi.advanceTimersByTime(31_000));
+    setScroll(0.1);
+    expect(document.querySelector('.toast-root')).toBeNull();
+  });
+
+  it('appears once BOTH the timer and the 40% scroll threshold are met', () => {
+    render(<AnnouncementToast />);
+    act(() => vi.advanceTimersByTime(31_000));
+    act(() => setScroll(0.5));
+    expect(document.querySelector('.toast-root')).toBeTruthy();
+  });
+});
+```
+
+Adapt selectors/mocks to the component's real render (the `.toast-root` class
+exists; if the visible toast requires `visible === true` to render at all,
+these assertions hold). rAF throttling: if the implementation defers the
+flag behind requestAnimationFrame, stub rAF to run synchronously in the spec
+(`vi.stubGlobal('requestAnimationFrame', (cb) => { cb(0); return 0; })`).
+Run → the second test FAILS against the current component (it appears on
+timer alone... actually the current component shows after the timer with NO
+scroll — so test 1 FAILS: the toast IS visible at 0.1 scroll). Either way at
+least one test must fail pre-change; paste which.
+
+- [ ] **Step 2: Implement the gate**
+
+In `AnnouncementToast.tsx`, replace the single-condition effect:
+
+```tsx
+  const [timerDone, setTimerDone] = useState(false);
+  const [scrolledEnough, setScrolledEnough] = useState(false);
+
+  useEffect(() => {
+    try {
+      if (localStorage.getItem(STORAGE_KEY) === 'true') return;
+    } catch {
+      return;
+    }
+    const timer = setTimeout(() => setTimerDone(true), DELAY_MS);
+    return () => clearTimeout(timer);
+  }, []);
+
+  // Intent gate (spec 2026-08-31): the toast waits for BOTH the delay and a
+  // 40% scroll depth — it should meet readers who are reading, not arrivals.
+  useEffect(() => {
+    if (scrolledEnough) return undefined;
+    let raf = 0;
+    const check = () => {
+      raf = 0;
+      const doc = document.documentElement;
+      const denom = Math.max(1, doc.scrollHeight - window.innerHeight);
+      if (window.scrollY / denom >= 0.4) {
+        setScrolledEnough(true);
+      }
+    };
+    const onScroll = () => {
+      if (!raf) raf = requestAnimationFrame(check);
+    };
+    window.addEventListener('scroll', onScroll, { passive: true });
+    check();
+    return () => {
+      window.removeEventListener('scroll', onScroll);
+      if (raf) cancelAnimationFrame(raf);
+    };
+  }, [scrolledEnough]);
+
+  useEffect(() => {
+    if (timerDone && scrolledEnough) setVisible(true);
+  }, [timerDone, scrolledEnough]);
+```
+
+(`setVisible` and the mounted-transition effect stay; the dismissal path is
+untouched. Note the scroll listener detaches once satisfied.)
+
+NOTE the denominator: 40% of the SCROLLABLE range
+(`scrollHeight - innerHeight`), not raw scrollHeight — update the spec's
+`setScroll` math to match (fraction * (5000 - 1000)) so tests and code agree.
+
+- [ ] **Step 3: Run the toast spec (2/2) + full suite + commit**
+
+```bash
+git add apps/website/src
+git commit -m "feat(website): intent-gate the announcement toast on scroll depth"
+```
+
+---
+
+### Task 6: Verification gate
+
+- [ ] Full suite: no new failures vs the known-red baseline (4 files / 7 docs-chrome tests). Every file this plan touched: green.
+- [ ] `npx nx build website --configuration=production` → exit 0.
+- [ ] Visual pass (Browser pane, `website-dev`, 1440px + 375px, DOM-first):
+  Promises rows with visible marker sweeps; PilotBlock numerals + rows; the
+  bare rotated paper card (no browser chrome); rail headers on Articles +
+  DemoShowcase; toast does NOT appear after 35s at top of page, DOES appear
+  after scrolling past ~40% (drive with JS scroll + fake time not possible
+  live — verify by scrolling and waiting; report what you observed).
+- [ ] Commit any fixes; stop. No push/PR — separate decision.
+
+## Deviations that require stopping
+
+- DemoShowcase.spec assertions that need more than minimal header updates.
+- Any WhitePaperBlock form/analytics behavior change (the spec from Task 3
+  step 1 failing after the visual change = STOP and fix the visual change).

--- a/docs/superpowers/specs/2026-08-31-homepage-lower-half-design.md
+++ b/docs/superpowers/specs/2026-08-31-homepage-lower-half-design.md
@@ -1,0 +1,98 @@
+# Homepage lower half — the established language, applied
+
+**Date:** 2026-08-31
+**Status:** Approved in mockup review (all four sections + toast option A).
+**Branch:** `blove/homepage-lower-half`
+
+## Scope
+
+The last homepage sections untouched by the redesign arcs: `Promises`,
+`PilotBlock`, `WhitePaperBlock`, `RecentArticles`, plus the `DemoShowcase`
+header and the sitewide `AnnouncementToast` behavior. No new design devices —
+only the shipped ones: rail headers, the claim→tail rows grammar, specimen
+numerals, the marker sweep, paper elevation.
+
+## 1 · Promises — cards become a ledger
+
+Rail header (kicker "Built on principles" + hairline + italic aside "honest
+commitments, not aspirations"), heading unchanged, subhead absorbed into the
+aside. The five Cards become five rows (2px cap, hairline rules, max-width
+~56ch): the **"No X" phrase gets the marker sweep** (`.marker-highlight` —
+its only appearance below the hero), the substance follows inline after an
+em-dash, the mono tail carries the proof term.
+
+Rows (exact copy):
+- **No runtime lock-in** — every package is MIT, commercial or not. → `MIT, all packages`
+- **No abandoned majors** — Angular's current and previous LTS, always. → `support policy`
+- **No required cloud** — run everything in your own VPC. → `self-host`
+- **No hidden telemetry** — events require an explicit application action. → `installation is inert`
+- **No model lock-in** — swap providers without touching Angular code. → `any LLM your runtime runs`
+
+The left-hugging ~56ch ledger with open right whitespace is deliberate
+(treatment C asymmetry).
+
+## 2 · PilotBlock — rows + specimen numerals
+
+Rail kicker ("For teams" + hairline). Headline, subhead sentence, and both
+CTAs unchanged. The OUTCOMES checklist becomes four rows:
+- A working agent demo on your domain → `your data`
+- Hardened error, fallback, observability patterns → `production-ready`
+- Deploy-ready integration → `your CI/CD`
+- Team trained on the framework → `runbook, yours`
+
+The four timeline Cards become a numbered ledger (no Card chrome): 2px top
+cap, per-step ghost Garamond numerals 01–04 (~44px, `--color-border` grey,
+aria-hidden), bold step title + one-line body, hairline rules between.
+Step copy unchanged except tightened Build line ("A working demo on your
+real data, in your real app.").
+
+## 3 · WhitePaperBlock — the paper becomes paper
+
+Rail kicker ("Field report" + hairline). Heading unchanged. The three
+BULLETS become rows:
+- Six production-readiness dimensions → `18 pages`
+- Error boundaries, fallbacks, observability, deploy → `concrete patterns`
+- No vendor pitch — what we learned shipping it → `free`
+
+New right-column visual: a document mock — white card, ~-1.2deg rotation,
+deep soft shadow (treatment D values), containing mono kicker "FIELD REPORT ·
+18 PAGES", serif title "From Prototype to Production", three skeleton lines
+(6px rounded rects, last at 70%), mono "THREADPLANE" footer. Pure
+CSS/markup, aria-hidden (decorative). The form, its states, the fetch, and
+every analytics event stay byte-identical. If the current component has an
+existing right-column visual, it is replaced by the mock.
+
+## 4 · Rail-header conversions
+
+`RecentArticles` and `DemoShowcase`: centered header → rail anatomy (kicker +
+hairline; RecentArticles gains italic aside "recent articles" and its heading
+is absorbed by it — kicker "Blog", no h2 change if one is structurally
+needed for aria; keep the h2, visually integrated). Content untouched.
+Implementation may use the `SectionHeader` rail variant OR the local
+railkick pattern the feature blocks use — match whichever needs fewer
+special cases, but do not fork a third header anatomy.
+
+## 5 · AnnouncementToast — intent gating (option A)
+
+Current: 30s timer, sitewide (layout.tsx), localStorage dismissal. New: the
+toast appears only when BOTH hold — the existing 30s timer has fired AND the
+reader has scrolled ≥40% of the document height (passive scroll listener,
+rAF-throttled, cleaned up on satisfy). Applies on all viewports and all
+pages (the "past the Yes wall" framing generalizes to scroll depth — the
+Yes wall sits at roughly 40% of the homepage). Dismissal behavior, storage
+key, analytics, and copy unchanged.
+
+## Testing
+
+- Promises/PilotBlock/WhitePaperBlock/RecentArticles have no colocated specs
+  today (verify by ls before assuming); WhitePaperBlock's form behavior must
+  keep working — add a spec pinning: submit fires the two analytics events
+  and renders the done state (mock fetch + analytics).
+- AnnouncementToast: add a spec — not visible before scroll threshold even
+  after timer; visible after both; dismissal persists.
+- Full suite (the 7 docs-chrome failures are pre-existing on main — see task
+  chip; not this branch's concern), prod build, visual pass 1440/375.
+
+## Out of scope
+
+Footer, Nav, FAQ accordion internals, the toast's copy/steps, PostCard.


### PR DESCRIPTION
## Summary

The last homepage sections get the established design language, per `docs/superpowers/specs/2026-08-31-homepage-lower-half-design.md`:

- **Promises → ledger.** Five cards become five rows; the "No X" commitments get the marker sweep (its only appearance below the hero); mono tails carry the proof terms.
- **PilotBlock.** The outcomes checklist becomes claim→tail rows; the four timeline Cards become a ghost-numeral ledger (01–04, Garamond, aria-hidden).
- **WhitePaperBlock.** Bullets become rows (`18 pages` · `concrete patterns` · `free`); the BrowserFrame cover becomes a bare rotated paper card with treatment-D shadows. A new spec pins the form's analytics + done state — written first, passing before and after.
- **Rail headers** for RecentArticles and DemoShowcase — the last centered headers on the page.
- **AnnouncementToast intent gate**: appears only after the 30s delay AND ≥40% scroll of the scrollable range (rAF-throttled passive listener, detaches on satisfy). Dismissal/analytics untouched; three-test spec including a denominator-pinning boundary and dismissal persistence.

Also: `npm ci` revealed the "7 failing docs-chrome tests" were a stale `node_modules` missing `lucide-react` — not broken code. Suite is fully green.

## Test Plan
- [x] `nx test website` — 48 files / 389 tests, all green
- [x] `nx build website --configuration=production` — green
- [x] DOM-verified at 1440px: 5 marker-swept rows, 01–04 numerals, bare paper card, rail headers, no horizontal scroll
- [x] Toast gate unit-proven (hidden-pane rAF freeze makes live observation impossible in the harness; correct in visible browsers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)