### PR TITLE
docs: normalize AG-UI branding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1015,7 +1015,7 @@ jobs:
           NODE
 
   ag-ui-demo-deploy:
-    name: ag-ui demo → Vercel
+    name: AG-UI demo → Vercel
     timeout-minutes: 30 # fail fast instead of blocking the main concurrency group on a hang
     needs: [examples-ag-ui-e2e]
     runs-on: ubuntu-latest
@@ -1024,10 +1024,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - name: Require ag-ui demo prerequisite jobs
+      - name: Require AG-UI demo prerequisite jobs
         run: |
           if [ "${{ needs.examples-ag-ui-e2e.result }}" != "success" ]; then
-            echo "::error::examples/ag-ui — e2e finished with ${{ needs.examples-ag-ui-e2e.result }}; refusing to deploy the ag-ui demo."
+            echo "::error::examples/ag-ui — e2e finished with ${{ needs.examples-ag-ui-e2e.result }}; refusing to deploy the AG-UI demo."
             exit 1
           fi
       # Same staleness guard as the other production promotions.
@@ -1043,11 +1043,11 @@ jobs:
           fi
           if [ "$tip" != "${{ github.sha }}" ]; then
             echo "stale=true" >> "$GITHUB_OUTPUT"
-            echo "::warning::main has advanced to ${tip} since this run started (${{ github.sha }}); skipping the ag-ui demo promotion."
+            echo "::warning::main has advanced to ${tip} since this run started (${{ github.sha }}); skipping the AG-UI demo promotion."
           else
             echo "stale=false" >> "$GITHUB_OUTPUT"
           fi
-      - name: Check if ag-ui demo changed
+      - name: Check if AG-UI demo changed
         id: ag_ui_changed
         run: |
           base_sha="${{ github.event.before }}"
@@ -1065,7 +1065,7 @@ jobs:
           fi
           echo "changed=$ag_ui_changed" >> "$GITHUB_OUTPUT"
           if [ "$ag_ui_changed" != "true" ]; then
-            echo "::notice::No ag-ui demo files changed; skipping ag-ui demo deploy."
+            echo "::notice::No AG-UI demo files changed; skipping AG-UI demo deploy."
           fi
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         if: steps.freshness.outputs.stale != 'true' && steps.ag_ui_changed.outputs.changed == 'true'
@@ -1079,7 +1079,7 @@ jobs:
           python-version: '3.12'
       - if: steps.freshness.outputs.stale != 'true' && steps.ag_ui_changed.outputs.changed == 'true'
         run: npm ci
-      - name: Build and assemble ag-ui demo
+      - name: Build and assemble AG-UI demo
         if: steps.freshness.outputs.stale != 'true' && steps.ag_ui_changed.outputs.changed == 'true'
         env:
           # Baked into the SPA bundle by inject-env at build time. Without the
@@ -1089,7 +1089,7 @@ jobs:
           GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
           GOOGLE_MAPS_MAP_ID: 86d464ea7d5306034fe2a254
         run: npx tsx scripts/assemble-ag-ui-demo.ts
-      - name: Deploy ag-ui demo SPA to Vercel (production)
+      - name: Deploy AG-UI demo SPA to Vercel (production)
         if: steps.freshness.outputs.stale != 'true' && steps.ag_ui_changed.outputs.changed == 'true'
         run: |
           mkdir -p deploy/ag-ui-demo/.vercel
@@ -1099,7 +1099,7 @@ jobs:
           cd deploy/ag-ui-demo
           npx vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
           npx vercel deploy --prebuilt --prod --yes --token=${{ secrets.VERCEL_TOKEN }}
