### PR TITLE
fix(website): give library-neutral docs pages an honest control plane

### DIFF
--- a/apps/website/src/app/blog/[slug]/page.tsx
+++ b/apps/website/src/app/blog/[slug]/page.tsx
@@ -110,13 +110,7 @@ export default async function BlogPostPage({ params }: Params) {
             <TagChips tags={post.frontmatter.tags} />
           ) : null}
         </header>
-        <MdxRenderer
-          source={post.content}
-          library="langgraph"
-          section="blog"
-          slug={post.slug}
-          title={post.frontmatter.title}
-        />
+        <MdxRenderer source={post.content} />
       </article>
         <DocsTOC headings={headings} />
       </div>

--- a/apps/website/src/app/docs/[library]/[section]/[slug]/page.tsx
+++ b/apps/website/src/app/docs/[library]/[section]/[slug]/page.tsx
@@ -107,13 +107,7 @@ export default async function DocsPage({ params }: DocsRouteProps) {
             />
           </div>
           <article className="flex-1 py-8 px-4 sm:px-6 md:px-12 md:max-w-3xl overflow-x-hidden">
-            <MdxRenderer
-              source={doc.body}
-              library={library as LibraryId}
-              section={section}
-              slug={slug}
-              title={doc.title}
-            />
+            <MdxRenderer source={doc.body} />
           </article>
           {section === 'api' && (() => {
             const entries = loadApiDocs(library);

--- a/apps/website/src/app/docs/choosing-an-adapter/page.tsx
+++ b/apps/website/src/app/docs/choosing-an-adapter/page.tsx
@@ -1,23 +1,13 @@
 import fs from 'fs';
 import path from 'path';
 import { notFound } from 'next/navigation';
-import { MDXRemote } from 'next-mdx-remote/rsc';
-import rehypePrettyCode from 'rehype-pretty-code';
-import rehypeSlug from 'rehype-slug';
-import remarkGfm from 'remark-gfm';
-import { tokens } from '@threadplane/design-tokens';
-import { Container } from '../../../components/ui/Container';
-import { Section } from '../../../components/ui/Section';
-import { Eyebrow } from '../../../components/ui/Eyebrow';
-import { Callout } from '../../../components/docs/mdx/Callout';
-import { Steps, Step } from '../../../components/docs/mdx/Steps';
-import { Tabs, Tab } from '../../../components/docs/mdx/Tabs';
-import { Card, CardGroup } from '../../../components/docs/mdx/Card';
-import { CodeGroup } from '../../../components/docs/mdx/CodeGroup';
-import { Pre } from '../../../components/docs/mdx/CodeBlock';
-import { mdxHeadingComponents } from '../../../components/docs/mdx/headings';
+import { DocsControlPlane } from '../../../components/docs/DocsControlPlane';
+import { DocsSearch } from '../../../components/docs/DocsSearch';
+import { MdxRenderer } from '../../../components/docs/MdxRenderer';
 import { createPageMetadata } from '../../../lib/site-metadata';
 import { stripFrontmatter } from '../../../lib/docs';
+
+const PAGE_TITLE = 'Choosing an adapter';
 
 export const metadata = createPageMetadata({
   title: 'Choosing an adapter — Threadplane',
@@ -25,29 +15,6 @@ export const metadata = createPageMetadata({
   pathname: '/docs/choosing-an-adapter',
   type: 'website',
 });
-
-const mdxComponents = {
-  Callout,
-  Steps,
-  Step,
-  Tabs,
-  Tab,
-  Card,
-  CardGroup,
-  CodeGroup,
-  pre: Pre,
-  table: ({ children, ...rest }: React.HTMLAttributes<HTMLTableElement>) => (
-    <div className="docs-table-scroll">
-      <table {...rest}>{children}</table>
-    </div>
-  ),
-  ...mdxHeadingComponents,
-};
-
-const rehypeOptions = {
-  theme: 'tokyo-night',
-  keepBackground: true,
-};
 
 function resolveContentFile(): string | null {
   const candidates = [
@@ -64,49 +31,29 @@ export default function ChoosingAnAdapterPage() {
   const filePath = resolveContentFile();
   if (!filePath) notFound();
 
-  const raw = fs.readFileSync(filePath, 'utf8');
-  const source = stripFrontmatter(raw);
+  const source = stripFrontmatter(fs.readFileSync(filePath, 'utf8'));
 
   return (
-    <>
-      <Section surface="canvas" ariaLabelledBy="choosing-an-adapter-heading">
-        <Container>
-          <div className="adapter-hero-inner">
-            <Eyebrow tone="accent" className="adapter-eyebrow-spaced">
-              Documentation
-            </Eyebrow>
-            <div id="choosing-an-adapter-heading" />
-          </div>
-        </Container>
-      </Section>
-
-      <Section surface="canvas">
-        <Container>
+    <div className="flex min-h-screen docs-shell-page">
+      <DocsSearch />
+      {/* This page is deliberately library-neutral: it is the page that helps
+       * you pick one, so the picker opens with nothing selected. */}
+      <DocsControlPlane
+        activeLibrary={null}
+        activeSection=""
+        activeSlug=""
+        pageTitle={PAGE_TITLE}
+      />
+      <div className="flex-1 flex min-w-0 docs-shell-body">
+        <div className="flex-1 min-w-0">
           <article
-            className="docs-prose prose prose-slate max-w-none adapter-article"
-            style={
-              {
-                '--tw-prose-body': tokens.colors.textSecondary,
-                '--tw-prose-headings': tokens.colors.textPrimary,
-                '--tw-prose-code': tokens.colors.accent,
-                '--tw-prose-links': tokens.colors.accent,
-              } as React.CSSProperties
-            }
+            aria-label={PAGE_TITLE}
+            className="flex-1 py-8 px-4 sm:px-6 md:px-12 md:max-w-3xl overflow-x-hidden"
           >
-            <MDXRemote
-              source={source}
-              components={mdxComponents}
-              options={{
-                mdxOptions: {
-                  remarkPlugins: [remarkGfm],
-                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                  rehypePlugins: [rehypeSlug, [rehypePrettyCode, rehypeOptions] as any],
-                },
-              }}
-            />
+            <MdxRenderer source={source} />
           </article>
-        </Container>
-      </Section>
-    </>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/apps/website/src/components/docs/DocsControlPlane.spec.tsx
+++ b/apps/website/src/components/docs/DocsControlPlane.spec.tsx
@@ -232,6 +232,45 @@ describe('DocsControlPlane', () => {
   });
 });
 
+describe('DocsControlPlane — library-neutral', () => {
+  it('states only what it knows in Scope', () => {
+    render(
+      <DocsControlPlane
+        activeLibrary={null}
+        activeSection=""
+        activeSlug=""
+        pageTitle="Choosing an adapter"
+      />,
+    );
+
+    const scope = screen.getByRole('heading', { name: 'Scope' }).closest('section');
+    if (!scope) throw new Error('Expected Scope section');
+    expect(within(scope).getByText('Choosing an adapter')).toBeTruthy();
+    expect(within(scope).queryByText('LangGraph')).toBeNull();
+    expect(within(scope).queryByText('Getting Started')).toBeNull();
+  });
+
+  it('offers an unselected picker and no section tree', () => {
+    render(
+      <DocsControlPlane
+        activeLibrary={null}
+        activeSection=""
+        activeSlug=""
+        pageTitle="Choosing an adapter"
+      />,
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Choose a library' });
+    fireEvent.click(trigger);
+    const items = screen.getAllByRole('menuitemradio');
+    expect(items.length).toBeGreaterThan(0);
+    expect(items.every((i) => i.getAttribute('aria-checked') === 'false')).toBe(true);
+
+    // No library means there is no section tree to show.
+    expect(screen.queryByRole('button', { name: 'Getting Started' })).toBeNull();
+  });
+});
+
 describe('DocsContextContent', () => {
   it('reuses the same sentence-case navigation content for mobile', () => {
     render(

--- a/apps/website/src/components/docs/DocsControlPlane.tsx
+++ b/apps/website/src/components/docs/DocsControlPlane.tsx
@@ -28,7 +28,8 @@ import { buildCockpitModeHref } from '../../lib/cockpit-links';
 import { DocsNavigation } from './DocsSidebar';
 
 export interface DocsControlPlaneProps {
-  activeLibrary: LibraryId;
+  /** `null` on a library-neutral docs page, e.g. /docs/choosing-an-adapter. */
+  activeLibrary: LibraryId | null;
   activeSection: string;
   activeSlug: string;
   pageTitle: string;
@@ -46,8 +47,8 @@ export function DocsContextContent({
   onNavigate,
 }: DocsControlPlaneProps & { mobile?: boolean; onNavigate?: () => void }) {
   const preferences = useControlPlanePreferences('docs');
-  const library = getLibraryConfig(activeLibrary);
-  const section = getDocsSection(activeLibrary, activeSection);
+  const library = activeLibrary ? getLibraryConfig(activeLibrary) : undefined;
+  const section = activeLibrary ? getDocsSection(activeLibrary, activeSection) : undefined;
   const openSearch = () => {
     if (!mobile) {
       dispatchSearch();
@@ -65,8 +66,11 @@ export function DocsContextContent({
     <div data-docs-control-plane-context data-mobile={mobile || undefined}>
       <ControlPlaneSection title="Scope" collapsible={false}>
         <div className="docs-control-plane-scope">
-          <span>{library?.title ?? activeLibrary}</span>
-          <span>{section?.title ?? activeSection}</span>
+          {/* A neutral page has no library and no section. Say only what is
+           * true — inventing them is how the mobile drawer came to claim
+           * "LangGraph / Getting Started" on the adapter-comparison page. */}
+          <span>{library?.title ?? 'Docs'}</span>
+          {library && section ? <span>{section.title}</span> : null}
           <strong>{pageTitle}</strong>
         </div>
       </ControlPlaneSection>
@@ -118,11 +122,13 @@ export function DocsContextContent({
 
 export function DocsControlPlane(props: DocsControlPlaneProps) {
   const identity = {
-    library: props.activeLibrary,
+    library: props.activeLibrary ?? '',
     section: props.activeSection,
     slug: props.activeSlug,
   };
-  const currentPath = `/docs/${props.activeLibrary}/${props.activeSection}/${props.activeSlug}`;
+  const currentPath = props.activeLibrary
+    ? `/docs/${props.activeLibrary}/${props.activeSection}/${props.activeSlug}`
+    : '/docs';
 
   return (
     <div className="docs-control-plane" data-docs-control-plane>

--- a/apps/website/src/components/docs/DocsSidebar.tsx
+++ b/apps/website/src/components/docs/DocsSidebar.tsx
@@ -33,7 +33,8 @@ import {
 import { LibraryMark } from './LibraryMark';
 
 export interface DocsNavigationProps {
-  activeLibrary: LibraryId;
+  /** `null` on a library-neutral docs page. */
+  activeLibrary: LibraryId | null;
   activeSection: string;
   activeSlug: string;
   expanded?: Record<string, boolean>;
@@ -62,7 +63,7 @@ function LibraryDropdown({
   activeLibrary,
   onNavigate,
 }: {
-  activeLibrary: LibraryId;
+  activeLibrary: LibraryId | null;
   onNavigate?: () => void;
 }) {
   const [open, setOpen] = useState(false);
@@ -74,7 +75,8 @@ function LibraryDropdown({
 
   useEffect(() => {
     const handler = (event: MouseEvent) => {
-      if (ref.current && !ref.current.contains(event.target as Node)) setOpen(false);
+      if (ref.current && !ref.current.contains(event.target as Node))
+        setOpen(false);
     };
     document.addEventListener('mousedown', handler);
     return () => document.removeEventListener('mousedown', handler);
@@ -82,7 +84,8 @@ function LibraryDropdown({
 
   useEffect(() => {
     if (!open) return;
-    const items = menuRef.current?.querySelectorAll<HTMLElement>(MENU_ITEM_SELECTOR);
+    const items =
+      menuRef.current?.querySelectorAll<HTMLElement>(MENU_ITEM_SELECTOR);
     items?.[initialFocusRef.current]?.focus();
   }, [open]);
 
@@ -98,7 +101,10 @@ function LibraryDropdown({
       const trigger = triggerRef.current;
       const menu = menuRef.current;
       if (!trigger || !menu) return;
-      const available = window.innerHeight - trigger.getBoundingClientRect().bottom - MENU_VIEWPORT_GUTTER;
+      const available =
+        window.innerHeight -
+        trigger.getBoundingClientRect().bottom -
+        MENU_VIEWPORT_GUTTER;
       menu.style.maxHeight = `${Math.max(MENU_MIN_HEIGHT, available)}px`;
     };
     resize();
@@ -118,19 +124,22 @@ function LibraryDropdown({
 
   const onMenuKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     const items = Array.from(
-      menuRef.current?.querySelectorAll<HTMLElement>(MENU_ITEM_SELECTOR) ?? [],
+      menuRef.current?.querySelectorAll<HTMLElement>(MENU_ITEM_SELECTOR) ?? []
     );
-    const current = Math.max(0, items.indexOf(document.activeElement as HTMLElement));
+    const current = Math.max(
+      0,
+      items.indexOf(document.activeElement as HTMLElement)
+    );
     const nextIndex =
       event.key === 'Home'
         ? 0
         : event.key === 'End'
-          ? items.length - 1
-          : event.key === 'ArrowDown'
-            ? (current + 1) % items.length
-            : event.key === 'ArrowUp'
-              ? (current - 1 + items.length) % items.length
-              : -1;
+        ? items.length - 1
+        : event.key === 'ArrowDown'
+        ? (current + 1) % items.length
+        : event.key === 'ArrowUp'
+        ? (current - 1 + items.length) % items.length
+        : -1;
     if (nextIndex >= 0) {
       event.preventDefault();
       items[nextIndex]?.focus();
@@ -144,7 +153,9 @@ function LibraryDropdown({
     }
   };
 
-  const currentLibrary = getLibraryConfig(activeLibrary);
+  const currentLibrary = activeLibrary
+    ? getLibraryConfig(activeLibrary)
+    : undefined;
 
   return (
     <div ref={ref} className="docs-sidebar-library">
@@ -167,12 +178,22 @@ function LibraryDropdown({
         className="docs-sidebar-lib-trigger"
       >
         <span className="docs-sidebar-lib-trigger-inner">
-          <LibraryMark library={activeLibrary} size={20} />
-          <span className="docs-sidebar-lib-trigger-label">
-            {currentLibrary?.title ?? activeLibrary}
+          {activeLibrary ? (
+            <LibraryMark library={activeLibrary} size={20} />
+          ) : null}
+          <span
+            className="docs-sidebar-lib-trigger-label"
+            data-placeholder={activeLibrary ? undefined : ''}
+          >
+            {currentLibrary?.title ?? 'Choose a library'}
           </span>
         </span>
-        <ChevronDown size={16} strokeWidth={2} aria-hidden="true" data-open={open || undefined} />
+        <ChevronDown
+          size={16}
+          strokeWidth={2}
+          aria-hidden="true"
+          data-open={open || undefined}
+        />
       </button>
 
       {open ? (
@@ -185,7 +206,9 @@ function LibraryDropdown({
         >
           {LIBRARY_GROUPS.map((group, groupIndex) => (
             <div role="group" aria-label={group.label} key={group.id}>
-              {groupIndex > 0 ? <span className="docs-sidebar-lib-divider" aria-hidden="true" /> : null}
+              {groupIndex > 0 ? (
+                <span className="docs-sidebar-lib-divider" aria-hidden="true" />
+              ) : null}
               <span className="docs-sidebar-lib-group" aria-hidden="true">
                 {group.label}
               </span>
@@ -211,11 +234,16 @@ function LibraryDropdown({
                         <LibraryMark library={library.id} size={20} />
                       </span>
                       <span className="docs-sidebar-lib-item-text">
-                        <span className="docs-sidebar-lib-item-title" data-active={isActive || undefined}>
+                        <span
+                          className="docs-sidebar-lib-item-title"
+                          data-active={isActive || undefined}
+                        >
                           {library.title}
                         </span>
                         {library.tagline ? (
-                          <span className="docs-sidebar-lib-item-desc">{library.tagline}</span>
+                          <span className="docs-sidebar-lib-item-desc">
+                            {library.tagline}
+                          </span>
                         ) : null}
                       </span>
                     </Link>
@@ -229,7 +257,10 @@ function LibraryDropdown({
   );
 }
 
-const SECTION_ICONS: Record<string, ComponentType<{ size?: number; 'aria-hidden'?: boolean }>> = {
+const SECTION_ICONS: Record<
+  string,
+  ComponentType<{ size?: number; 'aria-hidden'?: boolean }>
+> = {
   'getting-started': Rocket,
   guides: BookOpen,
   concepts: Lightbulb,
@@ -288,7 +319,8 @@ function SectionGroup({
           className="docs-sidebar-section-links"
         >
           {section.pages.map((page) => {
-            const isActive = page.section === activeSection && page.slug === activeSlug;
+            const isActive =
+              page.section === activeSection && page.slug === activeSlug;
             return (
               <Link
                 key={`${page.section}/${page.slug}`}
@@ -317,12 +349,15 @@ export function DocsNavigation({
   onExpandedChange,
   onNavigate,
 }: DocsNavigationProps) {
-  const library = getLibraryConfig(activeLibrary);
+  const library = activeLibrary ? getLibraryConfig(activeLibrary) : undefined;
   const pathname = usePathname();
 
   return (
     <div data-docs-navigation>
-      <nav aria-label="Featured documentation" className="docs-sidebar-top-links">
+      <nav
+        aria-label="Featured documentation"
+        className="docs-sidebar-top-links"
+      >
         {specialDocsPages.map((page) => (
           <Link
             key={page.path}
@@ -340,21 +375,25 @@ export function DocsNavigation({
 
       <LibraryDropdown activeLibrary={activeLibrary} onNavigate={onNavigate} />
 
-      {library?.sections.map((section) => {
-        const key = `Learn:${activeLibrary}:${section.id}`;
-        return (
-          <SectionGroup
-            key={section.id}
-            section={section}
-            activeLibrary={activeLibrary}
-            activeSection={activeSection}
-            activeSlug={activeSlug}
-            open={expanded[key] ?? true}
-            onOpenChange={(open) => onExpandedChange?.(key, open)}
-            onNavigate={onNavigate}
-          />
-        );
-      })}
+      {/* No library means no section tree. Narrowing on `activeLibrary` rather
+       * than `library` keeps SectionGroup's non-null contract honest. */}
+      {activeLibrary && library
+        ? library.sections.map((section) => {
+            const key = `Learn:${activeLibrary}:${section.id}`;
+            return (
+              <SectionGroup
+                key={section.id}
+                section={section}
+                activeLibrary={activeLibrary}
+                activeSection={activeSection}
+                activeSlug={activeSlug}
+                open={expanded[key] ?? true}
+                onOpenChange={(open) => onExpandedChange?.(key, open)}
+                onNavigate={onNavigate}
+              />
+            );
+          })
+        : null}
     </div>
   );
 }

--- a/apps/website/src/components/docs/MdxRenderer.tsx
+++ b/apps/website/src/components/docs/MdxRenderer.tsx
@@ -10,7 +10,6 @@ import { FeatureChips } from './mdx/FeatureChips';
 import { mdxHeadingComponents } from './mdx/headings';
 import { ArchFlowDiagram } from './ArchFlowDiagram';
 import { AgUiArchDiagram } from './AgUiArchDiagram';
-import { type LibraryId } from '../../lib/docs-config';
 import rehypePrettyCode from 'rehype-pretty-code';
 import rehypeSlug from 'rehype-slug';
 import remarkGfm from 'remark-gfm';
@@ -79,13 +78,9 @@ const rehypeOptions = {
 
 interface MdxRendererProps {
   source: string;
-  library: LibraryId;
-  section: string;
-  slug: string;
-  title: string;
 }
 
-export function MdxRenderer({ source, library, section, slug, title }: MdxRendererProps) {
+export function MdxRenderer({ source }: MdxRendererProps) {
   return (
     <div className="docs-prose prose prose-slate max-w-none"
       style={{

--- a/apps/website/src/components/shared/Nav.spec.tsx
+++ b/apps/website/src/components/shared/Nav.spec.tsx
@@ -4,12 +4,13 @@ import { fireEvent, render, screen, waitFor, within } from '@testing-library/rea
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Nav } from './Nav';
 
-const { trackCtaClick } = vi.hoisted(() => ({
+const { trackCtaClick, pathnameRef } = vi.hoisted(() => ({
   trackCtaClick: vi.fn(),
+  pathnameRef: { current: '/docs/langgraph/guides/streaming' },
 }));
 
 vi.mock('next/navigation', () => ({
-  usePathname: () => '/docs/langgraph/guides/streaming',
+  usePathname: () => pathnameRef.current,
   useRouter: () => ({ push: vi.fn() }),
 }));
 
@@ -22,6 +23,27 @@ describe('Docs mobile navigation', () => {
   beforeEach(() => {
     window.localStorage.clear();
     trackCtaClick.mockClear();
+    pathnameRef.current = '/docs/langgraph/guides/streaming';
+  });
+
+  it('does not invent a library on a library-neutral docs page', () => {
+    pathnameRef.current = '/docs/choosing-an-adapter';
+    render(<Nav />);
+    fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+    const dialog = screen.getByRole('dialog', { name: 'Mobile navigation' });
+
+    // `/docs/choosing-an-adapter` has no library segment. Falling back to
+    // 'langgraph' made the Scope card read "LangGraph / Getting Started /
+    // Documentation" — three fabrications in the one card whose job is saying
+    // where you are.
+    const scope = within(dialog).getByRole('heading', { name: 'Scope' }).closest('section');
+    if (!scope) throw new Error('Expected a Scope section');
+    expect(within(scope).queryByText('LangGraph')).toBeNull();
+    expect(within(scope).queryByText('Getting Started')).toBeNull();
+    expect(within(scope).getByText('Choosing an adapter')).toBeTruthy();
+
+    expect(within(dialog).queryByRole('button', { name: 'LangGraph' })).toBeNull();
+    expect(within(dialog).getByRole('button', { name: 'Choose a library' })).toBeTruthy();
   });
 
   it('uses the existing header trigger for the control-plane Docs drawer', () => {

--- a/apps/website/src/components/shared/Nav.tsx
+++ b/apps/website/src/components/shared/Nav.tsx
@@ -2,7 +2,12 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { findDocsPage, getLibraryConfig, type LibraryId } from '../../lib/docs-config';
+import {
+  findDocsPage,
+  getLibraryConfig,
+  specialDocsPages,
+  type LibraryId,
+} from '../../lib/docs-config';
 import { trackCtaClick, trackExternalLinkClick } from '../../lib/analytics/client';
 import type { AnalyticsLibrary } from '../../lib/analytics/events';
 import { LogoMark } from '../ui/LogoMark';
@@ -17,7 +22,7 @@ const links = [
   { label: 'Examples', href: 'https://cockpit.threadplane.ai', external: true },
 ];
 
-const toAnalyticsLibrary = (library: LibraryId): AnalyticsLibrary => {
+const toAnalyticsLibrary = (library: LibraryId | null): AnalyticsLibrary => {
   switch (library) {
     case 'langgraph':
     case 'render':
@@ -95,8 +100,15 @@ export function Nav() {
   const activeLibrary = isDocsPage && pathParts.length >= 2 ? pathParts[1] : '';
   const activeSection = isDocsPage && pathParts.length >= 3 ? pathParts[2] : '';
   const activeSlug = isDocsPage && pathParts.length >= 4 ? pathParts[3] : '';
-  const docsLibrary = (getLibraryConfig(activeLibrary)?.id ?? 'langgraph') as LibraryId;
-  const docsPageTitle = findDocsPage(activeLibrary, activeSection, activeSlug)?.title ?? 'Documentation';
+  // A docs URL without a library segment (e.g. /docs/choosing-an-adapter) is
+  // library-neutral. Defaulting to a library here made the drawer claim the
+  // reader was inside LangGraph's docs.
+  const docsLibrary = (getLibraryConfig(activeLibrary)?.id ?? null) as LibraryId | null;
+  const specialDocsPage = specialDocsPages.find((page) => page.path === pathname);
+  const docsPageTitle =
+    findDocsPage(activeLibrary, activeSection, activeSlug)?.title ??
+    specialDocsPage?.title ??
+    'Documentation';
   const mobileTriggerRef = useRef<HTMLButtonElement>(null);
   const mobileDialogRef = useRef<HTMLDivElement>(null);
   const closeMobileMenu = useCallback(() => {

--- a/apps/website/src/styles/docs.css
+++ b/apps/website/src/styles/docs.css
@@ -1730,6 +1730,11 @@
   font-family: var(--font-inter);
   font-size: 13px;
 }
+/* Library-neutral pages: the picker is an invitation, not a statement. */
+.docs-sidebar-lib-trigger-label[data-placeholder] {
+  color: var(--color-text-muted);
+  font-weight: 400;
+}
 .docs-sidebar-lib-trigger > svg { transition: transform 150ms ease; }
 .docs-sidebar-lib-trigger > svg[data-open] { transform: rotate(180deg); }
 .docs-sidebar-lib-menu {

--- a/docs/superpowers/specs/2026-09-01-docs-library-neutral-pages-design.md
+++ b/docs/superpowers/specs/2026-09-01-docs-library-neutral-pages-design.md
@@ -1,0 +1,139 @@
+# Library-neutral docs pages
+
+**Date:** 2026-09-01
+**Scope:** `/docs/choosing-an-adapter` and the control plane's missing
+"no library selected" state
+**Status:** approved, ready to implement
+
+## Context
+
+Follow-ups recorded during the adapter-picker refresh (#911). Re-checked against
+`main` before writing this, and both moved:
+
+- **"There is no docs nav below `lg`" is already fixed.** #892 added a mobile
+  drawer with Site/Docs tabs that renders `DocsContextContent`. The original
+  note was taken against the pre-#892 tree.
+- **"`/docs` has no control plane" is not a defect.** `/docs` is a designed
+  landing page — "Start building with Threadplane", pick-your-backend cards.
+  It is the front door; a sidebar would damage it. Only
+  `/docs/choosing-an-adapter` is a content page missing its shell.
+
+What the re-check *did* surface is a worse bug than the one originally noted.
+
+## Problems
+
+### 1. The mobile drawer fabricates a location
+
+On `/docs/choosing-an-adapter` at 375px the Scope card reads:
+
+> **LangGraph** / Getting Started / **Documentation**
+
+Three fabrications in the one card whose job is telling you where you are.
+`Nav.tsx:95` derives `activeLibrary` from `pathParts[1]`, which here is
+`"choosing-an-adapter"` — not a library. `getLibraryConfig()` returns
+undefined, and line 98 falls back to `'langgraph'`. The drawer then shows
+LangGraph's picker, LangGraph's whole section tree, and the page title
+`'Documentation'`.
+
+The failure mode is silence: it renders something plausible.
+
+### 2. The page has no control plane
+
+Only `[library]/[section]/[slug]` renders `DocsControlPlane`. Following the
+"Choosing an adapter" link from the sidebar drops the reader into a page with
+no nav out.
+
+### 3. The section has no accessible name
+
+`aria-labelledby="choosing-an-adapter-heading"` points at an empty `<div>`.
+Verified: the target's text content is `""`.
+
+### 4. A 144px dead gap
+
+Measured, between the eyebrow and the H1 — an empty hero `Section` stacked
+above the content `Section`.
+
+### 5. The MDX pipeline is duplicated
+
+`choosing-an-adapter/page.tsx` carries ~60 lines of `mdxComponents`,
+`rehypeOptions` and prose token styles that already exist in `MdxRenderer`,
+which the `[slug]` route uses.
+
+Problems 2–5 are all symptoms of one cause: the page is bespoke and drifted
+from the shell every other docs page uses.
+
+**Not a problem:** a hydration error seen while investigating was an artifact of
+resizing the tab mid-hydration. A fresh tab logs no console errors on either
+page. Not pursued.
+
+## Design
+
+### Nullable library
+
+`DocsControlPlaneProps.activeLibrary` and `DocsNavigationProps.activeLibrary`
+become `LibraryId | null`. `null` means library-neutral — a state the control
+plane has never had, and whose absence produced problem 1.
+
+### The neutral states
+
+| Element | With a library | Neutral |
+| --- | --- | --- |
+| Scope | library / section / page | `Docs` / page |
+| Picker trigger | mark + library name | `Choose a library`, muted, no mark |
+| Picker menu | current entry `aria-checked` | nothing checked |
+| Learn | special links + picker + sections | special links + picker only |
+
+The neutral picker label is coherent on this page in particular: the reader is
+literally on the page that helps them choose.
+
+### `Nav.tsx`
+
+- `docsLibrary`: `getLibraryConfig(activeLibrary)?.id ?? null` — the
+  `?? 'langgraph'` fallback is the bug.
+- `docsPageTitle`: look up `specialDocsPages` by pathname before falling back to
+  `'Documentation'`.
+
+This corrects the drawer on every library-neutral route, not just this one.
+
+### The page
+
+`choosing-an-adapter/page.tsx` adopts the `docs-shell-page` layout used by the
+`[slug]` route, with `<DocsControlPlane activeLibrary={null} …>`, and:
+
+- **Deletes the empty hero `Section`.** Removes the 144px gap and the dangling
+  `aria-labelledby` target in one move; the section takes a real `aria-label`.
+- **Replaces its MDX pipeline with `<MdxRenderer source={…} />`.**
+
+### `MdxRenderer`
+
+Props reduce to `{ source }`. `library`, `section`, `slug` and `title` are
+accepted and never read — they are four of the website's existing lint
+warnings. The `[slug]` call site updates accordingly.
+
+### Not needed
+
+The rail's Run/Code/API links already fall back to the cockpit root when
+`resolveCockpitIdentity` finds no mapping, which is the case for all but five
+docs pages. A null library needs no special handling there.
+
+## Testing
+
+Must fail against `main`:
+
+1. **`Nav` on `/docs/choosing-an-adapter`** — Scope does not say LangGraph, and
+   the page title is "Choosing an adapter". This is problem 1.
+
+New coverage:
+
+2. **Neutral control plane** — no library or section line in Scope, picker reads
+   "Choose a library", no section groups, nothing `aria-checked`.
+3. **The page renders the control plane and its H1**, with no empty
+   `aria-labelledby` target.
+4. **A library page is unchanged** — Scope still shows library and section, and
+   the picker still shows the current library checked. Guards against the
+   nullable change quietly degrading the normal path.
+
+## Out of scope
+
+`/docs` keeps its landing-page treatment. If it should ever gain the control
+plane that is a separate design question about the front door, not a defect.


### PR DESCRIPTION
Picks up the two follow-ups from [#911](https://github.com/cacheplane/angular-agent-framework/pull/911). Re-checking them against `main` first changed both, so this PR is not quite what those notes described.

## One follow-up was already done

**"There is no docs nav below `lg`" is fixed** — #892 added a mobile drawer. That note was taken against the pre-#892 tree.

**"`/docs` has no control plane" is not a defect.** `/docs` is a designed landing page — "Start building with Threadplane", pick-your-backend cards. It's the front door; a sidebar would damage it. Left alone.

## What the re-check found instead

On `/docs/choosing-an-adapter` at 375px, the drawer's Scope card read:

> **LangGraph** / Getting Started / **Documentation**

Three fabrications in the one card whose job is telling you where you are. `Nav.tsx` derives the library from `pathParts[1]` — here `"choosing-an-adapter"`, not a library — so `getLibraryConfig()` returned undefined and the code fell back to `'langgraph'`. The drawer then showed LangGraph's picker, LangGraph's entire section tree, and a title of "Documentation".

The failure mode is silence: it renders something plausible.

**Root cause:** the control plane had no "no library selected" state, so every caller had to invent one.

## The fix

`activeLibrary` becomes `LibraryId | null` through `DocsControlPlane` and `DocsNavigation`. Neutral pages get `Docs / <page>` in Scope, a `Choose a library` picker with nothing checked, and no section tree. `Nav` stops defaulting and resolves special-page titles — correcting the drawer on every library-neutral route, not just this one.

| `/docs/choosing-an-adapter`, mobile | Before | After |
|---|---|---|
| Scope | `LangGraph / Getting Started / Documentation` | `Docs / Choosing an adapter` |
| Picker | `LangGraph` | `Choose a library` |
| Section tree | LangGraph's, in full | none |

## The page was also bespoke

That drift produced the rest of its symptoms. It now uses the same shell as every other docs page, which:

- gives it the control plane it never had;
- deletes an empty hero `Section` that opened a **measured 144px gap** above the H1, and whose empty `<div>` was the target of `aria-labelledby` — leaving the section with **no accessible name at all**;
- replaces ~60 duplicated lines of MDX pipeline with the existing `MdxRenderer`.

`MdxRenderer`'s `library`/`section`/`slug`/`title` props were accepted and never read — four of the website's lint warnings. Dropped. The blog route was passing `library="langgraph"` for blog posts, which only ever looked harmless because the value was discarded.

## Testing

404 tests pass, 0 lint errors, production build green.

`Nav.spec.tsx` → `'does not invent a library on a library-neutral docs page'` is the one that matters — it fails against `main` with `expected <span></span> to be null`, catching the fabricated LangGraph. The existing `'shows truthful scope and collapsed environment defaults'` doubles as the regression guard that real library pages are untouched; verified in the browser too (`LangGraph / Guides / Streaming`, picker and tree intact).

Design spec: `docs/superpowers/specs/2026-09-01-docs-library-neutral-pages-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)