### PR TITLE
refactor(website): drop the marketing footer from the docs tree

### DIFF
--- a/apps/website/src/app/layout.tsx
+++ b/apps/website/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import { EB_Garamond, Inter, JetBrains_Mono } from 'next/font/google';
 import './global.css';
 import { Nav } from '../components/shared/Nav';
-import { Footer } from '../components/shared/Footer';
+import { SiteFooter } from '../components/shared/SiteFooter';
 import { AnnouncementToast } from '../components/shared/AnnouncementToast';
 import { JsonLd } from '../components/shared/JsonLd';
 import { rootJsonLd } from '../lib/structured-data';
@@ -70,7 +70,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <Nav />
         <div id="site-content">
           <main>{children}</main>
-          <Footer />
+          <SiteFooter />
           <AnnouncementToast />
         </div>
       </body>

--- a/apps/website/src/components/shared/SiteFooter.spec.tsx
+++ b/apps/website/src/components/shared/SiteFooter.spec.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const pathname = vi.hoisted(() => ({ current: '/' }));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => pathname.current,
+}));
+
+import { SiteFooter } from './SiteFooter';
+
+afterEach(() => {
+  pathname.current = '/';
+});
+
+/**
+ * The footer is mounted once, in the root layout, so it is the docs shell's
+ * only way to opt out of it. These cases are the contract that opt-out obeys.
+ */
+describe('SiteFooter', () => {
+  it.each(['/', '/pricing', '/blog/some-post', '/docs-adjacent'])(
+    'renders the marketing footer on %s',
+    (route) => {
+      pathname.current = route;
+
+      const { container } = render(<SiteFooter />);
+
+      expect(container.querySelector('footer')).toBeTruthy();
+    },
+  );
+
+  it.each(['/docs', '/docs/choosing-an-adapter', '/docs/langgraph/guides/testing'])(
+    'suppresses it on %s so the docs stay a single sidebar pane',
+    (route) => {
+      pathname.current = route;
+
+      const { container } = render(<SiteFooter />);
+
+      expect(container.querySelector('footer')).toBeNull();
+    },
+  );
+});

--- a/apps/website/src/components/shared/SiteFooter.tsx
+++ b/apps/website/src/components/shared/SiteFooter.tsx
@@ -1,0 +1,17 @@
+'use client';
+import { usePathname } from 'next/navigation';
+import { Footer } from './Footer';
+
+/**
+ * Route gate for the marketing footer.
+ *
+ * The footer is mounted once in the root layout, so every route gets it unless
+ * something opts out here. The docs tree opts out: every /docs route renders
+ * the sidebar control plane and ends at its own prev/next rail, and a marketing
+ * footer bolted under that column breaks the single-pane reading experience.
+ */
+export function SiteFooter() {
+  const pathname = usePathname();
+  if (pathname === '/docs' || pathname?.startsWith('/docs/')) return null;
+  return <Footer />;
+}


### PR DESCRIPTION
## Why

Every `/docs` route now wears the sidebar control plane (#920, #921, #923). A marketing footer bolted under the article column breaks that single-pane reading experience — you scroll past prev/next into a newsletter form and a link farm.

## What

The footer is mounted once in the root layout, so it gets every route unless something opts out. `SiteFooter` is that gate: it returns `null` on `/docs` and `/docs/*`, and renders `<Footer />` everywhere else. Nothing else moves — no route-group restructuring, no CSS hiding, the node is genuinely absent from the tree.

Articles now end at `DocsPrevNext` with 48px of air; the docs index ends at the ⌘K search block with the same 48px. The `mt-24` that separated the footer lived on the footer itself, so it left with it — no dangling whitespace.

## Verification

- **Prerendered build output** — all **122** `/docs` HTML files contain zero `footer-root`; every other page still has one. (`_global-error.html` doesn't, which is expected: it replaces the root layout entirely.)
- **Live dev server** — homepage 1 footer; `/docs`, `/docs/choosing-an-adapter`, and `/docs/langgraph/getting-started/quickstart` all 0.
- **Tests** — `vitest run` 447/447 pass. The new spec pins both directions; mutation-tested by stubbing the guard out, which fails exactly the 3 suppression cases, so it isn't passing vacuously.
- `nx lint website` clean (warnings only, no errors) · `nx build website` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)