### PR TITLE
feat(website): library pages in the homepage manner

### DIFF
--- a/apps/website/src/app/ag-ui/page.spec.tsx
+++ b/apps/website/src/app/ag-ui/page.spec.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import AgUiPage from './page';
+
+vi.mock('../../lib/analytics/client', () => ({
+  track: vi.fn(),
+  trackCtaClick: vi.fn(),
+  trackExternalLinkClick: vi.fn(),
+  trackWhitepaperDownloadClick: vi.fn(),
+}));
+
+describe('AgUiPage', () => {
+  it('renders the package kicker, marker sweep, switcher, and dark closer', async () => {
+    const ui = await AgUiPage();
+    const { container } = render(ui);
+    expect(screen.getByText('@threadplane/ag-ui · protocol adapter')).toBeTruthy();
+    expect(container.querySelector('.marker-highlight')?.textContent).toBe('work the day they ship');
+    expect(screen.getAllByRole('tablist').length).toBeGreaterThanOrEqual(1);
+    const cta = [...container.querySelectorAll('[data-ui="section"]')].find((s) =>
+      s.querySelector('.final-cta-inner'),
+    );
+    expect(cta?.getAttribute('data-surface')).toBe('dark');
+  });
+});

--- a/apps/website/src/app/ag-ui/page.tsx
+++ b/apps/website/src/app/ag-ui/page.tsx
@@ -4,11 +4,14 @@ import { Section } from '../../components/ui/Section';
 import { Eyebrow } from '../../components/ui/Eyebrow';
 import { Button } from '../../components/ui/Button';
 import { Pill } from '../../components/ui/Pill';
-import { BrowserFrame } from '../../components/ui/BrowserFrame';
 import { FeatureBlock } from '../../components/landing/FeatureBlock';
+import { WhitePaperBlock } from '../../components/landing/WhitePaperBlock';
 import { FinalCTA } from '../../components/landing/FinalCTA';
+import { MediumSwitcher } from '../../components/landing/MediumSwitcher';
 import { BackendsGrid } from '../../components/landing/ag-ui/BackendsGrid';
 import { createPageMetadata, SHORT_POSITIONING_DESCRIPTION } from '../../lib/site-metadata';
