### PR TITLE
fix(ci): unbreak main — drop verify assertions for the removed pricing matrix

### DIFF
--- a/scripts/verify-angular-support.mjs
+++ b/scripts/verify-angular-support.mjs
@@ -8,11 +8,7 @@ import {
   ANGULAR_PEER_RANGE,
   SUPPORTED_ANGULAR_MAJORS,
 } from '../examples/chat/smoke/angular-versions.mjs';
-import {
-  WEBSITE_ANGULAR_SUPPORT_ROWS,
-  WEBSITE_PRICING_SUPPORT_SUMMARY,
-  WEBSITE_SUPPORTED_ANGULAR_MAJORS,
-} from '../apps/website/src/components/pricing/angular-support.mjs';
+import { WEBSITE_SUPPORTED_ANGULAR_MAJORS } from '../apps/website/src/components/pricing/angular-support.mjs';
 
 export { ANGULAR_PEER_RANGE };
 
@@ -248,19 +244,20 @@ export async function verifyDocumentation({ root = process.cwd() } = {}) {
   }
 }
 
+/**
+ * The pricing page's Angular compatibility matrix and support summary were
+ * removed in #908, taking WEBSITE_ANGULAR_SUPPORT_ROWS and
+ * WEBSITE_PRICING_SUPPORT_SUMMARY with them. The row/summary assertions that
+ * used to live here verified copy that no longer renders anywhere, so they are
+ * gone too. WEBSITE_SUPPORTED_ANGULAR_MAJORS still backs live page content and
+ * is still checked against the registry.
+ */
 export async function verifyWebsiteMajors({
-  websiteAngularSupportRows = WEBSITE_ANGULAR_SUPPORT_ROWS,
-  websitePricingSupportSummary = WEBSITE_PRICING_SUPPORT_SUMMARY,
   websiteSupportedAngularMajors = WEBSITE_SUPPORTED_ANGULAR_MAJORS,
 } = {}) {
   const errors = [];
   const expectedMajors = SUPPORTED_ANGULAR_MAJORS.join(', ');
   const actualMajors = websiteSupportedAngularMajors.join(', ');
-  const expectedSupportedVersions = `Angular ${expectedMajors}`;
-  const expectedPricingSupportSummary = `Angular ${SUPPORTED_ANGULAR_MAJORS.slice(
-    0,
-    -1
-  ).join(', ')}, and ${SUPPORTED_ANGULAR_MAJORS.at(-1)} support`;
 
   if (
     websiteSupportedAngularMajors.length !== SUPPORTED_ANGULAR_MAJORS.length ||
@@ -271,45 +268,6 @@ export async function verifyWebsiteMajors({
     errors.push(
       `website supported Angular majors expected "${expectedMajors}" but found "${actualMajors}".`
     );
-  }
-
-  const supportedRows = websiteAngularSupportRows.filter(
-    (row) => row.label === 'Supported'
-  );
-  const plannedRows = websiteAngularSupportRows.filter(
-    (row) => row.label === 'Planned'
-  );
-
-  if (supportedRows.length !== 1) {
-    errors.push(
-      `website must contain exactly one Supported row but found ${supportedRows.length}.`
-    );
-  } else if (supportedRows[0].versions !== expectedSupportedVersions) {
-    errors.push(
-      `website Supported row versions expected "${expectedSupportedVersions}" but found "${supportedRows[0].versions}".`
-    );
-  }
-
-  if (plannedRows.length !== 1) {
-    errors.push(
-      `website must contain exactly one Planned row but found ${plannedRows.length}.`
-    );
-  }
-
-  if (websitePricingSupportSummary !== expectedPricingSupportSummary) {
-    errors.push(
-      `website pricing support summary expected "${expectedPricingSupportSummary}" but found "${websitePricingSupportSummary}".`
-    );
-  }
-
-  for (const plannedRow of plannedRows) {
-    for (const major of SUPPORTED_ANGULAR_MAJORS) {
-      if (new RegExp(`\\b${major}\\b`).test(plannedRow.versions)) {
-        errors.push(
-          `website Planned row must not contain supported Angular major ${major}.`
-        );
-      }
-    }
   }
 
   if (errors.length > 0) {

--- a/scripts/verify-angular-support.spec.mjs
+++ b/scripts/verify-angular-support.spec.mjs
@@ -59,26 +59,8 @@ function runNode(args) {
   });
 }
 
-function createWebsiteFixture({
-  supportedMajors = [20, 21, 22],
-  supportedVersions = 'Angular 20, 21, 22',
-  plannedVersions = '—',
-  pricingSupportSummary = 'Angular 20, 21, and 22 support',
-} = {}) {
-  return {
-    websiteAngularSupportRows: [
-      {
-        label: 'Supported',
-        versions: supportedVersions,
-        tone: 'success',
-      },
-      { label: 'Experimental', versions: '—', tone: 'warn' },
-      { label: 'Planned', versions: plannedVersions, tone: 'info' },
-      { label: 'Unsupported', versions: 'Angular ≤19', tone: 'muted' },
-    ],
-    websiteSupportedAngularMajors: supportedMajors,
-    websitePricingSupportSummary: pricingSupportSummary,
-  };
+function createWebsiteFixture({ supportedMajors = [20, 21, 22] } = {}) {
+  return { websiteSupportedAngularMajors: supportedMajors };
 }
 
 async function createDocumentationFixture(t, updateDocumentation) {
@@ -245,94 +227,6 @@ test('reports website support data that advertises Angular 23', async () => {
       createWebsiteFixture({ supportedMajors: [20, 21, 22, 23] })
     ),
     /website supported Angular majors expected "20, 21, 22" but found "20, 21, 22, 23"/
-  );
-});
-
-test('reports a supported Angular major under the website Planned row', async () => {
-  await assert.rejects(
-    verifyWebsiteMajors(
-      createWebsiteFixture({ plannedVersions: 'Angular 22' })
-    ),
-    /website Planned row must not contain supported Angular major 22/
-  );
-});
-
-test('reports Supported row text that omits Angular 22', async () => {
-  await assert.rejects(
-    verifyWebsiteMajors(
-      createWebsiteFixture({ supportedVersions: 'Angular 20, 21' })
-    ),
-    /website Supported row versions expected "Angular 20, 21, 22" but found "Angular 20, 21"/
-  );
-});
-
-test('reports Supported row text that advertises Angular 23', async () => {
-  await assert.rejects(
-    verifyWebsiteMajors(
-      createWebsiteFixture({ supportedVersions: 'Angular 20, 21, 22, 23' })
-    ),
-    /website Supported row versions expected "Angular 20, 21, 22" but found "Angular 20, 21, 22, 23"/
-  );
-});
-
-test('reports a missing website Supported row', async () => {
-  const fixture = createWebsiteFixture();
-  fixture.websiteAngularSupportRows = fixture.websiteAngularSupportRows.filter(
-    (row) => row.label !== 'Supported'
-  );
-
-  await assert.rejects(
-    verifyWebsiteMajors(fixture),
-    /website must contain exactly one Supported row but found 0/
-  );
-});
-
-test('reports duplicate website Supported rows', async () => {
-  const fixture = createWebsiteFixture();
-  fixture.websiteAngularSupportRows = [
-    ...fixture.websiteAngularSupportRows,
-    { label: 'Supported', versions: 'Angular 20, 21, 22', tone: 'success' },
-  ];
-
-  await assert.rejects(
-    verifyWebsiteMajors(fixture),
-    /website must contain exactly one Supported row but found 2/
-  );
-});
-
-test('reports a missing website Planned row', async () => {
-  const fixture = createWebsiteFixture();
-  fixture.websiteAngularSupportRows = fixture.websiteAngularSupportRows.filter(
-    (row) => row.label !== 'Planned'
-  );
-
-  await assert.rejects(
-    verifyWebsiteMajors(fixture),
-    /website must contain exactly one Planned row but found 0/
-  );
-});
-
-test('reports duplicate website Planned rows', async () => {
-  const fixture = createWebsiteFixture();
-  fixture.websiteAngularSupportRows = [
-    ...fixture.websiteAngularSupportRows,
-    { label: 'Planned', versions: '—', tone: 'info' },
-  ];
-
-  await assert.rejects(
-    verifyWebsiteMajors(fixture),
-    /website must contain exactly one Planned row but found 2/
-  );
-});
-
-test('reports a pricing support summary that drifts from website majors', async () => {
-  await assert.rejects(
-    verifyWebsiteMajors(
-      createWebsiteFixture({
-        pricingSupportSummary: 'Angular 20 and 21 support',
-      })
-    ),
-    /website pricing support summary expected "Angular 20, 21, and 22 support" but found "Angular 20 and 21 support"/
   );
 });
 


### PR DESCRIPTION
**Main is red and every PR inherits it.**

[#908](https://github.com/cacheplane/angular-agent-framework/pull/908) tightened the pricing page, deleting `CompatibilityMatrix.tsx` along with the `WEBSITE_ANGULAR_SUPPORT_ROWS` and `WEBSITE_PRICING_SUPPORT_SUMMARY` exports. `scripts/verify-angular-support.mjs` still imported both, so the module throws at import time:

```
SyntaxError: The requested module '.../pricing/angular-support.mjs'
does not provide an export named 'WEBSITE_ANGULAR_SUPPORT_ROWS'
```

That fails `Library — lint / test / build` → `CI — required`. Main CI has failed on `e8dc1ba4` and `c20ab69d` since.

## The fix

The Supported-row, Planned-row, and pricing-summary assertions verified copy that no longer renders anywhere, so they go with the matrix rather than being propped up by restored constants.

`WEBSITE_SUPPORTED_ANGULAR_MAJORS` still backs live page content and is still checked against the registry — so the drift this script exists to catch (**the website advertising Angular majors the packages don't support**) stays covered.

Prunes the eight spec cases that drove only the removed assertions.

## Verification

Ran the library job's exact steps locally:

- `node --test examples/chat/smoke/*.spec.mjs scripts/verify-angular-support.spec.mjs` → **44 pass, 0 fail**
- `node scripts/verify-angular-support.mjs` → `Angular support metadata verified: 20, 21, 22`, exit 0
- No dangling references to either removed export outside an explanatory comment

## Note

If deleting the compatibility matrix was *not* intentional in #908, this is the wrong direction — the alternative is restoring `CompatibilityMatrix.tsx` and both exports. I read "tighten the pricing page" as deliberate, but the author should sanity-check that call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)