### PR TITLE
ci: gate deploys on the last promoted commit, not the last push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -650,6 +650,10 @@ jobs:
     runs-on: ubuntu-latest
     # Only deploy on pushes to main, not on pull requests
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    permissions:
+      # Needed to advance refs/deploy/last-promoted (see "Resolve deploy
+      # baseline"). Nothing else in this job writes to the repo.
+      contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -675,14 +679,53 @@ jobs:
           else
             echo "stale=false" >> "$GITHUB_OUTPUT"
           fi
-      - name: Detect deploy-relevant changes
-        id: deploy_preflight
+      - name: Resolve deploy baseline
+        id: deploy_baseline
         run: |
-          base_sha="${{ github.event.before }}"
+          # Gating on `github.event.before..sha` asks "what changed in THIS
+          # push", which silently drops work whenever a run does not reach the
+          # deploy steps. Pushes to main do not cancel in-progress runs, but
+          # GitHub keeps only the newest QUEUED run per concurrency group and
+          # cancels the rest, and a run can also fail on an unrelated job — in
+          # both cases that push's diff range is never re-examined. The next
+          # push only diffs its own range, so the skipped change stays
+          # undeployed until some later commit happens to touch a gated path.
+          #
+          # Seen live 2026-08-31: #902 (cockpit/ag-ui/subagents/angular) failed
+          # on an unrelated website e2e regression, and the two green runs after
+          # it touched no gated path — so the fix sat on main, undeployed,
+          # alongside the cockpit/runtimes examples from two culled runs. All
+          # three shipped only when #907 incidentally touched a gated file.
+          #
+          # refs/deploy/last-promoted advances only after a fully successful
+          # deploy job, so this range covers everything not yet promoted.
+          # Falls back to the old behaviour when the marker is absent
+          # (first run after this lands) or no longer resolves (history rewrite).
+          base_sha=""
+          marker="$(git ls-remote origin refs/deploy/last-promoted 2>/dev/null | cut -f1)"
+          if [ -n "$marker" ] && git cat-file -e "${marker}^{commit}" 2>/dev/null; then
+            base_sha="$marker"
+            echo "::notice::Deploy baseline: last promoted commit ${marker}."
+          else
+            base_sha="${{ github.event.before }}"
+            echo "::notice::No usable refs/deploy/last-promoted marker; falling back to github.event.before (${base_sha})."
+          fi
           head_sha="${{ github.sha }}"
           if [ -z "$base_sha" ] || [ "$base_sha" = "0000000000000000000000000000000000000000" ]; then
             base_sha="$(git rev-parse "$head_sha^")"
           fi
+          # Guarantee every consumer gets a resolvable commit: the fallback can
+          # name a commit this clone does not have (force-push, deleted branch).
+          if ! git cat-file -e "${base_sha}^{commit}" 2>/dev/null; then
+            echo "::warning::Deploy baseline ${base_sha} does not resolve; using ${head_sha}^ instead."
+            base_sha="$(git rev-parse "$head_sha^")"
+          fi
+          echo "base=$base_sha" >> "$GITHUB_OUTPUT"
+      - name: Detect deploy-relevant changes
+        id: deploy_preflight
+        run: |
+          base_sha="${{ steps.deploy_baseline.outputs.base }}"
+          head_sha="${{ github.sha }}"
 
           if ! git cat-file -e "$base_sha^{commit}" 2>/dev/null; then
             git fetch --no-tags origin "$base_sha"
@@ -702,11 +745,8 @@ jobs:
       - name: Check if examples changed
         id: examples_changed
         run: |
-          base_sha="${{ github.event.before }}"
+          base_sha="${{ steps.deploy_baseline.outputs.base }}"
           head_sha="${{ github.sha }}"
-          if [ -z "$base_sha" ] || [ "$base_sha" = "0000000000000000000000000000000000000000" ]; then
-            base_sha="$(git rev-parse "$head_sha^")"
-          fi
           changed_files="$(git diff --name-only "$base_sha" "$head_sha")"
           examples_changed=false
           if printf '%s\n' "$changed_files" | grep -E '^cockpit/.*/angular/' >/dev/null; then
@@ -739,11 +779,8 @@ jobs:
         if: steps.deploy_preflight.outputs.relevant == 'true'
         id: affected
         run: |