+import { SECTION_MEDIA } from '../../lib/section-media';
+import { buildPanes } from '../../lib/build-panes';
 
 export const metadata = createPageMetadata({
   title: '@threadplane/ag-ui — Threadplane',
@@ -18,18 +21,24 @@ export const metadata = createPageMetadata({
 });
 
 export default async function AgUiPage() {
+  const panes = await buildPanes(SECTION_MEDIA.libAgUi, SECTION_MEDIA.libAgUi.video?.url ?? '');
+
   return (
     <>
       {/* Hero */}
       <Section surface="canvas" ariaLabelledBy="ag-ui-hero-heading">
         <Container>
           <div className="ag-ui-page-hero-inner">
+            <div className="lib-hero-rail">
+              <Eyebrow tone="accent">@threadplane/ag-ui · protocol adapter</Eyebrow>
+              <span className="lib-hero-rail-line" aria-hidden="true" />
+            </div>
             <Eyebrow tone="accent" className="ag-ui-page-eyebrow-spaced">@threadplane/ag-ui</Eyebrow>
             <h1 id="ag-ui-hero-heading" className="ag-ui-page-h1">
               One adapter. Eight backends.
             </h1>
             <p className="ag-ui-page-hero-subtitle">
-              Build the Angular UI once, on the AG-UI protocol — eight runtimes speak it today, and new ones work the day they ship. History and checkpoint behavior stays with your backend.
+              Build the Angular UI once, on the AG-UI protocol — eight runtimes speak it today, and new ones <span className="marker-highlight">work the day they ship</span>. History and checkpoint behavior stays with your backend.
             </p>
             <div className="ag-ui-page-hero-buttons">
               <Button variant="primary" size="lg" href="/docs/ag-ui/getting-started/quickstart">Get started</Button>
@@ -80,35 +89,11 @@ export default async function AgUiPage() {
         ]}
         cta={{ label: 'API reference', href: '/docs/langgraph/api/inject-agent' }}
         visualLeft
-        visual={
-          <BrowserFrame url="app.config.ts" elevation="md">
-            <pre className="ag-ui-page-code-pre">
-{`import { provideAgent, injectAgent } from '@threadplane/ag-ui';
-import { ChatComponent } from '@threadplane/chat';
-
-// app.config.ts
-export const appConfig: ApplicationConfig = {
-  providers: [
-    provideAgent({
-      url: 'https://your.agent.endpoint',
-    }),
-  ],
-};
-
-// component
-@Component({
-  imports: [ChatComponent],
-  template: \`<chat [agent]="agent" />\`,
-})
-export class App {
-  protected readonly agent = injectAgent();
-}`}
-            </pre>
-          </BrowserFrame>
-        }
+        visual={<MediumSwitcher sectionId="lib-ag-ui" panes={panes} />}
       />
 
-      <FinalCTA />
+      <WhitePaperBlock paper="overview" />
+      <FinalCTA variant="dark" />
     </>
   );
 }

--- a/apps/website/src/app/ag-ui/page.tsx
+++ b/apps/website/src/app/ag-ui/page.tsx
@@ -29,7 +29,7 @@ export default async function AgUiPage() {
               One adapter. Eight backends.
             </h1>
             <p className="ag-ui-page-hero-subtitle">
-              Build an Angular agent UI on AG-UI-compatible runtimes including CrewAI, Mastra, Microsoft Agent Framework, AG2, Pydantic AI, AWS Strands, or LangGraph fronted by AG-UI. Same Agent contract and chat surface; runtime-specific history and checkpoint behavior stays with the backend.
+              Build the Angular UI once, on the AG-UI protocol — eight runtimes speak it today, and new ones work the day they ship. History and checkpoint behavior stays with your backend.
             </p>
             <div className="ag-ui-page-hero-buttons">
               <Button variant="primary" size="lg" href="/docs/ag-ui/getting-started/quickstart">Get started</Button>

--- a/apps/website/src/app/ag-ui/page.tsx
+++ b/apps/website/src/app/ag-ui/page.tsx
@@ -33,7 +33,6 @@ export default async function AgUiPage() {
               <Eyebrow tone="accent">@threadplane/ag-ui · protocol adapter</Eyebrow>
               <span className="lib-hero-rail-line" aria-hidden="true" />
             </div>
-            <Eyebrow tone="accent" className="ag-ui-page-eyebrow-spaced">@threadplane/ag-ui</Eyebrow>
             <h1 id="ag-ui-hero-heading" className="ag-ui-page-h1">
               One adapter. Eight backends.
             </h1>

--- a/apps/website/src/app/chat/page.spec.tsx
+++ b/apps/website/src/app/chat/page.spec.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import ChatPage from './page';
+
+vi.mock('../../lib/analytics/client', () => ({
+  track: vi.fn(),
+  trackCtaClick: vi.fn(),
+  trackExternalLinkClick: vi.fn(),
+  trackWhitepaperDownloadClick: vi.fn(),
+}));
+
+// The second FeatureBlock's showcase is an async Server Component (it awaits
+// shiki highlighting via HighlightedCode). react-dom/client cannot render an
+// async component at all outside Next's RSC pipeline ("Only Server
+// Components can be async at the moment") — stand in a sync placeholder so
+// the rest of the page (untouched by this task) can render in this harness.
+vi.mock('../../components/landing/chat-landing/ChatLandingCodeShowcase', () => ({
+  ChatLandingCodeShowcase: () => null,
+}));
+
+describe('ChatPage', () => {
+  it('renders the package kicker, marker sweep, switcher, and dark closer', async () => {
+    const ui = await ChatPage();
+    const { container } = render(ui);
+    expect(screen.getByText('@threadplane/chat · chat compositions')).toBeTruthy();
+    expect(container.querySelector('.marker-highlight')?.textContent).toBe('Production-shaped from day one');
+    expect(screen.getAllByRole('tablist').length).toBeGreaterThanOrEqual(1);
+    const cta = [...container.querySelectorAll('[data-ui="section"]')].find((s) =>
+      s.querySelector('.final-cta-inner'),
+    );
+    expect(cta?.getAttribute('data-surface')).toBe('dark');
+  });
+});

--- a/apps/website/src/app/chat/page.tsx
+++ b/apps/website/src/app/chat/page.tsx
@@ -3,12 +3,14 @@ import { Section } from '../../components/ui/Section';
 import { Eyebrow } from '../../components/ui/Eyebrow';
 import { Button } from '../../components/ui/Button';
 import { Pill } from '../../components/ui/Pill';
-import { BrowserFrame } from '../../components/ui/BrowserFrame';
 import { FeatureBlock } from '../../components/landing/FeatureBlock';
 import { WhitePaperBlock } from '../../components/landing/WhitePaperBlock';
 import { FinalCTA } from '../../components/landing/FinalCTA';
+import { MediumSwitcher } from '../../components/landing/MediumSwitcher';
 import { ChatLandingCodeShowcase } from '../../components/landing/chat-landing/ChatLandingCodeShowcase';
 import { createPageMetadata } from '../../lib/site-metadata';
+import { SECTION_MEDIA } from '../../lib/section-media';
+import { buildPanes } from '../../lib/build-panes';
 
 export const metadata = createPageMetadata({
   title: '@threadplane/chat — Batteries-Included Agent Chat for Angular',
@@ -18,18 +20,24 @@ export const metadata = createPageMetadata({
 });
 
 export default async function ChatPage() {
+  const panes = await buildPanes(SECTION_MEDIA.libChat, SECTION_MEDIA.libChat.video?.url ?? '');
+
   return (
     <>
       {/* Hero */}
       <Section surface="canvas" ariaLabelledBy="chat-hero-heading">
         <Container>
           <div className="chat-page-hero-inner">
+            <div className="lib-hero-rail">
+              <Eyebrow tone="accent">@threadplane/chat · chat compositions</Eyebrow>
+              <span className="lib-hero-rail-line" aria-hidden="true" />
+            </div>
             <Eyebrow tone="accent" className="chat-page-eyebrow-spaced">@threadplane/chat</Eyebrow>
             <h1 id="chat-hero-heading" className="chat-page-h1">
               Drop-in chat for Angular agents.
             </h1>
             <p className="chat-page-hero-subtitle">
-              chat-timeline + chat-debug + GenUI surfaces. Production-shaped from day one, themable to your design system, or use the headless primitives if you want full control.
+              chat-timeline + chat-debug + GenUI surfaces. <span className="marker-highlight">Production-shaped from day one</span>, themable to your design system, or use the headless primitives if you want full control.
             </p>
             <div className="chat-page-hero-buttons">
               <Button variant="primary" size="lg" href="/docs/chat/getting-started/introduction">Get started</Button>
@@ -57,26 +65,7 @@ export default async function ChatPage() {
           { claim: 'Thread navigation and history search', api: 'sidenav + palette' },
         ]}
         cta={{ label: 'See @threadplane/chat docs', href: '/docs/chat/getting-started/introduction' }}
-        visual={
-          <BrowserFrame url="cockpit.threadplane.ai/chat/core-capabilities/debug/overview/python" elevation="md">
-            <div className="chat-page-visual-panel">
-              <div className="chat-page-visual-pills-row">
-                <Pill variant="accent">streaming</Pill>
-                <Pill variant="neutral">3 tools</Pill>
-                <Pill variant="neutral">1 interrupt</Pill>
-              </div>
-              <div className="chat-page-tool-label">
-                tool · query_inventory · 240ms
-              </div>
-              <div className="chat-page-result-block">
-                {`{ items: 47, low_stock: 3, total_value: 12400 }`}
-              </div>
-              <div className="chat-page-replay-footer">
-                replay · 0:24 · paused on interrupt
-              </div>
-            </div>
-          </BrowserFrame>
-        }
+        visual={<MediumSwitcher sectionId="lib-chat" panes={panes} />}
       />
 
       <FeatureBlock
@@ -95,7 +84,7 @@ export default async function ChatPage() {
       />
 
       <WhitePaperBlock paper="chat" />
-      <FinalCTA />
+      <FinalCTA variant="dark" />
     </>
   );
 }

--- a/apps/website/src/app/chat/page.tsx
+++ b/apps/website/src/app/chat/page.tsx
@@ -32,7 +32,6 @@ export default async function ChatPage() {
               <Eyebrow tone="accent">@threadplane/chat · chat compositions</Eyebrow>
               <span className="lib-hero-rail-line" aria-hidden="true" />
             </div>
-            <Eyebrow tone="accent" className="chat-page-eyebrow-spaced">@threadplane/chat</Eyebrow>
             <h1 id="chat-hero-heading" className="chat-page-h1">
               Drop-in chat for Angular agents.
             </h1>

--- a/apps/website/src/app/langgraph/page.spec.tsx
+++ b/apps/website/src/app/langgraph/page.spec.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import LangGraphPage from './page';
+
+vi.mock('../../lib/analytics/client', () => ({
+  track: vi.fn(),
+  trackCtaClick: vi.fn(),
+  trackExternalLinkClick: vi.fn(),
+  trackWhitepaperDownloadClick: vi.fn(),
+}));
+
+// The second FeatureBlock's showcase is an async Server Component (it awaits
+// shiki highlighting via HighlightedCode). react-dom/client cannot render an
+// async component at all outside Next's RSC pipeline ("Only Server
+// Components can be async at the moment") — stand in a sync placeholder so
+// the rest of the page (untouched by this task) can render in this harness.
+vi.mock('../../components/landing/langgraph/LangGraphCodeShowcase', () => ({
+  LangGraphCodeShowcase: () => null,
+}));
+
+describe('LangGraphPage', () => {
+  it('renders the package kicker, marker sweep, switcher, and dark closer', async () => {
+    const ui = await LangGraphPage();
+    const { container } = render(ui);
+    expect(screen.getByText('@threadplane/langgraph · LangGraph adapter')).toBeTruthy();
+    expect(container.querySelector('.marker-highlight')?.textContent).toBe('humans stay in the loop');
+    expect(screen.getAllByRole('tablist').length).toBeGreaterThanOrEqual(1);
+    const cta = [...container.querySelectorAll('[data-ui="section"]')].find((s) =>
+      s.querySelector('.final-cta-inner'),
+    );
+    expect(cta?.getAttribute('data-surface')).toBe('dark');
+  });
+});

--- a/apps/website/src/app/langgraph/page.tsx
+++ b/apps/website/src/app/langgraph/page.tsx
@@ -32,7 +32,6 @@ export default async function LangGraphPage() {
               <Eyebrow tone="accent">@threadplane/langgraph · LangGraph adapter</Eyebrow>
               <span className="lib-hero-rail-line" aria-hidden="true" />
             </div>
-            <Eyebrow tone="angular" className="langgraph-page-eyebrow-spaced">@threadplane/langgraph</Eyebrow>
             <h1 id="angular-hero-heading" className="langgraph-page-h1">
               LangGraph agent UI for Angular.
             </h1>

--- a/apps/website/src/app/langgraph/page.tsx
+++ b/apps/website/src/app/langgraph/page.tsx
@@ -29,7 +29,7 @@ export default async function LangGraphPage() {
               LangGraph agent UI for Angular.
             </h1>
             <p className="langgraph-page-hero-subtitle">
-              Ship LangGraph agents inside your Angular 20–22 app with headless chat, durable threads, interrupts, branch/history, tool progress, and generative UI.
+              Ship LangGraph agents inside your Angular app. Agent state arrives as signals; threads survive reloads; humans stay in the loop.
             </p>
             <div className="langgraph-page-hero-buttons">
               <Button variant="primary" size="lg" href="/docs/langgraph/getting-started/introduction">Get started</Button>

--- a/apps/website/src/app/langgraph/page.tsx
+++ b/apps/website/src/app/langgraph/page.tsx
@@ -3,12 +3,14 @@ import { Section } from '../../components/ui/Section';
 import { Eyebrow } from '../../components/ui/Eyebrow';
 import { Button } from '../../components/ui/Button';
 import { Pill } from '../../components/ui/Pill';
-import { BrowserFrame } from '../../components/ui/BrowserFrame';
 import { FeatureBlock } from '../../components/landing/FeatureBlock';
 import { WhitePaperBlock } from '../../components/landing/WhitePaperBlock';
 import { FinalCTA } from '../../components/landing/FinalCTA';
+import { MediumSwitcher } from '../../components/landing/MediumSwitcher';
 import { LangGraphCodeShowcase } from '../../components/landing/langgraph/LangGraphCodeShowcase';
 import { createPageMetadata, SHORT_POSITIONING_DESCRIPTION } from '../../lib/site-metadata';
+import { SECTION_MEDIA } from '../../lib/section-media';
+import { buildPanes } from '../../lib/build-panes';
 
 export const metadata = createPageMetadata({
   title: '@threadplane/langgraph — Threadplane',
@@ -18,18 +20,24 @@ export const metadata = createPageMetadata({
 });
 
 export default async function LangGraphPage() {
+  const panes = await buildPanes(SECTION_MEDIA.libLanggraph, SECTION_MEDIA.libLanggraph.video?.url ?? '');
+
   return (
     <>
       {/* Hero */}
       <Section surface="canvas" ariaLabelledBy="angular-hero-heading">
         <Container>
           <div className="langgraph-page-hero-inner">
+            <div className="lib-hero-rail">
+              <Eyebrow tone="accent">@threadplane/langgraph · LangGraph adapter</Eyebrow>
+              <span className="lib-hero-rail-line" aria-hidden="true" />
+            </div>
             <Eyebrow tone="angular" className="langgraph-page-eyebrow-spaced">@threadplane/langgraph</Eyebrow>
             <h1 id="angular-hero-heading" className="langgraph-page-h1">
               LangGraph agent UI for Angular.
             </h1>
             <p className="langgraph-page-hero-subtitle">
-              Ship LangGraph agents inside your Angular app. Agent state arrives as signals; threads survive reloads; humans stay in the loop.
+              Ship LangGraph agents inside your Angular app. Agent state arrives as signals; threads survive reloads; <span className="marker-highlight">humans stay in the loop</span>.
             </p>
             <div className="langgraph-page-hero-buttons">
               <Button variant="primary" size="lg" href="/docs/langgraph/getting-started/introduction">Get started</Button>
@@ -58,29 +66,7 @@ export default async function LangGraphPage() {
           { claim: 'Deterministic tests without a backend', api: 'MockAgentTransport' },
         ]}
         cta={{ label: 'API reference', href: '/docs/langgraph/api/inject-agent' }}
-        visual={
-          <BrowserFrame url="app.config.ts" elevation="md">
-            <pre className="langgraph-page-code-pre">
-{`import { provideAgent } from '@threadplane/langgraph';
-
-export const appConfig: ApplicationConfig = {
-  providers: [
-    provideAgent({
-      apiUrl: '/agent',
-      assistantId: 'my-agent',
-    }),
-  ],
-};
-
-// any component
-export class ChatComponent {
-  agent = injectAgent();
-  messages = this.agent.messages;
-  status = this.agent.status;
-}`}
-            </pre>
-          </BrowserFrame>
-        }
+        visual={<MediumSwitcher sectionId="lib-langgraph" panes={panes} />}
       />
 
       <FeatureBlock
@@ -99,7 +85,7 @@ export class ChatComponent {
       />
 
       <WhitePaperBlock paper="angular" />
-      <FinalCTA />
+      <FinalCTA variant="dark" />
     </>
   );
 }

--- a/apps/website/src/app/page.tsx
+++ b/apps/website/src/app/page.tsx
@@ -2,14 +2,10 @@ import { Hero } from '../components/landing/Hero';
 import { LogoRibbon } from '../components/landing/LogoRibbon';
 import { YesWall } from '../components/landing/YesWall';
 import { FeatureBlock } from '../components/landing/FeatureBlock';
-import { BrowserFrame } from '../components/ui/BrowserFrame';
-import { ClipPlayer } from '../components/ui/ClipPlayer';
 import { DemoShowcase } from '../components/landing/DemoShowcase';
 import { MediumSwitcher } from '../components/landing/MediumSwitcher';
-import type { MediumPane } from '../components/landing/MediumSwitcher';
-import { HighlightedCode } from '../components/landing/HighlightedCode';
 import { SECTION_MEDIA } from '../lib/section-media';
-import type { SectionMedia } from '../lib/section-media';
+import { buildPanes } from '../lib/build-panes';
 import { PilotBlock } from '../components/landing/PilotBlock';
 import { ProofStrip } from '../components/landing/ProofStrip';
 import { WhitePaperBlock } from '../components/landing/WhitePaperBlock';
@@ -27,73 +23,6 @@ export const metadata = createPageMetadata({
   pathname: '/',
   type: 'website',
 });
-
-/**
- * Builds the panes for a section on the SERVER.
- *
- * `HighlightedCode` is an async Server Component, so it cannot be rendered from
- * inside the client `MediumSwitcher`. Highlighting here and passing the result
- * as a prop is what makes the code tab possible at all.
- */
-async function buildPanes(media: SectionMedia, clipUrl: string): Promise<MediumPane[]> {
-  // Typed, not inferred: `const panes = []` is `any[]` under this tsconfig and
-  // fails the production build's type check.
-  const panes: MediumPane[] = [];
-
-  if (media.video) {
-    const clip = media.video;
-    panes.push({
-      id: 'video',
-      key: 'video',
-      label: 'Video',
-      content: <ClipPlayer clip={clip} url={clipUrl} />,
-    });
-  }
-
-  const codeBlocks = media.code ?? [];
-  codeBlocks.forEach((block, index) => {
-    panes.push({
-      id: `code-${index}`,
-      key: 'code',
-      label: codeBlocks.length > 1 ? block.label : 'Code',
-      content: (
-        <div className="home-code-frame">
-          <HighlightedCode code={block.source} lang={block.language} />
-        </div>
-      ),
-    });
-  });
-
-  if (media.live) {
-    const mode = media.live.mode ?? 'embed';
-    panes.push({
-      id: 'live',
-      key: 'live',
-      label: 'Live',
-      content: (
-        <BrowserFrame url={clipUrl} elevation="lg">
-          <div className="home-live-frame">
-            {/*
-              Mounted only when its tab is selected — `MediumSwitcher` renders
-              one pane at a time, so this iframe is never requested on page load.
-              `?featured=` opens the demo on this section's own scenario; the id
-              is a key into the demo's curated list, so an unknown one falls back
-              rather than rendering anything this URL supplies.
-            */}
-            <iframe
-              src={`https://demo.threadplane.ai/${mode}?featured=${encodeURIComponent(media.live.featured)}`}
-              title="Threadplane live demo"
-              loading="lazy"
-              className="home-live-iframe"
-            />
-          </div>
-        </BrowserFrame>
-      ),
-    });
-  }
-
-  return panes;
-}
 
 export default async function HomePage() {
   const [streamPanes, renderPanes, shipPanes, approvePanes] = await Promise.all(

--- a/apps/website/src/app/render/page.spec.tsx
+++ b/apps/website/src/app/render/page.spec.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import RenderPage from './page';
+
+vi.mock('../../lib/analytics/client', () => ({
+  track: vi.fn(),
+  trackCtaClick: vi.fn(),
+  trackExternalLinkClick: vi.fn(),
+  trackWhitepaperDownloadClick: vi.fn(),
+}));
+
+// The second FeatureBlock's showcase is an async Server Component (it awaits
+// shiki highlighting via HighlightedCode). react-dom/client cannot render an
+// async component at all outside Next's RSC pipeline ("Only Server
+// Components can be async at the moment") — stand in a sync placeholder so
+// the rest of the page (untouched by this task) can render in this harness.
+vi.mock('../../components/landing/render/RenderCodeShowcase', () => ({
+  RenderCodeShowcase: () => null,
+}));
+
+describe('RenderPage', () => {
+  it('renders the package kicker, marker sweep, switcher, and dark closer', async () => {
+    const ui = await RenderPage();
+    const { container } = render(ui);
+    expect(screen.getByText('@threadplane/render · generative UI')).toBeTruthy();
+    expect(container.querySelector('.marker-highlight')?.textContent).toBe('components you already own');
+    expect(screen.getAllByRole('tablist').length).toBeGreaterThanOrEqual(1);
+    const cta = [...container.querySelectorAll('[data-ui="section"]')].find((s) =>
+      s.querySelector('.final-cta-inner'),
+    );
+    expect(cta?.getAttribute('data-surface')).toBe('dark');
+  });
+});

--- a/apps/website/src/app/render/page.tsx
+++ b/apps/website/src/app/render/page.tsx
@@ -3,12 +3,14 @@ import { Section } from '../../components/ui/Section';
 import { Eyebrow } from '../../components/ui/Eyebrow';
 import { Button } from '../../components/ui/Button';
 import { Pill } from '../../components/ui/Pill';
-import { BrowserFrame } from '../../components/ui/BrowserFrame';
 import { FeatureBlock } from '../../components/landing/FeatureBlock';
 import { WhitePaperBlock } from '../../components/landing/WhitePaperBlock';
 import { FinalCTA } from '../../components/landing/FinalCTA';
+import { MediumSwitcher } from '../../components/landing/MediumSwitcher';
 import { RenderCodeShowcase } from '../../components/landing/render/RenderCodeShowcase';
 import { createPageMetadata } from '../../lib/site-metadata';
+import { SECTION_MEDIA } from '../../lib/section-media';
+import { buildPanes } from '../../lib/build-panes';
 
 export const metadata = createPageMetadata({
   title: '@threadplane/render — Generative UI for Angular',
@@ -18,18 +20,24 @@ export const metadata = createPageMetadata({
 });
 
 export default async function RenderPage() {
+  const panes = await buildPanes(SECTION_MEDIA.libRender, SECTION_MEDIA.libRender.video?.url ?? '');
+
   return (
     <>
       {/* Hero */}
       <Section surface="canvas" ariaLabelledBy="render-hero-heading">
         <Container>
           <div className="render-page-hero-inner">
+            <div className="lib-hero-rail">
+              <Eyebrow tone="accent">@threadplane/render · generative UI</Eyebrow>
+              <span className="lib-hero-rail-line" aria-hidden="true" />
+            </div>
             <Eyebrow tone="accent" className="render-page-eyebrow-spaced">@threadplane/render</Eyebrow>
             <h1 id="render-hero-heading" className="render-page-h1">
               Generative UI without a second framework.
             </h1>
             <p className="render-page-hero-subtitle">
-              Server-emitted JSON specs render into Angular components you already own. Vercel json-render and Google A2UI both supported. Per-component fallback, readiness gate, no surprises.
+              Server-emitted JSON specs render into Angular <span className="marker-highlight">components you already own</span>. Vercel json-render and Google A2UI both supported. Per-component fallback, readiness gate, no surprises.
             </p>
             <div className="render-page-hero-buttons">
               <Button variant="primary" size="lg" href="/docs/render/getting-started/introduction">Get started</Button>
@@ -55,31 +63,7 @@ export default async function RenderPage() {
           { claim: 'Schema on the server, validation in the client', api: 'validated specs' },
         ]}
         cta={{ label: 'See @threadplane/render docs', href: '/docs/render/getting-started/introduction' }}
-        visual={
-          <BrowserFrame url="render · spec → component" elevation="md">
-            <div className="render-page-visual-panel">
-              <div className="render-page-spec-block">
-{`{
-  "type": "card",
-  "props": {
-    "title": "Q3 revenue",
-    "value": "$4.2M",
-    "delta": "+18%"
-  }
-}`}
-              </div>
-              <div className="render-page-rendered-card">
-                <div className="render-page-ai-label">
-                  AI-rendered · YourCardComponent
-                </div>
-                <div className="render-page-card-title">
-                  Q3 revenue: $4.2M
-                </div>
-                <div className="render-page-card-value">+18% vs Q2</div>
-              </div>
-            </div>
-          </BrowserFrame>
-        }
+        visual={<MediumSwitcher sectionId="lib-render" panes={panes} />}
       />
 
       <FeatureBlock
@@ -98,7 +82,7 @@ export default async function RenderPage() {
       />
 
       <WhitePaperBlock paper="render" />
-      <FinalCTA />
+      <FinalCTA variant="dark" />
     </>
   );
 }

--- a/apps/website/src/app/render/page.tsx
+++ b/apps/website/src/app/render/page.tsx
@@ -32,7 +32,6 @@ export default async function RenderPage() {
               <Eyebrow tone="accent">@threadplane/render · generative UI</Eyebrow>
               <span className="lib-hero-rail-line" aria-hidden="true" />
             </div>
-            <Eyebrow tone="accent" className="render-page-eyebrow-spaced">@threadplane/render</Eyebrow>
             <h1 id="render-hero-heading" className="render-page-h1">
               Generative UI without a second framework.
             </h1>

--- a/apps/website/src/components/landing/FinalCTA.spec.tsx
+++ b/apps/website/src/components/landing/FinalCTA.spec.tsx
@@ -11,7 +11,7 @@ vi.mock('../../lib/analytics/client', () => ({
 }));
 
 describe('FinalCTA', () => {
-  it('defaults to the tinted surface (used by 8 non-home pages)', () => {
+  it('defaults to the tinted surface (used by 4 non-home pages)', () => {
     const { container } = render(<FinalCTA />);
     expect(
       container.querySelector('[data-ui="section"]')?.getAttribute('data-surface'),

--- a/apps/website/src/lib/build-panes.tsx
+++ b/apps/website/src/lib/build-panes.tsx
@@ -1,0 +1,72 @@
+import { BrowserFrame } from '../components/ui/BrowserFrame';
+import { ClipPlayer } from '../components/ui/ClipPlayer';
+import { HighlightedCode } from '../components/landing/HighlightedCode';
+import type { MediumPane } from '../components/landing/MediumSwitcher';
+import type { SectionMedia } from './section-media';
+
+/**
+ * Builds the panes for a section on the SERVER.
+ *
+ * `HighlightedCode` is an async Server Component, so it cannot be rendered from
+ * inside the client `MediumSwitcher`. Highlighting here and passing the result
+ * as a prop is what makes the code tab possible at all.
+ */
+export async function buildPanes(media: SectionMedia, clipUrl: string): Promise<MediumPane[]> {
+  // Typed, not inferred: `const panes = []` is `any[]` under this tsconfig and
+  // fails the production build's type check.
+  const panes: MediumPane[] = [];
+
+  if (media.video) {
+    const clip = media.video;
+    panes.push({
+      id: 'video',
+      key: 'video',
+      label: 'Video',
+      content: <ClipPlayer clip={clip} url={clipUrl} />,
+    });
+  }
+
+  const codeBlocks = media.code ?? [];
+  codeBlocks.forEach((block, index) => {
+    panes.push({
+      id: `code-${index}`,
+      key: 'code',
+      label: codeBlocks.length > 1 ? block.label : 'Code',
+      content: (
+        <div className="home-code-frame">
+          <HighlightedCode code={block.source} lang={block.language} />
+        </div>
+      ),
+    });
+  });
+
+  if (media.live) {
+    const mode = media.live.mode ?? 'embed';
+    panes.push({
+      id: 'live',
+      key: 'live',
+      label: 'Live',
+      content: (
+        <BrowserFrame url={clipUrl} elevation="lg">
+          <div className="home-live-frame">
+            {/*
+              Mounted only when its tab is selected — `MediumSwitcher` renders
+              one pane at a time, so this iframe is never requested on page load.
+              `?featured=` opens the demo on this section's own scenario; the id
+              is a key into the demo's curated list, so an unknown one falls back
+              rather than rendering anything this URL supplies.
+            */}
+            <iframe
+              src={`https://demo.threadplane.ai/${mode}?featured=${encodeURIComponent(media.live.featured)}`}
+              title="Threadplane live demo"
+              loading="lazy"
+              className="home-live-iframe"
+            />
+          </div>
+        </BrowserFrame>
+      ),
+    });
+  }
+
+  return panes;
+}

--- a/apps/website/src/lib/section-media.ts
+++ b/apps/website/src/lib/section-media.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-import { HITL_CLIP, LANGGRAPH_CLIP, RENDER_CLIP, SHIP_CLIP, type DemoClip } from './demo-media';
+import { AG_UI_CLIP, HITL_CLIP, LANGGRAPH_CLIP, RENDER_CLIP, SHIP_CLIP, type DemoClip } from './demo-media';
 import type { SolutionCodeBlocks } from './solutions-data';
 
 /**
@@ -23,7 +23,10 @@ export interface SectionMedia {
   live?: { featured: string; mode?: 'embed' | 'popup' | 'sidebar' };
 }
 
-export const SECTION_MEDIA: Record<'stream' | 'render' | 'ship' | 'approve', SectionMedia> = {
+export const SECTION_MEDIA: Record<
+  'stream' | 'render' | 'ship' | 'approve' | 'libLanggraph' | 'libChat' | 'libAgUi' | 'libRender',
+  SectionMedia
+> = {
   stream: {
     video: LANGGRAPH_CLIP,
     live: { featured: 'tell-me-about-coral' },
@@ -103,6 +106,94 @@ const catalog = views({
 
   reject(reason: string) {
     this.agent.submit({ resume: { approved: false, reason } });
+  }
+}`,
+      },
+    ],
+  },
+
+  // The four library pages (/langgraph, /chat, /ag-ui, /render) reuse this
+  // table for their first FeatureBlock's medium switcher. Code sources below
+  // are lifted verbatim from each page's current static mock content — Task
+  // 3 of the library-pages plan deletes those page-local copies once the
+  // switcher is wired in, so for now the same source lives in both places.
+  libLanggraph: {
+    video: LANGGRAPH_CLIP,
+    live: { featured: 'tell-me-about-coral' },
+    code: [
+      {
+        label: 'app.config.ts',
+        language: 'typescript',
+        source: `import { provideAgent } from '@threadplane/langgraph';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideAgent({
+      apiUrl: '/agent',
+      assistantId: 'my-agent',
+    }),
+  ],
+};
+
+// any component
+export class ChatComponent {
+  agent = injectAgent();
+  messages = this.agent.messages;
+  status = this.agent.status;
+}`,
+      },
+    ],
+  },
+  libChat: {
+    video: SHIP_CLIP,
+    live: { featured: 'tell-me-about-coral' },
+    // No code pane: the /chat page's first FeatureBlock mocks a chat-debug
+    // panel (pills, tool call, replay footer), not a source snippet.
+  },
+  libAgUi: {
+    video: AG_UI_CLIP,
+    // No live tab: the demo host speaks LangGraph, and wiring AG-UI into it
+    // live is out of scope for this arc.
+    code: [
+      {
+        label: 'app.config.ts',
+        language: 'typescript',
+        source: `import { provideAgent, injectAgent } from '@threadplane/ag-ui';
+import { ChatComponent } from '@threadplane/chat';
+
+// app.config.ts
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideAgent({
+      url: 'https://your.agent.endpoint',
+    }),
+  ],
+};
+
+// component
+@Component({
+  imports: [ChatComponent],
+  template: \`<chat [agent]="agent" />\`,
+})
+export class App {
+  protected readonly agent = injectAgent();
+}`,
+      },
+    ],
+  },
+  libRender: {
+    video: RENDER_CLIP,
+    live: { featured: 'generative-ui-contact-form' },
+    code: [
+      {
+        label: 'render · spec → component',
+        language: 'typescript',
+        source: `{
+  "type": "card",
+  "props": {
+    "title": "Q3 revenue",
+    "value": "$4.2M",
+    "delta": "+18%"
   }
 }`,
       },

--- a/apps/website/src/lib/section-media.ts
+++ b/apps/website/src/lib/section-media.ts
@@ -113,10 +113,10 @@ const catalog = views({
   },
 
   // The four library pages (/langgraph, /chat, /ag-ui, /render) reuse this
-  // table for their first FeatureBlock's medium switcher. Code sources below
-  // are lifted verbatim from each page's current static mock content — Task
-  // 3 of the library-pages plan deletes those page-local copies once the
-  // switcher is wired in, so for now the same source lives in both places.
+  // table for their first FeatureBlock's medium switcher — except /ag-ui,
+  // whose switcher replaces its SECOND block's mock (see libAgUi below). The
+  // pages consume these entries via buildPanes; the page-local static mocks
+  // they were lifted from are gone.
   libLanggraph: {
     video: LANGGRAPH_CLIP,
     live: { featured: 'tell-me-about-coral' },
@@ -153,7 +153,9 @@ export class ChatComponent {
   libAgUi: {
     video: AG_UI_CLIP,
     // No live tab: the demo host speaks LangGraph, and wiring AG-UI into it
-    // live is out of scope for this arc.
+    // live is out of scope for this arc. Unlike the other three pages, this
+    // switcher lands on /ag-ui's SECOND FeatureBlock — its first block's
+    // visual is the real BackendsGrid, not a mock.
     code: [
       {
         label: 'app.config.ts',
@@ -186,7 +188,9 @@ export class App {
     live: { featured: 'generative-ui-contact-form' },
     code: [
       {
-        label: 'render · spec → component',
+        // 'json' isn't in SolutionCode's language union (typescript | python
+        // | html), so this stays tagged typescript for Shiki highlighting.
+        label: 'spec.json',
         language: 'typescript',
         source: `{
   "type": "card",

--- a/apps/website/src/styles/pages.css
+++ b/apps/website/src/styles/pages.css
@@ -9,6 +9,19 @@
  * Migration: docs/superpowers/plans/2026-08-29-inline-style-substrate-migration.md
  */
 
+/* Library pages hero kicker rail — shared by app/{langgraph,chat,ag-ui,render}/page.tsx */
+.lib-hero-rail {
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
+  margin-bottom: 16px;
+}
+.lib-hero-rail-line {
+  flex: 1;
+  height: 1px;
+  background: var(--color-border);
+}
+
 /* Docs index page — app/docs/page.tsx */
 .docs-index-hero-inner {
   max-width: 720px;
@@ -718,46 +731,6 @@
   gap: 8px;
   flex-wrap: wrap;
 }
-.render-page-visual-panel {
-  padding: 24px;
-  min-height: 320px;
-  background: var(--color-surface);
-}
-.render-page-spec-block {
-  background: var(--color-surface-tinted);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  padding: 12px;
-  margin-bottom: 12px;
-  font-family: var(--font-mono);
-  font-size: 11px;
-  color: var(--color-text-secondary);
-  white-space: pre;
-}
-.render-page-rendered-card {
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  padding: 16px;
-}
-.render-page-ai-label {
-  font-family: var(--font-mono);
-  font-size: 11px;
-  color: var(--color-accent);
-  margin-bottom: 8px;
-}
-.render-page-card-title {
-  font-family: var(--font-garamond);
-  font-size: 18px;
-  font-weight: 700;
-  color: var(--color-text-primary);
-  margin-bottom: 4px;
-}
-.render-page-card-value {
-  font-size: 13px;
-  color: var(--color-text-secondary);
-}
-
 /* Chat landing page — app/chat/page.tsx */
 .chat-page-hero-inner {
   max-width: 820px;
@@ -798,40 +771,6 @@
   gap: 8px;
   flex-wrap: wrap;
 }
-.chat-page-visual-panel {
-  padding: 24px;
-  min-height: 320px;
-  background: linear-gradient(180deg, #fff, #f8fafc);
-}
-.chat-page-visual-pills-row {
-  display: flex;
-  gap: 8px;
-  margin-bottom: 16px;
-}
-.chat-page-tool-label {
-  font-family: var(--font-mono);
-  font-size: 11px;
-  color: var(--color-text-muted);
-  margin-bottom: 8px;
-}
-.chat-page-result-block {
-  background: var(--color-surface-tinted);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  padding: 12px;
-  font-family: var(--font-mono);
-  font-size: 12px;
-  color: var(--color-text-primary);
-}
-.chat-page-replay-footer {
-  margin-top: 16px;
-  padding-top: 12px;
-  border-top: 1px solid var(--color-border);
-  font-family: var(--font-mono);
-  font-size: 11px;
-  color: var(--color-text-secondary);
-}
-
 /* AG-UI landing page — app/ag-ui/page.tsx */
 .ag-ui-page-hero-inner {
   max-width: 820px;
@@ -893,18 +832,6 @@
   text-decoration: none;
   font-weight: 600;
 }
-.ag-ui-page-code-pre {
-  margin: 0;
-  padding: 20px 22px;
-  background: #1a1b26;
-  color: #a9b1d6;
-  font-family: var(--font-mono);
-  font-size: 13px;
-  line-height: 1.6;
-  min-height: 320px;
-  overflow: auto;
-}
-
 /* LangGraph landing page — app/langgraph/page.tsx */
 .langgraph-page-hero-inner {
   max-width: 820px;
@@ -953,18 +880,6 @@
   gap: 8px;
   flex-wrap: wrap;
 }
-.langgraph-page-code-pre {
-  margin: 0;
-  padding: 20px 22px;
-  background: #1a1b26;
-  color: #a9b1d6;
-  font-family: var(--font-mono);
-  font-size: 13px;
-  line-height: 1.6;
-  min-height: 320px;
-  overflow: auto;
-}
-
 /* Blog index page — app/blog/page.tsx */
 .blog-index-page {
   padding-top: 80px;

--- a/apps/website/src/styles/pages.css
+++ b/apps/website/src/styles/pages.css
@@ -697,9 +697,6 @@
   margin: 0 auto;
   text-align: center;
 }
-.render-page-eyebrow-spaced {
-  margin-bottom: 16px;
-}
 .render-page-h1 {
   font-family: var(--font-garamond);
   font-size: var(--text-h1);
@@ -737,9 +734,6 @@
   margin: 0 auto;
   text-align: center;
 }
-.chat-page-eyebrow-spaced {
-  margin-bottom: 16px;
-}
 .chat-page-h1 {
   font-family: var(--font-garamond);
   font-size: var(--text-h1);
@@ -776,9 +770,6 @@
   max-width: 820px;
   margin: 0 auto;
   text-align: center;
-}
-.ag-ui-page-eyebrow-spaced {
-  margin-bottom: 16px;
 }
 .ag-ui-page-h1 {
   font-family: var(--font-garamond);
@@ -837,9 +828,6 @@
   max-width: 820px;
   margin: 0 auto;
   text-align: center;
-}
-.langgraph-page-eyebrow-spaced {
-  margin-bottom: 16px;
 }
 .langgraph-page-h1 {
   font-family: var(--font-garamond);

--- a/docs/superpowers/plans/2026-08-31-library-pages.md
+++ b/docs/superpowers/plans/2026-08-31-library-pages.md
@@ -1,0 +1,126 @@
+# Library Pages Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring `/langgraph`, `/chat`, `/ag-ui`, `/render` into the homepage manner per `docs/superpowers/specs/2026-08-31-library-pages-design.md`: medium switchers on each first FeatureBlock, dark FinalCTA closers, package-kicker heroes with marker sweeps, WhitePaperBlock parity on /ag-ui.
+
+**Architecture:** Next.js 16 / React 19. `buildPanes` is currently page-local in `app/page.tsx` — Task 1 extracts it to a shared module (it renders `HighlightedCode`, an async Server Component, so the shared module stays server-only TSX). `SECTION_MEDIA` in `lib/section-media.ts` is the single media config; its spec auto-validates entries (video URLs, live `featured` ids cross-checked off disk). UNLAYERED CSS; the marker/rail/dark devices all exist.
+
+**Test command:** `cd apps/website && npx vitest run --config vite.config.mts` — baseline ALL GREEN (48/390).
+**Branch:** `blove/library-pages`, expected starting HEAD `56a76a1f` or descendant.
+
+---
+
+### Task 1: Extract `buildPanes` to a shared module
+
+**Files:**
+- Create: `apps/website/src/lib/build-panes.tsx`
+- Modify: `apps/website/src/app/page.tsx`
+
+- [ ] **Step 1:** Move the `buildPanes` function (and ONLY it, with its doc comment) from `app/page.tsx` into `apps/website/src/lib/build-panes.tsx`, exporting it. Move the imports it needs (`ClipPlayer`, `BrowserFrame`, `HighlightedCode`, `MediumPane` type, `SectionMedia` type); adjust relative paths. `page.tsx` imports `{ buildPanes }` from `'../lib/build-panes'` and deletes its local copy + now-unused imports (check each: BrowserFrame/ClipPlayer/HighlightedCode may have no other use in page.tsx — remove only if unused).
+- [ ] **Step 2:** Full suite + `npx nx build website --configuration=production` (async-server-component extraction is exactly the kind of thing only the prod build catches). Both green — paste evidence.
+- [ ] **Step 3:** Commit: `git add apps/website/src && git commit -m "refactor(website): extract buildPanes for reuse by library pages"`
+
+---
+
+### Task 2: `SECTION_MEDIA` library entries
+
+**Files:**
+- Modify: `apps/website/src/lib/section-media.ts`
+- Possibly: `apps/website/src/lib/section-media.spec.ts` (only if it pins the key set)
+
+- [ ] **Step 1:** Read `section-media.ts` fully (types, `SolutionCodeBlocks` shape, how the four homepage entries structure `code`). Read `section-media.spec.ts` — if it asserts an exact key list, extend that list.
+- [ ] **Step 2:** Add four entries. Video/live per the spec's table (`libLanggraph`: LANGGRAPH_CLIP + `tell-me-about-coral`; `libChat`: SHIP_CLIP + `tell-me-about-coral`, NO code; `libAgUi`: AG_UI_CLIP, NO live; `libRender`: RENDER_CLIP + `generative-ui-contact-form`). The `code` sources are lifted VERBATIM from each page's current static `<pre>` content: `/langgraph` page lines ~63–80 (the provideAgent/injectAgent app.config.ts block, language `ts`, label `app.config.ts`); `/ag-ui` page's app.config.ts block; `/render` page's spec→component block (read it — if it is JSON+ts, split into labeled blocks the way homepage entries do, or one block; keep it faithful). `/chat` gets no code pane (its mock is a fake UI panel, not code).
+- [ ] **Step 3:** Run `section-media.spec` → PASS (it validates the new entries' clips + featured ids). Full suite green. Paste evidence.
+- [ ] **Step 4:** Commit: `feat(website): section media for the library pages`
+
+---
+
+### Task 3: The four pages adopt the manner
+
+**Files:**
+- Modify: `apps/website/src/app/{langgraph,chat,ag-ui,render}/page.tsx`
+- Create: `apps/website/src/app/{langgraph,chat,ag-ui,render}/page.spec.tsx` (four minimal specs)
+- Modify: `apps/website/src/styles/pages.css` (hero kicker rails — the library hero classes live there; grep to confirm)
+
+Per page (repeat 4×, one commit at the end):
+
+- [ ] **Step 1: Page spec FIRST** (each fails before the page change). Template per page — adapt literals:
+
+```tsx
+// apps/website/src/app/langgraph/page.spec.tsx
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import LangGraphPage from './page';
+
+vi.mock('../../lib/analytics/client', () => ({
+  track: vi.fn(),
+  trackCtaClick: vi.fn(),
+  trackExternalLinkClick: vi.fn(),
+  trackWhitepaperDownloadClick: vi.fn(),
+}));
+
+describe('LangGraphPage', () => {
+  it('renders the package kicker, marker sweep, switcher, and dark closer', async () => {
+    const ui = await LangGraphPage();
+    const { container } = render(ui);
+    expect(screen.getByText('@threadplane/langgraph · LangGraph adapter')).toBeTruthy();
+    expect(container.querySelector('.marker-highlight')?.textContent).toBe('humans stay in the loop');
+    expect(screen.getAllByRole('tablist').length).toBeGreaterThanOrEqual(1);
+    const cta = [...container.querySelectorAll('[data-ui="section"]')].find((s) =>
+      s.querySelector('.final-cta-inner'),
+    );
+    expect(cta?.getAttribute('data-surface')).toBe('dark');
+  });
+});
+```
+
+The pages are async server components (`buildPanes` await) after this change — hence `await LangGraphPage()`. If the current pages are sync, they become async in step 2; write the spec for the END state. Marker phrases per spec §3; kicker strings per spec §3. Run all four specs → FAIL. Paste one representative failure.
+
+- [ ] **Step 2: Page changes** (each page):
+  1. Page component becomes `async`; build panes: `const panes = await buildPanes(SECTION_MEDIA.libLanggraph, SECTION_MEDIA.libLanggraph.video?.url ?? '');` (per-page key).
+  2. First FeatureBlock: `visual={<MediumSwitcher sectionId="lib-langgraph" panes={panes} />}` — the static BrowserFrame mock is DELETED from the page (its code content now lives in section-media). Remove newly unused imports (BrowserFrame, Pill where only the mock used them — check per page; heroes also use Pill, keep where used).
+  3. Hero: above the `<h1>`, insert the rail kicker:
+```tsx
+            <div className="lib-hero-rail">
+              <Eyebrow tone="accent">@threadplane/langgraph · LangGraph adapter</Eyebrow>
+              <span className="lib-hero-rail-line" aria-hidden="true" />
+            </div>
+```
+  4. Subtitle: wrap the spec §3 phrase in `<span className="marker-highlight">…</span>` (the phrase text must remain byte-identical inside the span).
+  5. `<FinalCTA />` → `<FinalCTA variant="dark" />`.
+  6. `/ag-ui` only: add `<WhitePaperBlock paper="overview" />` before FinalCTA + import.
+  7. Second FeatureBlock, WhitePaperBlock (existing), everything else: untouched.
+
+- [ ] **Step 3: CSS** — add once to `pages.css` (shared by all four heroes):
+```css
+.lib-hero-rail {
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
+  margin-bottom: 16px;
+}
+.lib-hero-rail-line {
+  flex: 1;
+  height: 1px;
+  background: var(--color-border);
+}
+```
+Also delete each page's now-orphaned static-mock CSS (`langgraph-page-code-pre`, `chat-page-visual-*`, ag-ui/render equivalents) — grep each class after the page edits; delete only zero-consumer rules; report each deletion.
+
+- [ ] **Step 4:** All four page specs PASS; full suite green (48+4 files); commit: `feat(website): library pages — switchers, dark closers, package kickers`
+
+---
+
+### Task 4: Verification gate (controller-run)
+
+- [ ] Full suite + prod build (async pages + shared buildPanes must survive prod type-check).
+- [ ] Chrome MCP at 1440px: per page — kicker rail, marker sweep visible, switcher tabs render and switch (click Code/Live on /langgraph), dark closer, /ag-ui has the paper block; at ~390px: no horizontal scroll, switcher stacks.
+- [ ] Live pane iframes are lazy (only on tab select — shipped MediumSwitcher behavior; confirm no iframe requests on initial load via Chrome network).
+- [ ] Commit fixes; stop. No push/PR — separate decision.
+
+## Deviations that require stopping
+
+- `buildPanes` extraction breaking the prod build in a way import-path fixes don't resolve.
+- section-media.spec rejecting a `featured` id (would mean the curated list changed).
+- Any second-FeatureBlock or WhitePaperBlock diff appearing in a page's change.

--- a/docs/superpowers/specs/2026-08-31-library-hero-subtitles-design.md
+++ b/docs/superpowers/specs/2026-08-31-library-hero-subtitles-design.md
@@ -1,0 +1,19 @@
+# Library page hero subtitles — the last two litanies
+
+**Date:** 2026-08-31 · **Status:** Approved. · **Branch:** `blove/library-pages`
+
+The four library pages inherited the design language via shared components
+(FeatureBlock rows/rails, WhitePaperBlock paper, FinalCTA); their H1s and
+FeatureBlock bodies are already in voice. Two hero subtitles remain:
+
+1. `/langgraph` — the site's last six-noun litany. Replace subtitle with
+   EXACTLY: "Ship LangGraph agents inside your Angular app. Agent state
+   arrives as signals; threads survive reloads; humans stay in the loop."
+2. `/ag-ui` — a 45-word runtime enumeration the H1 already counts. Replace
+   subtitle with EXACTLY: "Build the Angular UI once, on the AG-UI protocol —
+   eight runtimes speak it today, and new ones work the day they ship.
+   History and checkpoint behavior stays with your backend."
+
+`/chat` and `/render` subtitles deliberately unchanged. Update any spec/e2e
+assertions on the old strings (grep first). This closes the recorded
+"five pages' headlines/bodies copy pass" follow-up as satisfied.

--- a/docs/superpowers/specs/2026-08-31-library-pages-design.md
+++ b/docs/superpowers/specs/2026-08-31-library-pages-design.md
@@ -15,7 +15,9 @@ the homepage wall).
 Each page's FIRST FeatureBlock swaps its static BrowserFrame mock for
 `MediumSwitcher`, panes built server-side via the homepage's `buildPanes`
 pattern (extract that helper from `app/page.tsx` into a shared module rather
-than copy it — it is currently page-local). The SECOND FeatureBlock keeps its
+than copy it — it is currently page-local). (/ag-ui deviates: its first
+block's visual is the real BackendsGrid; the switcher replaces the static
+mock on its second block instead.) The SECOND FeatureBlock keeps its
 CodeShowcase untouched.
 
 New `SECTION_MEDIA` entries (validation via the existing section-media.spec

--- a/docs/superpowers/specs/2026-08-31-library-pages-design.md
+++ b/docs/superpowers/specs/2026-08-31-library-pages-design.md
@@ -1,0 +1,68 @@
+# Library pages — the homepage manner
+
+**Date:** 2026-08-31 · **Status:** Approved in review. · **Branch:** `blove/library-pages`
+Supersedes the narrow subtitle-only reading (commit d85d0d4d stands as this
+arc's first commit).
+
+## Scope
+
+`/langgraph`, `/chat`, `/ag-ui`, `/render`: medium switchers, one dark
+arrival per page, hero polish. Cut: per-page Yes ledgers (would re-duplicate
+the homepage wall).
+
+## 1 · Medium switchers
+
+Each page's FIRST FeatureBlock swaps its static BrowserFrame mock for
+`MediumSwitcher`, panes built server-side via the homepage's `buildPanes`
+pattern (extract that helper from `app/page.tsx` into a shared module rather
+than copy it — it is currently page-local). The SECOND FeatureBlock keeps its
+CodeShowcase untouched.
+
+New `SECTION_MEDIA` entries (validation via the existing section-media.spec
+comes free):
+
+| key | video | live (`?featured=`) | code pane |
+|---|---|---|---|
+| `libLanggraph` | LANGGRAPH_CLIP | `tell-me-about-coral` | the page's current app.config.ts mock content |
+| `libChat` | SHIP_CLIP | `tell-me-about-coral` | the page's current cockpit mock content, if it is code; else omit code |
+| `libAgUi` | AG_UI_CLIP | — none (the demo host is the LangGraph demo; wiring AG-UI live is out of scope) | the page's current app.config.ts mock content |
+| `libRender` | RENDER_CLIP | `generative-ui-contact-form` | the page's current spec→component mock content |
+
+The switcher renders bare when only one medium exists (its shipped
+behavior); missing panes are omitted, never faked. /chat's clip is SHIP (the
+production chat surface); HITL was considered and declined.
+
+## 2 · Dark arrival
+
+`<FinalCTA variant="dark" />` on all four pages. Rule amendment recorded:
+the dark closer extends to product pages; commerce pages (/pricing,
+/pilot-to-prod, /solutions) stay tinted. The FinalCTA spec's default-tinted
+test continues to guard the others.
+
+## 3 · Hero polish
+
+Per page:
+- Mono package-identity kicker with rail hairline above the h1 (currently NO
+  kicker exists): `@threadplane/langgraph · LangGraph adapter`,
+  `@threadplane/chat · chat compositions`, `@threadplane/ag-ui · protocol
+  adapter`, `@threadplane/render · generative UI`.
+- One `.marker-highlight` sweep per subtitle on the load-bearing phrase:
+  langgraph → "humans stay in the loop"; ag-ui → "work the day they ship";
+  chat → "Production-shaped from day one"; render → "components you already
+  own".
+- `/ag-ui` gains `<WhitePaperBlock paper="overview" />` before FinalCTA
+  (parity with the other three; no ag-ui-specific PDF exists).
+
+## Testing
+
+- section-media.spec validates the new entries automatically.
+- Each page: no colocated page spec exists (verify) — add a minimal one per
+  page asserting: kicker text, marker span presence, switcher tablist when
+  >1 pane, dark FinalCTA surface. Keep them small.
+- Full suite + prod build + Chrome MCP visual pass (pane hidden-viewport
+  artifacts persist; Chrome is the visual surface).
+
+## Out of scope
+
+The AG-UI live demo wiring; MediumSwitcher/FeatureBlock internals; clip
+re-recording; /pilot-to-prod (5th page — engagement page, different genre).


### PR DESCRIPTION
## Summary

`/langgraph`, `/chat`, `/ag-ui`, `/render` get the homepage treatment, per `docs/superpowers/specs/2026-08-31-library-pages-design.md`:

- **Medium switchers** replace the static BrowserFrame mocks — each page's own clip (including the never-before-used `AG_UI_CLIP`), Live scenarios via `?featured=`, and Code panes lifted byte-verbatim from the old mocks into `SECTION_MEDIA` (auto-validated by the existing media spec). Panes omitted where media doesn't exist, never faked: `/chat` has no code pane, `/ag-ui` no live. `/ag-ui`'s switcher lands on its second block — the first is the real BackendsGrid, not a mock (ratified deviation, recorded in the spec).
- **Dark closers**: `FinalCTA variant="dark"` on all four; rule amendment recorded — dark closes product pages, commerce pages stay tinted (test-guarded).
- **Hero polish**: mono package-identity kickers with rail hairlines (the old plain eyebrows deleted — no doubled package names), one marker sweep per subtitle, `/ag-ui` gains WhitePaperBlock parity.
- `buildPanes` extracted from the homepage into a shared server module, byte-identical.
- Also retires the site's last two hero litanies (`/langgraph`, `/ag-ui` subtitles).

## Test Plan
- [x] `nx test website` — 52 files / 394 tests green (four new page specs pin kicker/marker/tablist/dark-closer per page)
- [x] `nx build website --configuration=production` — green (async pages + shared buildPanes)
- [x] Chrome: switcher tabs verified interactively on /langgraph (Code highlights, Live iframe mounts only on select — 0 iframes at load); all four pages DOM-verified; mobile 390px clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)