### PR TITLE
fix(cockpit): point docsPath at docs pages that actually exist

### DIFF
--- a/apps/cockpit/src/components/cockpit-shell.spec.tsx
+++ b/apps/cockpit/src/components/cockpit-shell.spec.tsx
@@ -23,6 +23,20 @@ const seedMode = (activeMode: 'Run' | 'Code' | 'Docs' | 'API') => {
   }));
 };
 
+const renderShellFor = (slug: string[]) => {
+  const pageModel = getCockpitPageModel(slug);
+  return render(
+    <ThemeProvider theme="light">
+      <CockpitShell
+        navigationTree={pageModel.navigationTree}
+        presentation={pageModel.presentation}
+        entryTitle={pageModel.entry.title}
+        contentBundle={contentBundle}
+      />
+    </ThemeProvider>,
+  );
+};
+
 const renderShell = () => render(
   <ThemeProvider theme="light">
     <CockpitShell
@@ -83,5 +97,31 @@ describe('CockpitShell control-plane mode state', () => {
 
     expect(screen.getByRole('region', { name: 'Run mode' })).toBeTruthy();
     expect(screen.getByRole('region', { name: 'Code mode' })).toBeTruthy();
+  });
+});
+
+describe('CockpitShell documentation link', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('links a capability to its page on the docs site', () => {
+    renderShellFor(['langgraph', 'core-capabilities', 'streaming', 'overview', 'python']);
+
+    const link = screen.getByRole('link', { name: /read docs/i });
+    expect(link.getAttribute('href')).toBe(
+      'https://threadplane.ai/docs/langgraph/guides/streaming'
+    );
+    expect(link.getAttribute('target')).toBe('_blank');
+    expect(link.getAttribute('rel')).toBe('noopener noreferrer');
+  });
+
+  it('renders no link for a capability with no published docs page', () => {
+    // deep-agents carries the NO_COCKPIT_DOCS_LINK sentinel: the website has no
+    // deep-agents library yet, so there is nothing to link to.
+    renderShellFor(['deep-agents', 'core-capabilities', 'planning', 'overview', 'python']);
+
+    expect(screen.queryByRole('link', { name: /read docs/i })).toBeNull();
   });
 });

