### PR TITLE
fix(website): restore padding on Shiki code blocks

### DIFF
--- a/apps/website/src/app/global.css
+++ b/apps/website/src/app/global.css
@@ -50,6 +50,31 @@ pre {
   overflow-x: auto;
 }
 
+/*
+ * Shiki `codeToHtml` output — components/landing/HighlightedCode.tsx and
+ * components/solutions/SolutionCodeBlock.tsx.
+ *
+ * Shiki writes the theme background INLINE on the <pre> but emits no padding,
+ * so without this the code text sits flush against the dark surface's edges.
+ * That padding used to come from a global `.shiki` rule, deleted in #863 on a
+ * docs-only survey ("zero elements matched") that missed these two TSX call
+ * sites — rehype-pretty-code really does not emit `.shiki`, but `codeToHtml`
+ * does. Selector is `pre.shiki`, not `.shiki`: both call sites put the class on
+ * a wrapper <div> too, and padding there lands OUTSIDE the dark surface.
+ *
+ * Held by a style contract (styles/style-contracts.spec.ts) — this comment is
+ * exactly the tell that registry asks for.
+ */
+pre.shiki {
+  margin: 0;
+  padding: 1.25rem 1.5rem;
+}
+pre.shiki code {
+  font-family: var(--font-mono), "JetBrains Mono", monospace;
+  font-size: inherit;
+  line-height: inherit;
+}
+
 /* Long unbreakable tokens (e.g. package names like @threadplane/chat,
  * file paths like app.config.ts) live inside marketing headings and pull
  * the layout wider than the viewport on narrow phones. Allow breaking

--- a/apps/website/src/components/landing/HighlightedCode.spec.tsx
+++ b/apps/website/src/components/landing/HighlightedCode.spec.tsx
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+import { describe, expect, it } from 'vitest';
+import { HighlightedCode } from './HighlightedCode';
+
+/**
+ * The markup half of the padding contract that regressed in #863.
+ *
+ * The CSS half — that `pre.shiki` actually declares a padding — is a style
+ * contract in styles/style-contracts.spec.ts. Both halves are needed and
+ * neither is sufficient: the contract survives this component switching
+ * highlighters (guarding a rule nothing emits any more), and these assertions
+ * survive the rule being deleted again as dead.
+ *
+ * What makes the pairing load-bearing is that Shiki puts the theme background
+ * INLINE on the <pre> while emitting no padding of its own. So the padding has
+ * to land on that same element — the wrapper <div> carries `shiki` too, and
+ * padding there sits outside the dark surface as a light gutter.
+ */
+async function renderToHtml() {
+  // An async Server Component: await the element and read the markup it hands
+  // to `dangerouslySetInnerHTML`, no DOM needed.
+  const element = await HighlightedCode({ code: 'const answer = 42;' });
+  return element.props.dangerouslySetInnerHTML.__html as string;
+}
+
+describe('HighlightedCode', () => {
+  it('emits a <pre class="shiki"> for the pre.shiki contract to match', async () => {
+    expect(await renderToHtml()).toMatch(/<pre class="shiki[^"]*"/);
+  });
+
+  it('carries the theme background inline on that <pre>', async () => {
+    // This is why padding must go on the <pre> and not on the wrapper.
+    expect(await renderToHtml()).toMatch(
+      /<pre class="shiki[^"]*"[^>]*style="[^"]*background-color:/,
+    );
+  });
+
+  it('emits no padding of its own, leaving CSS as the only source', async () => {
+    expect(await renderToHtml()).not.toMatch(/<pre[^>]*style="[^"]*padding/);
+  });
+
+  it('puts `shiki` on the wrapper too, so the rule must stay pre-scoped', async () => {
+    const element = await HighlightedCode({ code: 'const answer = 42;' });
+    expect(element.props.className).toBe('shiki');
+  });
+});

