### PR TITLE
fix(ag-ui): resolve the subagents agent URL against <base href>

### DIFF
--- a/apps/cockpit/ag-ui-agent-url.spec.ts
+++ b/apps/cockpit/ag-ui-agent-url.spec.ts
@@ -1,0 +1,65 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { capabilities } from './scripts/capability-registry';
+
+/**
+ * Guard for a failure mode production smoke cannot see.
+ *
+ * `scripts/assemble-examples.ts` rewrites each cockpit app's `<base href>` to
+ * `/<product>/<topic>/`, and the Vercel route table only proxies
+ * `^/ag-ui/([^/]+)/agent(/.*)?$` to the Railway runtime. An app that hardcodes
+ * a root-absolute `'/agent'` therefore requests `https://<host>/agent`, which
+ * matches no route, falls through the filesystem handle and lands on the 404
+ * catch-all — while still serving a perfectly healthy 200 index.html, so every
+ * page-reachability assertion keeps passing.
+ *
+ * Local dev is not a safety net either: dev serves with `<base href="/">`, so
+ * the literal and the base-relative form resolve identically to `/agent` and
+ * proxy.conf.mjs forwards both.
+ *
+ * The base-relative form is the only one that survives the base-href rewrite.
+ */
+const AGENT_URL_EXPR = "new URL('agent', document.baseURI).pathname";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+
+/**
+ * Both products are served by the same aggregated AG-UI runtime and both get
+ * their <base href> rewritten at assemble time, so both are exposed to this.
+ */
+const agentBackedCapabilities = capabilities.filter(
+  (c) => c.product === 'ag-ui' || c.product === 'runtimes'
+);
+
+describe('ag-ui agent URL is resolved against <base href>', () => {
+  it('covers every registered agent-backed capability', () => {
+    expect(agentBackedCapabilities.length).toBeGreaterThan(0);
+  });
+
+  for (const cap of agentBackedCapabilities) {
+    it(`${cap.product}/${cap.topic} resolves its agent URL relative to the base href`, () => {
+      const configPath = join(
+        repoRoot,
+        'cockpit',
+        cap.product,
+        cap.topic,
+        'angular/src/app/app.config.ts'
+      );
+      const source = readFileSync(configPath, 'utf8');
+
+      expect(
+        source,
+        `${configPath} must build the agent URL with ${AGENT_URL_EXPR} so it ` +
+          `resolves under the deployed <base href="/${cap.product}/${cap.topic}/">`
+      ).toContain(AGENT_URL_EXPR);
+
+      // A root-absolute literal silently 404s in production; see the note above.
+      expect(
+        source,
+        `${configPath} hardcodes a root-absolute agent URL, which does not ` +
+          `survive the <base href> rewrite in scripts/assemble-examples.ts`
+      ).not.toMatch(/url:\s*['"`]\/agent/);
+    });
+  }
+});

--- a/apps/cockpit/e2e/production-smoke.spec.ts
+++ b/apps/cockpit/e2e/production-smoke.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { capabilities } from '../scripts/capability-registry';
 
 /**
  * Production smoke test: verifies the deployed cockpit shell and deployed
@@ -69,6 +70,20 @@ const RENDER_CAPABILITIES = [
   'render/repeat-loops',
   'render/computed-functions',
 ] as const;
+
+/**
+ * Driven off the capability registry so a newly added ag-ui topic is covered
+ * automatically instead of silently going unasserted — the previous two
+ * hardcoded checks covered interrupts and streaming only.
+ *
+ * Scoped to the ag-ui product: `runtimes` capabilities share the Railway
+ * runtime but are not yet in the examples route table, so they have no
+ * /ag-ui/<topic>/ URL to assert against.
+ */
+const AG_UI_TOPICS = capabilities
+  .filter((c) => c.product === 'ag-ui' && c.pythonDir)
+  .map((c) => c.topic)
+  .sort();
 
 const SEND_RECEIVE_TIMEOUT_MS = 30_000;
 test.describe('Production: Angular chat example apps load', () => {
@@ -197,15 +212,47 @@ test.describe('ag-ui Railway runtime', () => {
     expect(await res.json()).toMatchObject({ ok: true });
   });
 
-  test('examples.threadplane.ai/ag-ui/interrupts is reachable', async ({ page }) => {
-    const res = await page.goto(`${EXAMPLES_URL}/ag-ui/interrupts/`);
-    expect(res?.status()).toBeLessThan(400);
-  });
+  for (const topic of AG_UI_TOPICS) {
+    test(`ag-ui/${topic} page is reachable`, async ({ page }) => {
+      const res = await page.goto(`${EXAMPLES_URL}/ag-ui/${topic}/`, {
+        timeout: 15_000,
+      });
+      expect(res?.status()).toBeLessThan(400);
+    });
 
-  test('examples.threadplane.ai/ag-ui/streaming is reachable', async ({ page }) => {
-    const res = await page.goto(`${EXAMPLES_URL}/ag-ui/streaming/`);
-    expect(res?.status()).toBeLessThan(400);
-  });
+    /**
+     * Page reachability is not enough, and /ok is not either. A misconfigured
+     * agent URL, a missing proxy route, or a Railway image that crashed on
+     * boot all leave a healthy 200 index.html and a healthy /ok while the
+     * runtime endpoint is dead — Railway keeps serving the last good image
+     * when a new one fails to boot. That combination hid a broken
+     * /agent/subagents for two and a half months.
+     *
+     * POSTing an empty body is a deliberate, token-free canary: the FastAPI
+     * request model rejects it before any graph or LLM call runs.
+     *   422 → healthy (proxy routed, internal token accepted, topic mounted)
+     *   404 → topic missing from the deployed image, or no proxy route
+     *   401 → AG_UI_INTERNAL_TOKEN mismatch between the proxy and Railway
+     */
+    test(`ag-ui/${topic} agent endpoint is routed and mounted`, async ({
+      request,
+    }) => {
+      const res = await request.post(`${EXAMPLES_URL}/ag-ui/${topic}/agent`, {
+        headers: { Origin: EXAMPLES_URL, 'content-type': 'application/json' },
+        data: {},
+      });
+      const status = res.status();
+      expect(
+        status,
+        `POST /ag-ui/${topic}/agent returned ${status}; 404 means the deployed image has no /agent/${topic} route (check the Railway build/boot log) or the Vercel proxy route is missing`
+      ).not.toBe(404);
+      expect(
+        status,
+        `POST /ag-ui/${topic}/agent returned 401 — AG_UI_INTERNAL_TOKEN mismatch between the Vercel proxy and Railway`
+      ).not.toBe(401);
+      expect(status).toBeLessThan(500);
+    });
+  }
 });
 
 /**

--- a/cockpit/ag-ui/subagents/angular/src/app/app.config.ts
+++ b/cockpit/ag-ui/subagents/angular/src/app/app.config.ts
@@ -5,7 +5,7 @@ import { provideChat } from '@threadplane/chat';
 
 export const appConfig: ApplicationConfig = {
   providers: [
-    provideAgent({ url: '/agent' }),
+    provideAgent({ url: new URL('agent', document.baseURI).pathname }),
     provideChat({}),
   ],
 };


### PR DESCRIPTION
`cockpit/ag-ui/subagents` was the only ag-ui app configuring a root-absolute agent URL:

```ts
provideAgent({ url: '/agent' })          // subagents
provideAgent({ url: new URL('agent', document.baseURI).pathname })  // the other six
```

`scripts/assemble-examples.ts` rewrites each app's `<base href>` to `/ag-ui/<topic>/`, and the Vercel route table only proxies `^/ag-ui/([^/]+)/agent(/.*)?$` to the Railway runtime. The literal therefore requested `https://examples.threadplane.ai/agent`, which matches no route, fell through the filesystem handle and landed on the 404 catch-all.

Local dev hid it: dev serves `<base href="/">`, so both forms resolve to `/agent` and `proxy.conf.mjs` forwards either one.

## ⚠️ This is half of a two-part fix — merge order matters

The subagents capability has **two** independent defects. This PR fixes the frontend one. The backend one — the topic's `from src.streaming...` absolute imports crash the aggregated Railway image on boot, so Railway has been serving the last good pre-subagents image since 2026-06-16 — is fixed on `blove/fix-ag-ui-deploy-boot`.

**Please merge the boot-gate branch first.** The production-smoke assertion added here asserts the agent endpoint is live, so it fails on `main` until that fix deploys. Neither fix alone makes the capability work.

Verify the backend fix actually rolled out before merging this:

```bash
curl -s -o /dev/null -w '%{http_code}\n' -X POST https://examples.threadplane.ai/ag-ui/subagents/agent -H 'content-type: application/json' -H 'origin: https://examples.threadplane.ai' -d '{}'
```

`422` = mounted and healthy. `404` = the deploy did not take (`railway up --detach` reports success at upload time, not on a successful build).

## Test coverage

Neither defect was catchable by the existing checks: page reachability returns a healthy 200 in both broken states, and `/ok` stays green because Railway keeps serving the last good image. `/ag-ui/subagents/` returns 200 today.

- **`apps/cockpit/ag-ui-agent-url.spec.ts`** — static guard asserting every agent-backed capability (ag-ui + runtimes, 9 total) builds its URL against the base href. Production smoke structurally cannot see a misconfigured client URL, so this has to be asserted against source. Mutation-tested: reverting the fix fails it.
- **`apps/cockpit/e2e/production-smoke.spec.ts`** — replaces two hardcoded page checks with registry-driven per-topic assertions on the endpoint each app actually talks to. An empty POST is a token-free canary: the FastAPI request model rejects it before any graph or LLM call, so `422` = mounted, `404` = missing, `401` = internal-token mismatch.

## Verification

- Built bundle contains `new URL("agent",document.baseURI).pathname`, zero `url:"/agent"` literals; production build exits 0.
- Cockpit unit suite: 192 passed (28 files). Lint exits 0.
- Production smoke, ag-ui block: 14 passed, 1 failed — the failure being the real outage this is gated on.

## Follow-ups (not in this PR)

- `assemble-examples.ts` deploys all registry products but its route table only rewrites `langgraph|deep-agents|render|chat|ag-ui`. `runtimes` is missing, so `/runtimes/microsoft-agent-framework/` will 404 once #896's CI finishes — same class of bug one level up.
- `deploy-ag-ui.yml` has no post-deploy verification. The boot gate on the other branch validates that the artifact imports, not that the rollout took — which is the specific gap that hid this for two and a half months.

🤖 Generated with [Claude Code](https://claude.com/claude-code)