### PR TITLE
ci: wire root scripts vitest suites into a real CI test target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
       cockpit_e2e: ${{ steps.scope.outputs.cockpit_e2e }}
       website_e2e: ${{ steps.scope.outputs.website_e2e }}
       posthog: ${{ steps.scope.outputs.posthog }}
+      scripts_tests: ${{ steps.scope.outputs.scripts_tests }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -76,6 +77,24 @@ jobs:
             --output "$GITHUB_OUTPUT"
       - name: Validate CI workflow guards
         run: node --test scripts/ci-workflow.spec.mjs
+
+  scripts-tests:
+    name: Scripts — generator / proxy vitest suites
+    needs: ci-scope
+    if: github.event_name == 'push' || needs.ci-scope.outputs.scripts_tests == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      # Vitest suites for the root deployment/proxy generators (drift checks,
+      # framework-adapter branching, requirements unions, rate limits). The
+      # node:test suites in scripts/ run in ci-scope and library instead —
+      # see scripts/vite.config.mts for the split.
+      - run: npx nx test scripts
 
   library:
     name: Library — lint / test / build
@@ -543,6 +562,7 @@ jobs:
       - cockpit-e2e-summary
       - website-e2e
       - posthog-sync-plan
+      - scripts-tests
     if: ${{ always() && github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
@@ -561,6 +581,7 @@ jobs:
           RESULT_COCKPIT_E2E: ${{ needs.cockpit-e2e-summary.result }}
           RESULT_WEBSITE_E2E: ${{ needs.website-e2e.result }}
           RESULT_POSTHOG: ${{ needs.posthog-sync-plan.result }}
+          RESULT_SCRIPTS_TESTS: ${{ needs.scripts-tests.result }}
           SCOPE_LIBRARY: ${{ needs.ci-scope.outputs.library }}
           SCOPE_ANGULAR_COMPATIBILITY: ${{ needs.ci-scope.outputs.angular_compatibility }}
           SCOPE_WEBSITE: ${{ needs.ci-scope.outputs.website }}
@@ -572,6 +593,7 @@ jobs:
           SCOPE_COCKPIT_E2E: ${{ needs.ci-scope.outputs.cockpit_e2e }}
           SCOPE_WEBSITE_E2E: ${{ needs.ci-scope.outputs.website_e2e }}
           SCOPE_POSTHOG: ${{ needs.ci-scope.outputs.posthog }}
+          SCOPE_SCRIPTS_TESTS: ${{ needs.ci-scope.outputs.scripts_tests }}
         run: |
           set -euo pipefail
 
@@ -624,6 +646,7 @@ jobs:
           require_scoped "cockpit_e2e" "Cockpit — e2e" "$RESULT_COCKPIT_E2E" "$SCOPE_COCKPIT_E2E"
           require_scoped "website_e2e" "Website — e2e" "$RESULT_WEBSITE_E2E" "$SCOPE_WEBSITE_E2E"
           require_scoped "posthog" "PostHog — dashboards-as-code drift check" "$RESULT_POSTHOG" "$SCOPE_POSTHOG"
+          require_scoped "scripts_tests" "Scripts — generator / proxy vitest suites" "$RESULT_SCRIPTS_TESTS" "$SCOPE_SCRIPTS_TESTS"
 
           if [[ "$failed" -ne 0 ]]; then
             exit 1

--- a/scripts/ci-scope.mjs
+++ b/scripts/ci-scope.mjs
@@ -16,6 +16,7 @@ export const SCOPE_KEYS = [
   'cockpit_e2e',
   'examples_chat',
   'posthog',
+  'scripts_tests',
 ];
 
 const GLOBAL_CI_FILES = new Set([

--- a/scripts/ci-scope.spec.mjs
+++ b/scripts/ci-scope.spec.mjs
@@ -338,7 +338,7 @@ describe('classifyFromAffected — tag isolation', () => {
 });
 
 describe('SCOPE_KEYS export', () => {
-  it('contains the 11 documented scope keys', () => {
+  it('contains the 12 documented scope keys', () => {
     assert.deepEqual(SCOPE_KEYS, [
       'library',
       'angular_compatibility',
@@ -351,6 +351,7 @@ describe('SCOPE_KEYS export', () => {
       'cockpit_e2e',
       'examples_chat',
       'posthog',
+      'scripts_tests',
     ]);
   });
 });

--- a/scripts/ci-workflow.spec.mjs
+++ b/scripts/ci-workflow.spec.mjs
@@ -347,6 +347,31 @@ describe('CI workflow', () => {
     );
   });
 
+  it('runs the root scripts vitest suites when the scripts project is affected', async () => {
+    const workflow = await readWorkflow();
+    const scriptsTestsJob = readJobBlock(workflow, 'scripts-tests');
+
+    assert.match(
+      scriptsTestsJob,
+      /if: github\.event_name == 'push' \|\| needs\.ci-scope\.outputs\.scripts_tests == 'true'/
+    );
+    assert.match(scriptsTestsJob, /npx nx test scripts/);
+
+    const requiredPrChecksJob = await readRequiredPrChecksJob();
+    assert.match(
+      requiredPrChecksJob,
+      /RESULT_SCRIPTS_TESTS:\s*\$\{\{\s*needs\.scripts-tests\.result\s*\}\}/
+    );
+    assert.match(
+      requiredPrChecksJob,
+      /SCOPE_SCRIPTS_TESTS:\s*\$\{\{\s*needs\.ci-scope\.outputs\.scripts_tests\s*\}\}/
+    );
+    assert.match(
+      requiredPrChecksJob,
+      /require_scoped "scripts_tests" "Scripts — generator \/ proxy vitest suites"/
+    );
+  });
+
   it('provides one stable required PR check that waits for scoped CI jobs', async () => {
     const requiredPrChecksJob = await readRequiredPrChecksJob();
     const expectedNeeds = [
@@ -363,6 +388,7 @@ describe('CI workflow', () => {
       'cockpit-e2e-summary',
       'website-e2e',
       'posthog-sync-plan',
+      'scripts-tests',
     ];
 
     assert.match(requiredPrChecksJob, /name:\s*CI — required/);

--- a/scripts/project.json
+++ b/scripts/project.json
@@ -1,0 +1,15 @@
+{
+  "name": "scripts",
+  "$schema": "../node_modules/nx/schemas/project-schema.json",
+  "projectType": "library",
+  "tags": ["scope:scripts-tests", "type:tooling"],
+  "implicitDependencies": [],
+  "targets": {
+    "test": {
+      "executor": "@nx/vitest:test",
+      "options": {
+        "configFile": "scripts/vite.config.mts"
+      }
+    }
+  }
+}

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node", "vitest/globals"],
+    "lib": ["es2022"]
+  },
+  "include": ["*.ts", "*.mts"]
+}

--- a/scripts/vite.config.mts
+++ b/scripts/vite.config.mts
@@ -1,0 +1,38 @@
+import { defineConfig } from 'vite';
+
+// Vitest config for the root deployment/proxy generator scripts.
+//
+// Two runners share scripts/: the node:test suites listed in `exclude`
+// below are invoked directly by .github/workflows/ci.yml (`node --test`),
+// everything else matching `include` runs under vitest via `nx test scripts`.
+// A new *.spec.ts / *.spec.mjs file here is picked up automatically; a new
+// node:test suite must be added to `exclude` AND to the ci.yml `node --test`
+// invocation, otherwise vitest fails loudly on it ("no test suite found") —
+// loud-by-default beats silently unrun.
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    include: ['*.spec.ts', '*.spec.mjs'],
+    exclude: [
+      // node:test suites — run by ci.yml directly, not by vitest.
+      'ci-scope.spec.mjs',
+      'ci-workflow.spec.mjs',
+      'cockpit-matrix.spec.mjs',
+      'cockpit-ports.spec.mjs',
+      'verify-angular-support.spec.mjs',
+      // STALE (excluded deliberately, not a runner mismatch): this one-time
+      // #881 cutover checklist now fails against main on two counts —
+      // libs/licensing is still tracked (and consumed by Angular bundles),
+      // and the Mastra runtime content/lockfiles legitimately mention the
+      // "excluded competitor". Reinstate only after the spec is reconciled
+      // with current policy.
+      'mit-cutover.spec.mjs',
+    ],
+    // Generator specs shell out to `npx tsx` and (re)generate committed
+    // deployment manifests; keep them serial to avoid write races.
+    fileParallelism: false,
+    testTimeout: 60000,
+    hookTimeout: 60000,
+  },
+});


### PR DESCRIPTION
## The gap

Eight vitest spec files under root `scripts/` — including the deployment-generator drift checks and framework-adapter branching specs from #894/#898 — were wired into no Nx target and run by nothing in CI. Only the `node:test` suites (`ci-scope`, `ci-workflow`, `cockpit-matrix`, `cockpit-ports`, `verify-angular-support`) were executed, via direct `node --test` steps in ci.yml.

## Inventory (root scripts/*.spec.*)

| Spec | Runner | Ran in CI before | Runs now via |
| --- | --- | --- | --- |
| ci-scope.spec.mjs | node:test | yes (ci-scope job) | unchanged |
| ci-workflow.spec.mjs | node:test | yes (ci-scope job) | unchanged |
| cockpit-matrix.spec.mjs | node:test | yes (ci-scope job) | unchanged |
| cockpit-ports.spec.mjs | node:test | yes (ci-scope job) | unchanged |
| verify-angular-support.spec.mjs | node:test | yes (library job) | unchanged |
| generate-ag-ui-deployment-config.spec.ts | vitest | **no** | `nx test scripts` |
| generate-shared-deployment-config.spec.ts | vitest | **no** | `nx test scripts` |
| ag-ui-proxy.spec.ts | vitest | **no** | `nx test scripts` |
| langgraph-proxy.spec.ts | vitest | **no** | `nx test scripts` |
| rate-limit.spec.ts | vitest | **no** | `nx test scripts` |
| upstash-rate-limit.spec.ts | vitest | **no** | `nx test scripts` |
| verify-release-versions.spec.mjs | vitest | **no** | `nx test scripts` |
| mit-cutover.spec.mjs | vitest | **no** | excluded — stale, see below |

## Wiring

- New Nx project `scripts` (`scripts/project.json`) with an `@nx/vitest:test` target — same executor/config-file convention as the libs. `scripts/vite.config.mts` includes `*.spec.{ts,mjs}` and excludes the five node:test suites by name; a future node:test spec added without updating the exclude fails loudly under vitest instead of silently not running.
- `scope:scripts-tests` tag + new `scripts_tests` key in `scripts/ci-scope.mjs`, so `nx show projects --affected` flips the scope whenever any file in `scripts/` changes (verified with a probe commit: touching `generate-ag-ui-deployment-config.ts` → `scripts_tests=true`).
- New ci.yml job `scripts-tests` (`npx nx test scripts`), gated on `push || scripts_tests == 'true'`, and wired into `required-pr-checks` (needs + RESULT/SCOPE env + `require_scoped`) so a red run blocks the required PR check.
- Guard test added to `ci-workflow.spec.mjs` asserting the job, its scope gate, and its required-pr-checks wiring exist.

## Mutation evidence

- Mutated the generator's `GENERATED` header → `nx test scripts` exits 1 with the drift byte-equality + header specs failing (3 failed / 50 passed); restored → exit 0.
- Deleted the `npx nx test scripts` step from ci.yml → `node --test scripts/ci-workflow.spec.mjs` goes red (`runs the root scripts vitest suites when the scripts project is affected`); restored → green.

## Excluded: mit-cutover.spec.mjs (stale — needs a policy decision)

Never run since #881 landed it, and it now fails against main on two counts: it asserts `libs/licensing` no longer exists (it is tracked and consumed by Angular bundles), and it asserts zero tracked references to the excluded competitor (yesterday's Mastra runtime content and `deployments/ag-ui-mastra/package-lock.json` legitimately contain them). Excluded with a comment in `vite.config.mts`; reconcile the spec with current policy in a follow-up rather than weakening it silently here.

## Verification

- `nx test scripts`: 7 files / 53 tests green
- All node:test suites green post-edit (ci-scope 68, ci-workflow 20, chat smoke 29)
- `nx test telemetry` green; `nx show projects` intact after the graph split
- Fresh worktree, single `npm ci`, no lockfile changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)