--- a/apps/website/src/components/solutions/SolutionCodeBlock.tsx
+++ b/apps/website/src/components/solutions/SolutionCodeBlock.tsx
@@ -45,8 +45,9 @@ export async function SolutionCodeBlock({ code }: { code: SolutionCodeBlocks }) 
                 {block.label}
               </p>
           {/*
-            Shiki emits a complete <pre> that already carries its own background,
-            padding, and `overflow-x: auto`, so this wrapper owns only the frame.
+            Shiki emits a <pre> carrying its own background; its padding and
+            `overflow-x: auto` come from the `pre.shiki` / `pre` rules in
+            global.css, so this wrapper owns only the frame.
             `overflow: hidden` is what makes the radius clip that background — it
             must not be `auto`, which would nest a second scroll container around
             a element that already scrolls and can show two scrollbars.

--- a/apps/website/src/styles/landing.css
+++ b/apps/website/src/styles/landing.css
@@ -986,16 +986,19 @@
 }
 
 /* HighlightedCode — components/landing/HighlightedCode.tsx
- * `.shiki[data-ui="highlighted-code"]` (specificity 0,2,0) intentionally beats
- * the plain `.shiki` rule in docs.css (0,1,0) regardless of stylesheet import
- * order, so this landing-only override of margin/padding/font-size/line-height
- * keeps winning the way the inline style used to. */
+ * The wrapper <div> owns only type scale; the frame around it
+ * (.home-code-frame, .lg-show-card, ...) owns radius and clipping. Padding
+ * belongs on the <pre>, which is where Shiki's dark background lives — putting
+ * it here would inset the code from a light gutter instead. The base
+ * `pre.shiki` padding is in global.css; this is the tighter landing scale. */
 .shiki[data-ui="highlighted-code"] {
   margin: 0;
   border-radius: 0;
-  padding: 16px 20px;
   font-size: 0.78rem;
   line-height: 1.65;
+}
+.shiki[data-ui="highlighted-code"] > pre.shiki {
+  padding: 16px 20px;
 }
 
 /* RenderCodeShowcase — components/landing/render/RenderCodeShowcase.tsx */

--- a/apps/website/src/styles/style-contracts.spec.ts
+++ b/apps/website/src/styles/style-contracts.spec.ts
@@ -50,6 +50,14 @@ const CONTRACTS: StyleContract[] = [
     },
   },
   {
+    file: '../app/global.css',
+    selector: 'pre.shiki',
+    why: "Shiki writes the theme background inline on the <pre> but emits no padding, so losing this sits the code flush against the dark surface's edges — on the homepage Code tabs, /langgraph, /render, /chat and every /solutions page. Deleted once already in #863, on a docs-only survey that concluded `.shiki` matched nothing.",
+    requires: {
+      padding: /padding:/,
+    },
+  },
+  {
     file: 'docs.css',
     selector: '.docs-control-plane [data-control-plane-pane]',
     why: 'The pane holds the whole docs nav in a fixed-height column. Without its own scrolling the lower sections are unreachable on short viewports.',


### PR DESCRIPTION
## Cause

PR #863 (\"docs polish 2/3\") deleted the global `.shiki` rules from `docs.css`:

```css
.shiki { padding: 1.5rem; background: var(--docs-code-bg) !important; overflow-x: auto; }
.shiki code { font-family: var(--font-mono), monospace; font-size: 0.75rem; line-height: 1.7; }
```

on the finding \"zero elements matched, on docs and blog.\" That was true for docs and blog — `rehype-pretty-code` writes its background inline and never emits a `.shiki` class. But two TSX call sites highlight with Shiki's `codeToHtml` directly, which **does** emit `<pre class="shiki tokyo-night">`:

- `components/landing/HighlightedCode.tsx` — the homepage **Code** tabs, plus `/langgraph`, `/render`, `/chat`
- `components/solutions/SolutionCodeBlock.tsx` — every `/solutions/*` page

Those `<pre>` elements lost their padding. The dark theme background rides inline on the `<pre>`, while the landing override put its `16px 20px` on the wrapper `<div>` (which carries `shiki` too) — *outside* the dark box. Measured before the fix: wrapper padding `16px 20px`, `<pre>` padding `0px`. The result was a light gutter with the code flush against the dark edges.

## Fix

- `global.css` — a `pre.shiki` base rule restoring padding and the mono font. Scoped to `pre.shiki`, not `.shiki`, precisely because both call sites also put the class on a wrapper div.
- `styles/landing.css` — the landing override's padding moves off the wrapper onto `> pre.shiki`; it keeps the tighter `16px 20px` scale.
- `SolutionCodeBlock.tsx` — corrects the comment asserting Shiki emits its own padding. That wrong premise is what made the deletion look safe.

## Verification (Chrome, dev server)

| Surface | wrapper pad | `<pre>` pad | bg | wrapper↔pre gap |
|---|---|---|---|---|
| homepage, all 4 Code panes | `0px` | `16px 20px` | `rgb(26,27,38)` | 0 |
| `/langgraph`, `/render`, `/chat` | `0px` | `16px 20px` | `rgb(26,27,38)` | 0 |
| `/solutions/compliance` | `0px` | `20px 24px` | `rgb(26,27,38)` | 0 |

Docs pages still match **0** `pre.shiki` elements with their own `[data-rehype-pretty-code-figure] pre` rules intact — unaffected.

## Guards

Two halves, since neither is sufficient alone:

- **CSS half** — a style contract in `styles/style-contracts.spec.ts`, using the registry #926 landed. This is exactly the \"comment in a stylesheet explaining why a declaration must not be removed\" that registry asks you to convert into an entry. Mutation-tested both ways it requires: deleting the `padding` declaration (fails `declares padding`) and renaming the selector wholesale (fails `has a rule at all`).
- **Markup half** — `HighlightedCode.spec.tsx`: that Shiki still emits a `pre.shiki` carrying an inline background and no padding of its own. Without it the contract could sit guarding a rule nothing matches any more — which is how #863 happened.

`nx lint website`: 0 errors. Website suite: 440/440 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)