### PR TITLE
ci(ag-ui): verify the deployed runtime mounts every topic after deploy

### DIFF
--- a/.github/workflows/deploy-ag-ui.yml
+++ b/.github/workflows/deploy-ag-ui.yml
@@ -71,3 +71,15 @@ jobs:
         run: railway up --service ag-ui-dev --detach
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+
+      # The boot gate above proves the aggregated server IMPORTS. It cannot
+      # prove the rollout took: `railway up --detach` returns at upload time,
+      # and when a new image fails to start Railway keeps serving the last good
+      # one — so a broken deploy looks identical to a healthy one from CI.
+      # That is exactly how /agent/subagents stayed 404 in production from
+      # 2026-06-16 to 2026-08-31 behind green deploys, and why /ok is no help:
+      # a stale image answers it happily. Assert the endpoints instead.
+      - name: Verify the deployed runtime mounts every topic
+        run: npx tsx scripts/verify-ag-ui-runtime.ts
+        env:
+          EXAMPLES_URL: https://examples.threadplane.ai

--- a/scripts/verify-ag-ui-runtime.spec.ts
+++ b/scripts/verify-ag-ui-runtime.spec.ts
@@ -1,0 +1,71 @@
+import { agentUrlFor, classifyStatus, deployedTopics } from './verify-ag-ui-runtime';
+
+/**
+ * These pin the semantics that make the check meaningful. A well-intentioned
+ * "simplify this to status < 500" would keep the suite green while silently
+ * reintroducing the blind spot it exists to close: a 404 from a stale image.
+ */
+describe('classifyStatus', () => {
+  it('treats 422 as healthy — the request model rejected an empty body, so the route exists', () => {
+    expect(classifyStatus(422)).toEqual({ ok: true, status: 422 });
+  });
+
+  it('fails a 404 and names the deployed image as a suspect', () => {
+    const verdict = classifyStatus(404);
+    expect(verdict.ok).toBe(false);
+    expect(verdict.ok === false && verdict.reason).toMatch(/route not found/);
+  });
+
+  it('fails a 401 and points at the internal-token mismatch', () => {
+    const verdict = classifyStatus(401);
+    expect(verdict.ok).toBe(false);
+    expect(verdict.ok === false && verdict.reason).toMatch(/AG_UI_INTERNAL_TOKEN/);
+  });
+
+  it('fails upstream 5xx rather than reporting a healthy topic', () => {
+    expect(classifyStatus(502).ok).toBe(false);
+  });
+
+  it('does not treat a 200 as a failure', () => {
+    expect(classifyStatus(200).ok).toBe(true);
+  });
+});
+
+describe('deployedTopics', () => {
+  it('includes subagents — the topic whose absence this check was built to catch', () => {
+    expect(deployedTopics().map((t) => t.topic)).toContain('subagents');
+  });
+
+  it('covers the runtimes product, which shares the same deployed runtime', () => {
+    expect(deployedTopics().map((t) => t.product)).toContain('runtimes');
+  });
+
+  it('excludes capabilities hosted outside ag-ui-dev', () => {
+    // mastra declares no pythonDir — its backend is deployments/ag-ui-mastra,
+    // so probing it here would assert against a runtime that never mounts it.
+    expect(deployedTopics().map((t) => t.topic)).not.toContain('mastra');
+  });
+
+  it('is driven off the registry so new topics are covered without editing this script', () => {
+    const topics = deployedTopics().map((t) => t.topic);
+    expect(topics.length).toBeGreaterThanOrEqual(9);
+    expect([...topics]).toEqual([...topics].sort());
+  });
+});
+
+describe('agentUrlFor', () => {
+  it('serves ag-ui capabilities under /ag-ui', () => {
+    expect(agentUrlFor({ product: 'ag-ui', topic: 'subagents' })).toBe(
+      '/ag-ui/subagents/agent'
+    );
+  });
+
+  it('serves runtimes capabilities under /runtimes, not /ag-ui', () => {
+    // Both proxy to the same Railway app, but the examples route table has a
+    // separate rule per product — probing a runtime under /ag-ui would pass
+    // through the wrong rule and stop reflecting what the SPA actually calls.
+    expect(agentUrlFor({ product: 'runtimes', topic: 'aws-strands' })).toBe(
+      '/runtimes/aws-strands/agent'
+    );
+  });
+});