--- a/apps/cockpit/src/components/cockpit-shell.tsx
+++ b/apps/cockpit/src/components/cockpit-shell.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import { cockpitManifest } from '@threadplane/cockpit-registry';
-import { Menu } from 'lucide-react';
+import { BookOpen, Menu } from 'lucide-react';
 import {
   parseControlPlaneMode,
   useControlPlanePreferences,
@@ -11,6 +11,7 @@ import {
 import type { ContentBundle } from '../lib/content-bundle';
 import type { CapabilityPresentation, NavigationProduct } from '../lib/route-resolution';
 import { PRODUCT_LABELS } from '../lib/navigation-labels';
+import { resolveDocsUrl } from '../lib/docs-links';
 import { CodeMode } from './code-mode/code-mode';
 import { ApiMode } from './api-mode/api-mode';
 import { NarrativeDocs } from './narrative-docs/narrative-docs';
@@ -47,6 +48,9 @@ export function CockpitShell({
   const backendAssetPaths = isCapability ? (presentation.backendAssetPaths ?? []) : [];
   const entry = presentation.entry;
   const contextLabel = `${PRODUCT_LABELS[entry.product] ?? toLabel(entry.product)} / ${toLabel(entry.section)} / ${toLabel(entry.topic)}`;
+  // Null for the capabilities that have no published docs page yet — those
+  // render no link at all rather than one that 404s.
+  const docsUrl = resolveDocsUrl(presentation.docsPath);
 
   useEffect(() => {
     if (!preferences.hydrated || queryHandled.current) return;
@@ -111,6 +115,17 @@ export function CockpitShell({
             </button>
             <p className="hidden md:block text-[var(--ds-text-muted)] font-mono text-xs truncate">{contextLabel}</p>
           </div>
+          {docsUrl ? (
+            <a
+              className="shrink-0 inline-flex items-center gap-1.5 text-xs text-[var(--ds-text-secondary)] hover:text-[var(--ds-text-primary)] no-underline"
+              href={docsUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <BookOpen size={14} aria-hidden="true" />
+              Read docs
+            </a>
+          ) : null}
         </header>
 
         <div className="min-h-0 relative">

--- a/apps/cockpit/src/lib/docs-links.spec.ts
+++ b/apps/cockpit/src/lib/docs-links.spec.ts
@@ -1,0 +1,146 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  COCKPIT_DOCS_LINKS,
+  COCKPIT_TOPICS_WITHOUT_DOCS,
+  NO_COCKPIT_DOCS_LINK,
+  cockpitManifest,
+} from '@threadplane/cockpit-registry';
+import { docsConfig } from '../../../website/src/lib/docs-config';
+
+/**
+ * Guard for the cockpit -> website documentation links.
+ *
+ * `docsPath` used to be generated from a five-segment formula that matched no
+ * route the website has ever served, so every link 404'd and nothing noticed:
+ * the shape was asserted against a regex, never against reality. This spec
+ * checks each declared path against the website's real content tree and its
+ * real nav config, so a docs rename breaks a test instead of a link.
+ */
+
+const findWorkspaceRoot = (): string => {
+  let dir = process.cwd();
+  while (dir !== resolve(dir, '..')) {
+    if (existsSync(join(dir, 'nx.json'))) return dir;
+    dir = resolve(dir, '..');
+  }
+  throw new Error('workspace root (nx.json) not found');
+};
+
+const WORKSPACE_ROOT = findWorkspaceRoot();
+const DOCS_CONTENT_ROOT = join(WORKSPACE_ROOT, 'apps/website/content/docs');
+
+/** Every `/docs/<library>/<section>/<slug>` the website's nav actually offers. */
+const navRoutes = new Set(
+  docsConfig.flatMap((library) =>
+    library.sections.flatMap((section) =>
+      section.pages.map((page) => `/docs/${library.id}/${section.id}/${page.slug}`)
+    )
+  )
+);
+
+/** Every `/docs/<library>/<section>/<slug>` backed by an `.mdx` file on disk. */
+const contentRoutes = new Set<string>();
+for (const library of readdirSync(DOCS_CONTENT_ROOT, { withFileTypes: true })) {
+  if (!library.isDirectory()) continue;
+  const libraryDir = join(DOCS_CONTENT_ROOT, library.name);
+  for (const section of readdirSync(libraryDir, { withFileTypes: true })) {
+    if (!section.isDirectory()) continue;
+    const sectionDir = join(libraryDir, section.name);
+    for (const file of readdirSync(sectionDir)) {
+      if (!file.endsWith('.mdx')) continue;
+      contentRoutes.add(
+        `/docs/${library.name}/${section.name}/${file.slice(0, -'.mdx'.length)}`
+      );
+    }
+  }
+}
+
+/**
+ * Descriptors are duplicated per example (cockpit examples are standalone), so
+ * they are read off disk rather than imported — an example whose module nobody
+ * imports still has to declare a link that resolves.
+ */
+const readDescriptorDocsPaths = (): { file: string; key: string; docsPath: string }[] => {
+  const results: { file: string; key: string; docsPath: string }[] = [];
+  const cockpitRoot = join(WORKSPACE_ROOT, 'cockpit');
+  for (const product of readdirSync(cockpitRoot, { withFileTypes: true })) {
+    if (!product.isDirectory()) continue;
+    const productDir = join(cockpitRoot, product.name);
+    for (const topic of readdirSync(productDir, { withFileTypes: true })) {
+      if (!topic.isDirectory()) continue;
+      for (const lane of readdirSync(join(productDir, topic.name), { withFileTypes: true })) {
+        if (!lane.isDirectory()) continue;
+        const file = join(productDir, topic.name, lane.name, 'src/index.ts');
+        if (!existsSync(file)) continue;
+        const source = readFileSync(file, 'utf-8');
+        const identity = /manifestIdentity:\s*\{[^}]*?product:\s*'([^']+)'[^}]*?section:\s*'([^']+)'[^}]*?topic:\s*'([^']+)'/s.exec(
+          source
+        );
+        const declared = /\n {2}docsPath: '([^']*)',/.exec(source);
+        if (!identity || !declared) continue;
+        results.push({
+          file: file.slice(WORKSPACE_ROOT.length + 1),
+          key: `${identity[1]}/${identity[2]}/${identity[3]}`,
+          docsPath: declared[1],
+        });
+      }
+    }
+  }
+  return results;
+};
+
+const descriptors = readDescriptorDocsPaths();
+
+describe('cockpit docs links', () => {
+  it('reads a docs route list from the website that is not empty', () => {
+    // Guards the guard: an empty derived list would let everything below pass.
+    expect(navRoutes.size).toBeGreaterThan(50);
+    expect(contentRoutes.size).toBeGreaterThan(50);
+  });
+
+  it('points every mapped capability at a page the website actually serves', () => {
+    const broken = Object.entries(COCKPIT_DOCS_LINKS)
+      .filter(([, path]) => path !== NO_COCKPIT_DOCS_LINK)
+      .filter(([, path]) => !contentRoutes.has(path) || !navRoutes.has(path))
+      .map(([key, path]) => `${key} -> ${path}`);
+
+    expect(broken).toEqual([]);
+  });
+
+  it('blanks only the capabilities that are known to have no docs page', () => {
+    const blanked = Object.entries(COCKPIT_DOCS_LINKS)
+      .filter(([, path]) => path === NO_COCKPIT_DOCS_LINK)
+      .map(([key]) => key)
+      .sort();
+
+    expect(blanked).toEqual([...COCKPIT_TOPICS_WITHOUT_DOCS].sort());
+  });
+
+  it('maps every manifest entry', () => {
+    const unmapped = cockpitManifest
+      .filter((entry) => !(`${entry.product}/${entry.section}/${entry.topic}` in COCKPIT_DOCS_LINKS))
+      .map((entry) => `${entry.product}/${entry.section}/${entry.topic}`);
+
+    expect(unmapped).toEqual([]);
+  });
+
+  it('keeps every per-example descriptor in step with the shared table', () => {
+    expect(descriptors.length).toBeGreaterThan(60);
+
+    const drifted = descriptors
+      .filter(({ key, docsPath }) => docsPath !== COCKPIT_DOCS_LINKS[key])
+      .map(({ file, key, docsPath }) => `${file}: ${key} declares ${docsPath || '(blank)'}`);
+
+    expect(drifted).toEqual([]);
+  });
+
+  it('declares no five-segment legacy docs path anywhere', () => {
+    const legacy = descriptors
+      .filter(({ docsPath }) => docsPath.split('/').filter(Boolean).length > 4)
+      .map(({ file, docsPath }) => `${file}: ${docsPath}`);
+
+    expect(legacy).toEqual([]);
+  });
+});

--- a/apps/cockpit/src/lib/docs-links.ts
+++ b/apps/cockpit/src/lib/docs-links.ts
@@ -1,0 +1,22 @@
+import { NO_COCKPIT_DOCS_LINK } from '@threadplane/cockpit-registry';
+
+/**
+ * Absolute URL for a capability's `docsPath`.
+ *
+ * `docsPath` is a website-relative path (`/docs/<library>/<section>/<slug>`),
+ * but the cockpit is served from its own origin (cockpit.threadplane.ai), so
+ * the link has to be absolutised against the docs site.
+ *
+ * Returns `null` when the capability has no published docs page — callers
+ * render no link rather than one that 404s.
+ */
+export function resolveDocsUrl(docsPath: string | undefined): string | null {
+  if (!docsPath || docsPath === NO_COCKPIT_DOCS_LINK) return null;
+  if (/^https?:\/\//.test(docsPath)) return docsPath;
+
+  const baseUrl = (
+    process.env['NEXT_PUBLIC_COCKPIT_DOCS_BASE_URL'] ?? 'https://threadplane.ai'
+  ).replace(/\/$/, '');
+
+  return `${baseUrl}${docsPath.startsWith('/') ? docsPath : `/${docsPath}`}`;
+}

--- a/apps/cockpit/src/lib/route-resolution.spec.ts
+++ b/apps/cockpit/src/lib/route-resolution.spec.ts
@@ -176,11 +176,11 @@ describe('getCapabilityPresentation', () => {
 
     expect(getCapabilityPresentation(docsEntry)).toMatchObject({
       kind: 'docs-only',
-      docsPath: '/docs/deep-agents/getting-started/overview/overview/python',
+      docsPath: '',
     });
     expect(getCapabilityPresentation(capabilityEntry)).toMatchObject({
       kind: 'capability',
-      docsPath: '/docs/langgraph/core-capabilities/streaming/overview/python',
+      docsPath: '/docs/langgraph/guides/streaming',
       promptAssetPaths: ['cockpit/langgraph/streaming/python/prompts/streaming.md'],
       codeAssetPaths: [
         'cockpit/langgraph/streaming/angular/src/app/streaming.component.ts',
@@ -237,7 +237,7 @@ describe('getCapabilityPresentation', () => {
 
     expect(presentation).toMatchObject({
       kind: 'capability',
-      docsPath: '/docs/langgraph/core-capabilities/durable-execution/overview/python',
+      docsPath: '/docs/langgraph/guides/persistence',
       docsAssetPaths: ['cockpit/langgraph/durable-execution/python/docs/guide.md'],
     });
   });
@@ -255,7 +255,7 @@ describe('getCapabilityPresentation', () => {
 
     expect(presentation).toMatchObject({
       kind: 'capability',
-      docsPath: '/docs/render/core-capabilities/spec-rendering/overview/python',
+      docsPath: '/docs/render/guides/specs',
     });
   });
 
@@ -272,7 +272,7 @@ describe('getCapabilityPresentation', () => {
 
     expect(presentation).toMatchObject({
       kind: 'capability',
-      docsPath: '/docs/chat/core-capabilities/messages/overview/python',
+      docsPath: '/docs/chat/concepts/message-model',
     });
   });
 

--- a/apps/cockpit/vite.config.mts
+++ b/apps/cockpit/vite.config.mts
@@ -1,12 +1,31 @@
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vite';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
 
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
 export default defineConfig({
   plugins: [nxViteTsPaths()],
+  // The capability matrix specs (see `test.include`) live outside this app's
+  // directory, and Vite's dev server refuses to serve files above its root
+  // unless they are allow-listed. Without this the matrix specs fail to load
+  // with ERR_MODULE_NOT_FOUND on a `/@fs/...` path under `nx test cockpit`.
+  server: { fs: { allow: [resolve(__dirname, '../..')] } },
   test: {
     environment: 'jsdom',
     globals: true,
-    include: ['src/**/*.spec.ts', 'src/**/*.spec.tsx', '*.spec.ts', 'scripts/**/*.spec.ts'],
+    include: [
+      'src/**/*.spec.ts',
+      'src/**/*.spec.tsx',
+      '*.spec.ts',
+      'scripts/**/*.spec.ts',
+      // The per-product capability matrix specs live beside the examples they
+      // describe and had no test target of their own, which is how their
+      // docsPath assertion drifted into asserting a URL shape the website has
+      // never served. Run them here so `nx test cockpit` covers them.
+      '../../cockpit/*/matrix.spec.ts',
+    ],
     setupFiles: ['./test-setup.ts'],
   },
 });

--- a/cockpit/ag-ui/a2ui/angular/src/index.ts
+++ b/cockpit/ag-ui/a2ui/angular/src/index.ts
@@ -24,7 +24,7 @@ export const agUiA2uiAngularModule: CockpitCapabilityModule = {
     language: 'angular',
   },
   title: 'AG-UI A2UI (Angular)',
-  docsPath: '/docs/ag-ui/core-capabilities/a2ui/overview/angular',
+  docsPath: '/docs/a2ui/getting-started/introduction',
   promptAssetPaths: [],
   codeAssetPaths: [
     'cockpit/ag-ui/a2ui/angular/src/app/a2ui.component.ts',

--- a/cockpit/ag-ui/a2ui/python/src/index.ts
+++ b/cockpit/ag-ui/a2ui/python/src/index.ts
@@ -27,7 +27,7 @@ export const agUiA2uiPythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'AG-UI A2UI (Python)',
-  docsPath: '/docs/ag-ui/core-capabilities/a2ui/overview/python',
+  docsPath: '/docs/a2ui/getting-started/introduction',
   promptAssetPaths: ['cockpit/ag-ui/a2ui/python/prompts/a2ui.md'],
   codeAssetPaths: [
     'cockpit/ag-ui/a2ui/angular/src/app/a2ui.component.ts',

--- a/cockpit/ag-ui/client-tools/angular/src/index.ts
+++ b/cockpit/ag-ui/client-tools/angular/src/index.ts
@@ -12,7 +12,7 @@ export const agUiClientToolsAngularModule: CockpitCapabilityModule = {
   id: 'ag-ui-client-tools-angular',
   manifestIdentity: { product: 'ag-ui', section: 'core-capabilities', topic: 'client-tools', page: 'overview', language: 'angular' },
   title: 'AG-UI Client Tools (Angular)',
-  docsPath: '/docs/ag-ui/core-capabilities/client-tools/overview/angular',
+  docsPath: '/docs/chat/guides/client-tools',
   promptAssetPaths: ['cockpit/ag-ui/client-tools/angular/prompts/client-tools.md'],
   codeAssetPaths: [
     'cockpit/ag-ui/client-tools/angular/src/app/client-tools.component.ts',

--- a/cockpit/ag-ui/client-tools/python/src/index.ts
+++ b/cockpit/ag-ui/client-tools/python/src/index.ts
@@ -15,7 +15,7 @@ export const agUiClientToolsPythonModule: CockpitCapabilityModule = {
   id: 'ag-ui-client-tools-python',
   manifestIdentity: { product: 'ag-ui', section: 'core-capabilities', topic: 'client-tools', page: 'overview', language: 'python' },
   title: 'AG-UI Client Tools (Python)',
-  docsPath: '/docs/ag-ui/core-capabilities/client-tools/overview/python',
+  docsPath: '/docs/chat/guides/client-tools',
   promptAssetPaths: ['cockpit/ag-ui/client-tools/python/prompts/client-tools.md'],
   codeAssetPaths: [
     'cockpit/ag-ui/client-tools/angular/src/app/client-tools.component.ts',

--- a/cockpit/ag-ui/interrupts/angular/src/index.ts
+++ b/cockpit/ag-ui/interrupts/angular/src/index.ts
@@ -23,7 +23,7 @@ export const agUiInterruptsAngularModule: CockpitCapabilityModule = {
     language: 'angular',
   },
   title: 'AG-UI Interrupts (Angular)',
-  docsPath: '/docs/ag-ui/core-capabilities/interrupts/overview/angular',
+  docsPath: '/docs/ag-ui/guides/interrupts',
   promptAssetPaths: [
     'cockpit/ag-ui/interrupts/angular/prompts/interrupts.md',
   ],

--- a/cockpit/ag-ui/interrupts/python/src/index.ts
+++ b/cockpit/ag-ui/interrupts/python/src/index.ts
@@ -27,7 +27,7 @@ export const agUiInterruptsPythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'AG-UI Interrupts (Python)',
-  docsPath: '/docs/ag-ui/core-capabilities/interrupts/overview/python',
+  docsPath: '/docs/ag-ui/guides/interrupts',
   promptAssetPaths: ['cockpit/ag-ui/interrupts/python/prompts/interrupts.md'],
   codeAssetPaths: [
     'cockpit/ag-ui/interrupts/angular/src/app/interrupts.component.ts',

--- a/cockpit/ag-ui/json-render/angular/src/index.ts
+++ b/cockpit/ag-ui/json-render/angular/src/index.ts
@@ -24,7 +24,7 @@ export const agUiJsonRenderAngularModule: CockpitCapabilityModule = {
     language: 'angular',
   },
   title: 'AG-UI JSON Render (Angular)',
-  docsPath: '/docs/ag-ui/core-capabilities/json-render/overview/angular',
+  docsPath: '/docs/render/getting-started/introduction',
   promptAssetPaths: ['cockpit/ag-ui/json-render/python/prompts/json-render.md'],
   codeAssetPaths: [
     'cockpit/ag-ui/json-render/angular/src/app/json-render.component.ts',

--- a/cockpit/ag-ui/json-render/python/src/index.ts
+++ b/cockpit/ag-ui/json-render/python/src/index.ts
@@ -27,7 +27,7 @@ export const agUiJsonRenderPythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'AG-UI JSON Render (Python)',
-  docsPath: '/docs/ag-ui/core-capabilities/json-render/overview/python',
+  docsPath: '/docs/render/getting-started/introduction',
   promptAssetPaths: ['cockpit/ag-ui/json-render/python/prompts/json-render.md'],
   codeAssetPaths: [
     'cockpit/ag-ui/json-render/angular/src/app/json-render.component.ts',

--- a/cockpit/ag-ui/streaming/angular/src/index.ts
+++ b/cockpit/ag-ui/streaming/angular/src/index.ts
@@ -24,7 +24,7 @@ export const agUiStreamingAngularModule: CockpitCapabilityModule = {
     language: 'angular',
   },
   title: 'AG-UI Streaming (Angular)',
-  docsPath: '/docs/ag-ui/core-capabilities/streaming/overview/angular',
+  docsPath: '/docs/ag-ui/reference/event-mapping',
   promptAssetPaths: [
     'cockpit/ag-ui/streaming/angular/prompts/streaming.md',
   ],

--- a/cockpit/ag-ui/streaming/python/src/index.ts
+++ b/cockpit/ag-ui/streaming/python/src/index.ts
@@ -27,7 +27,7 @@ export const agUiStreamingPythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'AG-UI Streaming (Python)',
-  docsPath: '/docs/ag-ui/core-capabilities/streaming/overview/python',
+  docsPath: '/docs/ag-ui/reference/event-mapping',
   promptAssetPaths: ['cockpit/ag-ui/streaming/python/prompts/streaming.md'],
   codeAssetPaths: [
     'cockpit/ag-ui/streaming/angular/src/app/streaming.component.ts',

--- a/cockpit/ag-ui/subagents/angular/src/index.ts
+++ b/cockpit/ag-ui/subagents/angular/src/index.ts
@@ -24,7 +24,7 @@ export const agUiSubagentsAngularModule: CockpitCapabilityModule = {
     language: 'angular',
   },
   title: 'AG-UI Subagents (Angular)',
-  docsPath: '/docs/ag-ui/core-capabilities/subagents/overview/angular',
+  docsPath: '/docs/chat/components/chat-subagent-card',
   promptAssetPaths: [
     'cockpit/ag-ui/subagents/angular/prompts/subagents.md',
   ],

--- a/cockpit/ag-ui/subagents/python/src/index.ts
+++ b/cockpit/ag-ui/subagents/python/src/index.ts
@@ -27,7 +27,7 @@ export const agUiSubagentsPythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'AG-UI Subagents (Python)',
-  docsPath: '/docs/ag-ui/core-capabilities/subagents/overview/python',
+  docsPath: '/docs/chat/components/chat-subagent-card',
   promptAssetPaths: ['cockpit/ag-ui/subagents/python/prompts/subagents.md'],
   codeAssetPaths: [
     'cockpit/ag-ui/subagents/angular/src/app/subagents.component.ts',

--- a/cockpit/ag-ui/tool-views/angular/src/index.ts
+++ b/cockpit/ag-ui/tool-views/angular/src/index.ts
@@ -24,7 +24,7 @@ export const agUiToolViewsAngularModule: CockpitCapabilityModule = {
     language: 'angular',
   },
   title: 'AG-UI Tool Views (Angular)',
-  docsPath: '/docs/ag-ui/core-capabilities/tool-views/overview/angular',
+  docsPath: '/docs/chat/components/chat-tool-calls',
   promptAssetPaths: ['cockpit/ag-ui/tool-views/angular/prompts/tool-views.md'],
   codeAssetPaths: [
     'cockpit/ag-ui/tool-views/angular/src/app/tool-views.component.ts',

--- a/cockpit/ag-ui/tool-views/python/src/index.ts
+++ b/cockpit/ag-ui/tool-views/python/src/index.ts
@@ -27,7 +27,7 @@ export const agUiToolViewsPythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'AG-UI Tool Views (Python)',
-  docsPath: '/docs/ag-ui/core-capabilities/tool-views/overview/python',
+  docsPath: '/docs/chat/components/chat-tool-calls',
   promptAssetPaths: ['cockpit/ag-ui/tool-views/python/prompts/tool-views.md'],
   codeAssetPaths: [
     'cockpit/ag-ui/tool-views/angular/src/app/tool-views.component.ts',

--- a/cockpit/chat/a2ui/angular/src/index.ts
+++ b/cockpit/chat/a2ui/angular/src/index.ts
@@ -23,7 +23,7 @@ export const chatA2uiAngularModule: CockpitCapabilityModule = {
     language: 'angular',
   },
   title: 'Chat A2UI (Angular)',
-  docsPath: '/docs/chat/core-capabilities/a2ui/overview/angular',
+  docsPath: '/docs/chat/a2ui/overview',
   promptAssetPaths: ['cockpit/chat/a2ui/python/prompts/a2ui.md'],
   codeAssetPaths: ['cockpit/chat/a2ui/angular/src/app/a2ui.component.ts'],
 };

--- a/cockpit/chat/a2ui/python/src/index.ts
+++ b/cockpit/chat/a2ui/python/src/index.ts
@@ -27,7 +27,7 @@ export const chatA2uiPythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'Chat A2UI (Python)',
-  docsPath: '/docs/chat/core-capabilities/a2ui/overview/python',
+  docsPath: '/docs/chat/a2ui/overview',
   promptAssetPaths: ['cockpit/chat/a2ui/python/prompts/a2ui.md'],
   codeAssetPaths: [
     'cockpit/chat/a2ui/angular/src/app/a2ui.component.ts',

--- a/cockpit/chat/debug/angular/src/index.ts
+++ b/cockpit/chat/debug/angular/src/index.ts
@@ -23,7 +23,7 @@ export const chatDebugAngularModule: CockpitCapabilityModule = {
     language: 'angular',
   },
   title: 'Chat Debug (Angular)',
-  docsPath: '/docs/chat/core-capabilities/debug/overview/angular',
+  docsPath: '/docs/chat/components/chat-debug',
   promptAssetPaths: ['cockpit/chat/debug/python/prompts/debug.md'],
   codeAssetPaths: ['cockpit/chat/debug/angular/src/app/debug.component.ts'],
 };

--- a/cockpit/chat/debug/python/src/index.ts
+++ b/cockpit/chat/debug/python/src/index.ts
@@ -27,7 +27,7 @@ export const chatDebugPythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'Chat Debug (Python)',
-  docsPath: '/docs/chat/core-capabilities/debug/overview/python',
+  docsPath: '/docs/chat/components/chat-debug',
   promptAssetPaths: ['cockpit/chat/debug/python/prompts/debug.md'],
   codeAssetPaths: [
     'cockpit/chat/debug/angular/src/app/debug.component.ts',

--- a/cockpit/chat/generative-ui/angular/src/index.ts
+++ b/cockpit/chat/generative-ui/angular/src/index.ts
@@ -23,7 +23,7 @@ export const chatGenerativeUiAngularModule: CockpitCapabilityModule = {
     language: 'angular',
   },
   title: 'Chat Generative UI (Angular)',
-  docsPath: '/docs/chat/core-capabilities/generative-ui/overview/angular',
+  docsPath: '/docs/chat/guides/generative-ui',
   promptAssetPaths: ['cockpit/chat/generative-ui/python/prompts/generative-ui.md'],
   codeAssetPaths: ['cockpit/chat/generative-ui/angular/src/app/generative-ui.component.ts'],
 };

--- a/cockpit/chat/generative-ui/python/src/index.ts
+++ b/cockpit/chat/generative-ui/python/src/index.ts
@@ -27,7 +27,7 @@ export const chatGenerativeUiPythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'Chat Generative UI (Python)',
-  docsPath: '/docs/chat/core-capabilities/generative-ui/overview/python',
+  docsPath: '/docs/chat/guides/generative-ui',
   promptAssetPaths: ['cockpit/chat/generative-ui/python/prompts/generative-ui.md'],
   codeAssetPaths: [
     'cockpit/chat/generative-ui/angular/src/app/generative-ui.component.ts',

--- a/cockpit/chat/input/angular/src/index.ts
+++ b/cockpit/chat/input/angular/src/index.ts
@@ -23,7 +23,7 @@ export const chatInputAngularModule: CockpitCapabilityModule = {
     language: 'angular',
   },
   title: 'Chat Input (Angular)',
-  docsPath: '/docs/chat/core-capabilities/input/overview/angular',
+  docsPath: '/docs/chat/components/chat-input',
   promptAssetPaths: ['cockpit/chat/input/python/prompts/input.md'],
   codeAssetPaths: ['cockpit/chat/input/angular/src/app/input.component.ts'],
 };

--- a/cockpit/chat/input/python/src/index.ts
+++ b/cockpit/chat/input/python/src/index.ts
@@ -27,7 +27,7 @@ export const chatInputPythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'Chat Input (Python)',
-  docsPath: '/docs/chat/core-capabilities/input/overview/python',
+  docsPath: '/docs/chat/components/chat-input',
   promptAssetPaths: ['cockpit/chat/input/python/prompts/input.md'],
   codeAssetPaths: [
     'cockpit/chat/input/angular/src/app/input.component.ts',

--- a/cockpit/chat/interrupts/angular/src/index.ts
+++ b/cockpit/chat/interrupts/angular/src/index.ts
@@ -23,7 +23,7 @@ export const chatInterruptsAngularModule: CockpitCapabilityModule = {
     language: 'angular',
   },
   title: 'Chat Interrupts (Angular)',
-  docsPath: '/docs/chat/core-capabilities/interrupts/overview/angular',
+  docsPath: '/docs/chat/components/chat-interrupt-panel',
   promptAssetPaths: ['cockpit/chat/interrupts/python/prompts/interrupts.md'],
   codeAssetPaths: ['cockpit/chat/interrupts/angular/src/app/interrupts.component.ts'],
 };

--- a/cockpit/chat/interrupts/python/src/index.ts
+++ b/cockpit/chat/interrupts/python/src/index.ts
@@ -27,7 +27,7 @@ export const chatInterruptsPythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'Chat Interrupts (Python)',
-  docsPath: '/docs/chat/core-capabilities/interrupts/overview/python',
+  docsPath: '/docs/chat/components/chat-interrupt-panel',
   promptAssetPaths: ['cockpit/chat/interrupts/python/prompts/interrupts.md'],
   codeAssetPaths: [
     'cockpit/chat/interrupts/angular/src/app/interrupts.component.ts',

--- a/cockpit/chat/matrix.spec.ts
+++ b/cockpit/chat/matrix.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { getCockpitDocsPath } from '@threadplane/cockpit-registry';
 import { chatMessagesPythonModule } from './messages/python/src/index';
 import { chatInputPythonModule } from './input/python/src/index';
 import { chatInterruptsPythonModule } from './interrupts/python/src/index';
@@ -46,9 +47,18 @@ describe('Chat matrix slice', () => {
         page: 'overview',
         language: 'python',
       });
+      // The docs link is a table lookup, not a formula derived from the
+      // identity: the cockpit tree and the website's docs tree do not share a
+      // naming scheme. The table's targets are checked against the website's
+      // real content tree in apps/cockpit/src/lib/docs-links.spec.ts.
       expect(module.docsPath).toBe(
-        `/docs/chat/core-capabilities/${module.manifestIdentity.topic}/overview/python`
+        getCockpitDocsPath(
+          module.manifestIdentity.product,
+          module.manifestIdentity.section,
+          module.manifestIdentity.topic
+        )
       );
+      expect(module.docsPath).toMatch(/^\/docs\/[a-z0-9-]+\/[a-z0-9-]+\/[a-z0-9-]+$/);
       expect(module.promptAssetPaths.length).toBe(1);
       expect(module.codeAssetPaths.length).toBeGreaterThanOrEqual(1);
     }

--- a/cockpit/chat/messages/angular/src/index.ts
+++ b/cockpit/chat/messages/angular/src/index.ts
@@ -23,7 +23,7 @@ export const chatMessagesAngularModule: CockpitCapabilityModule = {
     language: 'angular',
   },
   title: 'Chat Messages (Angular)',
-  docsPath: '/docs/chat/core-capabilities/messages/overview/angular',
+  docsPath: '/docs/chat/concepts/message-model',
   promptAssetPaths: ['cockpit/chat/messages/python/prompts/messages.md'],
   codeAssetPaths: ['cockpit/chat/messages/angular/src/app/messages.component.ts'],
 };

--- a/cockpit/chat/messages/python/src/index.ts
+++ b/cockpit/chat/messages/python/src/index.ts
@@ -27,7 +27,7 @@ export const chatMessagesPythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'Chat Messages (Python)',
-  docsPath: '/docs/chat/core-capabilities/messages/overview/python',
+  docsPath: '/docs/chat/concepts/message-model',
   promptAssetPaths: ['cockpit/chat/messages/python/prompts/messages.md'],
   codeAssetPaths: [
     'cockpit/chat/messages/angular/src/app/messages.component.ts',

--- a/cockpit/chat/subagents/angular/src/index.ts
+++ b/cockpit/chat/subagents/angular/src/index.ts
@@ -23,7 +23,7 @@ export const chatSubagentsAngularModule: CockpitCapabilityModule = {
     language: 'angular',
   },
   title: 'Chat Subagents (Angular)',
-  docsPath: '/docs/chat/core-capabilities/subagents/overview/angular',
+  docsPath: '/docs/chat/components/chat-subagent-card',
   promptAssetPaths: ['cockpit/chat/subagents/python/prompts/subagents.md'],
   codeAssetPaths: ['cockpit/chat/subagents/angular/src/app/subagents.component.ts'],
 };

--- a/cockpit/chat/subagents/python/src/index.ts
+++ b/cockpit/chat/subagents/python/src/index.ts
@@ -27,7 +27,7 @@ export const chatSubagentsPythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'Chat Subagents (Python)',
-  docsPath: '/docs/chat/core-capabilities/subagents/overview/python',
+  docsPath: '/docs/chat/components/chat-subagent-card',
   promptAssetPaths: ['cockpit/chat/subagents/python/prompts/subagents.md'],
   codeAssetPaths: [
     'cockpit/chat/subagents/angular/src/app/subagents.component.ts',

--- a/cockpit/chat/theming/angular/src/index.ts
+++ b/cockpit/chat/theming/angular/src/index.ts
@@ -23,7 +23,7 @@ export const chatThemingAngularModule: CockpitCapabilityModule = {
     language: 'angular',
   },
   title: 'Chat Theming (Angular)',
-  docsPath: '/docs/chat/core-capabilities/theming/overview/angular',
+  docsPath: '/docs/chat/guides/theming',
   promptAssetPaths: ['cockpit/chat/theming/python/prompts/theming.md'],
   codeAssetPaths: ['cockpit/chat/theming/angular/src/app/theming.component.ts'],
 };

--- a/cockpit/chat/theming/python/src/index.ts
+++ b/cockpit/chat/theming/python/src/index.ts
@@ -27,7 +27,7 @@ export const chatThemingPythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'Chat Theming (Python)',
-  docsPath: '/docs/chat/core-capabilities/theming/overview/python',
+  docsPath: '/docs/chat/guides/theming',
   promptAssetPaths: ['cockpit/chat/theming/python/prompts/theming.md'],
   codeAssetPaths: [
     'cockpit/chat/theming/angular/src/app/theming.component.ts',

--- a/cockpit/chat/threads/angular/src/index.ts
+++ b/cockpit/chat/threads/angular/src/index.ts
@@ -23,7 +23,7 @@ export const chatThreadsAngularModule: CockpitCapabilityModule = {
     language: 'angular',
   },
   title: 'Chat Threads (Angular)',
-  docsPath: '/docs/chat/core-capabilities/threads/overview/angular',
+  docsPath: '/docs/chat/guides/thread-routing',
   promptAssetPaths: ['cockpit/chat/threads/python/prompts/threads.md'],
   codeAssetPaths: ['cockpit/chat/threads/angular/src/app/threads.component.ts'],
 };

--- a/cockpit/chat/threads/python/src/index.ts
+++ b/cockpit/chat/threads/python/src/index.ts
@@ -27,7 +27,7 @@ export const chatThreadsPythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'Chat Threads (Python)',
-  docsPath: '/docs/chat/core-capabilities/threads/overview/python',
+  docsPath: '/docs/chat/guides/thread-routing',
   promptAssetPaths: ['cockpit/chat/threads/python/prompts/threads.md'],
   codeAssetPaths: [
     'cockpit/chat/threads/angular/src/app/threads.component.ts',

--- a/cockpit/chat/timeline/angular/src/index.ts
+++ b/cockpit/chat/timeline/angular/src/index.ts
@@ -23,7 +23,7 @@ export const chatTimelineAngularModule: CockpitCapabilityModule = {
     language: 'angular',
   },
   title: 'Chat Timeline (Angular)',
-  docsPath: '/docs/chat/core-capabilities/timeline/overview/angular',
+  docsPath: '/docs/chat/components/chat-trace',
   promptAssetPaths: ['cockpit/chat/timeline/python/prompts/timeline.md'],
   codeAssetPaths: ['cockpit/chat/timeline/angular/src/app/timeline.component.ts'],
 };

--- a/cockpit/chat/timeline/python/src/index.ts
+++ b/cockpit/chat/timeline/python/src/index.ts
@@ -27,7 +27,7 @@ export const chatTimelinePythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'Chat Timeline (Python)',
-  docsPath: '/docs/chat/core-capabilities/timeline/overview/python',
+  docsPath: '/docs/chat/components/chat-trace',
   promptAssetPaths: ['cockpit/chat/timeline/python/prompts/timeline.md'],
   codeAssetPaths: [
     'cockpit/chat/timeline/angular/src/app/timeline.component.ts',

--- a/cockpit/chat/tool-calls/angular/src/index.ts
+++ b/cockpit/chat/tool-calls/angular/src/index.ts
@@ -23,7 +23,7 @@ export const chatToolCallsAngularModule: CockpitCapabilityModule = {
     language: 'angular',
   },
   title: 'Chat Tool Calls (Angular)',
-  docsPath: '/docs/chat/core-capabilities/tool-calls/overview/angular',
+  docsPath: '/docs/chat/components/chat-tool-calls',
   promptAssetPaths: ['cockpit/chat/tool-calls/python/prompts/tool-calls.md'],
   codeAssetPaths: ['cockpit/chat/tool-calls/angular/src/app/tool-calls.component.ts'],
 };

--- a/cockpit/chat/tool-calls/python/src/index.ts
+++ b/cockpit/chat/tool-calls/python/src/index.ts
@@ -27,7 +27,7 @@ export const chatToolCallsPythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'Chat Tool Calls (Python)',
-  docsPath: '/docs/chat/core-capabilities/tool-calls/overview/python',
+  docsPath: '/docs/chat/components/chat-tool-calls',
   promptAssetPaths: ['cockpit/chat/tool-calls/python/prompts/tool-calls.md'],
   codeAssetPaths: [
     'cockpit/chat/tool-calls/angular/src/app/tool-calls.component.ts',

--- a/cockpit/deep-agents/filesystem/angular/src/index.ts
+++ b/cockpit/deep-agents/filesystem/angular/src/index.ts
@@ -23,7 +23,9 @@ export const deepAgentsFilesystemAngularModule: CockpitCapabilityModule = {
     language: 'angular',
   },
   title: 'Deep Agents Filesystem (Angular)',
-  docsPath: '/docs/deep-agents/core-capabilities/filesystem/overview/angular',
+  // No `deep-agents` library exists on the website yet; the empty string is
+  // the "no published docs page" sentinel and renders no Docs link.
+  docsPath: '',
   promptAssetPaths: [
     'cockpit/deep-agents/filesystem/angular/prompts/filesystem.md',
   ],

--- a/cockpit/deep-agents/filesystem/python/src/index.ts
+++ b/cockpit/deep-agents/filesystem/python/src/index.ts
@@ -27,7 +27,9 @@ export const deepAgentsFilesystemPythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'Deep Agents Filesystem (Python)',
-  docsPath: '/docs/deep-agents/core-capabilities/filesystem/overview/python',
+  // No `deep-agents` library exists on the website yet; the empty string is
+  // the "no published docs page" sentinel and renders no Docs link.
+  docsPath: '',
   promptAssetPaths: ['cockpit/deep-agents/filesystem/python/prompts/filesystem.md'],
   codeAssetPaths: [
     'cockpit/deep-agents/filesystem/angular/src/app/filesystem.component.ts',

--- a/cockpit/deep-agents/memory/angular/src/index.ts
+++ b/cockpit/deep-agents/memory/angular/src/index.ts
@@ -23,7 +23,9 @@ export const deepAgentsMemoryAngularModule: CockpitCapabilityModule = {
     language: 'angular',
   },
   title: 'Deep Agents Memory (Angular)',
-  docsPath: '/docs/deep-agents/core-capabilities/memory/overview/angular',
+  // No `deep-agents` library exists on the website yet; the empty string is
+  // the "no published docs page" sentinel and renders no Docs link.
+  docsPath: '',
   promptAssetPaths: [
     'cockpit/deep-agents/memory/angular/prompts/memory.md',
   ],

--- a/cockpit/deep-agents/memory/python/src/index.ts
+++ b/cockpit/deep-agents/memory/python/src/index.ts
@@ -27,7 +27,9 @@ export const deepAgentsMemoryPythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'Deep Agents Memory (Python)',
-  docsPath: '/docs/deep-agents/core-capabilities/memory/overview/python',
+  // No `deep-agents` library exists on the website yet; the empty string is
+  // the "no published docs page" sentinel and renders no Docs link.
+  docsPath: '',
   promptAssetPaths: ['cockpit/deep-agents/memory/python/prompts/memory.md'],
   codeAssetPaths: [
     'cockpit/deep-agents/memory/angular/src/app/memory.component.ts',

--- a/cockpit/deep-agents/planning/angular/src/index.ts
+++ b/cockpit/deep-agents/planning/angular/src/index.ts
@@ -23,7 +23,9 @@ export const deepAgentsPlanningAngularModule: CockpitCapabilityModule = {
     language: 'angular',
   },
   title: 'Deep Agents Planning (Angular)',
-  docsPath: '/docs/deep-agents/core-capabilities/planning/overview/angular',
+  // No `deep-agents` library exists on the website yet; the empty string is
+  // the "no published docs page" sentinel and renders no Docs link.
+  docsPath: '',
   promptAssetPaths: [
     'cockpit/deep-agents/planning/angular/prompts/planning.md',
   ],

--- a/cockpit/deep-agents/planning/python/src/index.ts
+++ b/cockpit/deep-agents/planning/python/src/index.ts
@@ -27,7 +27,9 @@ export const deepAgentsPlanningPythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'Deep Agents Planning (Python)',
-  docsPath: '/docs/deep-agents/core-capabilities/planning/overview/python',
+  // No `deep-agents` library exists on the website yet; the empty string is
+  // the "no published docs page" sentinel and renders no Docs link.
+  docsPath: '',
   promptAssetPaths: ['cockpit/deep-agents/planning/python/prompts/planning.md'],
   codeAssetPaths: [
     'cockpit/deep-agents/planning/angular/src/app/planning.component.ts',

--- a/cockpit/deep-agents/sandboxes/angular/src/index.ts
+++ b/cockpit/deep-agents/sandboxes/angular/src/index.ts
@@ -23,7 +23,9 @@ export const deepAgentsSandboxesAngularModule: CockpitCapabilityModule = {
     language: 'angular',
   },
   title: 'Deep Agents Sandboxes (Angular)',
-  docsPath: '/docs/deep-agents/core-capabilities/sandboxes/overview/angular',
+  // No `deep-agents` library exists on the website yet; the empty string is
+  // the "no published docs page" sentinel and renders no Docs link.
+  docsPath: '',
   promptAssetPaths: [
     'cockpit/deep-agents/sandboxes/angular/prompts/sandboxes.md',
   ],

--- a/cockpit/deep-agents/sandboxes/python/src/index.ts
+++ b/cockpit/deep-agents/sandboxes/python/src/index.ts
@@ -27,7 +27,9 @@ export const deepAgentsSandboxesPythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'Deep Agents Sandboxes (Python)',
-  docsPath: '/docs/deep-agents/core-capabilities/sandboxes/overview/python',
+  // No `deep-agents` library exists on the website yet; the empty string is
+  // the "no published docs page" sentinel and renders no Docs link.
+  docsPath: '',
   promptAssetPaths: ['cockpit/deep-agents/sandboxes/python/prompts/sandboxes.md'],
   codeAssetPaths: [
     'cockpit/deep-agents/sandboxes/angular/src/app/sandboxes.component.ts',

--- a/cockpit/deep-agents/skills/angular/src/index.ts
+++ b/cockpit/deep-agents/skills/angular/src/index.ts
@@ -23,7 +23,9 @@ export const deepAgentsSkillsAngularModule: CockpitCapabilityModule = {
     language: 'angular',
   },
   title: 'Deep Agents Skills (Angular)',
-  docsPath: '/docs/deep-agents/core-capabilities/skills/overview/angular',
+  // No `deep-agents` library exists on the website yet; the empty string is
+  // the "no published docs page" sentinel and renders no Docs link.
+  docsPath: '',
   promptAssetPaths: [
     'cockpit/deep-agents/skills/angular/prompts/skills.md',
   ],

--- a/cockpit/deep-agents/skills/python/src/index.ts
+++ b/cockpit/deep-agents/skills/python/src/index.ts
@@ -27,7 +27,9 @@ export const deepAgentsSkillsPythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'Deep Agents Skills (Python)',
-  docsPath: '/docs/deep-agents/core-capabilities/skills/overview/python',
+  // No `deep-agents` library exists on the website yet; the empty string is
+  // the "no published docs page" sentinel and renders no Docs link.
+  docsPath: '',
   promptAssetPaths: ['cockpit/deep-agents/skills/python/prompts/skills.md'],
   codeAssetPaths: [
     'cockpit/deep-agents/skills/angular/src/app/skills.component.ts',

--- a/cockpit/deep-agents/subagents/angular/src/index.ts
+++ b/cockpit/deep-agents/subagents/angular/src/index.ts
@@ -23,7 +23,9 @@ export const deepAgentsSubagentsAngularModule: CockpitCapabilityModule = {
     language: 'angular',
   },
   title: 'Deep Agents Subagents (Angular)',
-  docsPath: '/docs/deep-agents/core-capabilities/subagents/overview/angular',
+  // No `deep-agents` library exists on the website yet; the empty string is
+  // the "no published docs page" sentinel and renders no Docs link.
+  docsPath: '',
   promptAssetPaths: [
     'cockpit/deep-agents/subagents/angular/prompts/subagents.md',
   ],

--- a/cockpit/deep-agents/subagents/python/src/index.ts
+++ b/cockpit/deep-agents/subagents/python/src/index.ts
@@ -27,7 +27,9 @@ export const deepAgentsSubagentsPythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'Deep Agents Subagents (Python)',
-  docsPath: '/docs/deep-agents/core-capabilities/subagents/overview/python',
+  // No `deep-agents` library exists on the website yet; the empty string is
+  // the "no published docs page" sentinel and renders no Docs link.
+  docsPath: '',
   promptAssetPaths: ['cockpit/deep-agents/subagents/python/prompts/subagents.md'],
   codeAssetPaths: [
     'cockpit/deep-agents/subagents/angular/src/app/subagents.component.ts',

--- a/cockpit/langgraph/client-tools/angular/src/index.ts
+++ b/cockpit/langgraph/client-tools/angular/src/index.ts
@@ -23,7 +23,7 @@ export const langgraphClientToolsAngularModule: CockpitCapabilityModule = {
     language: 'angular',
   },
   title: 'LangGraph Client Tools (Angular)',
-  docsPath: '/docs/langgraph/core-capabilities/client-tools/overview/angular',
+  docsPath: '/docs/chat/guides/client-tools',
   promptAssetPaths: [
     'cockpit/langgraph/client-tools/angular/prompts/client-tools.md',
   ],

--- a/cockpit/langgraph/client-tools/python/src/index.ts
+++ b/cockpit/langgraph/client-tools/python/src/index.ts
@@ -27,7 +27,7 @@ export const langgraphClientToolsPythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'LangGraph Client Tools (Python)',
-  docsPath: '/docs/langgraph/core-capabilities/client-tools/overview/python',
+  docsPath: '/docs/chat/guides/client-tools',
   promptAssetPaths: ['cockpit/langgraph/client-tools/python/prompts/client-tools.md'],
   codeAssetPaths: [
     'cockpit/langgraph/client-tools/angular/src/app/client-tools.component.ts',

--- a/cockpit/langgraph/deployment-runtime/angular/src/index.ts
+++ b/cockpit/langgraph/deployment-runtime/angular/src/index.ts
@@ -23,7 +23,7 @@ export const langgraphDeploymentRuntimeAngularModule: CockpitCapabilityModule = 
     language: 'angular',
   },
   title: 'LangGraph Deployment & Runtime (Angular)',
-  docsPath: '/docs/langgraph/core-capabilities/deployment-runtime/overview/angular',
+  docsPath: '/docs/langgraph/guides/deployment',
   promptAssetPaths: [
     'cockpit/langgraph/deployment-runtime/angular/prompts/deployment-runtime.md',
   ],

--- a/cockpit/langgraph/deployment-runtime/python/src/index.ts
+++ b/cockpit/langgraph/deployment-runtime/python/src/index.ts
@@ -27,7 +27,7 @@ export const langgraphDeploymentRuntimePythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'LangGraph Deployment Runtime (Python)',
-  docsPath: '/docs/langgraph/core-capabilities/deployment-runtime/overview/python',
+  docsPath: '/docs/langgraph/guides/deployment',
   promptAssetPaths: [
     'cockpit/langgraph/deployment-runtime/python/prompts/deployment-runtime.md',
   ],

--- a/cockpit/langgraph/durable-execution/angular/src/index.ts
+++ b/cockpit/langgraph/durable-execution/angular/src/index.ts
@@ -23,7 +23,7 @@ export const langgraphDurableExecutionAngularModule: CockpitCapabilityModule = {
     language: 'angular',
   },
   title: 'LangGraph Durable Execution (Angular)',
-  docsPath: '/docs/langgraph/core-capabilities/durable-execution/overview/angular',
+  docsPath: '/docs/langgraph/guides/persistence',
   promptAssetPaths: [
     'cockpit/langgraph/durable-execution/angular/prompts/durable-execution.md',
   ],

--- a/cockpit/langgraph/durable-execution/python/src/index.ts
+++ b/cockpit/langgraph/durable-execution/python/src/index.ts
@@ -27,7 +27,7 @@ export const langgraphDurableExecutionPythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'LangGraph Durable Execution (Python)',
-  docsPath: '/docs/langgraph/core-capabilities/durable-execution/overview/python',
+  docsPath: '/docs/langgraph/guides/persistence',
   promptAssetPaths: ['cockpit/langgraph/durable-execution/python/prompts/durable-execution.md'],
   codeAssetPaths: [
     'cockpit/langgraph/durable-execution/angular/src/app/durable-execution.component.ts',

--- a/cockpit/langgraph/interrupts/angular/src/index.ts
+++ b/cockpit/langgraph/interrupts/angular/src/index.ts
@@ -23,7 +23,7 @@ export const langgraphInterruptsAngularModule: CockpitCapabilityModule = {
     language: 'angular',
   },
   title: 'LangGraph Interrupts (Angular)',
-  docsPath: '/docs/langgraph/core-capabilities/interrupts/overview/angular',
+  docsPath: '/docs/langgraph/guides/interrupts',
   promptAssetPaths: [
     'cockpit/langgraph/interrupts/angular/prompts/interrupts.md',
   ],

--- a/cockpit/langgraph/interrupts/python/src/index.ts
+++ b/cockpit/langgraph/interrupts/python/src/index.ts
@@ -27,7 +27,7 @@ export const langgraphInterruptsPythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'LangGraph Interrupts (Python)',
-  docsPath: '/docs/langgraph/core-capabilities/interrupts/overview/python',
+  docsPath: '/docs/langgraph/guides/interrupts',
   promptAssetPaths: ['cockpit/langgraph/interrupts/python/prompts/interrupts.md'],
   codeAssetPaths: [
     'cockpit/langgraph/interrupts/angular/src/app/interrupts.component.ts',

--- a/cockpit/langgraph/matrix.spec.ts
+++ b/cockpit/langgraph/matrix.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { getCockpitDocsPath } from '@threadplane/cockpit-registry';
 import { langgraphStreamingPythonModule } from './streaming/python/src/index';
 import { langgraphPersistencePythonModule } from './persistence/python/src/index';
 import { langgraphDurableExecutionPythonModule } from './durable-execution/python/src/index';
@@ -40,11 +41,22 @@ describe('LangGraph matrix slice', () => {
         page: 'overview',
         language: 'python',
       });
+      // The docs link is a table lookup, not a formula derived from the
+      // identity: the cockpit tree and the website's docs tree do not share a
+      // naming scheme. The table's targets are checked against the website's
+      // real content tree in apps/cockpit/src/lib/docs-links.spec.ts.
       expect(module.docsPath).toBe(
-        `/docs/langgraph/core-capabilities/${module.manifestIdentity.topic}/overview/python`
+        getCockpitDocsPath(
+          module.manifestIdentity.product,
+          module.manifestIdentity.section,
+          module.manifestIdentity.topic
+        )
       );
+      expect(module.docsPath).toMatch(/^\/docs\/[a-z0-9-]+\/[a-z0-9-]+\/[a-z0-9-]+$/);
       expect(module.promptAssetPaths.length).toBe(1);
-      expect(module.codeAssetPaths.length).toBe(1);
+      // Examples grew extra code assets after this spec stopped running; it
+      // is a floor, matching the chat and render matrix slices.
+      expect(module.codeAssetPaths.length).toBeGreaterThanOrEqual(1);
     }
   });
 });

--- a/cockpit/langgraph/memory/angular/src/index.ts
+++ b/cockpit/langgraph/memory/angular/src/index.ts
@@ -23,7 +23,7 @@ export const langgraphMemoryAngularModule: CockpitCapabilityModule = {
     language: 'angular',
   },
   title: 'LangGraph Memory (Angular)',
-  docsPath: '/docs/langgraph/core-capabilities/memory/overview/angular',
+  docsPath: '/docs/langgraph/guides/memory',
   promptAssetPaths: [
     'cockpit/langgraph/memory/angular/prompts/memory.md',
   ],

--- a/cockpit/langgraph/memory/python/src/index.ts
+++ b/cockpit/langgraph/memory/python/src/index.ts
@@ -27,7 +27,7 @@ export const langgraphMemoryPythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'LangGraph Memory (Python)',
-  docsPath: '/docs/langgraph/core-capabilities/memory/overview/python',
+  docsPath: '/docs/langgraph/guides/memory',
   promptAssetPaths: ['cockpit/langgraph/memory/python/prompts/memory.md'],
   codeAssetPaths: [
     'cockpit/langgraph/memory/angular/src/app/memory.component.ts',

--- a/cockpit/langgraph/persistence/angular/src/index.ts
+++ b/cockpit/langgraph/persistence/angular/src/index.ts
@@ -23,7 +23,7 @@ export const langgraphPersistenceAngularModule: CockpitCapabilityModule = {
     language: 'angular',
   },
   title: 'LangGraph Persistence (Angular)',
-  docsPath: '/docs/langgraph/core-capabilities/persistence/overview/angular',
+  docsPath: '/docs/langgraph/guides/persistence',
   promptAssetPaths: [
     'cockpit/langgraph/persistence/angular/prompts/persistence.md',
   ],

--- a/cockpit/langgraph/persistence/python/src/index.ts
+++ b/cockpit/langgraph/persistence/python/src/index.ts
@@ -27,7 +27,7 @@ export const langgraphPersistencePythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'LangGraph Persistence (Python)',
-  docsPath: '/docs/langgraph/core-capabilities/persistence/overview/python',
+  docsPath: '/docs/langgraph/guides/persistence',
   promptAssetPaths: ['cockpit/langgraph/persistence/python/prompts/persistence.md'],
   codeAssetPaths: [
     'cockpit/langgraph/persistence/angular/src/app/persistence.component.ts',

--- a/cockpit/langgraph/streaming/angular/src/index.ts
+++ b/cockpit/langgraph/streaming/angular/src/index.ts
@@ -23,7 +23,7 @@ export const langgraphStreamingAngularModule: CockpitCapabilityModule = {
     language: 'angular',
   },
   title: 'LangGraph Streaming (Angular)',
-  docsPath: '/docs/langgraph/core-capabilities/streaming/overview/angular',
+  docsPath: '/docs/langgraph/guides/streaming',
   promptAssetPaths: [
     'cockpit/langgraph/streaming/angular/prompts/streaming.md',
   ],

--- a/cockpit/langgraph/streaming/python/src/index.ts
+++ b/cockpit/langgraph/streaming/python/src/index.ts
@@ -27,7 +27,7 @@ export const langgraphStreamingPythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'LangGraph Streaming (Python)',
-  docsPath: '/docs/langgraph/core-capabilities/streaming/overview/python',
+  docsPath: '/docs/langgraph/guides/streaming',
   promptAssetPaths: ['cockpit/langgraph/streaming/python/prompts/streaming.md'],
   codeAssetPaths: [
     'cockpit/langgraph/streaming/angular/src/app/streaming.component.ts',

--- a/cockpit/langgraph/subgraphs/angular/src/index.ts
+++ b/cockpit/langgraph/subgraphs/angular/src/index.ts
@@ -23,7 +23,7 @@ export const langgraphSubgraphsAngularModule: CockpitCapabilityModule = {
     language: 'angular',
   },
   title: 'LangGraph Subgraphs (Angular)',
-  docsPath: '/docs/langgraph/core-capabilities/subgraphs/overview/angular',
+  docsPath: '/docs/langgraph/guides/subgraphs',
   promptAssetPaths: [
     'cockpit/langgraph/subgraphs/angular/prompts/subgraphs.md',
   ],

--- a/cockpit/langgraph/subgraphs/python/src/index.ts
+++ b/cockpit/langgraph/subgraphs/python/src/index.ts
@@ -27,7 +27,7 @@ export const langgraphSubgraphsPythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'LangGraph Subgraphs (Python)',
-  docsPath: '/docs/langgraph/core-capabilities/subgraphs/overview/python',
+  docsPath: '/docs/langgraph/guides/subgraphs',
   promptAssetPaths: ['cockpit/langgraph/subgraphs/python/prompts/subgraphs.md'],
   codeAssetPaths: [
     'cockpit/langgraph/subgraphs/angular/src/app/agent-ref.ts',

--- a/cockpit/langgraph/time-travel/angular/src/index.ts
+++ b/cockpit/langgraph/time-travel/angular/src/index.ts
@@ -23,7 +23,7 @@ export const langgraphTimeTravelAngularModule: CockpitCapabilityModule = {
     language: 'angular',
   },
   title: 'LangGraph Time Travel (Angular)',
-  docsPath: '/docs/langgraph/core-capabilities/time-travel/overview/angular',
+  docsPath: '/docs/langgraph/guides/time-travel',
   promptAssetPaths: [
     'cockpit/langgraph/time-travel/angular/prompts/time-travel.md',
   ],

--- a/cockpit/langgraph/time-travel/python/src/index.ts
+++ b/cockpit/langgraph/time-travel/python/src/index.ts
@@ -27,7 +27,7 @@ export const langgraphTimeTravelPythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'LangGraph Time Travel (Python)',
-  docsPath: '/docs/langgraph/core-capabilities/time-travel/overview/python',
+  docsPath: '/docs/langgraph/guides/time-travel',
   promptAssetPaths: ['cockpit/langgraph/time-travel/python/prompts/time-travel.md'],
   codeAssetPaths: [
     'cockpit/langgraph/time-travel/angular/src/app/time-travel.component.ts',

--- a/cockpit/render/computed-functions/angular/src/index.ts
+++ b/cockpit/render/computed-functions/angular/src/index.ts
@@ -23,7 +23,7 @@ export const renderComputedFunctionsAngularModule: CockpitCapabilityModule = {
     language: 'angular',
   },
   title: 'Render Computed Functions (Angular)',
-  docsPath: '/docs/render/core-capabilities/computed-functions/overview/angular',
+  docsPath: '/docs/render/api/provide-render',
   promptAssetPaths: ['cockpit/render/computed-functions/angular/prompts/computed-functions.md'],
   codeAssetPaths: ['cockpit/render/computed-functions/angular/src/app/computed-functions.component.ts'],
 };

--- a/cockpit/render/computed-functions/python/src/index.ts
+++ b/cockpit/render/computed-functions/python/src/index.ts
@@ -27,7 +27,7 @@ export const renderComputedFunctionsPythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'Render Computed Functions (Python)',
-  docsPath: '/docs/render/core-capabilities/computed-functions/overview/python',
+  docsPath: '/docs/render/api/provide-render',
   promptAssetPaths: ['cockpit/render/computed-functions/python/prompts/computed-functions.md'],
   codeAssetPaths: [
     'cockpit/render/computed-functions/angular/src/app/computed-functions.component.ts',

--- a/cockpit/render/element-rendering/angular/src/index.ts
+++ b/cockpit/render/element-rendering/angular/src/index.ts
@@ -23,7 +23,7 @@ export const renderElementRenderingAngularModule: CockpitCapabilityModule = {
     language: 'angular',
   },
   title: 'Render Element Rendering (Angular)',
-  docsPath: '/docs/render/core-capabilities/element-rendering/overview/angular',
+  docsPath: '/docs/render/api/render-spec-component',
   promptAssetPaths: ['cockpit/render/element-rendering/angular/prompts/element-rendering.md'],
   codeAssetPaths: ['cockpit/render/element-rendering/angular/src/app/element-rendering.component.ts'],
 };

--- a/cockpit/render/element-rendering/python/src/index.ts
+++ b/cockpit/render/element-rendering/python/src/index.ts
@@ -27,7 +27,7 @@ export const renderElementRenderingPythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'Render Element Rendering (Python)',
-  docsPath: '/docs/render/core-capabilities/element-rendering/overview/python',
+  docsPath: '/docs/render/api/render-spec-component',
   promptAssetPaths: ['cockpit/render/element-rendering/python/prompts/element-rendering.md'],
   codeAssetPaths: [
     'cockpit/render/element-rendering/angular/src/app/element-rendering.component.ts',

--- a/cockpit/render/matrix.spec.ts
+++ b/cockpit/render/matrix.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { getCockpitDocsPath } from '@threadplane/cockpit-registry';
 import { renderSpecRenderingPythonModule } from './spec-rendering/python/src/index';
 import { renderElementRenderingPythonModule } from './element-rendering/python/src/index';
 import { renderStateManagementPythonModule } from './state-management/python/src/index';
@@ -34,9 +35,18 @@ describe('Render matrix slice', () => {
         page: 'overview',
         language: 'python',
       });
+      // The docs link is a table lookup, not a formula derived from the
+      // identity: the cockpit tree and the website's docs tree do not share a
+      // naming scheme. The table's targets are checked against the website's
+      // real content tree in apps/cockpit/src/lib/docs-links.spec.ts.
       expect(module.docsPath).toBe(
-        `/docs/render/core-capabilities/${module.manifestIdentity.topic}/overview/python`
+        getCockpitDocsPath(
+          module.manifestIdentity.product,
+          module.manifestIdentity.section,
+          module.manifestIdentity.topic
+        )
       );
+      expect(module.docsPath).toMatch(/^\/docs\/[a-z0-9-]+\/[a-z0-9-]+\/[a-z0-9-]+$/);
       expect(module.promptAssetPaths.length).toBe(1);
       expect(module.codeAssetPaths.length).toBeGreaterThanOrEqual(1);
     }

--- a/cockpit/render/registry/angular/src/index.ts
+++ b/cockpit/render/registry/angular/src/index.ts
@@ -23,7 +23,7 @@ export const renderRegistryAngularModule: CockpitCapabilityModule = {
     language: 'angular',
   },
   title: 'Render Registry (Angular)',
-  docsPath: '/docs/render/core-capabilities/registry/overview/angular',
+  docsPath: '/docs/render/guides/registry',
   promptAssetPaths: ['cockpit/render/registry/angular/prompts/registry.md'],
   codeAssetPaths: ['cockpit/render/registry/angular/src/app/registry.component.ts'],
 };

--- a/cockpit/render/registry/python/src/index.ts
+++ b/cockpit/render/registry/python/src/index.ts
@@ -27,7 +27,7 @@ export const renderRegistryPythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'Render Registry (Python)',
-  docsPath: '/docs/render/core-capabilities/registry/overview/python',
+  docsPath: '/docs/render/guides/registry',
   promptAssetPaths: ['cockpit/render/registry/python/prompts/registry.md'],
   codeAssetPaths: [
     'cockpit/render/registry/angular/src/app/registry.component.ts',

--- a/cockpit/render/repeat-loops/angular/src/index.ts
+++ b/cockpit/render/repeat-loops/angular/src/index.ts
@@ -23,7 +23,7 @@ export const renderRepeatLoopsAngularModule: CockpitCapabilityModule = {
     language: 'angular',
   },
   title: 'Render Repeat Loops (Angular)',
-  docsPath: '/docs/render/core-capabilities/repeat-loops/overview/angular',
+  docsPath: '/docs/render/guides/specs',
   promptAssetPaths: ['cockpit/render/repeat-loops/angular/prompts/repeat-loops.md'],
   codeAssetPaths: ['cockpit/render/repeat-loops/angular/src/app/repeat-loops.component.ts'],
 };

--- a/cockpit/render/repeat-loops/python/src/index.ts
+++ b/cockpit/render/repeat-loops/python/src/index.ts
@@ -27,7 +27,7 @@ export const renderRepeatLoopsPythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'Render Repeat Loops (Python)',
-  docsPath: '/docs/render/core-capabilities/repeat-loops/overview/python',
+  docsPath: '/docs/render/guides/specs',
   promptAssetPaths: ['cockpit/render/repeat-loops/python/prompts/repeat-loops.md'],
   codeAssetPaths: [
     'cockpit/render/repeat-loops/angular/src/app/repeat-loops.component.ts',

--- a/cockpit/render/spec-rendering/angular/src/index.ts
+++ b/cockpit/render/spec-rendering/angular/src/index.ts
@@ -23,7 +23,7 @@ export const renderSpecRenderingAngularModule: CockpitCapabilityModule = {
     language: 'angular',
   },
   title: 'Render Spec Rendering (Angular)',
-  docsPath: '/docs/render/core-capabilities/spec-rendering/overview/angular',
+  docsPath: '/docs/render/guides/specs',
   promptAssetPaths: ['cockpit/render/spec-rendering/angular/prompts/spec-rendering.md'],
   codeAssetPaths: ['cockpit/render/spec-rendering/angular/src/app/spec-rendering.component.ts'],
 };

--- a/cockpit/render/spec-rendering/python/src/index.ts
+++ b/cockpit/render/spec-rendering/python/src/index.ts
@@ -27,7 +27,7 @@ export const renderSpecRenderingPythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'Render Spec Rendering (Python)',
-  docsPath: '/docs/render/core-capabilities/spec-rendering/overview/python',
+  docsPath: '/docs/render/guides/specs',
   promptAssetPaths: ['cockpit/render/spec-rendering/python/prompts/spec-rendering.md'],
   codeAssetPaths: [
     'cockpit/render/spec-rendering/angular/src/app/spec-rendering.component.ts',

--- a/cockpit/render/state-management/angular/src/index.ts
+++ b/cockpit/render/state-management/angular/src/index.ts
@@ -23,7 +23,7 @@ export const renderStateManagementAngularModule: CockpitCapabilityModule = {
     language: 'angular',
   },
   title: 'Render State Management (Angular)',
-  docsPath: '/docs/render/core-capabilities/state-management/overview/angular',
+  docsPath: '/docs/render/guides/state-store',
   promptAssetPaths: ['cockpit/render/state-management/angular/prompts/state-management.md'],
   codeAssetPaths: ['cockpit/render/state-management/angular/src/app/state-management.component.ts'],
 };

--- a/cockpit/render/state-management/python/src/index.ts
+++ b/cockpit/render/state-management/python/src/index.ts
@@ -27,7 +27,7 @@ export const renderStateManagementPythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'Render State Management (Python)',
-  docsPath: '/docs/render/core-capabilities/state-management/overview/python',
+  docsPath: '/docs/render/guides/state-store',
   promptAssetPaths: ['cockpit/render/state-management/python/prompts/state-management.md'],
   codeAssetPaths: [
     'cockpit/render/state-management/angular/src/app/state-management.component.ts',

--- a/cockpit/runtimes/aws-strands/angular/src/index.ts
+++ b/cockpit/runtimes/aws-strands/angular/src/index.ts
@@ -23,7 +23,7 @@ export const runtimesAwsStrandsAngularModule: CockpitCapabilityModule = {
     language: 'angular',
   },
   title: 'Runtimes — AWS Strands (Angular)',
-  docsPath: '/docs/runtimes/core-capabilities/aws-strands/overview/angular',
+  docsPath: '/docs/runtimes/aws-strands/overview',
   promptAssetPaths: [
     'cockpit/runtimes/aws-strands/angular/prompts/aws-strands.md',
   ],

--- a/cockpit/runtimes/aws-strands/python/src/index.ts
+++ b/cockpit/runtimes/aws-strands/python/src/index.ts
@@ -27,7 +27,7 @@ export const runtimesAwsStrandsPythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'Runtimes — AWS Strands (Python)',
-  docsPath: '/docs/runtimes/core-capabilities/aws-strands/overview/python',
+  docsPath: '/docs/runtimes/aws-strands/overview',
   promptAssetPaths: ['cockpit/runtimes/aws-strands/python/prompts/aws-strands.md'],
   codeAssetPaths: [
     'cockpit/runtimes/aws-strands/angular/src/app/aws-strands.component.ts',

--- a/cockpit/runtimes/mastra/angular/src/index.ts
+++ b/cockpit/runtimes/mastra/angular/src/index.ts
@@ -27,7 +27,7 @@ export const runtimesMastraAngularModule: CockpitCapabilityModule = {
     language: 'angular',
   },
   title: 'Runtimes — Mastra (Angular)',
-  docsPath: '/docs/runtimes/core-capabilities/mastra/overview/angular',
+  docsPath: '/docs/runtimes/mastra/overview',
   promptAssetPaths: [
     'cockpit/runtimes/mastra/angular/prompts/mastra-backend.md',
     'cockpit/runtimes/mastra/angular/prompts/mastra.md',

--- a/cockpit/runtimes/microsoft-agent-framework/angular/src/index.ts
+++ b/cockpit/runtimes/microsoft-agent-framework/angular/src/index.ts
@@ -23,7 +23,7 @@ export const runtimesMicrosoftAgentFrameworkAngularModule: CockpitCapabilityModu
     language: 'angular',
   },
   title: 'Runtimes — Microsoft Agent Framework (Angular)',
-  docsPath: '/docs/runtimes/core-capabilities/microsoft-agent-framework/overview/angular',
+  docsPath: '/docs/runtimes/microsoft-agent-framework/overview',
   promptAssetPaths: [
     'cockpit/runtimes/microsoft-agent-framework/angular/prompts/microsoft-agent-framework.md',
   ],

--- a/cockpit/runtimes/microsoft-agent-framework/python/src/index.ts
+++ b/cockpit/runtimes/microsoft-agent-framework/python/src/index.ts
@@ -27,7 +27,7 @@ export const runtimesMicrosoftAgentFrameworkPythonModule: CockpitCapabilityModul
     language: 'python',
   },
   title: 'Runtimes — Microsoft Agent Framework (Python)',
-  docsPath: '/docs/runtimes/core-capabilities/microsoft-agent-framework/overview/python',
+  docsPath: '/docs/runtimes/microsoft-agent-framework/overview',
   promptAssetPaths: ['cockpit/runtimes/microsoft-agent-framework/python/prompts/microsoft-agent-framework.md'],
   codeAssetPaths: [
     'cockpit/runtimes/microsoft-agent-framework/angular/src/app/microsoft-agent-framework.component.ts',

--- a/deployments/ag-ui-dev/deps/a2ui/src/index.ts
+++ b/deployments/ag-ui-dev/deps/a2ui/src/index.ts
@@ -27,7 +27,7 @@ export const agUiA2uiPythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'AG-UI A2UI (Python)',
-  docsPath: '/docs/ag-ui/core-capabilities/a2ui/overview/python',
+  docsPath: '/docs/a2ui/getting-started/introduction',
   promptAssetPaths: ['cockpit/ag-ui/a2ui/python/prompts/a2ui.md'],
   codeAssetPaths: [
     'cockpit/ag-ui/a2ui/angular/src/app/a2ui.component.ts',

--- a/deployments/ag-ui-dev/deps/aws_strands/src/index.ts
+++ b/deployments/ag-ui-dev/deps/aws_strands/src/index.ts
@@ -27,7 +27,7 @@ export const runtimesAwsStrandsPythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'Runtimes — AWS Strands (Python)',
-  docsPath: '/docs/runtimes/core-capabilities/aws-strands/overview/python',
+  docsPath: '/docs/runtimes/aws-strands/overview',
   promptAssetPaths: ['cockpit/runtimes/aws-strands/python/prompts/aws-strands.md'],
   codeAssetPaths: [
     'cockpit/runtimes/aws-strands/angular/src/app/aws-strands.component.ts',

--- a/deployments/ag-ui-dev/deps/client_tools/src/index.ts
+++ b/deployments/ag-ui-dev/deps/client_tools/src/index.ts
@@ -15,7 +15,7 @@ export const agUiClientToolsPythonModule: CockpitCapabilityModule = {
   id: 'ag-ui-client-tools-python',
   manifestIdentity: { product: 'ag-ui', section: 'core-capabilities', topic: 'client-tools', page: 'overview', language: 'python' },
   title: 'AG-UI Client Tools (Python)',
-  docsPath: '/docs/ag-ui/core-capabilities/client-tools/overview/python',
+  docsPath: '/docs/chat/guides/client-tools',
   promptAssetPaths: ['cockpit/ag-ui/client-tools/python/prompts/client-tools.md'],
   codeAssetPaths: [
     'cockpit/ag-ui/client-tools/angular/src/app/client-tools.component.ts',

--- a/deployments/ag-ui-dev/deps/interrupts/src/index.ts
+++ b/deployments/ag-ui-dev/deps/interrupts/src/index.ts
@@ -27,7 +27,7 @@ export const agUiInterruptsPythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'AG-UI Interrupts (Python)',
-  docsPath: '/docs/ag-ui/core-capabilities/interrupts/overview/python',
+  docsPath: '/docs/ag-ui/guides/interrupts',
   promptAssetPaths: ['cockpit/ag-ui/interrupts/python/prompts/interrupts.md'],
   codeAssetPaths: [
     'cockpit/ag-ui/interrupts/angular/src/app/interrupts.component.ts',

--- a/deployments/ag-ui-dev/deps/json_render/src/index.ts
+++ b/deployments/ag-ui-dev/deps/json_render/src/index.ts
@@ -27,7 +27,7 @@ export const agUiJsonRenderPythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'AG-UI JSON Render (Python)',
-  docsPath: '/docs/ag-ui/core-capabilities/json-render/overview/python',
+  docsPath: '/docs/render/getting-started/introduction',
   promptAssetPaths: ['cockpit/ag-ui/json-render/python/prompts/json-render.md'],
   codeAssetPaths: [
     'cockpit/ag-ui/json-render/angular/src/app/json-render.component.ts',

--- a/deployments/ag-ui-dev/deps/microsoft_agent_framework/src/index.ts
+++ b/deployments/ag-ui-dev/deps/microsoft_agent_framework/src/index.ts
@@ -27,7 +27,7 @@ export const runtimesMicrosoftAgentFrameworkPythonModule: CockpitCapabilityModul
     language: 'python',
   },
   title: 'Runtimes — Microsoft Agent Framework (Python)',
-  docsPath: '/docs/runtimes/core-capabilities/microsoft-agent-framework/overview/python',
+  docsPath: '/docs/runtimes/microsoft-agent-framework/overview',
   promptAssetPaths: ['cockpit/runtimes/microsoft-agent-framework/python/prompts/microsoft-agent-framework.md'],
   codeAssetPaths: [
     'cockpit/runtimes/microsoft-agent-framework/angular/src/app/microsoft-agent-framework.component.ts',

--- a/deployments/ag-ui-dev/deps/streaming/src/index.ts
+++ b/deployments/ag-ui-dev/deps/streaming/src/index.ts
@@ -27,7 +27,7 @@ export const agUiStreamingPythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'AG-UI Streaming (Python)',
-  docsPath: '/docs/ag-ui/core-capabilities/streaming/overview/python',
+  docsPath: '/docs/ag-ui/reference/event-mapping',
   promptAssetPaths: ['cockpit/ag-ui/streaming/python/prompts/streaming.md'],
   codeAssetPaths: [
     'cockpit/ag-ui/streaming/angular/src/app/streaming.component.ts',

--- a/deployments/ag-ui-dev/deps/subagents/src/index.ts
+++ b/deployments/ag-ui-dev/deps/subagents/src/index.ts
@@ -27,7 +27,7 @@ export const agUiSubagentsPythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'AG-UI Subagents (Python)',
-  docsPath: '/docs/ag-ui/core-capabilities/subagents/overview/python',
+  docsPath: '/docs/chat/components/chat-subagent-card',
   promptAssetPaths: ['cockpit/ag-ui/subagents/python/prompts/subagents.md'],
   codeAssetPaths: [
     'cockpit/ag-ui/subagents/angular/src/app/subagents.component.ts',

--- a/deployments/ag-ui-dev/deps/tool_views/src/index.ts
+++ b/deployments/ag-ui-dev/deps/tool_views/src/index.ts
@@ -27,7 +27,7 @@ export const agUiToolViewsPythonModule: CockpitCapabilityModule = {
     language: 'python',
   },
   title: 'AG-UI Tool Views (Python)',
-  docsPath: '/docs/ag-ui/core-capabilities/tool-views/overview/python',
+  docsPath: '/docs/chat/components/chat-tool-calls',
   promptAssetPaths: ['cockpit/ag-ui/tool-views/python/prompts/tool-views.md'],
   codeAssetPaths: [
     'cockpit/ag-ui/tool-views/angular/src/app/tool-views.component.ts',

--- a/libs/cockpit-registry/src/index.ts
+++ b/libs/cockpit-registry/src/index.ts
@@ -1,3 +1,4 @@
+export * from './lib/docs-links';
 export * from './lib/manifest';
 export * from './lib/manifest.types';
 export * from './lib/resolve-language';

--- a/libs/cockpit-registry/src/lib/docs-links.ts
+++ b/libs/cockpit-registry/src/lib/docs-links.ts
@@ -1,0 +1,133 @@
+/**
+ * Cockpit capability -> website documentation link.
+ *
+ * The cockpit serves a demo per `<product>/<section>/<topic>`; the website
+ * serves documentation on a three-segment route, `/docs/<library>/<section>/<slug>`
+ * (see `apps/website/src/app/docs/[library]/[section]/[slug]/page.tsx`). The two
+ * trees do not share a naming scheme, so the link between them is a table, not
+ * a formula. An earlier five-segment formula
+ * (`/docs/<product>/core-capabilities/<topic>/overview/<language>`) produced a
+ * URL that 404s for every product.
+ *
+ * Rules for this table:
+ *
+ * - Values are the page that best serves someone looking at that cockpit demo.
+ *   Cross-library links are expected and fine (an AG-UI demo whose most useful
+ *   page lives under `chat` links to `chat`).
+ * - `NO_COCKPIT_DOCS_LINK` (the empty string) is the sentinel for "no published
+ *   page covers this yet". Consumers must not render a link for it. Every
+ *   sentinel entry is listed in `COCKPIT_TOPICS_WITHOUT_DOCS` below, so nobody
+ *   can silently blank an entry that used to point somewhere real.
+ * - `apps/cockpit/src/lib/docs-links.spec.ts` checks every non-sentinel value
+ *   against the website's actual content tree and nav config. A docs rename
+ *   breaks that test rather than the link.
+ */
+
+/** Sentinel meaning "this capability has no published docs page yet." */
+export const NO_COCKPIT_DOCS_LINK = '';
+
+/**
+ * Keyed by `${product}/${section}/${topic}`.
+ *
+ * The key deliberately omits `language`: the website's documentation is not
+ * split by language (it has its own adapter picker), so the Angular and Python
+ * lanes of one cockpit demo point at the same page.
+ */
+export const COCKPIT_DOCS_LINKS: Readonly<Record<string, string>> = {
+  // deep-agents — no `deep-agents` library exists on the website yet.
+  'deep-agents/getting-started/overview': NO_COCKPIT_DOCS_LINK,
+  'deep-agents/core-capabilities/planning': NO_COCKPIT_DOCS_LINK,
+  'deep-agents/core-capabilities/filesystem': NO_COCKPIT_DOCS_LINK,
+  'deep-agents/core-capabilities/subagents': NO_COCKPIT_DOCS_LINK,
+  'deep-agents/core-capabilities/memory': NO_COCKPIT_DOCS_LINK,
+  'deep-agents/core-capabilities/skills': NO_COCKPIT_DOCS_LINK,
+  'deep-agents/core-capabilities/sandboxes': NO_COCKPIT_DOCS_LINK,
+
+  // langgraph
+  'langgraph/getting-started/overview': '/docs/langgraph/getting-started/introduction',
+  'langgraph/core-capabilities/persistence': '/docs/langgraph/guides/persistence',
+  // Durable execution is the checkpointer story; persistence is where it is written up.
+  'langgraph/core-capabilities/durable-execution': '/docs/langgraph/guides/persistence',
+  'langgraph/core-capabilities/streaming': '/docs/langgraph/guides/streaming',
+  'langgraph/core-capabilities/interrupts': '/docs/langgraph/guides/interrupts',
+  'langgraph/core-capabilities/memory': '/docs/langgraph/guides/memory',
+  'langgraph/core-capabilities/subgraphs': '/docs/langgraph/guides/subgraphs',
+  'langgraph/core-capabilities/time-travel': '/docs/langgraph/guides/time-travel',
+  'langgraph/core-capabilities/deployment-runtime': '/docs/langgraph/guides/deployment',
+  // The demo's visible half is the browser-declared tool, which `chat` documents.
+  'langgraph/core-capabilities/client-tools': '/docs/chat/guides/client-tools',
+
+  // ag-ui
+  'ag-ui/getting-started/overview': '/docs/ag-ui/getting-started/introduction',
+  // AG-UI has no streaming guide; event mapping is where token streaming is specified.
+  'ag-ui/core-capabilities/streaming': '/docs/ag-ui/reference/event-mapping',
+  'ag-ui/core-capabilities/interrupts': '/docs/ag-ui/guides/interrupts',
+  'ag-ui/core-capabilities/tool-views': '/docs/chat/components/chat-tool-calls',
+  'ag-ui/core-capabilities/json-render': '/docs/render/getting-started/introduction',
+  'ag-ui/core-capabilities/client-tools': '/docs/chat/guides/client-tools',
+  'ag-ui/core-capabilities/a2ui': '/docs/a2ui/getting-started/introduction',
+  'ag-ui/core-capabilities/subagents': '/docs/chat/components/chat-subagent-card',
+
+  // render
+  'render/getting-started/overview': '/docs/render/getting-started/introduction',
+  'render/core-capabilities/spec-rendering': '/docs/render/guides/specs',
+  'render/core-capabilities/element-rendering': '/docs/render/api/render-spec-component',
+  'render/core-capabilities/state-management': '/docs/render/guides/state-store',
+  'render/core-capabilities/registry': '/docs/render/guides/registry',
+  // Repeat loops are a spec feature, documented under "Repeat Loops" in the specs guide.
+  'render/core-capabilities/repeat-loops': '/docs/render/guides/specs',
+  // `$computed` resolves against the `functions` map registered by provideRender().
+  'render/core-capabilities/computed-functions': '/docs/render/api/provide-render',
+
+  // chat
+  'chat/getting-started/overview': '/docs/chat/getting-started/introduction',
+  'chat/core-capabilities/messages': '/docs/chat/concepts/message-model',
+  'chat/core-capabilities/input': '/docs/chat/components/chat-input',
+  'chat/core-capabilities/interrupts': '/docs/chat/components/chat-interrupt-panel',
+  'chat/core-capabilities/tool-calls': '/docs/chat/components/chat-tool-calls',
+  'chat/core-capabilities/subagents': '/docs/chat/components/chat-subagent-card',
+  'chat/core-capabilities/threads': '/docs/chat/guides/thread-routing',
+  // No chat-timeline page yet; the trace row is the primitive the timeline renders.
+  'chat/core-capabilities/timeline': '/docs/chat/components/chat-trace',
+  'chat/core-capabilities/generative-ui': '/docs/chat/guides/generative-ui',
+  'chat/core-capabilities/debug': '/docs/chat/components/chat-debug',
+  'chat/core-capabilities/theming': '/docs/chat/guides/theming',
+  'chat/core-capabilities/a2ui': '/docs/chat/a2ui/overview',
+
+  // runtimes
+  'runtimes/getting-started/overview': '/docs/runtimes/getting-started/introduction',
+  'runtimes/core-capabilities/microsoft-agent-framework':
+    '/docs/runtimes/microsoft-agent-framework/overview',
+  'runtimes/core-capabilities/aws-strands': '/docs/runtimes/aws-strands/overview',
+  'runtimes/core-capabilities/mastra': '/docs/runtimes/mastra/overview',
+};
+
+/**
+ * The capabilities that deliberately carry `NO_COCKPIT_DOCS_LINK`.
+ *
+ * Kept as an explicit list so the guard spec can assert that the only blank
+ * entries are these — a rename that accidentally blanks a real link fails
+ * instead of quietly dropping the "Docs" button from a page.
+ */
+export const COCKPIT_TOPICS_WITHOUT_DOCS: readonly string[] = [
+  'deep-agents/getting-started/overview',
+  'deep-agents/core-capabilities/planning',
+  'deep-agents/core-capabilities/filesystem',
+  'deep-agents/core-capabilities/subagents',
+  'deep-agents/core-capabilities/memory',
+  'deep-agents/core-capabilities/skills',
+  'deep-agents/core-capabilities/sandboxes',
+];
+
+/**
+ * Resolve the website documentation URL for a cockpit capability.
+ *
+ * Returns `NO_COCKPIT_DOCS_LINK` for capabilities with no published page, and
+ * for any identity missing from the table — an unmapped capability renders no
+ * link rather than a guessed one that 404s.
+ */
+export const getCockpitDocsPath = (
+  product: string,
+  section: string,
+  topic: string
+): string => COCKPIT_DOCS_LINKS[`${product}/${section}/${topic}`] ?? NO_COCKPIT_DOCS_LINK;

--- a/libs/cockpit-registry/src/lib/manifest.spec.ts
+++ b/libs/cockpit-registry/src/lib/manifest.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import fs from 'node:fs';
 import { cockpitManifest } from './manifest';
+import { getCockpitDocsPath, NO_COCKPIT_DOCS_LINK } from './docs-links';
 import type { CockpitManifestEntry } from './manifest.types';
 
 const expectedTopics = {
@@ -110,9 +111,17 @@ describe('cockpitManifest', () => {
 
     for (const entry of capabilityEntries) {
       expect(entry.supportedLanguages).toEqual(['python']);
+      // The docs link is a table lookup (see ./docs-links.ts), not a formula
+      // derived from the identity. Assert the shape the website actually
+      // serves — /docs/<library>/<section>/<slug> — or the "no page yet"
+      // sentinel. The exact targets are checked against the website's content
+      // tree in apps/cockpit/src/lib/docs-links.spec.ts.
       expect(entry.docsPath).toBe(
-        `/docs/${entry.product}/${entry.section}/${entry.topic}/overview/python`
+        getCockpitDocsPath(entry.product, entry.section, entry.topic)
       );
+      if (entry.docsPath !== NO_COCKPIT_DOCS_LINK) {
+        expect(entry.docsPath).toMatch(/^\/docs\/[a-z0-9-]+\/[a-z0-9-]+\/[a-z0-9-]+$/);
+      }
       expect(entry.implementationStatus).toBe('implemented');
       expect(entry.docsStatus).toBe('docs-authored');
       expect(entry.testStatus).toBe('smoke-tested');

--- a/libs/cockpit-registry/src/lib/manifest.ts
+++ b/libs/cockpit-registry/src/lib/manifest.ts
@@ -1,3 +1,4 @@
+import { getCockpitDocsPath } from './docs-links';
 import type {
   CockpitManifestEntry,
   CockpitManifestIdentity,
@@ -126,11 +127,18 @@ const getOverviewIdentity = (product: CockpitProduct): CockpitManifestIdentity =
   language: 'python',
 });
 
+/**
+ * The website documentation page for a capability.
+ *
+ * This is a table lookup, not a formula: the cockpit tree and the docs tree do
+ * not share a naming scheme. See `./docs-links.ts`. Returns the empty string
+ * for capabilities with no published page.
+ */
 const getDocsPath = (
   product: CockpitProduct,
   section: CockpitManifestEntry['section'],
   topic: string
-): string => `/docs/${product}/${section}/${topic}/overview/python`;
+): string => getCockpitDocsPath(product, section, topic);
 
 const getPromptAssetPath = (product: CockpitProduct, topic: string): string =>
   `cockpit/${product}/${topic}/${getLane(product, topic)}/prompts/${topic}.md`;


### PR DESCRIPTION
## The finding

Every cockpit capability declared `docsPath` in a five-segment shape — `/docs/<product>/core-capabilities/<topic>/overview/<lang>`. The website serves docs on a **three**-segment route, `/docs/[library]/[section]/[slug]`. Every one of those URLs 404s, for every product:

```
$ curl -o /dev/null -w '%{http_code}' https://threadplane.ai/docs/langgraph/core-capabilities/streaming/overview/python
404
```

Two things kept it invisible: the field was rendered nowhere, so no link ever visibly broke; and the only assertion was a regex over the shape the generator itself produced, never a check against a real route.

## What this does

**Maps it.** `libs/cockpit-registry/src/lib/docs-links.ts` holds the cockpit → docs mapping as a **table, not a formula**. The two trees do not share a naming scheme — that mismatch is exactly what made a formula wrong. Cross-library links are expected (an AG-UI demo whose best page lives under `chat` links to `chat`).

**Sentinel.** Empty string (`NO_COCKPIT_DOCS_LINK`) means "no published page yet". Seven `deep-agents` entries carry it — the website has no `deep-agents` library. Those render no link rather than a bad one. The sentinel list is pinned in a test, so a rename cannot silently blank a real link.

**Rewrites consumers.** All 83 per-example descriptors (cockpit examples are standalone, so each carries its own literal) and the 9 generated `deployments/ag-ui-dev/deps/*` copies. Generator re-run; drift check clean and idempotent.

**Renders it.** A "Read docs" link in the cockpit capability header, on `--ds-*` tokens, `target="_blank"`. Labelled "Read docs" rather than "Docs" so it does not collide with the existing Docs *mode* tab.

**Guards it.** `apps/cockpit/src/lib/docs-links.spec.ts` derives the set of valid docs routes two ways — the `.mdx` files on disk and the website's `docsConfig` nav — and requires every mapped path in both. It also checks every descriptor on disk agrees with the table, and that no five-segment path survives anywhere.

**Makes the matrix specs run.** `cockpit/*/matrix.spec.ts` had **no test target at all** — that is how the stale assertion survived. They now run under `nx test cockpit`. Doing so surfaced a second piece of the same rot: the LangGraph slice asserted `codeAssetPaths.length === 1` while examples had grown to 2+.

## Mapping

Lives in `libs/cockpit-registry/src/lib/docs-links.ts`, commented per non-obvious choice. 35 distinct targets; **all 35 verified 200 on production threadplane.ai.**

Judgement calls worth a look:

| Capability | Target | Why |
|---|---|---|
| `langgraph/durable-execution` | `/docs/langgraph/guides/persistence` | Checkpointing is the durability mechanism; no separate page |
| `langgraph/client-tools`, `ag-ui/client-tools` | `/docs/chat/guides/client-tools` | The demo's visible half is the browser-declared tool |
| `ag-ui/streaming` | `/docs/ag-ui/reference/event-mapping` | AG-UI has no streaming guide; token streaming is specified here |
| `render/computed-functions` | `/docs/render/api/provide-render` | `$computed` resolves against the `functions` map registered there |
| `render/repeat-loops` | `/docs/render/guides/specs` | The "Repeat Loops" section; shares a page with `spec-rendering` |
| `chat/timeline` | `/docs/chat/components/chat-trace` | No `chat-timeline` page yet; the trace row is the primitive it renders |
| `deep-agents/*` (7) | *sentinel* | No `deep-agents` docs library exists |

## Verification

- `nx test cockpit` — **33 files, 214 tests green** (baseline 30/209; +6 guard, matrix specs newly running)
- `nx test cockpit-registry`, `nx test cockpit-shell` green; `nx lint` 0 errors; `nx build cockpit` green
- Deployment generator re-run, output byte-identical on a second run
- Render check against a live cockpit server — one page per product:

```
langgraph/streaming  -> https://threadplane.ai/docs/langgraph/guides/streaming
ag-ui/a2ui           -> https://threadplane.ai/docs/a2ui/getting-started/introduction
chat/theming         -> https://threadplane.ai/docs/chat/guides/theming
render/registry      -> https://threadplane.ai/docs/render/guides/registry
runtimes/aws-strands -> https://threadplane.ai/docs/runtimes/aws-strands/overview
deep-agents/planning -> NO DOCS LINK   (sentinel, as intended)
```

### Guard mutation evidence

Every guard was mutation-tested and restored:

| Mutation | Result |
|---|---|
| Table → `/docs/langgraph/guides/streaming-renamed` | 2 tests fail, naming the bad path |
| A descriptor drifts from the table | fails, naming file + declared value |
| A real link silently blanked to the sentinel | 2 tests fail (sentinel list + descriptor drift) |
| `resolveDocsUrl` always returns `null` | render test fails — "Unable to find link /read docs/i" |
| Sentinel renders a link anyway | deep-agents test fails — expected `<a>` to be null |

🤖 Generated with [Claude Code](https://claude.com/claude-code)