### PR TITLE
fix(ci): accept branded AG-UI compatibility marker

### DIFF
--- a/examples/chat/smoke/runtime-smoke.mjs
+++ b/examples/chat/smoke/runtime-smoke.mjs
@@ -359,7 +359,9 @@ async function assertCompatibilityMarkers(
     );
     await marker.waitFor();
     const markerText = await marker.innerText();
-    if (markerText !== `${packageName} ready`) {
+    const expectedText =
+      packageName === 'ag-ui' ? 'AG-UI ready' : `${packageName} ready`;
+    if (markerText !== expectedText) {
       throw new Error(
         `${packageName} compatibility probe reported "${markerText}"`
       );

--- a/examples/chat/smoke/runtime-smoke.spec.mjs
+++ b/examples/chat/smoke/runtime-smoke.spec.mjs
@@ -393,7 +393,7 @@ test('requires every visible compatibility marker to report exact readiness', as
   const markerText = new Map(
     COMPATIBILITY_PACKAGES.map((packageName) => [
       packageName,
-      `${packageName} ready`,
+      packageName === 'ag-ui' ? 'AG-UI ready' : `${packageName} ready`,
     ])
   );
   markerText.set('telemetry', 'telemetry unavailable');


### PR DESCRIPTION
## Summary

- accept the user-facing `AG-UI ready` label in packaged-consumer runtime smoke
- preserve exact readiness checks for every other compatibility marker
- update the regression test to cover the branded label

## Why

#928 correctly normalized the visible marker from `ag-ui ready` to `AG-UI ready`, but the runtime smoke still derived its expected text from the machine identifier. Angular 20 and Angular 22 packaged-consumer jobs therefore failed after rendering the correct ready state.

## Verification

- `node --test examples/chat/smoke/runtime-smoke.spec.mjs` (17/17)
- `npx nx test scripts --skip-nx-cache`
- `npx prettier --check examples/chat/smoke/runtime-smoke.mjs examples/chat/smoke/runtime-smoke.spec.mjs`
- `git diff --check`