--- a/scripts/verify-ag-ui-runtime.ts
+++ b/scripts/verify-ag-ui-runtime.ts
@@ -1,0 +1,188 @@
+#!/usr/bin/env npx tsx
+/**
+ * Verify that the deployed ag-ui Railway runtime actually serves every topic
+ * in the capability registry.
+ *
+ * Why this exists: `deploy-ag-ui.yml` ships with `railway up --detach`, which
+ * returns as soon as the upload is accepted — long before Railway builds or
+ * starts the image. A build that fails afterwards leaves the PREVIOUS image
+ * running while the workflow reports success, so a topic can be missing from
+ * production for months with every check green. That is exactly how
+ * `/agent/subagents` went missing: three successful uploads carried the route,
+ * but the live instance kept serving the pre-subagents route table.
+ *
+ * `/ok` cannot catch this — a stale image answers it happily. The only signal
+ * that distinguishes image vintage is whether each topic's route is registered.
+ *
+ * Probing goes through the public Vercel proxy rather than Railway directly:
+ * the FastAPI middleware requires X-Internal-Token, which lives on Railway and
+ * Vercel but is deliberately not a CI secret. The proxy injects it.
+ *
+ * An empty POST body is a deliberate, token-free canary — the request model
+ * rejects it before any graph or LLM call runs:
+ *   422 → healthy (proxy routed, token accepted, topic registered)
+ *   404 → topic missing from the deployed image, or no Vercel proxy route
+ *   401 → AG_UI_INTERNAL_TOKEN mismatch between the proxy and Railway
+ *
+ * Usage:
+ *   npx tsx scripts/verify-ag-ui-runtime.ts
+ *   EXAMPLES_URL=https://examples.threadplane.ai npx tsx scripts/verify-ag-ui-runtime.ts
+ */
+import { pathToFileURL } from 'url';
+import { capabilities } from '../apps/cockpit/scripts/capability-registry';
+
+const EXAMPLES_URL = process.env['EXAMPLES_URL'] ?? 'https://examples.threadplane.ai';
+const RAILWAY_URL =
+  process.env['AG_UI_RAILWAY_URL'] ?? 'https://ag-ui-dev-production.up.railway.app';
+
+/** How long to keep polling while Railway builds and rolls out the new image. */
+const DEADLINE_MS = Number(process.env['AG_UI_VERIFY_TIMEOUT_MS'] ?? 15 * 60 * 1000);
+const POLL_INTERVAL_MS = Number(process.env['AG_UI_VERIFY_INTERVAL_MS'] ?? 20_000);
+
+export type TopicVerdict =
+  | { ok: true; status: number }
+  | { ok: false; status: number; reason: string };
+
+/**
+ * Classify an agent-endpoint response. Anything that is not a routing or auth
+ * failure means the topic is registered and reachable — which is all this
+ * check claims.
+ */
+export function classifyStatus(status: number): TopicVerdict {
+  if (status === 404) {
+    return {
+      ok: false,
+      status,
+      reason:
+        'route not found — the deployed Railway image has no handler for this topic, or the Vercel proxy route is missing',
+    };
+  }
+  if (status === 401) {
+    return {
+      ok: false,
+      status,
+      reason:
+        'unauthorized — AG_UI_INTERNAL_TOKEN differs between the Vercel proxy and Railway',
+    };
+  }
+  if (status >= 500) {
+    return { ok: false, status, reason: 'upstream error from the Railway runtime' };
+  }
+  return { ok: true, status };
+}
+
+export interface DeployedTopic {
+  /** URL segment the examples site serves this capability under. */
+  product: 'ag-ui' | 'runtimes';
+  topic: string;
+}
+
+/**
+ * Mirrors collectTopics() in scripts/generate-ag-ui-deployment-config.ts: the
+ * 'ag-ui' and 'runtimes' products are both AG-UI-served FastAPI backends
+ * aggregated into the single ag-ui-dev deployment, and a capability without a
+ * pythonDir is hosted elsewhere (mastra is Node-hosted). Deriving the list the
+ * same way the generator does keeps this check honest — it asserts exactly
+ * what the deployment was generated to mount, so a new topic is covered with
+ * no edit here.
+ */
+export function deployedTopics(): DeployedTopic[] {
+  const topics = capabilities
+    .filter(
+      (c) => (c.product === 'ag-ui' || c.product === 'runtimes') && c.pythonDir
+    )
+    .map((c) => ({ product: c.product as DeployedTopic['product'], topic: c.topic }))
+    .sort((a, b) => a.topic.localeCompare(b.topic));
+  if (topics.length === 0) {
+    throw new Error('No ag-ui topics with pythonDir found in capability registry');
+  }
+  return topics;
+}
+
+/** Public path the SPA for this capability calls; both proxy to the same runtime. */
+export function agentUrlFor({ product, topic }: DeployedTopic): string {
+  return `/${product}/${topic}/agent`;
+}
+
+async function probeTopic(entry: DeployedTopic): Promise<TopicVerdict> {
+  try {
+    const res = await fetch(`${EXAMPLES_URL}${agentUrlFor(entry)}`, {
+      method: 'POST',
+      headers: { origin: EXAMPLES_URL, 'content-type': 'application/json' },
+      body: '{}',
+    });
+    return classifyStatus(res.status);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { ok: false, status: 0, reason: `request failed — ${message}` };
+  }
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function main(): Promise<void> {
+  const topics = deployedTopics();
+  console.log(
+    `Verifying ${topics.length} deployed topics via ${EXAMPLES_URL} (Railway: ${RAILWAY_URL})`
+  );
+
+  const deadline = Date.now() + DEADLINE_MS;
+  let pending: DeployedTopic[] = [...topics];
+  const verdicts = new Map<string, TopicVerdict>();
+
+  // Poll rather than probe once: `railway up --detach` returns before the new
+  // image is live, so an immediate check would assert against the old one.
+  for (;;) {
+    const results = await Promise.all(
+      pending.map(async (entry) => [entry, await probeTopic(entry)] as const)
+    );
+    for (const [entry, verdict] of results) verdicts.set(entry.topic, verdict);
+    pending = results.filter(([, v]) => !v.ok).map(([e]) => e);
+
+    if (pending.length === 0) break;
+    if (Date.now() >= deadline) break;
+
+    const remainingS = Math.round((deadline - Date.now()) / 1000);
+    console.log(
+      `⏳ still unhealthy: ${pending.map((e) => e.topic).join(', ')} — retrying in ${POLL_INTERVAL_MS / 1000}s (${remainingS}s left)`
+    );
+    await sleep(POLL_INTERVAL_MS);
+  }
+
+  const summary = topics.map((entry) => ({
+    topic: entry.topic,
+    url: agentUrlFor(entry),
+    verdict: verdicts.get(entry.topic) ?? {
+      ok: false as const,
+      status: 0,
+      reason: 'never probed',
+    },
+  }));
+
+  for (const { topic, url, verdict } of summary) {
+    if (verdict.ok) {
+      console.log(`✅ ${topic}: mounted at ${url} (HTTP ${verdict.status})`);
+    } else {
+      console.error(`❌ ${topic}: ${url} → HTTP ${verdict.status} — ${verdict.reason}`);
+    }
+  }
+
+  const failed = summary.filter(({ verdict }) => !verdict.ok);
+  console.log(`\n${summary.length - failed.length} healthy, ${failed.length} failing`);
+  if (failed.length > 0) {
+    console.error(
+      '\nThe deployed image does not serve every registered topic. Check the ' +
+        'Railway build log for the ag-ui-dev service — `railway up --detach` ' +
+        'reports success on upload, not on a successful build.'
+    );
+    process.exit(1);
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`❌ ag-ui runtime verification failed — ${message}`);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
Closes the gap that hid the subagents outage for two and a half months.

The boot gate from [#899](https://github.com/cacheplane/angular-agent-framework/pull/899) proves the aggregated server **imports** with the pinned deps. It can't prove the **rollout took**:

- `railway up --detach` returns at upload time, before the image builds or starts.
- When a new image fails to start, **Railway keeps serving the last good one**.
- `/ok` is no help — a stale image answers it happily.

So from CI, a broken deploy is indistinguishable from a healthy one. `/agent/subagents` was 404 in production from 2026-06-16 to 2026-08-31 while every deploy reported success, and today's runtime topics couldn't appear either.

## The check

Poll the endpoints the SPAs actually call until each topic answers; fail the deploy if any doesn't.

An empty POST is a token-free canary — the FastAPI request model rejects it before any graph or LLM call runs:

| Status | Meaning |
|---|---|
| `422` | mounted and healthy |
| `404` | missing from the deployed image, or no proxy route |
| `401` | `AG_UI_INTERNAL_TOKEN` mismatch |

Probing goes through the public Vercel proxy because the middleware requires `X-Internal-Token`, which is deliberately not a CI secret.

The topic list mirrors `collectTopics()` in the deployment generator, so it asserts exactly what the deployment was generated to mount — a new topic is covered with no edit here. URLs are product-aware: `ag-ui` and `runtimes` share the runtime, but the examples route table has a separate rule per product, so probing a runtime under `/ag-ui` would pass through the wrong rule and stop reflecting what the SPA calls.

## Verification

Against production right now — **9/9 mounted, exit 0**:

```
✅ aws-strands: mounted at /runtimes/aws-strands/agent (HTTP 422)
✅ subagents:   mounted at /ag-ui/subagents/agent (HTTP 422)
… 7 more
9 healthy, 0 failing
```

Against the outage it was written for, it named the failing topic and pointed at the Railway build log rather than reporting green.

Unit spec: 11 pass, pinning the status semantics (a well-meaning "simplify to `status < 500`" would silently reintroduce the blind spot) and the per-product URL mapping.

`eslint` reports one `@nx/enforce-module-boundaries` error for the relative registry import — identical to the existing `scripts/generate-ag-ui-deployment-config.ts`, and root `scripts/` isn't in any lint target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)