-          base_sha="${{ github.event.before }}"
+          base_sha="${{ steps.deploy_baseline.outputs.base }}"
           head_sha="${{ github.sha }}"
-          if [ -z "$base_sha" ] || [ "$base_sha" = "0000000000000000000000000000000000000000" ]; then
-            base_sha="$(git rev-parse "$head_sha^")"
-          fi
 
           if ! git cat-file -e "$base_sha^{commit}" 2>/dev/null; then
             git fetch --no-tags origin "$base_sha"
@@ -839,6 +876,14 @@ jobs:
           EOF
           npx vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
           npx vercel deploy --prebuilt --prod --yes --token=${{ secrets.VERCEL_TOKEN }}
+
+      # Advance only when the whole job succeeded and actually promoted. On a
+      # stale run, a failure, or a partial deploy the marker stays put, so the
+      # next run's range still covers whatever did not ship. Never `always()`:
+      # advancing past unshipped work is the bug this step exists to prevent.
+      - name: Record this commit as promoted
+        if: success() && steps.freshness.outputs.stale != 'true'
+        run: git push origin --force "${{ github.sha }}:refs/deploy/last-promoted"
 
   demo-deploy:
     name: Canonical demo → Vercel


### PR DESCRIPTION
The deploy job decides what to redeploy by diffing `github.event.before..sha` — *"what changed in THIS push"*. That silently drops work whenever a run doesn't reach the deploy steps, and nothing ever re-examines the range:

- Pushes to main don't cancel in-progress runs, but GitHub keeps only the newest **queued** run per concurrency group and cancels the rest.
- A run can fail on a job unrelated to what it changed.

Either way, the next push diffs only *its own* range — so the skipped change stays undeployed until some later commit happens to touch a gated path.

## Seen live, 2026-08-31

[#902](https://github.com/cacheplane/angular-agent-framework/pull/902) fixed the subagents agent URL under `cockpit/ag-ui/subagents/angular/` and merged green. Its run failed on an unrelated `Website — e2e` regression before reaching the deploy job. The two green runs after it touched no gated path, so the fix sat on main — undeployed — next to the `cockpit/runtimes` examples stranded by two culled runs.

All three shipped ~2.5h later only because [#907](https://github.com/cacheplane/angular-agent-framework/pull/907) incidentally touched `scripts/assemble-examples.ts`.

**The failure mode is silent.** Main is green, the deploy job reports success, and production is stale. Confirmed at the time via response headers: `last-modified` on the live bundle was the *previous* deploy, hours after the merge.

#907 documented this hazard at its trigger sites; this fixes the mechanism.

## The change

Resolve the baseline once from `refs/deploy/last-promoted` — which advances only after a fully successful, non-stale deploy job — and feed it to all three gates (`deploy_preflight`, `examples_changed`, `affected`). The range then covers *everything not yet promoted* rather than one push.

Fail-safe by construction:

- **No marker** (the first run after this lands) or an unresolvable one → falls back to the previous `github.event.before` behaviour, so rollout is a no-op.
- **Stale, failed, or partial run** → marker is not advanced. Deliberately `success() && !stale`, never `always()`: advancing past unshipped work is the exact bug being fixed.
- The resolved baseline is verified to be a real commit before use, so a force-push or deleted branch degrades to `HEAD^` instead of failing the diff.

Adds `permissions: contents: write` to the deploy job — needed only to push the marker ref. The `website` job already uses a job-level write grant for the api-docs bot, so this follows existing convention.

## Verification

- `actionlint` reports nothing on the changed lines (pre-existing findings at 94/97/422/1156 only).
- `scripts/ci-workflow.spec.mjs` 19 pass, `scripts/ci-scope.spec.mjs` 53 pass.
- YAML parses; deploy job resolves to 19 steps, ending in `Record this commit as promoted`.

Worth a careful review — it changes the production deploy path, and the first real exercise is the merge itself. Expect `No usable refs/deploy/last-promoted marker; falling back to…` in that run's log, then the marker existing from then on.

## Not covered

`ag-ui-demo-deploy` and `posthog-sync-plan` gate on `github.event.before` the same way. Each deploys a different target and would need its own marker, so I left them out to keep this reviewable — happy to follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)