### PR TITLE
docs(ci): document the culled-run deploy-gate hazard (and retrigger dropped deploys)

### DIFF
--- a/apps/cockpit/scripts/capability-registry.ts
+++ b/apps/cockpit/scripts/capability-registry.ts
@@ -38,6 +38,9 @@ export interface Capability {
   framework?: CapabilityFramework;
 }
 
+// NOTE: registry changes must reach production through a run whose diff range
+// includes this file — see the deploy-gate hazard note in
+// scripts/assemble-examples.ts before assuming a green main run deployed them.
 export const capabilities: readonly Capability[] = [
   { id: 'streaming', product: 'langgraph', topic: 'streaming', angularProject: 'cockpit-langgraph-streaming-angular', port: 4300, pythonPort: 5300, pythonDir: 'cockpit/langgraph/streaming/python', graphName: 'streaming' },
   { id: 'persistence', product: 'langgraph', topic: 'persistence', angularProject: 'cockpit-langgraph-persistence-angular', port: 4301, pythonPort: 5301, pythonDir: 'cockpit/langgraph/persistence/python', graphName: 'persistence' },

--- a/scripts/assemble-examples.ts
+++ b/scripts/assemble-examples.ts
@@ -13,6 +13,15 @@ import { cpSync, mkdirSync, rmSync, existsSync, writeFileSync, readFileSync } fr
 import { resolve } from 'path';
 import { capabilities as registryCapabilities } from '../apps/cockpit/scripts/capability-registry';
 
+// DEPLOY-GATE HAZARD: ci.yml's deploy steps diff `github.event.before..sha` to
+// decide whether examples/cockpit redeploy. Runs waiting in the CI-main
+// concurrency queue are cancelled when a newer push arrives, and a cancelled
+// run's diff range is never re-examined — so a change that skipped deploy in a
+// culled run can stay undeployed until a later commit touches a gated path
+// (this file is one). Seen live 2026-08-31: the cockpit/runtimes examples
+// merged green but never deployed. If pages are missing in production after a
+// green main run, check for culled runs before suspecting the code.
+
 const root = resolve(__dirname, '..');
 const deployDir = resolve(root, 'deploy/examples');
 const skipBuild = process.argv.includes('--skip-build');


### PR DESCRIPTION
Two comment-only edits with a double purpose.

**The hazard, seen live today:** ci.yml's deploy steps diff `github.event.before..sha`. Runs cancelled while waiting in the CI-main concurrency queue never get their ranges re-examined — so the cockpit/runtimes examples merged green (#896/#898/#903) but their examples/cockpit deploys were skipped in the surviving docs-only run and dropped with the culled runs. Production still 404s `/runtimes/*` on examples and 500s the runtimes pages on cockpit while the code sits merged.

**The retrigger:** these comments live in gated files (`scripts/assemble-examples.ts` hits the examples gate; `apps/cockpit/scripts/capability-registry.ts` makes cockpit nx-affected), so merging this lands the dropped deploys at current main.

A durable fix (diffing against the last *deployed* state instead of the push range) is worth a follow-up; this documents the trap where a future debugger will find it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)