### PR TITLE
test(website): unblock main deploys — landing e2e asserts redesigned copy

### DIFF
--- a/apps/website/e2e/website.spec.ts
+++ b/apps/website/e2e/website.spec.ts
@@ -23,8 +23,8 @@ test('landing page states the all-MIT and explicit-telemetry commitments', async
   await page.goto('/');
   const main = page.locator('main');
 
-  await expect(main).toContainText('Every Threadplane package is MIT-licensed');
-  await expect(main).toContainText('Package installation is inert');
+  await expect(main).toContainText('every package is MIT');
+  await expect(main).toContainText('No hidden telemetry');
 });
 
 test('pricing page presents three software and support paths', async ({ page }) => {


### PR DESCRIPTION
Website e2e has been red on main since the homepage redesign: the 'landing page states the all-MIT and explicit-telemetry commitments' guard asserts pre-redesign sentences that #885/#890 rephrased. Because `ci.yml`'s **deploy job needs website-e2e**, every website/cockpit deploy on main has been silently blocked — which is why the new `cockpit/runtimes` pages 404/500 in production while their code sits merged.

The commitments still exist on the page (Promises.tsx: *'every package is MIT, commercial or not'*, *'No hidden telemetry … installation is inert'*); only the guard's strings were stale. This updates the two assertions to the durable new phrasing. Intent of the guard unchanged.

Verified: spec passes locally against the current homepage; the prior CI failure is the evidence it fails on wrong text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)