-      - name: Deploy ag-ui backend to Railway
+      - name: Deploy AG-UI backend to Railway
         if: steps.freshness.outputs.stale != 'true' && steps.ag_ui_changed.outputs.changed == 'true'
         working-directory: examples/ag-ui/python
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,7 +120,7 @@
 
 - **ci:** never promote a superseded commit to production ([#816](https://github.com/cacheplane/angular-agent-framework/pull/816), [#813](https://github.com/cacheplane/angular-agent-framework/issues/813), [#814](https://github.com/cacheplane/angular-agent-framework/issues/814))
 - **deploy:** restore shared-deployment namespace merge broken by src/__init__.py ([#825](https://github.com/cacheplane/angular-agent-framework/pull/825), [#642](https://github.com/cacheplane/angular-agent-framework/issues/642))
-- **examples:** raise ag-ui demo initial bundle budget to chat parity ([#821](https://github.com/cacheplane/angular-agent-framework/pull/821))
+- **examples:** raise AG-UI demo initial bundle budget to chat parity ([#821](https://github.com/cacheplane/angular-agent-framework/pull/821))
 - **langgraph:** reject non-durable client tool flushes ([#809](https://github.com/cacheplane/angular-agent-framework/pull/809))
 - **langgraph:** retain client tool results across failed runs ([#810](https://github.com/cacheplane/angular-agent-framework/pull/810))
 - **website:** render grouped API entries on middleware helpers page ([#815](https://github.com/cacheplane/angular-agent-framework/pull/815))
@@ -164,7 +164,7 @@
 ### 🩹 Fixes
 
 - remove unused fake agent delay variable ([#787](https://github.com/cacheplane/angular-agent-framework/pull/787))
-- **ag-ui:** version authoritative snapshot rewrites ([#804](https://github.com/cacheplane/angular-agent-framework/pull/804))
+- **AG-UI:** version authoritative snapshot rewrites ([#804](https://github.com/cacheplane/angular-agent-framework/pull/804))
 - **chat:** closed drawer sidenav must not intercept clicks on content ([#778](https://github.com/cacheplane/angular-agent-framework/pull/778))
 - **chat:** never leave a client tool call unanswered on the server ([#807](https://github.com/cacheplane/angular-agent-framework/pull/807), [#782](https://github.com/cacheplane/angular-agent-framework/issues/782), [#805](https://github.com/cacheplane/angular-agent-framework/issues/805))
 - **cockpit-examples:** use CSS sidebar widths ([496db8e8](https://github.com/cacheplane/angular-agent-framework/commit/496db8e8))
@@ -359,7 +359,7 @@
 
 ### Added
 
-- **`Agent.regenerate(index)`** — new method on the `Agent` interface implemented by both LangGraph and ag-ui adapters. Replace-semantics: discards the target assistant message and all subsequent messages, then re-runs against the prior user prompt. (#199)
+- **`Agent.regenerate(index)`** — new method on the `Agent` interface implemented by both LangGraph and AG-UI adapters. Replace-semantics: discards the target assistant message and all subsequent messages, then re-runs against the prior user prompt. (#199)
 - **`<chat-message-actions>`** — regenerate button is disabled while `agent.isLoading()`. (#199)
 
 ### Fixed
@@ -481,8 +481,8 @@
 - relicense to MIT (selective; minting-service stays proprietary) ([#141](https://github.com/cacheplane/angular-agent-framework/pull/141))
 - **a2ui:** align validation with v0.9 CheckRule spec ([#97](https://github.com/cacheplane/angular-agent-framework/pull/97))
 - **a2ui:** v0.9 action envelope and sendDataModel transport ([#101](https://github.com/cacheplane/angular-agent-framework/pull/101))
-- **ag-ui:** @cacheplane/ag-ui adapter wrapping @ag-ui/client ([#139](https://github.com/cacheplane/angular-agent-framework/pull/139))
-- **ag-ui:** FakeAgent for offline cockpit demo ([#140](https://github.com/cacheplane/angular-agent-framework/pull/140))
+- **AG-UI:** @cacheplane/ag-ui adapter wrapping @ag-ui/client ([#139](https://github.com/cacheplane/angular-agent-framework/pull/139))
+- **AG-UI:** FakeAgent for offline cockpit demo ([#140](https://github.com/cacheplane/angular-agent-framework/pull/140))
 - **agent:** run license check at provider init ([fd95400f](https://github.com/cacheplane/angular-agent-framework/commit/fd95400f))
 - **chat:** Apple-clean UI redesign + streaming example integration ([499ef645](https://github.com/cacheplane/angular-agent-framework/commit/499ef645))
 - **chat:** eliminate streaming jank with append-only markdown and frame-synced pipeline ([#107](https://github.com/cacheplane/angular-agent-framework/pull/107))

--- a/apps/cockpit/ag-ui-agent-url.spec.ts
+++ b/apps/cockpit/ag-ui-agent-url.spec.ts
@@ -32,7 +32,7 @@ const agentBackedCapabilities = capabilities.filter(
   (c) => c.product === 'ag-ui' || c.product === 'runtimes'
 );
 
-describe('ag-ui agent URL is resolved against <base href>', () => {
+describe('AG-UI agent URL is resolved against <base href>', () => {
   it('covers every registered agent-backed capability', () => {
     expect(agentBackedCapabilities.length).toBeGreaterThan(0);
   });

--- a/apps/cockpit/cockpit-e2e-wiring.spec.ts
+++ b/apps/cockpit/cockpit-e2e-wiring.spec.ts
@@ -213,7 +213,7 @@ describe('cockpit e2e wiring', () => {
           errors.push(`${wiring.project}: proxy.conf.mjs does not call portsFor('${wiring.project}')`);
         }
       } else if (existsSync(proxyJson)) {
-        // Legacy (allowed for ag-ui exception only); not expected for any
+        // Legacy (allowed for AG-UI exception only); not expected for any
         // cap reaching this code path.
         const proxy = JSON.parse(readFileSync(proxyJson, 'utf8')) as Record<string, { target?: string }>;
         const target = proxy['/api']?.target;
@@ -293,7 +293,7 @@ describe('cockpit e2e wiring', () => {
     const errors: string[] = [];
 
     const capProjects = listProjectJsonFiles(join(repoRoot, 'cockpit'))
-      .filter((p) => !p.includes('/ag-ui/'))   // ag-ui has no python; out of scope
+      .filter((p) => !p.includes('/ag-ui/'))   // AG-UI has no python; out of scope
       .filter((p) => p.includes('/angular/') || p.includes('/python/'))
       .map((p) => ({
         path: p,

--- a/apps/cockpit/e2e/production-smoke.spec.ts
+++ b/apps/cockpit/e2e/production-smoke.spec.ts
@@ -72,11 +72,11 @@ const RENDER_CAPABILITIES = [
 ] as const;
 
 /**
- * Driven off the capability registry so a newly added ag-ui topic is covered
+ * Driven off the capability registry so a newly added AG-UI topic is covered
  * automatically instead of silently going unasserted — the previous two
  * hardcoded checks covered interrupts and streaming only.
  *
- * Scoped to the ag-ui product: `runtimes` capabilities share the Railway
+ * Scoped to the AG-UI product: `runtimes` capabilities share the Railway
  * runtime but are not yet in the examples route table, so they have no
  * /ag-ui/<topic>/ URL to assert against.
  */
@@ -241,7 +241,7 @@ test.describe('Production: canonical demo sends runtime telemetry', () => {
   });
 });
 
-test.describe('ag-ui Railway runtime', () => {
+test.describe('AG-UI Railway runtime', () => {
   const RAILWAY_URL = process.env['AG_UI_RAILWAY_URL'] ?? 'https://ag-ui-dev-production.up.railway.app';
 
   test('healthcheck /ok responds 200', async ({ request }) => {
@@ -327,7 +327,7 @@ test.describe('examples langgraph proxy hardening', () => {
   });
 });
 
-test.describe('ag-ui demo (ag-ui.threadplane.ai)', () => {
+test.describe('AG-UI demo (ag-ui.threadplane.ai)', () => {
   const DEMO = process.env['AG_UI_DEMO_URL'] ?? 'https://ag-ui.threadplane.ai';
 
   test('demo SPA is reachable', async ({ page }) => {

--- a/apps/cockpit/scripts/capability-registry.ts
+++ b/apps/cockpit/scripts/capability-registry.ts
@@ -22,7 +22,7 @@ export interface Capability {
   /**
    * 'runtimes' is the one-capability-many-runtimes axis
    * (cockpit/runtimes/<runtime>/): non-LangGraph AG-UI backends measured
-   * against the same neutral Agent contract. Like 'ag-ui' caps, they are
+   * against the same neutral Agent contract. Like AG-UI caps, they are
    * served by the aggregated deployments/ag-ui-dev FastAPI app.
    */
   product: 'langgraph' | 'deep-agents' | 'render' | 'chat' | 'ag-ui' | 'runtimes';
@@ -30,7 +30,7 @@ export interface Capability {
   angularProject: string;
   port: number;
   pythonPort?: number;
-  /** Optional — ag-ui caps run in-process via FakeAgent and have no Python backend. */
+  /** Optional — AG-UI caps run in-process via FakeAgent and have no Python backend. */
   pythonDir?: string;
   /** Optional — see pythonDir. */
   graphName?: string;
@@ -85,7 +85,7 @@ export const capabilities: readonly Capability[] = [
   { id: 'ag-ui-a2ui', product: 'ag-ui', topic: 'a2ui', angularProject: 'cockpit-ag-ui-a2ui-angular', port: 4324, pythonPort: 5324, pythonDir: 'cockpit/ag-ui/a2ui/python' },
   { id: 'ag-ui-subagents', product: 'ag-ui', topic: 'subagents', angularProject: 'cockpit-ag-ui-subagents-angular', port: 4326, pythonPort: 5326, pythonDir: 'cockpit/ag-ui/subagents/python' },
   // Runtime-portability examples (one capability, many runtimes; AG-UI-served
-  // like the ag-ui caps, but the backend is genuinely non-LangGraph)
+  // like the AG-UI caps, but the backend is genuinely non-LangGraph)
   { id: 'rt-maf', product: 'runtimes', topic: 'microsoft-agent-framework', angularProject: 'cockpit-runtimes-microsoft-agent-framework-angular', port: 4330, pythonPort: 5330, pythonDir: 'cockpit/runtimes/microsoft-agent-framework/python', framework: 'microsoft-agent-framework' },
   { id: 'rt-strands', product: 'runtimes', topic: 'aws-strands', angularProject: 'cockpit-runtimes-aws-strands-angular', port: 4331, pythonPort: 5331, pythonDir: 'cockpit/runtimes/aws-strands/python', framework: 'aws-strands' },
   // No pythonDir: the Mastra topic's backend is the hand-written Node

--- a/apps/cockpit/scripts/generate-combined-langgraph.ts
+++ b/apps/cockpit/scripts/generate-combined-langgraph.ts
@@ -40,7 +40,7 @@ const graphs: Record<string, string> = {};
 const dependencies = new Set<string>();
 for (const c of capabilities) {
   if (!c.pythonDir || !c.graphName) {
-    continue; // ag-ui (in-process) and other no-Python caps
+    continue; // AG-UI (in-process) and other no-Python caps
   }
   graphs[c.graphName] = `./${c.pythonDir}/${normalizeEntrypoint(c.pythonDir, c.graphName)}`;
   dependencies.add(`./${c.pythonDir}`);

--- a/apps/cockpit/scripts/serve-example.spec.ts
+++ b/apps/cockpit/scripts/serve-example.spec.ts
@@ -3,7 +3,7 @@ import { backendCommand, COCKPIT_RUNTIME_ENV, formatAllModeSummary } from './ser
 import { capabilities, findCapability, type Capability } from './capability-registry';
 
 describe('backendCommand', () => {
-  it('uses uvicorn on the registry pythonPort for ag-ui caps', () => {
+  it('uses uvicorn on the registry pythonPort for AG-UI caps', () => {
     const cap = findCapability('ag-ui-streaming')!;
     const cmd = backendCommand(cap)!;
     expect(cmd).toContain('cd cockpit/ag-ui/streaming/python');

--- a/apps/website/content/blog/2026-05-21-build-fullstack-agentic-angular-apps-using-ag-ui.mdx
+++ b/apps/website/content/blog/2026-05-21-build-fullstack-agentic-angular-apps-using-ag-ui.mdx
@@ -2,7 +2,7 @@
 title: "Build Fullstack Agentic Angular Apps Using AG-UI"
 description: "A practical walkthrough for wiring any AG-UI backend — LangGraph, CrewAI, Mastra, Pydantic AI, and more — to a production Angular chat UI."
 date: 2026-05-21
-tags: [tutorial, ag-ui, angular, agents, langgraph]
+tags: [tutorial, AG-UI, angular, agents, langgraph]
 author: brian
 featured: true
 ---

--- a/apps/website/content/blog/2026-06-04-human-in-the-loop-ag-ui-agents-in-angular.mdx
+++ b/apps/website/content/blog/2026-06-04-human-in-the-loop-ag-ui-agents-in-angular.mdx
@@ -2,7 +2,7 @@
 title: "Human-in-the-Loop AG-UI Agents in Angular"
 description: "Build a human-in-the-loop AG-UI agent in Angular — the same chat-approval-card composition as the LangGraph version, wired to AG-UI via @threadplane/ag-ui."
 date: 2026-06-04
-tags: [tutorial, ag-ui, angular, agents, hitl, interrupts]
+tags: [tutorial, AG-UI, angular, agents, hitl, interrupts]
 author: brian
 featured: true
 ---

--- a/apps/website/content/blog/2026-08-09-agentic-ui-in-angular-production-patterns.mdx
+++ b/apps/website/content/blog/2026-08-09-agentic-ui-in-angular-production-patterns.mdx
@@ -2,7 +2,7 @@
 title: 'Agentic UI in Angular: Production Patterns After the Demo'
 description: 'Production patterns for agentic UI in Angular: signals, tool progress, approvals, durable threads, constrained generative UI, and recovery.'
 date: 2026-08-09
-tags: [opinion, patterns, agentic-ui, ag-ui, angular, production]
+tags: [opinion, patterns, agentic-ui, AG-UI, angular, production]
 author: brian
 draft: false
 featured: false

--- a/apps/website/content/blog/2026-08-09-build-an-aws-strands-agent-ui-in-angular-with-ag-ui.mdx
+++ b/apps/website/content/blog/2026-08-09-build-an-aws-strands-agent-ui-in-angular-with-ag-ui.mdx
@@ -2,7 +2,7 @@
 title: 'Build an AWS Strands Agent UI in Angular with AG-UI'
 description: 'Connect an AWS Strands agent to an Angular chat over AG-UI SSE with Threadplane, then prepare the same server for optional AgentCore deployment.'
 date: 2026-08-09
-tags: [tutorial, aws-strands, ag-ui, angular, agentic-ui]
+tags: [tutorial, aws-strands, AG-UI, angular, agentic-ui]
 author: brian
 featured: true
 draft: false

--- a/apps/website/content/blog/2026-08-13-angular-chat-app-tutorial-with-ag-ui.mdx
+++ b/apps/website/content/blog/2026-08-13-angular-chat-app-tutorial-with-ag-ui.mdx
@@ -2,7 +2,7 @@
 title: 'Angular Chat App Tutorial with AG-UI'
 description: 'Build an Angular chat app on AG-UI where the browser owns its own tools — action, view, and ask tools rendering real components inline, plus shared state.'
 date: 2026-08-13
-tags: [tutorial, ag-ui, angular, client-tools, agentic-ui]
+tags: [tutorial, AG-UI, angular, client-tools, agentic-ui]
 author: brian
 featured: false
 draft: false

--- a/apps/website/content/blog/2026-08-31-we-measured-the-runtime-swap.mdx
+++ b/apps/website/content/blog/2026-08-31-we-measured-the-runtime-swap.mdx
@@ -2,7 +2,7 @@
 title: 'We Measured the Runtime Swap: Three Non-LangGraph Backends, One Angular Contract'
 description: 'Strands, Microsoft Agent Framework, and Mastra against the neutral Agent contract. Messages, tools, and state ported. Both defects we found were ours.'
 date: 2026-08-31
-tags: [ag-ui, angular, architecture, portability, agentic-ui]
+tags: [AG-UI, angular, architecture, portability, agentic-ui]
 author: brian
 featured: false
 draft: false

--- a/apps/website/content/blog/2026-08-31-what-changes-when-the-runtime-changes.mdx
+++ b/apps/website/content/blog/2026-08-31-what-changes-when-the-runtime-changes.mdx
@@ -2,7 +2,7 @@
 title: 'What Changes in Your Angular Code When the Agent Runtime Changes'
 description: 'AG-UI and LangGraph land on the same Angular contract. Here is what actually differs — and which differences are the protocol, not the adapter.'
 date: 2026-08-31
-tags: [ag-ui, langgraph, angular, architecture, agentic-ui]
+tags: [AG-UI, langgraph, angular, architecture, agentic-ui]
 author: brian
 featured: false
 draft: false

--- a/apps/website/content/docs/ag-ui/guides/testing.mdx
+++ b/apps/website/content/docs/ag-ui/guides/testing.mdx
@@ -3,7 +3,7 @@
 `@threadplane/ag-ui` gives you two test doubles, smallest scope first:
 
 - **`provideFakeAgent()`** — a one-call fake backend that runs the real adapter pipeline and streams canned tokens. No server, no LLM.
-- **`mockAgent()`** (from `@threadplane/chat`) — a writable-signal mock for component/unit tests. The ag-ui agent _is_ the neutral `Agent` contract, so there is no ag-ui-specific mock — use the neutral one directly.
+- **`mockAgent()`** (from `@threadplane/chat`) — a writable-signal mock for component/unit tests. The AG-UI agent _is_ the neutral `Agent` contract, so there is no AG-UI-specific mock — use the neutral one directly.
 
 See [Choosing an adapter → Testing](/docs/choosing-an-adapter#testing) for when to use each test double.
 
@@ -89,7 +89,7 @@ describe('chat via provideFakeAgent', () => {
 
 For component and unit tests where you don't need a streaming pipeline at all, use the neutral `mockAgent(initial)` from `@threadplane/chat`. It returns an `Agent` whose state surface is exposed as **writable signals** — set state directly and assert your component reacts. Nothing is real.
 
-The ag-ui adapter exposes exactly the neutral `Agent` contract, so there is no ag-ui-specific mock — `mockAgent()` is the right tool.
+The AG-UI adapter exposes exactly the neutral `Agent` contract, so there is no AG-UI-specific mock — `mockAgent()` is the right tool.
 
 ```typescript
 import { mockAgent } from '@threadplane/chat';

--- a/apps/website/content/docs/chat/api/api-docs.json
+++ b/apps/website/content/docs/chat/api/api-docs.json
@@ -6600,7 +6600,7 @@
   {
     "name": "Citation",
     "kind": "interface",
-    "description": "Provider-agnostic citation entry. Populated by adapters from message\nmetadata (LangGraph additional_kwargs.citations, ag-ui STATE_DELTA at\n/citations/{messageId}). Pandoc-formatted [^id]: ... defs in message\ncontent remain in the markdown AST sidecar and are merged via\nCitationsResolverService at render time.",
+    "description": "Provider-agnostic citation entry. Populated by adapters from message\nmetadata (LangGraph additional_kwargs.citations, AG-UI STATE_DELTA at\n/citations/{messageId}). Pandoc-formatted [^id]: ... defs in message\ncontent remain in the markdown AST sidecar and are merged via\nCitationsResolverService at render time.",
     "properties": [
       {
         "name": "extra",
@@ -7525,7 +7525,7 @@
       {
         "name": "lifecycle",
         "type": "object",
-        "description": "Minimal lifecycle stub the chat lib's effects subscribe to. We only\nmodel the signals the chat composition currently reads; richer adapter\nlifecycles (langgraph, ag-ui) extend this contract on their own mocks.\nThe public `lifecycle` view is a readonly signal; tests drive the\nvalue via `_internal.streamStartedAt.set(...)` below.",
+        "description": "Minimal lifecycle stub the chat lib's effects subscribe to. We only\nmodel the signals the chat composition currently reads; richer adapter\nlifecycles (langgraph, AG-UI) extend this contract on their own mocks.\nThe public `lifecycle` view is a readonly signal; tests drive the\nvalue via `_internal.streamStartedAt.set(...)` below.",
         "optional": false
       },
       {

--- a/apps/website/src/components/docs/LibraryMark.spec.tsx
+++ b/apps/website/src/components/docs/LibraryMark.spec.tsx
@@ -20,7 +20,7 @@ describe('LibraryMark', () => {
     expect(container.querySelector('svg')).not.toBeNull();
   });
 
-  it('maps ag-ui and a2ui to their vendor logos', () => {
+  it('maps AG-UI and a2ui to their vendor logos', () => {
     const { container: a } = render(<LibraryMark library="ag-ui" />);
     expect(a.querySelector('img')?.getAttribute('src')).toBe('/logos/ag-ui.svg');
     const { container: b } = render(<LibraryMark library="a2ui" />);

--- a/apps/website/src/components/landing/DemoShowcase.spec.tsx
+++ b/apps/website/src/components/landing/DemoShowcase.spec.tsx
@@ -76,7 +76,7 @@ describe('DemoShowcase', () => {
     render(<DemoShowcase />);
 
     fireEvent.click(screen.getAllByRole('tab')[1]);
-    fireEvent.click(screen.getByRole('button', { name: /launch ag-ui live demo/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Launch AG-UI live demo' }));
 
     expect(trackCtaClickMock).toHaveBeenCalledWith(
       expect.objectContaining({ surface: 'home_demo', cta_id: 'home_demo_launch_ag_ui' }),

--- a/cockpit/ag-ui/subagents/angular/e2e/subagents.spec.ts
+++ b/cockpit/ag-ui/subagents/angular/e2e/subagents.spec.ts
@@ -52,13 +52,13 @@ async function readSubagents(page: Page): Promise<SubagentProbe> {
 }
 
 // Research delegation over the AG-UI transport: the orchestrator LLM calls the
-// `task` tool, the subagent LLM streams a summary, and the ag-ui server
+// `task` tool, the subagent LLM streams a summary, and the AG-UI server
 // converts the subagent_activity CUSTOM events into native ACTIVITY_SNAPSHOT/
 // ACTIVITY_DELTA. The @threadplane/ag-ui reducer projects the activity to
 // agent.subagents(), which the inline <chat-subagent-card> (rendered in place of
 // the `task` tool call) binds to. The child's research text must stay OUT of the
 // parent's bubble.
-test('ag-ui subagents: orchestrator dispatches subagent cards that settle complete', async ({
+test('AG-UI subagents: orchestrator dispatches subagent cards that settle complete', async ({
   page,
 }) => {
   const bubble = await submitAndWaitForResponse(page, PROMPT);

--- a/cockpit/ports.mjs
+++ b/cockpit/ports.mjs
@@ -8,10 +8,10 @@
 /**
  * Single source of truth for cockpit cap port allocation.
  *
- * ag-ui examples (cockpit-ag-ui-*) run a uvicorn `ag-ui-langgraph`
+ * AG-UI examples (cockpit-ag-ui-*) run a uvicorn `ag-ui-langgraph`
  * FastAPI backend; the `langgraph` field holds that backend port and
  * the Angular dev-server proxies /agent to it — so "langgraph" means
- * "backend port" for ag-ui caps, not a LangGraph Studio instance.
+ * "backend port" for AG-UI caps, not a LangGraph Studio instance.
  *
  * Port ranges:
  *   - angular: [4000, 5000)
@@ -34,7 +34,7 @@ export const PORTS = Object.freeze({
   'cockpit-ag-ui-subagents-angular': { angular: 4326, langgraph: 5326 },
   'cockpit-runtimes-microsoft-agent-framework-angular': { angular: 4330, langgraph: 5330 },
   'cockpit-runtimes-aws-strands-angular': { angular: 4331, langgraph: 5331 },
-  // rt-mastra: 'langgraph' here means backend port (the ag-ui convention);
+  // rt-mastra: 'langgraph' here means backend port (the AG-UI convention);
   // the backend is the deployments/ag-ui-mastra Node service, not Python.
   'cockpit-runtimes-mastra-angular': { angular: 4332, langgraph: 5332 },
   'cockpit-chat-a2ui-angular': { angular: 4511, langgraph: 5511 },

--- a/cockpit/runtimes/mastra/angular/e2e/global-setup-impl.ts
+++ b/cockpit/runtimes/mastra/angular/e2e/global-setup-impl.ts
@@ -22,7 +22,7 @@ const angularProject = 'cockpit-runtimes-mastra-angular';
 // `backendCwd: '<path>'` literal shape).
 const wiring = { backendCwd: 'deployments/ag-ui-mastra' };
 const backendCwd = wiring.backendCwd;
-const backendPort = ports.langgraph; // "backend port" by the ag-ui convention
+const backendPort = ports.langgraph; // "backend port" by the AG-UI convention
 const angularPort = ports.angular;
 const INTERNAL_TOKEN = 'dev-local-token'; // proxy.conf.mjs injects the same default
 

--- a/deployments/ag-ui-dev/README.md
+++ b/deployments/ag-ui-dev/README.md
@@ -51,10 +51,10 @@ uv run uvicorn src.app:app --port 5320
 ## Rotating `AG_UI_INTERNAL_TOKEN`
 
 The token lives in two places: Railway (this service) and each Vercel project
-that hosts a cockpit ag-ui example. Rotation order:
+that hosts a cockpit AG-UI example. Rotation order:
 
 1. Generate a new token: `openssl rand -hex 32`.
-2. Update the Vercel env var on every ag-ui cockpit project. Redeploy each.
+2. Update the Vercel env var on every AG-UI cockpit project. Redeploy each.
 3. Update the Railway env var. Redeploy the service.
 
 Tokens valid in both places overlap briefly during step 2.

--- a/examples/ag-ui/angular/e2e/README.md
+++ b/examples/ag-ui/angular/e2e/README.md
@@ -1,8 +1,8 @@
 # examples-ag-ui-angular e2e
 
-Cross-stack E2E harness for the ag-ui example. A repository-owned fixture server provides deterministic OpenAI-compatible responses; the Python ag-ui backend (`uvicorn src.server:app`) is launched with `OPENAI_BASE_URL` pointed at it; Playwright drives the Angular `/embed` route in real Chromium.
+Cross-stack E2E harness for the AG-UI example. A repository-owned fixture server provides deterministic OpenAI-compatible responses; the Python AG-UI backend (`uvicorn src.server:app`) is launched with `OPENAI_BASE_URL` pointed at it; Playwright drives the Angular `/embed` route in real Chromium.
 
-The graph is identical to the chat example — aimock mocks the LLM provider _below_ the transport, so the same graph served over AG-UI with the same committed fixtures produces the same output. The only differences from the chat harness are the backend launcher (uvicorn ag-ui server on `:8000` instead of `langgraph dev` on `:2024`) and the Angular dev-server port (`:4201`).
+The graph is identical to the chat example — aimock mocks the LLM provider _below_ the transport, so the same graph served over AG-UI with the same committed fixtures produces the same output. The only differences from the chat harness are the backend launcher (uvicorn AG-UI server on `:8000` instead of `langgraph dev` on `:2024`) and the Angular dev-server port (`:4201`).
 
 ## Run the suite
 
@@ -16,8 +16,8 @@ Replay-only. No `OPENAI_API_KEY` needed. Reads committed fixtures from `fixtures
 
 - `aimock-runner.ts` — programmatic boot of the mock server.
 - `fixtures/` — committed JSON fixtures keyed by scenario name.
-- `playwright.config.ts` — Playwright config with globalSetup that boots aimock + the ag-ui uvicorn backend + the Angular dev server.
-- `global-setup.ts` — boots aimock (`:0`), uvicorn ag-ui backend (`:8000`, `OPENAI_BASE_URL` → aimock), and `nx serve examples-ag-ui-angular` (`:4201`); waits on `/ok` and `/` respectively.
+- `playwright.config.ts` — Playwright config with globalSetup that boots aimock + the AG-UI uvicorn backend + the Angular dev server.
+- `global-setup.ts` — boots aimock (`:0`), uvicorn AG-UI backend (`:8000`, `OPENAI_BASE_URL` → aimock), and `nx serve examples-ag-ui-angular` (`:4201`); waits on `/ok` and `/` respectively.
 - `global-teardown.ts` — SIGTERMs the angular + backend children and stops aimock.
 - `test-helpers.ts` — pure DOM helpers (`sendPromptAndWait`, browser-hygiene attach, devtools open/close, etc.). Transport-agnostic; shared verbatim with the chat harness.
 

--- a/examples/ag-ui/angular/e2e/a2ui-single-bubble.spec.ts
+++ b/examples/ag-ui/angular/e2e/a2ui-single-bubble.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test';
 import { sendPromptAndWait } from './test-helpers';
 
 // a2ui generative-UI parity over AG-UI: the wrapped a2ui content reaches the
-// chat composition over ag-ui identically to langgraph; the surface mounts once
+// chat composition over AG-UI identically to langgraph; the surface mounts once
 // the host binds a `views` catalog (`[views]` on <chat>). See issue #616.
 test('a2ui single bubble: one assistant bubble carries the rendered surface', async ({ page }) => {
   await sendPromptAndWait(page, 'Demo: render a feedback form');

--- a/examples/ag-ui/angular/e2e/citations.spec.ts
+++ b/examples/ag-ui/angular/e2e/citations.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test';
 import { sendPromptAndWait } from './test-helpers';
 
 // Twin of examples/chat's citations spec. AG-UI delivers citations differently
-// (the backend surfaces them as state.citations[messageId], which the ag-ui
+// (the backend surfaces them as state.citations[messageId], which the AG-UI
 // adapter mirrors and bridgeCitationsState() maps onto Message.citations) — but
 // the rendered surface is the shared @threadplane/chat markers/preview/panel, so
 // the assertions match. The graph runs the REAL search_documents tool; its

--- a/examples/ag-ui/angular/e2e/global-setup.ts
+++ b/examples/ag-ui/angular/e2e/global-setup.ts
@@ -64,7 +64,7 @@ export default async function globalSetup(): Promise<void> {
 
   await waitForPort('http://localhost:8000/ok', 60_000);
   // eslint-disable-next-line no-console
-  console.log('[aimock-e2e] ag-ui backend ready on :8000');
+  console.log('[aimock-e2e] AG-UI backend ready on :8000');
 
   const angular = spawn(
     'npx',

--- a/examples/ag-ui/angular/e2e/initial-render.spec.ts
+++ b/examples/ag-ui/angular/e2e/initial-render.spec.ts
@@ -2,11 +2,11 @@
 import { test, expect } from '@playwright/test';
 import { attachBrowserHygiene, messageInput, sendButton } from './test-helpers';
 
-// The ag-ui example is a single-route chat (no demo-shell modes/toolbar). This
+// The AG-UI example is a single-route chat (no demo-shell modes/toolbar). This
 // asserts the app mounts cleanly over the AG-UI transport: the chat composition
 // renders, the composer is present and starts disabled (empty input), and the
 // page loads with no console errors or failed requests.
-test('initial render: the ag-ui chat app loads with a usable composer', async ({
+test('initial render: the AG-UI chat app loads with a usable composer', async ({
   page,
 }) => {
   const hygiene = attachBrowserHygiene(page);

--- a/examples/ag-ui/angular/e2e/subagent-card.spec.ts
+++ b/examples/ag-ui/angular/e2e/subagent-card.spec.ts
@@ -64,7 +64,7 @@ async function readSubagents(page: Page): Promise<SubagentProbe> {
 // `research` tool, the langgraph child subgraph runs a genuine reason → tool →
 // answer loop (an LLM call that returns a `lookup` tool_call, the offline
 // `lookup` tool, then a second plain LLM call that writes the summary), and the
-// ag-ui server converts the subagent_activity CUSTOM events into native
+// AG-UI server converts the subagent_activity CUSTOM events into native
 // ACTIVITY_SNAPSHOT/ACTIVITY_DELTA. The @threadplane/ag-ui reducer projects the
 // activity to agent.subagents() (the ordered transcript chat-subagent-card
 // renders) and the child's research text must stay OUT of the parent's bubble.

--- a/examples/ag-ui/angular/proxy.conf.mjs
+++ b/examples/ag-ui/angular/proxy.conf.mjs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Dev only: routes the relative /agent calls to the local uvicorn ag-ui server.
+// Dev only: routes the relative /agent calls to the local uvicorn AG-UI server.
 export default {
   '/agent': { target: 'http://localhost:8000', secure: false, changeOrigin: true, ws: true },
 };

--- a/examples/ag-ui/angular/src/app/shell/palette-persistence.service.spec.ts
+++ b/examples/ag-ui/angular/src/app/shell/palette-persistence.service.spec.ts
@@ -5,7 +5,7 @@ import { PalettePersistence } from './palette-persistence.service';
 
 const KEY = 'threadplane-ag-ui-demo:palette';
 
-describe('PalettePersistence (ag-ui)', () => {
+describe('PalettePersistence (AG-UI)', () => {
   beforeEach(() => {
     localStorage.clear();
   });

--- a/examples/ag-ui/python/Dockerfile
+++ b/examples/ag-ui/python/Dockerfile
@@ -1,4 +1,4 @@
-# Multi-stage build for the ag-ui demo backend (examples/ag-ui).
+# Multi-stage build for the AG-UI demo backend (examples/ag-ui).
 FROM python:3.12-slim@sha256:d764629ce0ddd8c71fd371e9901efb324a95789d2315a47db7e4d27e78f1b0e9 AS builder
 WORKDIR /build
 COPY requirements.txt .

--- a/examples/ag-ui/python/src/graph.py
+++ b/examples/ag-ui/python/src/graph.py
@@ -543,7 +543,7 @@ class State(TypedDict):
     tools: Optional[list]
     # Per-message citations, keyed by AI message id. Unlike the LangGraph
     # transport (which reads AIMessage.additional_kwargs.citations directly),
-    # the ag-ui protocol streams message TEXT without additional_kwargs, so
+    # the AG-UI protocol streams message TEXT without additional_kwargs, so
     # citations must travel as STATE. The ag-ui-langgraph adapter mirrors this
     # channel to the client, where bridgeCitationsState() reads
     # state.citations[messageId] onto Message.citations for rendering.
@@ -865,8 +865,8 @@ async def attach_citations(state: State) -> dict:
             ),
         ],
         # Also surface citations as STATE, keyed by the AI message id. The
-        # ag-ui protocol drops additional_kwargs when streaming message text,
-        # so this STATE channel is the only path by which the ag-ui client
+        # AG-UI protocol drops additional_kwargs when streaming message text,
+        # so this STATE channel is the only path by which the AG-UI client
         # (via bridgeCitationsState) can render them.
         "citations": {last.id: citations},
     }

--- a/examples/ag-ui/python/src/server.py
+++ b/examples/ag-ui/python/src/server.py
@@ -2,7 +2,7 @@
 """Standalone AG-UI server for the examples/ag-ui demo.
 
 Wraps the (transport-agnostic) chat graph with ag-ui-langgraph and serves it
-over an AG-UI FastAPI endpoint at /agent. Mirrors the cockpit ag-ui pattern.
+over an AG-UI FastAPI endpoint at /agent. Mirrors the cockpit AG-UI pattern.
 
 Auth is OPTIONAL for clone-and-run: the X-Internal-Token check is enforced
 only when AG_UI_INTERNAL_TOKEN is set (production), so `uvicorn src.server:app`

--- a/examples/chat/smoke/template/src/compatibility-probe.ts
+++ b/examples/chat/smoke/template/src/compatibility-probe.ts
@@ -28,7 +28,7 @@ const PACKAGE_REFS = [
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `<aside aria-label="Threadplane compatibility probes">
     <span data-threadplane-compatibility="ag-ui">{{
-      agUiReady ? 'ag-ui ready' : 'ag-ui unavailable'
+      agUiReady ? 'AG-UI ready' : 'AG-UI unavailable'
     }}</span>
     <span data-threadplane-compatibility="chat">{{
       packageReady('chat') ? 'chat ready' : 'chat unavailable'

--- a/libs/ag-ui/README.md
+++ b/libs/ag-ui/README.md
@@ -161,7 +161,7 @@ providers: [provideFakeAgent({ tokens: ['Hello', ' world'] })];
 ```
 
 For component/unit tests, use the neutral writable-signal mock `mockAgent()`
-from `@threadplane/chat` — the ag-ui agent _is_ the neutral `Agent` contract,
+from `@threadplane/chat` — the AG-UI agent _is_ the neutral `Agent` contract,
 so there is no adapter-specific mock. See
 [Choosing an adapter → Testing](https://threadplane.ai/docs/choosing-an-adapter#testing).
 

--- a/libs/ag-ui/src/lib/internal/apply-patch.ts
+++ b/libs/ag-ui/src/lib/internal/apply-patch.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Minimal RFC-6902 JSON Patch implementation, scoped to the ops the ag-ui
+// Minimal RFC-6902 JSON Patch implementation, scoped to the ops the AG-UI
 // reducer actually receives via STATE_DELTA events: add, replace, remove,
 // move, copy, test. Pure ESM, zero deps. Replaces a CommonJS-only third-party
 // dependency that broke ESM-strict consumers (Vitest, Vite test envs).

--- a/libs/ag-ui/src/lib/reducer.spec.ts
+++ b/libs/ag-ui/src/lib/reducer.spec.ts
@@ -238,7 +238,7 @@ describe('reduceEvent', () => {
   });
 
   it('MESSAGES_SNAPSHOT re-applies citations from prior STATE onto the final message', () => {
-    // Reproduces the ag-ui citation-delivery ordering: STATE_SNAPSHOT carries
+    // Reproduces the AG-UI citation-delivery ordering: STATE_SNAPSHOT carries
     // citations keyed by the final AI message id, but arrives BEFORE the
     // MESSAGES_SNAPSHOT that swaps the streamed chunk-id message for the final
     // one. Without re-bridging in the MESSAGES_SNAPSHOT handler the citations

--- a/libs/chat/src/lib/agent/citation.ts
+++ b/libs/chat/src/lib/agent/citation.ts
@@ -2,7 +2,7 @@
 
 /**
  * Provider-agnostic citation entry. Populated by adapters from message
- * metadata (LangGraph additional_kwargs.citations, ag-ui STATE_DELTA at
+ * metadata (LangGraph additional_kwargs.citations, AG-UI STATE_DELTA at
  * /citations/{messageId}). Pandoc-formatted [^id]: ... defs in message
  * content remain in the markdown AST sidecar and are merged via
  * CitationsResolverService at render time.

--- a/libs/chat/src/lib/testing/mock-agent.ts
+++ b/libs/chat/src/lib/testing/mock-agent.ts
@@ -29,7 +29,7 @@ export interface MockAgent extends Agent {
   /**
    * Minimal lifecycle stub the chat lib's effects subscribe to. We only
    * model the signals the chat composition currently reads; richer adapter
-   * lifecycles (langgraph, ag-ui) extend this contract on their own mocks.
+   * lifecycles (langgraph, AG-UI) extend this contract on their own mocks.
    * The public `lifecycle` view is a readonly signal; tests drive the
    * value via `_internal.streamStartedAt.set(...)` below.
    */

--- a/libs/chat/testing/reasoning-fixture.ts
+++ b/libs/chat/testing/reasoning-fixture.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 //
 // Provider-neutral fixture for the reasoning conformance test. Both
-// adapters (langgraph + ag-ui) translate this abstract sequence into
+// adapters (langgraph + AG-UI) translate this abstract sequence into
 // their own wire format and assert that the resulting Agent.messages()
 // produces a single assistant Message with the expected reasoning
 // string, response content, and a numeric (>= 0) reasoningDurationMs.

--- a/libs/cockpit-registry/src/lib/docs-links.ts
+++ b/libs/cockpit-registry/src/lib/docs-links.ts
@@ -57,7 +57,7 @@ export const COCKPIT_DOCS_LINKS: Readonly<Record<string, string>> = {
   // The demo's visible half is the browser-declared tool, which `chat` documents.
   'langgraph/core-capabilities/client-tools': '/docs/chat/guides/client-tools',
 
-  // ag-ui
+  // AG-UI
   'ag-ui/getting-started/overview': '/docs/ag-ui/getting-started/introduction',
   // AG-UI has no streaming guide; event mapping is where token streaming is specified.
   'ag-ui/core-capabilities/streaming': '/docs/ag-ui/reference/event-mapping',

--- a/libs/cockpit-registry/src/lib/manifest.spec.ts
+++ b/libs/cockpit-registry/src/lib/manifest.spec.ts
@@ -134,7 +134,7 @@ describe('cockpitManifest', () => {
     }
   });
 
-  it('includes ag-ui after langgraph with streaming + interrupts topics', () => {
+  it('includes AG-UI after langgraph with streaming + interrupts topics', () => {
     const products = cockpitManifest.map((e) => e.product);
     expect(products).toContain('ag-ui');
     expect(products.indexOf('ag-ui')).toBeGreaterThan(products.indexOf('langgraph'));

--- a/libs/e2e-harness/src/ag-ui-global-setup-factory.ts
+++ b/libs/e2e-harness/src/ag-ui-global-setup-factory.ts
@@ -26,7 +26,7 @@ interface SharedState {
   /** Present when the backend is a langgraph dev server. */
   langgraph?: ChildProcess;
   langgraphPort?: number;
-  /** Present when the backend is a uvicorn ag-ui server. */
+  /** Present when the backend is a uvicorn AG-UI server. */
   backend?: ChildProcess;
   backendPort?: number;
   angular: ChildProcess;

--- a/libs/e2e-harness/src/global-setup-factory.ts
+++ b/libs/e2e-harness/src/global-setup-factory.ts
@@ -26,7 +26,7 @@ interface SharedState {
   /** Present when the backend is a langgraph dev server. */
   langgraph?: ChildProcess;
   langgraphPort?: number;
-  /** Present when the backend is a uvicorn ag-ui server. */
+  /** Present when the backend is a uvicorn AG-UI server. */
   backend?: ChildProcess;
   backendPort?: number;
   angular: ChildProcess;

--- a/libs/e2e-harness/src/global-teardown.ts
+++ b/libs/e2e-harness/src/global-teardown.ts
@@ -9,7 +9,7 @@ interface SharedState {
   /** Present when the backend is a langgraph dev server. */
   langgraph?: ChildProcess;
   langgraphPort?: number;
-  /** Present when the backend is a uvicorn ag-ui server. */
+  /** Present when the backend is a uvicorn AG-UI server. */
   backend?: ChildProcess;
   backendPort?: number;
   angular: ChildProcess;
@@ -85,7 +85,7 @@ export default async function globalTeardown(): Promise<void> {
   if (!states) return;
   for (const state of states.values()) {
     killGroup(state.angular);
-    // Kill whichever backend variant is present (langgraph dev or uvicorn ag-ui).
+    // Kill whichever backend variant is present (langgraph dev or uvicorn AG-UI).
     if (state.langgraph) killGroup(state.langgraph);
     if (state.backend) killGroup(state.backend);
     await state.aimock.stop();

--- a/libs/langgraph/src/lib/client-tools.ts
+++ b/libs/langgraph/src/lib/client-tools.ts
@@ -13,7 +13,7 @@ import type { LangGraphSubmitOptions } from './agent.types';
 
 /**
  * A patch written onto a local ToolCall when a client tool resolves.
- * Mirrors the fields the ag-ui adapter writes directly onto its WritableSignal.
+ * Mirrors the fields the AG-UI adapter writes directly onto its WritableSignal.
  */
 export interface ClientToolResultPatch {
   result: unknown;

--- a/scripts/ag-ui-demo-middleware.ts
+++ b/scripts/ag-ui-demo-middleware.ts
@@ -1,7 +1,7 @@
 // scripts/ag-ui-demo-middleware.ts
 // SPDX-License-Identifier: MIT
 /**
- * Vercel Node serverless proxy for the examples/ag-ui demo
+ * Vercel Node serverless proxy for the AG-UI demo
  * (ag-ui.threadplane.ai). Forwards /agent* to the Railway-hosted
  * ag-ui-langgraph backend with origin allowlist + Upstash rate-limit
  * (fail-open) + X-Internal-Token injection. Bundled by

--- a/scripts/ag-ui-proxy.spec.ts
+++ b/scripts/ag-ui-proxy.spec.ts
@@ -44,7 +44,7 @@ function makeReq(url: string, origin = 'https://examples.threadplane.ai') {
 
 const RAILWAY_DEFAULT = 'https://ag-ui-dev-production.up.railway.app';
 
-describe('ag-ui proxy', () => {
+describe('AG-UI proxy', () => {
   beforeEach(() => {
     process.env['AG_UI_INTERNAL_TOKEN'] = 'test-token';
     delete process.env['AG_UI_RAILWAY_URL'];

--- a/scripts/ag-ui-proxy.ts
+++ b/scripts/ag-ui-proxy.ts
@@ -125,7 +125,7 @@ function parseProxyPath(url: string): { topic: string; rest: string } | null {
   const segments = u.pathname.split('/').filter(Boolean);
   // Expected: ['ag-ui' | 'runtimes', '<topic>', 'agent', ...rest]. The
   // 'runtimes' product (cockpit/runtimes/<topic>/) is AG-UI-served exactly
-  // like the ag-ui product; the upstream URL is /agent/<topic> either way.
+  // like the AG-UI product; the upstream URL is /agent/<topic> either way.
   if (
     (segments[0] !== 'ag-ui' && segments[0] !== 'runtimes') ||
     !segments[1] ||

--- a/scripts/assemble-ag-ui-demo.ts
+++ b/scripts/assemble-ag-ui-demo.ts
@@ -98,4 +98,4 @@ writeFileSync(resolve(outputDir, 'config.json'), JSON.stringify({
 }, null, 2));
 
 console.log('✅ .vercel/output/ (Build Output API with serverless proxy)');
-console.log(`\nAssembled ag-ui demo to ${deployDir}`);
+console.log(`\nAssembled AG-UI demo to ${deployDir}`);

--- a/scripts/assemble-examples.ts
+++ b/scripts/assemble-examples.ts
@@ -107,7 +107,7 @@ writeFileSync(resolve(funcDir, '.vc-config.json'), JSON.stringify({
   shouldAddHelpers: true,
 }, null, 2));
 
-// Build the ag-ui proxy serverless function (forwards /ag-ui/<topic>/agent
+// Build the AG-UI proxy serverless function (forwards /ag-ui/<topic>/agent
 // requests to the Railway-hosted FastAPI runtime with origin allowlist +
 // Upstash rate limit + X-Internal-Token injection).
 mkdirSync(agUiFuncDir, { recursive: true });
@@ -126,7 +126,7 @@ writeFileSync(resolve(agUiFuncDir, '.vc-config.json'), JSON.stringify({
 writeFileSync(resolve(outputDir, 'config.json'), JSON.stringify({
   version: 3,
   routes: [
-    // ag-ui proxy: /ag-ui/<topic>/agent[/rest] → ag-ui-proxy function.
+    // AG-UI proxy: /ag-ui/<topic>/agent[/rest] → ag-ui-proxy function.
     // Mirrors the langgraph rule exactly: dest names the catch-all function
     // (`[[...path]]`), which invokes it while PRESERVING the original request
     // URL in req.url. The function (scripts/ag-ui-proxy.ts) parses the topic
@@ -148,6 +148,6 @@ writeFileSync(resolve(outputDir, 'config.json'), JSON.stringify({
   ],
 }, null, 2));
 
-console.log('✅ .vercel/output/ (Build Output API with langgraph + ag-ui proxies)');
+console.log('✅ .vercel/output/ (Build Output API with langgraph + AG-UI proxies)');
 
 console.log(`\nAssembled ${capabilities.length} apps + proxy to ${deployDir}`);

--- a/scripts/capture-blog-screenshots.mjs
+++ b/scripts/capture-blog-screenshots.mjs
@@ -1,4 +1,4 @@
-// Capture three screenshots for the ag-ui interrupts blog post.
+// Capture three screenshots for the AG-UI interrupts blog post.
 // Drives the running localhost:4320 cockpit example end-to-end.
 import { chromium } from 'playwright';
 import { mkdirSync } from 'node:fs';

--- a/scripts/generate-ag-ui-deployment-config.spec.ts
+++ b/scripts/generate-ag-ui-deployment-config.spec.ts
@@ -13,7 +13,7 @@ describe('generateAgUiDeployment', () => {
     outDir = mkdtempSync(join(tmpdir(), 'ag-ui-deploy-'));
   });
 
-  it('stages each ag-ui python tree under deps/<topic>/', () => {
+  it('stages each AG-UI python tree under deps/<topic>/', () => {
     generateAgUiDeployment({ repoRoot: REPO_ROOT, outDir });
     expect(statSync(join(outDir, 'deps/interrupts/src/graph.py')).isFile()).toBe(true);
     expect(statSync(join(outDir, 'deps/streaming/src/graph.py')).isFile()).toBe(true);

--- a/scripts/generate-ag-ui-deployment-config.ts
+++ b/scripts/generate-ag-ui-deployment-config.ts
@@ -117,7 +117,7 @@ function collectTopics(): AgUiTopic[] {
     });
   topics.sort((a, b) => a.topic.localeCompare(b.topic));
   if (topics.length === 0) {
-    throw new Error('No ag-ui topics with pythonDir found in capability registry');
+    throw new Error('No AG-UI topics with pythonDir found in capability registry');
   }
   return topics;
 }

--- a/scripts/generate-shared-deployment-config.spec.ts
+++ b/scripts/generate-shared-deployment-config.spec.ts
@@ -22,8 +22,8 @@ describe('generate-shared-deployment-config', () => {
     expect(manifest.dependencies.some((d) => d.includes('examples-chat'))).toBe(true);
   });
 
-  it('excludes ag-ui capabilities (Railway-deployed; no langgraph.json)', () => {
-    // Regression: ag-ui capabilities gained a pythonDir when they got real
+  it('excludes AG-UI capabilities (Railway-deployed; no langgraph.json)', () => {
+    // Regression: AG-UI capabilities gained a pythonDir when they got real
     // uvicorn backends, which made the generator try to read a langgraph.json
     // they don't have — crashing every LangGraph deploy. They must be skipped
     // (they deploy via scripts/generate-ag-ui-deployment-config.ts → Railway).

--- a/scripts/generate-shared-deployment-config.ts
+++ b/scripts/generate-shared-deployment-config.ts
@@ -65,7 +65,7 @@ mkdirSync(stagedDependenciesDir, { recursive: true });
 
 for (const capability of capabilities) {
   if (!capability.pythonDir || capability.product === 'ag-ui' || capability.product === 'runtimes') {
-    // No-Python caps have nothing to deploy. ag-ui and runtimes caps DO have
+    // No-Python caps have nothing to deploy. AG-UI and runtimes caps DO have
     // a pythonDir (uvicorn AG-UI FastAPI apps) but deploy to Railway via
     // generate-ag-ui-deployment-config.ts — they ship no langgraph.json.
     continue;

--- a/scripts/upstash-rate-limit.ts
+++ b/scripts/upstash-rate-limit.ts
@@ -4,7 +4,7 @@
  * Per-IP token-bucket rate limit backed by Upstash Redis, shaped to the
  * createProxyHandler `checkRateLimit` contract. Sibling to the Neon-backed
  * scripts/rate-limit.ts — same interface, different backend. Used by the
- * threadplane-examples langgraph proxy; the ag-ui proxy on the same project
+ * threadplane-examples langgraph proxy; the AG-UI proxy on the same project
  * uses the same Upstash creds.
  *
  * Fail-open: if UPSTASH_* env is unset at module load, or the limit call


### PR DESCRIPTION
## Summary
- normalize visible AG-UI casing across the website, docs, blog tags, changelog, CI labels, demo surfaces, and contributor-facing prose
- regenerate affected API reference content from source comments
- preserve lowercase machine identifiers such as package names, routes, product keys, selectors, and telemetry values

## Test plan
- [x] `npm run generate-api-docs`
- [x] `npx nx test website --skip-nx-cache`
- [x] `npx nx test scripts --skip-nx-cache`
- [x] `npx nx test cockpit-registry --skip-nx-cache`
- [x] `npx nx test cockpit --skip-nx-cache`
- [x] `npx nx lint website --skip-nx-cache`
- [x] `npx nx build website --configuration=production --skip-nx-cache`
- [x] repository-wide AG-UI terminology regression search
- [x] `git diff --check`
