### PR TITLE
feat(cockpit): make Run discoverable from Code

### DIFF
--- a/apps/cockpit/src/app/[...slug]/page.spec.tsx
+++ b/apps/cockpit/src/app/[...slug]/page.spec.tsx
@@ -1,0 +1,72 @@
+/** @vitest-environment jsdom */
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('next/navigation', () => ({
+  redirect: vi.fn(() => {
+    throw new Error('redirect() should not be called for a canonical slug');
+  }),
+}));
+
+vi.mock('../../lib/content-bundle', () => ({
+  getContentBundle: vi.fn().mockResolvedValue({
+    codeFiles: {},
+    promptFiles: {},
+    runtimeUrl: null,
+    docSections: [],
+    narrativeDocs: [],
+  }),
+}));
+
+import CockpitRoutePage from './page';
+import { getCockpitPageModel } from '../../lib/cockpit-page';
+
+describe('CockpitRoutePage', () => {
+  it('keys the rendered CockpitShell on the canonical path', async () => {
+    const slug = [
+      'langgraph',
+      'core-capabilities',
+      'streaming',
+      'overview',
+      'python',
+    ];
+    const { canonicalPath } = getCockpitPageModel(slug);
+
+    const element = await CockpitRoutePage({
+      params: Promise.resolve({ slug }),
+    });
+
+    expect(element.key).toBe(canonicalPath);
+  });
+
+  it('gives two different capabilities two different keys', async () => {
+    const streamingSlug = [
+      'langgraph',
+      'core-capabilities',
+      'streaming',
+      'overview',
+      'python',
+    ];
+    const persistenceSlug = [
+      'langgraph',
+      'core-capabilities',
+      'persistence',
+      'overview',
+      'python',
+    ];
+
+    const streamingElement = await CockpitRoutePage({
+      params: Promise.resolve({ slug: streamingSlug }),
+    });
+    const persistenceElement = await CockpitRoutePage({
+      params: Promise.resolve({ slug: persistenceSlug }),
+    });
+
+    expect(streamingElement.key).not.toBe(persistenceElement.key);
+    expect(streamingElement.key).toBe(
+      getCockpitPageModel(streamingSlug).canonicalPath
+    );
+    expect(persistenceElement.key).toBe(
+      getCockpitPageModel(persistenceSlug).canonicalPath
+    );
+  });
+});

--- a/apps/cockpit/src/app/[...slug]/page.tsx
+++ b/apps/cockpit/src/app/[...slug]/page.tsx
@@ -27,6 +27,7 @@ export default async function CockpitRoutePage({
 
   return (
     <CockpitShell
+      key={canonicalPath}
       navigationTree={navigationTree}
       presentation={presentation}
       entryTitle={entry.title}

--- a/apps/cockpit/src/app/[...slug]/page.tsx
+++ b/apps/cockpit/src/app/[...slug]/page.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { redirect } from 'next/navigation';
 import { CockpitShell } from '../../components/cockpit-shell';
 import { getContentBundle } from '../../lib/content-bundle';

--- a/apps/cockpit/src/app/cockpit.css
+++ b/apps/cockpit/src/app/cockpit.css
@@ -387,7 +387,21 @@ pre.shiki {
   flex-direction: column;
   gap: 4px;
 }
-.cockpit-control-plane [data-control-plane-rail-group="utilities"] { margin-top: auto; }
+.cockpit-control-plane [data-control-plane-rail-group="utilities"] {
+  margin-top: auto;
+  padding-top: 8px;
+  border-top: 1px solid var(--ds-border);
+}
+.cockpit-control-plane [data-control-plane-rail-group-label] {
+  display: block;
+  padding-bottom: 4px;
+  color: var(--ds-text-muted);
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  text-align: center;
+}
 .cockpit-control-plane-utility-anchor { display: contents; }
 .cockpit-control-plane [data-control-plane-rail-item] {
   position: relative;
@@ -400,7 +414,7 @@ pre.shiki {
   align-items: center;
   justify-content: center;
   gap: 4px;
-  color: var(--ds-text-muted);
+  color: var(--ds-text-secondary);
   background: transparent;
   text-decoration: none;
   cursor: pointer;

--- a/apps/cockpit/src/app/cockpit.css
+++ b/apps/cockpit/src/app/cockpit.css
@@ -410,6 +410,7 @@ pre.shiki {
 }
 .cockpit-control-plane-utility-anchor { display: contents; }
 .cockpit-control-plane [data-control-plane-rail-item] {
+  --cockpit-rail-status-ring: var(--ds-surface-tinted);
   position: relative;
   min-height: 48px;
   padding: 6px 2px;
@@ -427,6 +428,7 @@ pre.shiki {
   transition: background 120ms ease, color 120ms ease;
 }
 .cockpit-control-plane [data-control-plane-rail-item]:hover {
+  --cockpit-rail-status-ring: var(--ds-surface);
   color: var(--ds-text-primary);
   background: var(--ds-surface);
 }
@@ -445,7 +447,7 @@ pre.shiki {
   right: 11px;
   width: 7px;
   height: 7px;
-  border: 2px solid var(--ds-surface-tinted);
+  border: 2px solid var(--cockpit-rail-status-ring);
   border-radius: 999px;
 }
 .cockpit-control-plane [data-control-plane-rail-status="success"] {
@@ -986,6 +988,10 @@ pre.shiki {
     border: 1px solid CanvasText;
     border-radius: 7px;
     color: CanvasText;
+    background: Canvas;
+  }
+  .cockpit-control-plane [data-control-plane-rail-status] {
+    border: 1px solid CanvasText;
     background: Canvas;
   }
   .cockpit-control-plane [data-control-plane-overflow-menu] {

--- a/apps/cockpit/src/app/cockpit.css
+++ b/apps/cockpit/src/app/cockpit.css
@@ -390,13 +390,17 @@ pre.shiki {
 .cockpit-control-plane [data-control-plane-rail-group="utilities"] {
   margin-top: auto;
   padding-top: 8px;
-  border-top: 1px solid var(--ds-border);
+  /* --ds-border is a 1-value difference from --ds-surface-tinted (the rail
+     background) in dark mode -- rgb(45,45,45) on rgb(44,44,44), effectively
+     invisible. --ds-border-strong is the token the pane divider already
+     uses for the same reason (cockpit.css ~L460). */
+  border-top: 1px solid var(--ds-border-strong);
 }
 .cockpit-control-plane [data-control-plane-rail-group-label] {
   display: block;
   padding-bottom: 4px;
-  color: var(--ds-text-muted);
-  font-size: 9px;
+  color: var(--ds-text-secondary);
+  font-size: 10px;
   font-weight: 600;
   letter-spacing: 0.09em;
   text-transform: uppercase;

--- a/apps/cockpit/src/app/cockpit.css
+++ b/apps/cockpit/src/app/cockpit.css
@@ -363,6 +363,7 @@ pre.shiki {
 .cockpit-control-plane {
   --cockpit-state-error: #b42318;
   --cockpit-state-success: #1a7a40;
+  --cockpit-state-working: #9a6700;
   display: grid;
   grid-template-columns: 56px minmax(0, 272px);
   height: 100%;
@@ -373,6 +374,7 @@ pre.shiki {
 [data-theme="dark"] .cockpit-control-plane {
   --cockpit-state-error: #ff6369;
   --cockpit-state-success: #4cc38a;
+  --cockpit-state-working: #e0a02f;
 }
 .cockpit-control-plane [data-control-plane-rail] {
   min-width: 0;
@@ -436,6 +438,24 @@ pre.shiki {
   font-size: 10px;
   line-height: 1;
   font-weight: 600;
+}
+.cockpit-control-plane [data-control-plane-rail-status] {
+  position: absolute;
+  top: 7px;
+  right: 11px;
+  width: 7px;
+  height: 7px;
+  border: 2px solid var(--ds-surface-tinted);
+  border-radius: 999px;
+}
+.cockpit-control-plane [data-control-plane-rail-status="success"] {
+  background: var(--cockpit-state-success);
+}
+.cockpit-control-plane [data-control-plane-rail-status="working"] {
+  background: var(--cockpit-state-working);
+}
+.cockpit-control-plane [data-control-plane-rail-status="error"] {
+  background: var(--cockpit-state-error);
 }
 .cockpit-control-plane [data-control-plane-rail-icon],
 [data-cockpit-activity-icon] {

--- a/apps/cockpit/src/components/cockpit-shell.spec.tsx
+++ b/apps/cockpit/src/components/cockpit-shell.spec.tsx
@@ -188,7 +188,9 @@ describe('CockpitShell operational composition', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByRole('button', { name: RUN_RAIL_ITEM }).getAttribute('aria-pressed')
+        screen
+          .getByRole('button', { name: RUN_RAIL_ITEM })
+          .getAttribute('aria-pressed')
       ).toBe('true');
     });
     expect(
@@ -218,7 +220,9 @@ describe('CockpitShell operational composition', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByRole('button', { name: RUN_RAIL_ITEM }).getAttribute('aria-pressed')
+        screen
+          .getByRole('button', { name: RUN_RAIL_ITEM })
+          .getAttribute('aria-pressed')
       ).toBe('true');
     });
     expect(window.location.search).toBe('');
@@ -260,7 +264,9 @@ describe('CockpitShell operational composition', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByRole('button', { name: RUN_RAIL_ITEM }).getAttribute('aria-pressed')
+        screen
+          .getByRole('button', { name: RUN_RAIL_ITEM })
+          .getAttribute('aria-pressed')
       ).toBe('true');
     });
     expect(
@@ -330,9 +336,30 @@ describe('CockpitShell operational composition', () => {
     ).not.toHaveLength(0);
 
     openActivity();
-    expect(screen.getAllByRole('button', { name: 'Activity' })).not.toHaveLength(
-      0
+    expect(
+      screen.getAllByRole('button', { name: 'Activity' })
+    ).not.toHaveLength(0);
+
+    // Clearing the log must reset the marker too. If it did not, the marker
+    // would stay at N over an empty log and silently swallow the next N
+    // problems for the rest of the page visit.
+    fireEvent.click(
+      screen.getAllByRole('button', { name: 'Activity actions' })[0]
     );
+    fireEvent.click(
+      screen.getAllByRole('menuitem', { name: 'Clear session activity' })[0]
+    );
+    act(() => {
+      operationalMocks.latestControllerOptions?.onActivity({
+        id: 'post-clear-event',
+        at: '2026-08-31T17:03:00.000Z',
+        kind: 'runtime_unresponsive',
+        capability: 'streaming',
+      });
+    });
+    expect(
+      screen.getAllByRole('button', { name: 'Activity, 1 unread problem' })
+    ).not.toHaveLength(0);
   });
 
   it('does not reset drawer focus when shared operational state rerenders', async () => {

--- a/apps/cockpit/src/components/cockpit-shell.spec.tsx
+++ b/apps/cockpit/src/components/cockpit-shell.spec.tsx
@@ -94,8 +94,7 @@ const baseContentBundle = {
   narrativeDocs: [],
 };
 
-const seedMode = (
-  activeMode: 'Run' | 'Code' | 'Docs' | 'API',
+const seedExpanded = (
   expanded: Record<string, boolean> = {
     Capability: true,
     Runtime: true,
@@ -106,7 +105,7 @@ const seedMode = (
     JSON.stringify({
       version: 1,
       docs: { expanded: { Learn: true, Environment: false } },
-      cockpit: { activeMode, expanded },
+      cockpit: { expanded },
     })
   );
 };
@@ -168,22 +167,34 @@ describe('CockpitShell operational composition', () => {
     vi.restoreAllMocks();
   });
 
-  it('initializes from the saved Cockpit mode after hydration', async () => {
-    seedMode('Docs');
+  it('always opens in Run, ignoring a stored activeMode from an older visit', async () => {
+    window.localStorage.setItem(
+      CONTROL_PLANE_STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        docs: { expanded: { Learn: true, Environment: false } },
+        cockpit: {
+          activeMode: 'Code',
+          expanded: { Capability: true, Runtime: true },
+        },
+      })
+    );
     renderShell();
 
     await waitFor(() => {
       expect(
         screen
-          .getByRole('button', { name: 'Docs' })
+          .getByRole('button', { name: 'Run' })
           .getAttribute('aria-pressed')
       ).toBe('true');
     });
-    expect(screen.getByRole('region', { name: 'Docs mode' })).toBeTruthy();
+    expect(
+      screen.getByRole('button', { name: 'Code' }).getAttribute('aria-pressed')
+    ).toBe('false');
   });
 
-  it('consumes a valid mode query once and persists it over the saved mode', async () => {
-    seedMode('Docs');
+  it('consumes a valid mode query once and lands in that mode', async () => {
+    seedExpanded();
     window.history.replaceState({}, '', '/?mode=code&keep=1');
     renderShell();
 
@@ -195,20 +206,16 @@ describe('CockpitShell operational composition', () => {
       ).toBe('true');
     });
     expect(window.location.search).toBe('?keep=1');
-    expect(
-      JSON.parse(window.localStorage.getItem(CONTROL_PLANE_STORAGE_KEY) ?? '{}')
-        .cockpit.activeMode
-    ).toBe('Code');
   });
 
-  it('ignores invalid mode queries and uses the saved mode', async () => {
-    seedMode('API');
+  it('ignores invalid mode queries and falls back to Run', async () => {
+    seedExpanded();
     window.history.replaceState({}, '', '/?mode=preview');
     renderShell();
 
     await waitFor(() => {
       expect(
-        screen.getByRole('button', { name: 'API' }).getAttribute('aria-pressed')
+        screen.getByRole('button', { name: 'Run' }).getAttribute('aria-pressed')
       ).toBe('true');
     });
   });
@@ -507,7 +514,7 @@ describe('CockpitShell operational composition', () => {
   });
 
   it('reloads only the iframe while preserving shell state and session Activity', async () => {
-    seedMode('Run', { Capability: true, Runtime: true });
+    seedExpanded({ Capability: true, Runtime: true });
     renderShell('https://runtime.test/path?secret=hidden');
     const firstFrame = await screen.findByTitle(
       'LangGraph Streaming live example'

--- a/apps/cockpit/src/components/cockpit-shell.spec.tsx
+++ b/apps/cockpit/src/components/cockpit-shell.spec.tsx
@@ -139,6 +139,11 @@ const renderShellFor = (
   );
 };
 
+// The Run rail item's accessible name carries the live runtime phase
+// ('Run, runtime ready'), so these mode assertions match the label prefix
+// instead of a name that depends on which phase the fixture happens to be in.
+const RUN_RAIL_ITEM = /^Run(,|$)/;
+
 const openActivity = () => {
   fireEvent.click(screen.getByRole('button', { name: /^Activity/ }));
   return screen.getByRole('heading', {
@@ -183,7 +188,7 @@ describe('CockpitShell operational composition', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByRole('button', { name: 'Run' }).getAttribute('aria-pressed')
+        screen.getByRole('button', { name: RUN_RAIL_ITEM }).getAttribute('aria-pressed')
       ).toBe('true');
     });
     expect(
@@ -213,7 +218,7 @@ describe('CockpitShell operational composition', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByRole('button', { name: 'Run' }).getAttribute('aria-pressed')
+        screen.getByRole('button', { name: RUN_RAIL_ITEM }).getAttribute('aria-pressed')
       ).toBe('true');
     });
     expect(window.location.search).toBe('');
@@ -255,7 +260,7 @@ describe('CockpitShell operational composition', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByRole('button', { name: 'Run' }).getAttribute('aria-pressed')
+        screen.getByRole('button', { name: RUN_RAIL_ITEM }).getAttribute('aria-pressed')
       ).toBe('true');
     });
     expect(
@@ -266,7 +271,7 @@ describe('CockpitShell operational composition', () => {
   it('owns one controller and one Activity store shared by desktop and mobile adapters', async () => {
     renderShell();
     await waitFor(() =>
-      expect(screen.getByRole('button', { name: 'Run' })).toBeTruthy()
+      expect(screen.getByRole('button', { name: RUN_RAIL_ITEM })).toBeTruthy()
     );
     expect(operationalMocks.controllerInstances).toBe(1);
 
@@ -280,6 +285,54 @@ describe('CockpitShell operational composition', () => {
     });
     expect(within(dialog).getByText('Mode changed to Code')).toBeTruthy();
     expect(operationalMocks.controllerInstances).toBe(1);
+  });
+
+  it('flags an unread runtime problem until Activity is opened, and survives recovery', async () => {
+    renderShell();
+    await waitFor(() =>
+      expect(operationalMocks.latestControllerOptions).not.toBeNull()
+    );
+
+    // Routine activity must not light the indicator.
+    act(() => {
+      operationalMocks.latestControllerOptions?.onActivity({
+        id: 'ready-event',
+        at: '2026-08-31T17:00:00.000Z',
+        kind: 'runtime_ready',
+        capability: 'streaming',
+      });
+    });
+    expect(screen.getByRole('button', { name: 'Activity' })).toBeTruthy();
+
+    act(() => {
+      operationalMocks.latestControllerOptions?.onActivity({
+        id: 'unresponsive-event',
+        at: '2026-08-31T17:01:00.000Z',
+        kind: 'runtime_unresponsive',
+        capability: 'streaming',
+      });
+    });
+    expect(
+      screen.getAllByRole('button', { name: 'Activity, 1 unread problem' })
+    ).not.toHaveLength(0);
+
+    // A self-recovering runtime clears the phase but not the unread problem.
+    act(() => {
+      operationalMocks.latestControllerOptions?.onActivity({
+        id: 'recovered-event',
+        at: '2026-08-31T17:02:00.000Z',
+        kind: 'runtime_recovered',
+        capability: 'streaming',
+      });
+    });
+    expect(
+      screen.getAllByRole('button', { name: 'Activity, 1 unread problem' })
+    ).not.toHaveLength(0);
+
+    openActivity();
+    expect(screen.getAllByRole('button', { name: 'Activity' })).not.toHaveLength(
+      0
+    );
   });
 
   it('does not reset drawer focus when shared operational state rerenders', async () => {
@@ -527,7 +580,7 @@ describe('CockpitShell operational composition', () => {
   it('records one fixed Activity event and one existing analytics event only for an actual mode change', async () => {
     renderShell();
     await waitFor(() =>
-      expect(screen.getByRole('button', { name: 'Run' })).toBeTruthy()
+      expect(screen.getByRole('button', { name: RUN_RAIL_ITEM })).toBeTruthy()
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Code' }));

--- a/apps/cockpit/src/components/cockpit-shell.spec.tsx
+++ b/apps/cockpit/src/components/cockpit-shell.spec.tsx
@@ -578,7 +578,9 @@ describe('CockpitShell operational composition', () => {
       )
     );
     expect(
-      screen.getByRole('button', { name: 'Run' }).getAttribute('aria-pressed')
+      screen
+        .getByRole('button', { name: 'Run, runtime starting' })
+        .getAttribute('aria-pressed')
     ).toBe('true');
     expect(window.location.pathname).toBe(routeBefore);
     expect(
@@ -603,7 +605,7 @@ describe('CockpitShell operational composition', () => {
     for (let index = 0; index < 22; index += 1) {
       fireEvent.click(
         screen.getByRole('button', {
-          name: index % 2 === 0 ? 'Code' : 'Run',
+          name: index % 2 === 0 ? 'Code' : 'Run, runtime starting',
         })
       );
     }

--- a/apps/cockpit/src/components/cockpit-shell.spec.tsx
+++ b/apps/cockpit/src/components/cockpit-shell.spec.tsx
@@ -183,9 +183,7 @@ describe('CockpitShell operational composition', () => {
 
     await waitFor(() => {
       expect(
-        screen
-          .getByRole('button', { name: 'Run' })
-          .getAttribute('aria-pressed')
+        screen.getByRole('button', { name: 'Run' }).getAttribute('aria-pressed')
       ).toBe('true');
     });
     expect(
@@ -218,6 +216,51 @@ describe('CockpitShell operational composition', () => {
         screen.getByRole('button', { name: 'Run' }).getAttribute('aria-pressed')
       ).toBe('true');
     });
+    expect(window.location.search).toBe('');
+  });
+
+  it('lands a newly navigated-to capability on Run even after switching to Code, when the shell remounts on the route key', async () => {
+    const { rerender } = render(
+      <ThemeProvider theme="light">
+        <CockpitShell
+          key={model.canonicalPath}
+          navigationTree={model.navigationTree}
+          presentation={model.presentation}
+          entryTitle={model.entry.title}
+          contentBundle={baseContentBundle}
+        />
+      </ThemeProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Code' }));
+    await waitFor(() => {
+      expect(
+        screen
+          .getByRole('button', { name: 'Code' })
+          .getAttribute('aria-pressed')
+      ).toBe('true');
+    });
+
+    rerender(
+      <ThemeProvider theme="light">
+        <CockpitShell
+          key={persistenceModel.canonicalPath}
+          navigationTree={persistenceModel.navigationTree}
+          presentation={persistenceModel.presentation}
+          entryTitle={persistenceModel.entry.title}
+          contentBundle={baseContentBundle}
+        />
+      </ThemeProvider>
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Run' }).getAttribute('aria-pressed')
+      ).toBe('true');
+    });
+    expect(
+      screen.getByRole('button', { name: 'Code' }).getAttribute('aria-pressed')
+    ).toBe('false');
   });
 
   it('owns one controller and one Activity store shared by desktop and mobile adapters', async () => {

--- a/apps/cockpit/src/components/cockpit-shell.tsx
+++ b/apps/cockpit/src/components/cockpit-shell.tsx
@@ -159,6 +159,7 @@ export function CockpitShell({
   const queryHandled = useRef(false);
   const mobileTriggerRef = useRef<HTMLButtonElement>(null);
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  const [activeMode, setActiveMode] = useState<ControlPlaneMode>('Run');
   const [isMobileOverlayPresent, setIsMobileOverlayPresent] = useState(false);
   const [activeUtility, setActiveUtility] = useState<CockpitUtility>(null);
   const [activityOpenCycle, setActivityOpenCycle] = useState(0);
@@ -203,12 +204,12 @@ export function CockpitShell({
   const docsUrl = resolveDocsUrl(presentation.docsPath);
 
   useEffect(() => {
-    if (!preferences.hydrated || queryHandled.current) return;
+    if (queryHandled.current) return;
     queryHandled.current = true;
     const url = new URL(window.location.href);
     const rawMode = url.searchParams.get('mode');
     const requestedMode = parseControlPlaneMode(rawMode);
-    if (requestedMode) preferences.setActiveMode(requestedMode);
+    if (requestedMode) setActiveMode(requestedMode);
     if (rawMode !== null) {
       url.searchParams.delete('mode');
       window.history.replaceState(
@@ -217,15 +218,14 @@ export function CockpitShell({
         url.pathname + url.search + url.hash
       );
     }
-  }, [preferences]);
+  }, []);
 
-  const activeMode: ControlPlaneMode = preferences.activeMode;
   const isMobileModalActive = isSidebarOpen || isMobileOverlayPresent;
 
   const handleModeChange = useCallback(
     (mode: ControlPlaneMode) => {
       if (mode === activeMode) return;
-      preferences.setActiveMode(mode);
+      setActiveMode(mode);
       appendActivity(
         createLocalActivityInput(entry.topic, {
           kind: 'mode_changed',
@@ -238,7 +238,7 @@ export function CockpitShell({
         to_mode: MODE_ANALYTICS[mode],
       });
     },
-    [activeMode, appendActivity, entry.topic, preferences]
+    [activeMode, appendActivity, entry.topic]
   );
 
   const handleActiveUtilityChange = useCallback(

--- a/apps/cockpit/src/components/cockpit-shell.tsx
+++ b/apps/cockpit/src/components/cockpit-shell.tsx
@@ -29,6 +29,7 @@ import type {
 } from '../lib/analytics/events';
 import {
   activityReducer,
+  countUnseenProblems,
   createSessionActivityEvent,
   type ActivityMode,
   type RuntimeActivityInput,
@@ -163,6 +164,7 @@ export function CockpitShell({
   const [isMobileOverlayPresent, setIsMobileOverlayPresent] = useState(false);
   const [activeUtility, setActiveUtility] = useState<CockpitUtility>(null);
   const [activityOpenCycle, setActivityOpenCycle] = useState(0);
+  const [seenActivityCount, setSeenActivityCount] = useState(0);
   const [events, dispatchActivity] = useReducer(activityReducer, []);
   const isCapability = presentation.kind === 'capability';
   const codeAssetPaths = isCapability ? presentation.codeAssetPaths : [];
@@ -245,10 +247,11 @@ export function CockpitShell({
     (utility: CockpitUtility) => {
       if (utility === 'activity' && activeUtility !== 'activity') {
         setActivityOpenCycle((cycle) => cycle + 1);
+        setSeenActivityCount(events.length);
       }
       setActiveUtility(utility);
     },
-    [activeUtility]
+    [activeUtility, events.length]
   );
 
   const closeMobileNavigation = useCallback(() => {
@@ -319,6 +322,7 @@ export function CockpitShell({
 
   const handleClearActivity = useCallback(() => {
     dispatchActivity({ type: 'clear' });
+    setSeenActivityCount(0);
   }, []);
 
   const handleRecheck = useCallback(() => {
@@ -392,6 +396,7 @@ export function CockpitShell({
       activityOpenCycle,
       runtimeSnapshot: controller.snapshot,
       events,
+      unseenProblems: countUnseenProblems(events, seenActivityCount),
       expanded: preferences.expanded,
       onExpandedChange: preferences.setExpanded,
       onClearActivity: handleClearActivity,
@@ -417,6 +422,7 @@ export function CockpitShell({
       navigationTree,
       preferences.expanded,
       preferences.setExpanded,
+      seenActivityCount,
     ]
   );
 

--- a/apps/cockpit/src/components/control-plane/activity-panel.spec.tsx
+++ b/apps/cockpit/src/components/control-plane/activity-panel.spec.tsx
@@ -176,7 +176,7 @@ describe('ActivityPanel', () => {
       />
     );
     expect(
-      screen.getByRole('list', { name: 'Activity, attention required' })
+      screen.getByRole('list', { name: 'Activity, unread problems' })
     ).toBeTruthy();
     expect(
       document

--- a/apps/cockpit/src/components/control-plane/activity-panel.tsx
+++ b/apps/cockpit/src/components/control-plane/activity-panel.tsx
@@ -81,7 +81,7 @@ export function ActivityPanel({
   formatTimestamp = defaultTimestamp,
 }: ActivityPanelProps) {
   const orderedEvents = [...events].sort(byNewest);
-  const label = attention ? 'Activity, attention required' : 'Activity';
+  const label = attention ? 'Activity, unread problems' : 'Activity';
 
   return (
     <ControlPlaneUtilityPanel title="Activity" onClose={onClose}>

--- a/apps/cockpit/src/components/control-plane/cockpit-control-plane.spec.tsx
+++ b/apps/cockpit/src/components/control-plane/cockpit-control-plane.spec.tsx
@@ -1,10 +1,20 @@
 /** @vitest-environment jsdom */
 import React, { useState } from 'react';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { cockpitManifest } from '@threadplane/cockpit-registry';
 import { ThemeProvider, type ControlPlaneMode } from '@threadplane/ui-react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { buildNavigationTree } from '../../lib/route-resolution';
+
+const workspaceRoot = process.cwd().endsWith('/apps/cockpit')
+  ? resolve(process.cwd(), '../..')
+  : process.cwd();
+const cockpitCss = readFileSync(
+  resolve(workspaceRoot, 'apps/cockpit/src/app/cockpit.css'),
+  'utf8'
+);
 import {
   createRuntimeSnapshot,
   parseRuntimeTarget,
@@ -222,5 +232,22 @@ describe('CockpitControlPlane', () => {
     expect(result.onExpandedChange).toHaveBeenCalledWith('Runtime', false);
     fireEvent.click(screen.getByRole('button', { name: 'Recheck' }));
     expect(result.onRecheck).toHaveBeenCalledTimes(1);
+  });
+
+  it('separates the mode group from the utilities and lifts resting contrast', () => {
+    expect(cockpitCss).toMatch(
+      /\[data-control-plane-rail-group="utilities"\][^}]*border-top/
+    );
+    expect(cockpitCss).not.toMatch(
+      /\[data-control-plane-rail-item\]\s*\{[^}]*--ds-text-muted/
+    );
+  });
+
+  it('names the mode group without adding a second landmark label', () => {
+    renderControlPlane();
+    const rail = screen.getByRole('navigation', { name: 'Cockpit modes' });
+    const cap = rail.querySelector('[data-control-plane-rail-group-label]');
+    expect(cap?.textContent).toBe('View');
+    expect(cap?.getAttribute('aria-hidden')).toBe('true');
   });
 });

--- a/apps/cockpit/src/components/control-plane/cockpit-control-plane.spec.tsx
+++ b/apps/cockpit/src/components/control-plane/cockpit-control-plane.spec.tsx
@@ -100,6 +100,7 @@ const renderControlPlane = (overrides: HarnessOverrides = {}) => {
           activityOpenCycle={1}
           runtimeSnapshot={runtimeSnapshot('ready')}
           events={activity}
+          unseenProblems={0}
           expanded={{ Capability: true, Runtime: true }}
           onExpandedChange={onExpandedChange}
           {...actions}
@@ -156,27 +157,30 @@ describe('CockpitControlPlane', () => {
     expect(within(pane).queryByText('Actions')).toBeNull();
   });
 
-  it('renders Activity above Settings with a nonnumeric attention indicator that opening does not clear', () => {
-    renderControlPlane({ runtimeSnapshot: runtimeSnapshot('unresponsive') });
+  it('flags unseen problems on Activity and clears them when the panel opens', () => {
+    renderControlPlane({ unseenProblems: 1 });
     const rail = screen.getByRole('navigation', { name: 'Cockpit modes' });
     const utilities = within(rail).getAllByRole('button').slice(4);
     expect(
       utilities.map((button) => button.getAttribute('aria-label'))
-    ).toEqual(['Activity, attention required', 'Settings']);
+    ).toEqual(['Activity, 1 unread problem', 'Settings']);
     expect(
       document.querySelector('[data-cockpit-activity-attention]')?.textContent
     ).toBe('');
+  });
 
-    fireEvent.click(
-      screen.getByRole('button', {
-        name: 'Activity, attention required',
-      })
-    );
-    expect(screen.getByRole('heading', { name: 'Activity' })).toBeTruthy();
+  it('does not flag Activity when nothing has gone wrong', () => {
+    renderControlPlane({ unseenProblems: 0 });
+    expect(screen.getByRole('button', { name: 'Activity' })).toBeTruthy();
     expect(
-      screen.getByRole('button', {
-        name: 'Activity, attention required',
-      })
+      document.querySelector('[data-cockpit-activity-attention]')
+    ).toBeNull();
+  });
+
+  it('pluralises the unseen problem count', () => {
+    renderControlPlane({ unseenProblems: 3 });
+    expect(
+      screen.getByRole('button', { name: 'Activity, 3 unread problems' })
     ).toBeTruthy();
   });
 

--- a/apps/cockpit/src/components/control-plane/cockpit-control-plane.spec.tsx
+++ b/apps/cockpit/src/components/control-plane/cockpit-control-plane.spec.tsx
@@ -1,20 +1,13 @@
 /** @vitest-environment jsdom */
 import React, { useState } from 'react';
 import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { resolve } from 'node:path';
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { cockpitManifest } from '@threadplane/cockpit-registry';
 import { ThemeProvider, type ControlPlaneMode } from '@threadplane/ui-react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { buildNavigationTree } from '../../lib/route-resolution';
-
-const workspaceRoot = process.cwd().endsWith('/apps/cockpit')
-  ? resolve(process.cwd(), '../..')
-  : process.cwd();
-const cockpitCss = readFileSync(
-  resolve(workspaceRoot, 'apps/cockpit/src/app/cockpit.css'),
-  'utf8'
-);
 import {
   createRuntimeSnapshot,
   parseRuntimeTarget,
@@ -26,6 +19,11 @@ import {
   type CockpitControlPlaneProps,
   type CockpitUtility,
 } from './cockpit-control-plane';
+
+const cockpitCss = readFileSync(
+  resolve(fileURLToPath(import.meta.url), '../../../app/cockpit.css'),
+  'utf8'
+);
 
 const entry = cockpitManifest.find(
   (candidate) =>
@@ -235,19 +233,29 @@ describe('CockpitControlPlane', () => {
   });
 
   it('separates the mode group from the utilities and lifts resting contrast', () => {
+    // The utilities separator must resolve to --ds-border-strong, not
+    // --ds-border: in dark mode --ds-border (rgb(45,45,45)) sits one value
+    // away from --ds-surface-tinted, the rail background (rgb(44,44,44)),
+    // which is an invisible 1.01:1 hairline. --ds-border-strong is what the
+    // pane divider already uses for the same reason. This is a text
+    // assertion, not a rendered-contrast check -- jsdom's getComputedStyle
+    // does not resolve var(), so it can't verify the resolved colour, only
+    // that the correct token is referenced.
     expect(cockpitCss).toMatch(
-      /\[data-control-plane-rail-group="utilities"\][^}]*border-top/
+      /\[data-control-plane-rail-group="utilities"\][^}]*border-top:\s*1px solid var\(--ds-border-strong\)/
     );
     expect(cockpitCss).not.toMatch(
       /\[data-control-plane-rail-item\]\s*\{[^}]*--ds-text-muted/
     );
   });
 
-  it('names the mode group without adding a second landmark label', () => {
+  it('names the mode group as an ARIA group announced to screen readers', () => {
     renderControlPlane();
     const rail = screen.getByRole('navigation', { name: 'Cockpit modes' });
-    const cap = rail.querySelector('[data-control-plane-rail-group-label]');
+    const group = screen.getByRole('group', { name: 'View' });
+    expect(rail.contains(group)).toBe(true);
+    const cap = group.querySelector('[data-control-plane-rail-group-label]');
     expect(cap?.textContent).toBe('View');
-    expect(cap?.getAttribute('aria-hidden')).toBe('true');
+    expect(cap?.getAttribute('aria-hidden')).toBeNull();
   });
 });

--- a/apps/cockpit/src/components/control-plane/cockpit-control-plane.spec.tsx
+++ b/apps/cockpit/src/components/control-plane/cockpit-control-plane.spec.tsx
@@ -274,6 +274,30 @@ describe('CockpitControlPlane', () => {
     expect(run.querySelector('[data-control-plane-rail-status]')).toBeNull();
   });
 
+  it('keeps the status dot ring on the item background and visible in forced colors', () => {
+    // jsdom does not resolve var() in getComputedStyle, so this asserts the
+    // authored rules, not a rendered colour. The ring must track the rail
+    // item's own background: --ds-surface-tinted at rest, --ds-surface on
+    // hover, which in dark is rgb(28,28,28) inside the rail's rgb(44,44,44)
+    // -- a fixed ring would read as a lighter halo whenever Run is hovered.
+    expect(cockpitCss).toMatch(
+      /\[data-control-plane-rail-status\]\s*\{[^}]*border:\s*2px solid var\(--cockpit-rail-status-ring\)/
+    );
+    expect(cockpitCss).toMatch(
+      /\[data-control-plane-rail-item\]\s*\{[^}]*--cockpit-rail-status-ring:\s*var\(--ds-surface-tinted\)/
+    );
+    expect(cockpitCss).toMatch(
+      /\[data-control-plane-rail-item\]:hover\s*\{[^}]*--cockpit-rail-status-ring:\s*var\(--ds-surface\)/
+    );
+    // Forced colors overrides background, so the dot needs an explicit
+    // treatment like the runtime pill it sits beside.
+    expect(
+      cockpitCss.slice(cockpitCss.indexOf('@media (forced-colors: active)'))
+    ).toMatch(
+      /\[data-control-plane-rail-status\]\s*\{[^}]*border:\s*1px solid CanvasText/
+    );
+  });
+
   it('names the mode group as an ARIA group announced to screen readers', () => {
     renderControlPlane();
     const rail = screen.getByRole('navigation', { name: 'Cockpit modes' });

--- a/apps/cockpit/src/components/control-plane/cockpit-control-plane.spec.tsx
+++ b/apps/cockpit/src/components/control-plane/cockpit-control-plane.spec.tsx
@@ -124,10 +124,15 @@ describe('CockpitControlPlane', () => {
       within(rail)
         .getAllByRole('button')
         .slice(0, 4)
-        .map((button) => button.textContent)
+        .map(
+          (button) =>
+            button.querySelector('[data-control-plane-rail-label]')?.textContent
+        )
     ).toEqual(['Docs', 'Run', 'Code', 'API']);
     expect(
-      screen.getByRole('button', { name: 'Run' }).getAttribute('aria-pressed')
+      screen
+        .getByRole('button', { name: 'Run, runtime ready' })
+        .getAttribute('aria-pressed')
     ).toBe('true');
 
     const pane = screen.getByRole('complementary', {
@@ -180,7 +185,9 @@ describe('CockpitControlPlane', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Activity' }));
     expect(screen.getByRole('heading', { name: 'Activity' })).toBeTruthy();
     expect(
-      screen.getByRole('button', { name: 'Run' }).getAttribute('aria-pressed')
+      screen
+        .getByRole('button', { name: 'Run, runtime ready' })
+        .getAttribute('aria-pressed')
     ).toBe('true');
 
     fireEvent.click(screen.getByRole('button', { name: 'Settings' }));
@@ -247,6 +254,24 @@ describe('CockpitControlPlane', () => {
     expect(cockpitCss).not.toMatch(
       /\[data-control-plane-rail-item\]\s*\{[^}]*--ds-text-muted/
     );
+  });
+
+  it('puts the runtime phase on the Run rail item', () => {
+    renderControlPlane({ runtimeSnapshot: runtimeSnapshot('unresponsive') });
+    const run = screen.getByRole('button', { name: 'Run, runtime error' });
+    expect(
+      run
+        .querySelector('[data-control-plane-rail-status]')
+        ?.getAttribute('data-control-plane-rail-status')
+    ).toBe('error');
+  });
+
+  it('shows no dot on Run when no runtime is configured', () => {
+    renderControlPlane({
+      runtimeSnapshot: runtimeSnapshot('not_configured'),
+    });
+    const run = screen.getByRole('button', { name: 'Run' });
+    expect(run.querySelector('[data-control-plane-rail-status]')).toBeNull();
   });
 
   it('names the mode group as an ARIA group announced to screen readers', () => {

--- a/apps/cockpit/src/components/control-plane/cockpit-control-plane.tsx
+++ b/apps/cockpit/src/components/control-plane/cockpit-control-plane.tsx
@@ -22,7 +22,6 @@ import type { NavigationProduct } from '../../lib/route-resolution';
 import { PRODUCT_LABELS } from '../../lib/navigation-labels';
 import type { SessionActivityEvent } from '../../lib/runtime/session-activity';
 import {
-  runtimeNeedsAttention,
   runtimeRailStatus,
   type RuntimeSnapshot,
 } from '../../lib/runtime/runtime-state';
@@ -60,6 +59,7 @@ export interface CockpitControlPlaneProps {
   activityOpenCycle: number;
   runtimeSnapshot: RuntimeSnapshot;
   events: readonly SessionActivityEvent[];
+  unseenProblems: number;
   expanded: Record<string, boolean>;
   onExpandedChange(key: string, open: boolean): void;
   onClearActivity(): void;
@@ -87,6 +87,7 @@ export function CockpitControlPlane({
   activityOpenCycle,
   runtimeSnapshot,
   events,
+  unseenProblems,
   expanded,
   onExpandedChange,
   onClearActivity,
@@ -100,9 +101,13 @@ export function CockpitControlPlane({
 }: CockpitControlPlaneProps) {
   const activityRef = useRef<HTMLSpanElement>(null);
   const settingsRef = useRef<HTMLSpanElement>(null);
-  const attention = runtimeNeedsAttention(runtimeSnapshot.phase);
   const railStatus = runtimeRailStatus(runtimeSnapshot.phase);
-  const activityLabel = attention ? 'Activity, attention required' : 'Activity';
+  const attention = unseenProblems > 0;
+  const activityLabel = attention
+    ? `Activity, ${unseenProblems} unread problem${
+        unseenProblems === 1 ? '' : 's'
+      }`
+    : 'Activity';
   const product = PRODUCT_LABELS[entry.product] ?? entry.product;
   const language = entry.language === 'typescript' ? 'TypeScript' : 'Python';
 

--- a/apps/cockpit/src/components/control-plane/cockpit-control-plane.tsx
+++ b/apps/cockpit/src/components/control-plane/cockpit-control-plane.tsx
@@ -23,6 +23,7 @@ import { PRODUCT_LABELS } from '../../lib/navigation-labels';
 import type { SessionActivityEvent } from '../../lib/runtime/session-activity';
 import {
   runtimeNeedsAttention,
+  runtimeRailStatus,
   type RuntimeSnapshot,
 } from '../../lib/runtime/runtime-state';
 import { CockpitSidebar } from '../sidebar/cockpit-sidebar';
@@ -100,6 +101,7 @@ export function CockpitControlPlane({
   const activityRef = useRef<HTMLSpanElement>(null);
   const settingsRef = useRef<HTMLSpanElement>(null);
   const attention = runtimeNeedsAttention(runtimeSnapshot.phase);
+  const railStatus = runtimeRailStatus(runtimeSnapshot.phase);
   const activityLabel = attention ? 'Activity, attention required' : 'Activity';
   const product = PRODUCT_LABELS[entry.product] ?? entry.product;
   const language = entry.language === 'typescript' ? 'TypeScript' : 'Python';
@@ -205,6 +207,7 @@ export function CockpitControlPlane({
             icon={<Icon size={18} aria-hidden="true" />}
             active={label === activeMode}
             onSelect={() => selectMode(label)}
+            status={label === 'Run' ? railStatus ?? undefined : undefined}
           />
         ))}
         utilities={

--- a/apps/cockpit/src/components/control-plane/cockpit-control-plane.tsx
+++ b/apps/cockpit/src/components/control-plane/cockpit-control-plane.tsx
@@ -197,6 +197,7 @@ export function CockpitControlPlane({
     >
       <ControlPlaneRail
         label="Cockpit modes"
+        primaryLabel="View"
         primary={MODES.map(({ label, icon: Icon }) => (
           <ControlPlaneRailItem
             key={label}

--- a/apps/cockpit/src/components/mobile-nav-overlay.spec.tsx
+++ b/apps/cockpit/src/components/mobile-nav-overlay.spec.tsx
@@ -195,7 +195,9 @@ describe('MobileNavOverlay', () => {
       expect(
         within(overlay).getByRole('heading', { name: utility })
       ).toBeTruthy();
-      // Run's accessible name carries the runtime phase; match the prefix.
+      // This fixture's runtime is not_configured, so Run has no status suffix
+      // and the bare name matches -- but the suffix exists in other phases, so
+      // match the label prefix rather than depending on the fixture.
       expect(
         within(overlay).getByRole('button', { name: /^Run(,|$)/ })
       ).toBeTruthy();

--- a/apps/cockpit/src/components/mobile-nav-overlay.spec.tsx
+++ b/apps/cockpit/src/components/mobile-nav-overlay.spec.tsx
@@ -71,6 +71,7 @@ const renderOverlay = ({
             activityOpenCycle: 0,
             runtimeSnapshot: snapshot,
             events: [],
+            unseenProblems: 0,
             expanded: { Capability: true, Runtime: true },
             onExpandedChange: vi.fn(),
             onClearActivity: vi.fn(),
@@ -194,7 +195,10 @@ describe('MobileNavOverlay', () => {
       expect(
         within(overlay).getByRole('heading', { name: utility })
       ).toBeTruthy();
-      expect(within(overlay).getByRole('button', { name: 'Run' })).toBeTruthy();
+      // Run's accessible name carries the runtime phase; match the prefix.
+      expect(
+        within(overlay).getByRole('button', { name: /^Run(,|$)/ })
+      ).toBeTruthy();
       expect(
         within(overlay).queryByRole('button', { name: 'Capability' })
       ).toBeNull();

--- a/apps/cockpit/src/lib/runtime/runtime-state.spec.ts
+++ b/apps/cockpit/src/lib/runtime/runtime-state.spec.ts
@@ -1,8 +1,9 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, it, test } from 'vitest';
 import {
   classifyRuntimeTerminalTransition,
   createRuntimeSnapshot,
   parseRuntimeTarget,
+  runtimeRailStatus,
   runtimeReducer,
   type RuntimeSnapshot,
 } from './runtime-state';
@@ -571,5 +572,42 @@ describe('classifyRuntimeTerminalTransition', () => {
         checkedAt: 2_000,
       }),
     ).toBeNull();
+  });
+});
+
+describe('runtimeRailStatus', () => {
+  it('maps every phase to a rail status', () => {
+    expect(runtimeRailStatus('ready')).toEqual({
+      kind: 'success',
+      label: 'runtime ready',
+    });
+    expect(runtimeRailStatus('connecting')).toEqual({
+      kind: 'working',
+      label: 'runtime starting',
+    });
+    expect(runtimeRailStatus('checking')).toEqual({
+      kind: 'working',
+      label: 'runtime starting',
+    });
+    expect(runtimeRailStatus('reloading')).toEqual({
+      kind: 'working',
+      label: 'runtime starting',
+    });
+    expect(runtimeRailStatus('unresponsive')).toEqual({
+      kind: 'error',
+      label: 'runtime error',
+    });
+    expect(runtimeRailStatus('error')).toEqual({
+      kind: 'error',
+      label: 'runtime error',
+    });
+    expect(runtimeRailStatus('invalid_configuration')).toEqual({
+      kind: 'error',
+      label: 'runtime error',
+    });
+  });
+
+  it('reports no status when there is no runtime to report on', () => {
+    expect(runtimeRailStatus('not_configured')).toBeNull();
   });
 });

--- a/apps/cockpit/src/lib/runtime/runtime-state.ts
+++ b/apps/cockpit/src/lib/runtime/runtime-state.ts
@@ -283,23 +283,6 @@ export function classifyRuntimeTerminalTransition(
   return result;
 }
 
-export function runtimeNeedsAttention(phase: RuntimePhase): boolean {
-  // Exhaustive with no `default`, so a new RuntimePhase is a compile error here
-  // just as it is in runtimeRailStatus rather than silently returning false.
-  switch (phase) {
-    case 'invalid_configuration':
-    case 'unresponsive':
-    case 'error':
-      return true;
-    case 'not_configured':
-    case 'connecting':
-    case 'checking':
-    case 'ready':
-    case 'reloading':
-      return false;
-  }
-}
-
 export function runtimeRailStatus(
   phase: RuntimePhase
 ): ControlPlaneRailItemStatus | null {

--- a/apps/cockpit/src/lib/runtime/runtime-state.ts
+++ b/apps/cockpit/src/lib/runtime/runtime-state.ts
@@ -284,11 +284,20 @@ export function classifyRuntimeTerminalTransition(
 }
 
 export function runtimeNeedsAttention(phase: RuntimePhase): boolean {
-  return (
-    phase === 'invalid_configuration' ||
-    phase === 'unresponsive' ||
-    phase === 'error'
-  );
+  // Exhaustive with no `default`, so a new RuntimePhase is a compile error here
+  // just as it is in runtimeRailStatus rather than silently returning false.
+  switch (phase) {
+    case 'invalid_configuration':
+    case 'unresponsive':
+    case 'error':
+      return true;
+    case 'not_configured':
+    case 'connecting':
+    case 'checking':
+    case 'ready':
+    case 'reloading':
+      return false;
+  }
 }
 
 export function runtimeRailStatus(

--- a/apps/cockpit/src/lib/runtime/runtime-state.ts
+++ b/apps/cockpit/src/lib/runtime/runtime-state.ts
@@ -1,3 +1,5 @@
+import type { ControlPlaneRailItemStatus } from '@threadplane/ui-react';
+
 export type RuntimePhase =
   | 'not_configured'
   | 'invalid_configuration'
@@ -287,4 +289,23 @@ export function runtimeNeedsAttention(phase: RuntimePhase): boolean {
     phase === 'unresponsive' ||
     phase === 'error'
   );
+}
+
+export function runtimeRailStatus(
+  phase: RuntimePhase
+): ControlPlaneRailItemStatus | null {
+  switch (phase) {
+    case 'ready':
+      return { kind: 'success', label: 'runtime ready' };
+    case 'connecting':
+    case 'checking':
+    case 'reloading':
+      return { kind: 'working', label: 'runtime starting' };
+    case 'unresponsive':
+    case 'error':
+    case 'invalid_configuration':
+      return { kind: 'error', label: 'runtime error' };
+    case 'not_configured':
+      return null;
+  }
 }

--- a/apps/cockpit/src/lib/runtime/session-activity.spec.ts
+++ b/apps/cockpit/src/lib/runtime/session-activity.spec.ts
@@ -8,7 +8,6 @@ import {
   type RuntimeActivityInput,
   type SessionActivityEvent,
 } from './session-activity';
-import { runtimeNeedsAttention, type RuntimePhase } from './runtime-state';
 
 const common = {
   id: 'event-1',
@@ -166,24 +165,6 @@ describe('activityReducer', () => {
   });
 });
 
-describe('runtimeNeedsAttention', () => {
-  test.each([
-    ['not_configured', false],
-    ['invalid_configuration', true],
-    ['connecting', false],
-    ['checking', false],
-    ['ready', false],
-    ['unresponsive', true],
-    ['reloading', false],
-    ['error', true],
-  ] satisfies ReadonlyArray<readonly [RuntimePhase, boolean]>)(
-    'derives attention for %s solely from phase',
-    (phase, expected) => {
-      expect(runtimeNeedsAttention(phase)).toBe(expected);
-    },
-  );
-});
-
 describe('countUnseenProblems', () => {
   const event = (
     id: string,
@@ -234,8 +215,15 @@ describe('countUnseenProblems', () => {
     expect(countUnseenProblems(events, 2)).toBe(1);
   });
 
-  test('treats a marker beyond the log as everything seen', () => {
-    const events = [event('a', 'runtime_unresponsive', 'error')];
+  test('treats a marker beyond a trimmed log as everything seen', () => {
+    // A stale marker must not make slice() count back from the tail, which
+    // would report already-seen errors as unseen.
+    const events = [
+      event('d', 'runtime_unresponsive', 'error'),
+      event('c', 'runtime_unresponsive', 'error'),
+      event('b', 'runtime_unresponsive', 'error'),
+      event('a', 'runtime_ready', 'success'),
+    ];
     expect(countUnseenProblems(events, 5)).toBe(0);
   });
 });

--- a/apps/cockpit/src/lib/runtime/session-activity.spec.ts
+++ b/apps/cockpit/src/lib/runtime/session-activity.spec.ts
@@ -1,8 +1,10 @@
 import { describe, expect, expectTypeOf, test } from 'vitest';
 import {
   activityReducer,
+  countUnseenProblems,
   createSessionActivityEvent,
   type ActivityKind,
+  type ActivitySeverity,
   type RuntimeActivityInput,
   type SessionActivityEvent,
 } from './session-activity';
@@ -180,4 +182,60 @@ describe('runtimeNeedsAttention', () => {
       expect(runtimeNeedsAttention(phase)).toBe(expected);
     },
   );
+});
+
+describe('countUnseenProblems', () => {
+  const event = (
+    id: string,
+    kind: ActivityKind,
+    severity: ActivitySeverity,
+  ): SessionActivityEvent => ({
+    id,
+    at: '2026-08-31T17:00:00.000Z',
+    kind,
+    severity,
+    capability: 'streaming',
+    summary: kind,
+  });
+
+  test('counts only error events beyond the seen marker', () => {
+    const events = [
+      event('a', 'runtime_ready', 'success'),
+      event('b', 'mode_changed', 'neutral'),
+      event('c', 'runtime_unresponsive', 'error'),
+    ];
+    expect(countUnseenProblems(events, 0)).toBe(1);
+  });
+
+  test('ignores routine activity entirely', () => {
+    const events = [
+      event('a', 'runtime_ready', 'success'),
+      event('b', 'mode_changed', 'neutral'),
+    ];
+    expect(countUnseenProblems(events, 0)).toBe(0);
+  });
+
+  test('ignores errors the user has already seen', () => {
+    const events = [
+      event('a', 'runtime_unresponsive', 'error'),
+      event('b', 'mode_changed', 'neutral'),
+    ];
+    expect(countUnseenProblems(events, 2)).toBe(0);
+  });
+
+  test('reads the unseen window from the newest end of the log', () => {
+    // activityReducer prepends, so index 0 is the most recent arrival and the
+    // seen prefix is the TAIL of the array.
+    const events = [
+      event('c', 'runtime_unresponsive', 'error'),
+      event('b', 'mode_changed', 'neutral'),
+      event('a', 'runtime_ready', 'success'),
+    ];
+    expect(countUnseenProblems(events, 2)).toBe(1);
+  });
+
+  test('treats a marker beyond the log as everything seen', () => {
+    const events = [event('a', 'runtime_unresponsive', 'error')];
+    expect(countUnseenProblems(events, 5)).toBe(0);
+  });
 });

--- a/apps/cockpit/src/lib/runtime/session-activity.ts
+++ b/apps/cockpit/src/lib/runtime/session-activity.ts
@@ -116,3 +116,25 @@ export function activityReducer(
       return [];
   }
 }
+
+/**
+ * Problems the user has not looked at yet.
+ *
+ * Errors only: `mode_changed` and `runtime_ready` fire during ordinary use, so
+ * counting every unread event would light the indicator from the user's own
+ * actions.
+ *
+ * `seenCount` is a marker over the append-ordered log, but `activityReducer`
+ * prepends, so the seen events are the array's TAIL and the unseen window runs
+ * from index 0. A marker past the end (possible only if the log was trimmed or
+ * cleared under it) means everything is seen.
+ */
+export function countUnseenProblems(
+  events: readonly SessionActivityEvent[],
+  seenCount: number,
+): number {
+  const unseen = Math.max(0, events.length - Math.max(0, seenCount));
+  return events
+    .slice(0, unseen)
+    .filter((event) => event.severity === 'error').length;
+}

--- a/apps/cockpit/src/lib/runtime/session-activity.ts
+++ b/apps/cockpit/src/lib/runtime/session-activity.ts
@@ -124,16 +124,19 @@ export function activityReducer(
  * counting every unread event would light the indicator from the user's own
  * actions.
  *
- * `seenCount` is a marker over the append-ordered log, but `activityReducer`
- * prepends, so the seen events are the array's TAIL and the unseen window runs
- * from index 0. A marker past the end (possible only if the log was trimmed or
- * cleared under it) means everything is seen.
+ * `seenCount` is a marker over the log, but `activityReducer` prepends, so the
+ * seen events are the array's TAIL and the unseen window runs from index 0.
+ *
+ * The clamp is load-bearing, not defensive: a marker past the end (possible if
+ * the log was trimmed or cleared under it) would otherwise give `slice` a
+ * negative end index, which counts back from the tail and reports already-seen
+ * errors as unseen.
  */
 export function countUnseenProblems(
   events: readonly SessionActivityEvent[],
   seenCount: number,
 ): number {
-  const unseen = Math.max(0, events.length - Math.max(0, seenCount));
+  const unseen = Math.max(0, events.length - seenCount);
   return events
     .slice(0, unseen)
     .filter((event) => event.severity === 'error').length;

--- a/docs/superpowers/plans/2026-08-31-cockpit-run-discoverability.md
+++ b/docs/superpowers/plans/2026-08-31-cockpit-run-discoverability.md
@@ -889,13 +889,16 @@ export function countUnseenProblems(
   events: readonly SessionActivityEvent[],
   seenCount: number,
 ): number {
+  const unseen = Math.max(0, events.length - Math.max(0, seenCount));
   return events
-    .slice(seenCount)
+    .slice(0, unseen)
     .filter((event) => event.severity === 'error').length;
 }
 ```
 
-The reducer appends, so index order is arrival order and a prefix count is a valid marker.
+**The reducer PREPENDS** (`[action.event, ...state]`), so the log is newest-first: seen
+events are the tail, and the unseen window runs from index 0. `slice(seenCount)` is
+inverted and still passes all three tests above — add a test that pins the direction.
 
 - [ ] **Step 4: Run test to verify it passes**
 

--- a/docs/superpowers/plans/2026-08-31-cockpit-run-discoverability.md
+++ b/docs/superpowers/plans/2026-08-31-cockpit-run-discoverability.md
@@ -596,31 +596,31 @@ Add to `apps/cockpit/src/lib/runtime/runtime-state.spec.ts`:
 describe('runtimeRailStatus', () => {
   it('maps every phase to a rail status', () => {
     expect(runtimeRailStatus('ready')).toEqual({
-      status: 'success',
+      kind: 'success',
       label: 'runtime ready',
     });
     expect(runtimeRailStatus('connecting')).toEqual({
-      status: 'working',
+      kind: 'working',
       label: 'runtime starting',
     });
     expect(runtimeRailStatus('checking')).toEqual({
-      status: 'working',
+      kind: 'working',
       label: 'runtime starting',
     });
     expect(runtimeRailStatus('reloading')).toEqual({
-      status: 'working',
+      kind: 'working',
       label: 'runtime starting',
     });
     expect(runtimeRailStatus('unresponsive')).toEqual({
-      status: 'error',
+      kind: 'error',
       label: 'runtime error',
     });
     expect(runtimeRailStatus('error')).toEqual({
-      status: 'error',
+      kind: 'error',
       label: 'runtime error',
     });
     expect(runtimeRailStatus('invalid_configuration')).toEqual({
-      status: 'error',
+      kind: 'error',
       label: 'runtime error',
     });
   });
@@ -643,30 +643,31 @@ Expected: FAIL — `runtimeRailStatus is not a function`.
 Append to `apps/cockpit/src/lib/runtime/runtime-state.ts`:
 
 ```ts
-export interface RuntimeRailStatus {
-  status: 'success' | 'working' | 'error';
-  label: string;
-}
+import type { ControlPlaneRailItemStatus } from '@threadplane/ui-react';
 
 export function runtimeRailStatus(
   phase: RuntimePhase
-): RuntimeRailStatus | null {
+): ControlPlaneRailItemStatus | null {
   switch (phase) {
     case 'ready':
-      return { status: 'success', label: 'runtime ready' };
+      return { kind: 'success', label: 'runtime ready' };
     case 'connecting':
     case 'checking':
     case 'reloading':
-      return { status: 'working', label: 'runtime starting' };
+      return { kind: 'working', label: 'runtime starting' };
     case 'unresponsive':
     case 'error':
     case 'invalid_configuration':
-      return { status: 'error', label: 'runtime error' };
+      return { kind: 'error', label: 'runtime error' };
     case 'not_configured':
       return null;
   }
 }
 ```
+
+`ControlPlaneRailItemStatus` is `{ kind, label }`, exported from `@threadplane/ui-react`
+by Task 3. Returning that shape directly means the rail item takes one prop, and a dot
+without an accessible label is unrepresentable.
 
 The exhaustive `switch` over `RuntimePhase` with no `default` means a future phase is a
 compile error rather than a silently missing dot.
@@ -724,8 +725,7 @@ and change the `primary` mapping so only Run carries it:
             icon={<Icon size={18} aria-hidden="true" />}
             active={label === activeMode}
             onSelect={() => selectMode(label)}
-            status={label === 'Run' ? railStatus?.status : undefined}
-            statusLabel={label === 'Run' ? railStatus?.label : undefined}
+            status={label === 'Run' ? railStatus ?? undefined : undefined}
           />
         ))}
 ```
@@ -774,6 +774,14 @@ Then add the dot itself, after the rail-label rule:
 
 Steady fills — no `animation`, deliberately.
 
+`position: absolute` is load-bearing, not cosmetic: the dot span is an in-flow child of a
+`display:flex; flex-direction:column; gap:4px` container, so left in flow it consumes a
+4px gap and nudges the icon and label even at zero size.
+
+Also verify by eye in Task 6: a status on a non-`iconOnly` item now shows a hover tooltip
+at `left: calc(100% + 8px)` (`cockpit.css:696-700`), positioning authored for the narrow
+icon rail. On the Run item that lands over the adjacent pane. No test covers it.
+
 - [ ] **Step 9: Run tests to verify they pass**
 
 Run: `npx nx test cockpit`
@@ -785,7 +793,7 @@ the intended contract change, not a regression.
 - [ ] **Step 10: Mutation-check the no-dot case**
 
 Temporarily change `runtimeRailStatus('not_configured')` to return
-`{ status: 'success', label: 'runtime ready' }` and confirm "shows no dot on Run when no
+`{ kind: 'success', label: 'runtime ready' }` and confirm "shows no dot on Run when no
 runtime is configured" fails. Revert. The assertion is an absence and would otherwise pass
 vacuously.
 

--- a/docs/superpowers/plans/2026-08-31-cockpit-run-discoverability.md
+++ b/docs/superpowers/plans/2026-08-31-cockpit-run-discoverability.md
@@ -48,7 +48,7 @@ Every capability opens in Run. `activeMode` leaves persisted preferences entirel
 - Test: `libs/ui-react/src/lib/control-plane/control-plane-preferences.spec.ts`
 - Test: `apps/cockpit/src/components/cockpit-shell.spec.tsx`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Add to `libs/ui-react/src/lib/control-plane/control-plane-preferences.spec.ts`:
 
@@ -74,13 +74,13 @@ This spec drives `window.localStorage` directly and clears it in `beforeEach` �
 no fake-storage helper to reuse. `CONTROL_PLANE_STORAGE_KEY` and
 `readControlPlanePreferences` are already imported at the top of the file.
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `npx nx test ui-react -- -t "ignores a stored activeMode"`
 Expected: FAIL — `expect(true).toBe(false)`, because `readControlPlanePreferences` still
 copies `activeMode` through.
 
-- [ ] **Step 3: Remove `activeMode` from the persisted shape**
+- [x] **Step 3: Remove `activeMode` from the persisted shape**
 
 In `control-plane-preferences.ts`:
 
@@ -143,12 +143,12 @@ Delete the `setActiveMode` callback entirely, and change the hook's return to:
 
 Note `surface` is still read by `setExpanded`, so it stays a parameter.
 
-- [ ] **Step 4: Run test to verify it passes**
+- [x] **Step 4: Run test to verify it passes**
 
 Run: `npx nx test ui-react -- -t "ignores a stored activeMode"`
 Expected: PASS
 
-- [ ] **Step 5: Fix the rest of the preferences suite**
+- [x] **Step 5: Fix the rest of the preferences suite**
 
 Run: `npx nx test ui-react`
 Expected: several existing assertions fail — they set and read `activeMode`
@@ -161,7 +161,7 @@ no longer has a subject — delete it.
 
 Re-run until green.
 
-- [ ] **Step 6: Move mode into the shell**
+- [x] **Step 6: Move mode into the shell**
 
 In `apps/cockpit/src/components/cockpit-shell.tsx`:
 
@@ -228,7 +228,7 @@ In `handleModeChange`, swap the setter and drop `preferences` from the dependenc
 `preferences` is still used for `expanded`, `setExpanded` and `hydrated` — leave the
 `useControlPlanePreferences('cockpit')` call in place.
 
-- [ ] **Step 7: Run the cockpit suite**
+- [x] **Step 7: Run the cockpit suite**
 
 Run: `npx nx test cockpit`
 Expected: failures in `cockpit-shell.spec.tsx` around lines 96, 107 and 195, which seed
@@ -242,13 +242,13 @@ Rewrite those so that:
 
 Re-run until green.
 
-- [ ] **Step 8: Mutation-check the stickiness test**
+- [x] **Step 8: Mutation-check the stickiness test**
 
 Temporarily re-add `activeMode` passthrough in `readControlPlanePreferences` and confirm
 the "stored `activeMode` does not change the landing view" test fails. Revert the
 mutation. This assertion is about an absence and would pass vacuously if mis-wired.
 
-- [ ] **Step 9: Commit**
+- [x] **Step 9: Commit**
 
 ```bash
 git add libs/ui-react/src/lib/control-plane/control-plane-preferences.ts libs/ui-react/src/lib/control-plane/control-plane-preferences.spec.ts apps/cockpit/src/components/cockpit-shell.tsx apps/cockpit/src/components/cockpit-shell.spec.tsx
@@ -264,7 +264,7 @@ git commit -m "fix(cockpit): stop persisting the active mode so every capability
 - Modify: `libs/ui-react/src/lib/control-plane/control-plane.tsx`
 - Test: `apps/cockpit/src/components/control-plane/cockpit-control-plane.spec.tsx`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Add to `cockpit-control-plane.spec.tsx`, copying the disk-read preamble that
 `activity-panel.spec.tsx:11-17` already uses (the cwd check matters — Nx runs this suite
@@ -304,13 +304,13 @@ it('names the mode group without adding a second landmark label', () => {
 
 `renderControlPlane` is the existing render helper in this spec file.
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `npx nx test cockpit -- -t "separates the mode group"`
 Expected: FAIL — no `border-top` on the utilities group, and the item rule still sets
 `--ds-text-muted`.
 
-- [ ] **Step 3: Add the group label to the primitive**
+- [x] **Step 3: Add the group label to the primitive**
 
 In `libs/ui-react/src/lib/control-plane/control-plane.tsx`, extend the rail:
 
@@ -350,7 +350,7 @@ export function ControlPlaneRail({
 It is `aria-hidden` on purpose: the `nav` already carries `aria-label="Cockpit modes"`, and
 a visible duplicate would announce the group twice.
 
-- [ ] **Step 4: Pass the label from the cockpit**
+- [x] **Step 4: Pass the label from the cockpit**
 
 In `apps/cockpit/src/components/control-plane/cockpit-control-plane.tsx`, on the
 `<ControlPlaneRail>` element add:
@@ -359,7 +359,7 @@ In `apps/cockpit/src/components/control-plane/cockpit-control-plane.tsx`, on the
         primaryLabel="View"
 ```
 
-- [ ] **Step 5: Update the CSS**
+- [x] **Step 5: Update the CSS**
 
 In `apps/cockpit/src/app/cockpit.css`, change the resting colour of the rail item:
 
@@ -403,13 +403,13 @@ Then replace the utilities rule and add the cap:
 }
 ```
 
-- [ ] **Step 6: Run tests to verify they pass**
+- [x] **Step 6: Run tests to verify they pass**
 
 Run: `npx nx test cockpit -- -t "separates the mode group"`
 Run: `npx nx test cockpit -- -t "names the mode group"`
 Expected: PASS
 
-- [ ] **Step 7: Run both suites**
+- [x] **Step 7: Run both suites**
 
 Run: `npx nx test ui-react`
 Run: `npx nx test cockpit`
@@ -417,7 +417,7 @@ Expected: green. `control-plane.spec.tsx` may need a case for `primaryLabel` bei
 omitted — if a snapshot or structural assertion breaks, update it to reflect the new
 optional wrapper.
 
-- [ ] **Step 8: Commit**
+- [x] **Step 8: Commit**
 
 ```bash
 git add libs/ui-react/src/lib/control-plane/control-plane.tsx apps/cockpit/src/components/control-plane/cockpit-control-plane.tsx apps/cockpit/src/app/cockpit.css apps/cockpit/src/components/control-plane/cockpit-control-plane.spec.tsx
@@ -435,7 +435,7 @@ Generic primitive change. No cockpit behaviour yet.
 - Modify: `libs/ui-react/src/index.ts`
 - Test: `libs/ui-react/src/lib/control-plane/control-plane.spec.tsx`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Add to `control-plane.spec.tsx`:
 
@@ -464,12 +464,12 @@ it('renders no status dot when status is omitted', () => {
 });
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `npx nx test ui-react -- -t "renders a status dot"`
 Expected: FAIL — `status` is not a valid prop and no element matches.
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 In `control-plane.tsx`, replace `ControlPlaneRailItemProps` and the body of
 `ControlPlaneRailItem`:
@@ -559,18 +559,18 @@ export function ControlPlaneRailItem({
 A labelled item with a status now gets a hover tooltip too, so the state has a
 non-colour, non-screen-reader home.
 
-- [ ] **Step 4: Export the new type**
+- [x] **Step 4: Export the new type**
 
 In `libs/ui-react/src/index.ts`, add `ControlPlaneRailStatus` alongside the existing
 `ControlPlaneRailItem` / `ControlPlaneMode` exports, matching the file's existing export
 style.
 
-- [ ] **Step 5: Run tests to verify they pass**
+- [x] **Step 5: Run tests to verify they pass**
 
 Run: `npx nx test ui-react`
 Expected: PASS, whole suite green.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add libs/ui-react/src/lib/control-plane/control-plane.tsx libs/ui-react/src/lib/control-plane/control-plane.spec.tsx libs/ui-react/src/index.ts
@@ -588,7 +588,7 @@ git commit -m "feat(ui-react): add a status dot slot to control plane rail items
 - Test: `apps/cockpit/src/lib/runtime/runtime-state.spec.ts`
 - Test: `apps/cockpit/src/components/control-plane/cockpit-control-plane.spec.tsx`
 
-- [ ] **Step 1: Write the failing test for the mapping**
+- [x] **Step 1: Write the failing test for the mapping**
 
 Add to `apps/cockpit/src/lib/runtime/runtime-state.spec.ts`:
 
@@ -633,12 +633,12 @@ describe('runtimeRailStatus', () => {
 
 Add `runtimeRailStatus` to the file's existing import from `./runtime-state`.
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `npx nx test cockpit -- -t "runtimeRailStatus"`
 Expected: FAIL — `runtimeRailStatus is not a function`.
 
-- [ ] **Step 3: Implement the mapping**
+- [x] **Step 3: Implement the mapping**
 
 Append to `apps/cockpit/src/lib/runtime/runtime-state.ts`:
 
@@ -672,12 +672,12 @@ without an accessible label is unrepresentable.
 The exhaustive `switch` over `RuntimePhase` with no `default` means a future phase is a
 compile error rather than a silently missing dot.
 
-- [ ] **Step 4: Run test to verify it passes**
+- [x] **Step 4: Run test to verify it passes**
 
 Run: `npx nx test cockpit -- -t "runtimeRailStatus"`
 Expected: PASS
 
-- [ ] **Step 5: Write the failing wiring test**
+- [x] **Step 5: Write the failing wiring test**
 
 Add to `cockpit-control-plane.spec.tsx`:
 
@@ -701,12 +701,12 @@ it('shows no dot on Run when no runtime is configured', () => {
 });
 ```
 
-- [ ] **Step 6: Run test to verify it fails**
+- [x] **Step 6: Run test to verify it fails**
 
 Run: `npx nx test cockpit -- -t "puts the runtime phase"`
 Expected: FAIL — no button named `Run, runtime error`.
 
-- [ ] **Step 7: Wire it**
+- [x] **Step 7: Wire it**
 
 In `cockpit-control-plane.tsx`, add `runtimeRailStatus` to the existing import from
 `../../lib/runtime/runtime-state`, then compute it next to `attention`:
@@ -730,7 +730,7 @@ and change the `primary` mapping so only Run carries it:
         ))}
 ```
 
-- [ ] **Step 8: Add the dot styling**
+- [x] **Step 8: Add the dot styling**
 
 In `apps/cockpit/src/app/cockpit.css`, add the working token to both blocks:
 
@@ -782,7 +782,7 @@ Also verify by eye in Task 6: a status on a non-`iconOnly` item now shows a hove
 at `left: calc(100% + 8px)` (`cockpit.css:696-700`), positioning authored for the narrow
 icon rail. On the Run item that lands over the adjacent pane. No test covers it.
 
-- [ ] **Step 9: Run tests to verify they pass**
+- [x] **Step 9: Run tests to verify they pass**
 
 Run: `npx nx test cockpit`
 Expected: PASS. Existing tests that query `screen.getByRole('button', { name: 'Run' })`
@@ -790,14 +790,14 @@ will now fail wherever the fixture snapshot has a phase other than `not_configur
 because Run's accessible name has changed. Update those queries to the new name — this is
 the intended contract change, not a regression.
 
-- [ ] **Step 10: Mutation-check the no-dot case**
+- [x] **Step 10: Mutation-check the no-dot case**
 
 Temporarily change `runtimeRailStatus('not_configured')` to return
 `{ kind: 'success', label: 'runtime ready' }` and confirm "shows no dot on Run when no
 runtime is configured" fails. Revert. The assertion is an absence and would otherwise pass
 vacuously.
 
-- [ ] **Step 11: Commit**
+- [x] **Step 11: Commit**
 
 ```bash
 git add apps/cockpit/src/lib/runtime/runtime-state.ts apps/cockpit/src/lib/runtime/runtime-state.spec.ts apps/cockpit/src/components/control-plane/cockpit-control-plane.tsx apps/cockpit/src/components/control-plane/cockpit-control-plane.spec.tsx apps/cockpit/src/app/cockpit.css
@@ -819,7 +819,7 @@ read".
 - Test: `apps/cockpit/src/lib/runtime/session-activity.spec.ts`
 - Test: `apps/cockpit/src/components/control-plane/cockpit-control-plane.spec.tsx`
 
-- [ ] **Step 1: Write the failing selector test**
+- [x] **Step 1: Write the failing selector test**
 
 Add to `apps/cockpit/src/lib/runtime/session-activity.spec.ts`:
 
@@ -868,12 +868,12 @@ describe('countUnseenProblems', () => {
 Import `countUnseenProblems`, `ActivityKind`, `ActivitySeverity` and
 `SessionActivityEvent` from `./session-activity`.
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `npx nx test cockpit -- -t "countUnseenProblems"`
 Expected: FAIL — `countUnseenProblems is not a function`.
 
-- [ ] **Step 3: Implement the selector**
+- [x] **Step 3: Implement the selector**
 
 Append to `apps/cockpit/src/lib/runtime/session-activity.ts`:
 
@@ -900,12 +900,12 @@ export function countUnseenProblems(
 events are the tail, and the unseen window runs from index 0. `slice(seenCount)` is
 inverted and still passes all three tests above — add a test that pins the direction.
 
-- [ ] **Step 4: Run test to verify it passes**
+- [x] **Step 4: Run test to verify it passes**
 
 Run: `npx nx test cockpit -- -t "countUnseenProblems"`
 Expected: PASS
 
-- [ ] **Step 5: Track the seen marker in the shell**
+- [x] **Step 5: Track the seen marker in the shell**
 
 In `cockpit-shell.tsx`, add state beside `activityOpenCycle`:
 
@@ -947,7 +947,7 @@ from `../lib/runtime/session-activity`, then inside `controlPlaneProps`:
 
 and add `seenActivityCount` to that `useMemo` dependency array.
 
-- [ ] **Step 6: Write the failing behaviour test**
+- [x] **Step 6: Write the failing behaviour test**
 
 In `cockpit-control-plane.spec.tsx`, **replace** the existing test named
 `'renders Activity above Settings with a nonnumeric attention indicator that opening does not clear'`
@@ -978,12 +978,12 @@ it('does not flag Activity when nothing has gone wrong', () => {
 `renderControlPlane` builds props from a defaults object in this spec — add
 `unseenProblems: 0` to those defaults so every other test keeps compiling.
 
-- [ ] **Step 7: Run test to verify it fails**
+- [x] **Step 7: Run test to verify it fails**
 
 Run: `npx nx test cockpit -- -t "flags unseen problems"`
 Expected: FAIL — `unseenProblems` is not a prop and the label is still phase-derived.
 
-- [ ] **Step 8: Wire the control plane**
+- [x] **Step 8: Wire the control plane**
 
 In `cockpit-control-plane.tsx`:
 
@@ -1012,7 +1012,7 @@ test table rather than leaving a tested, uncalled predicate behind.
 Everything downstream (`attention` passed to `ActivityPanel`, the
 `[data-cockpit-activity-attention]` marker) keeps working unchanged.
 
-- [ ] **Step 9: Update the panel's wording**
+- [x] **Step 9: Update the panel's wording**
 
 In `activity-panel.tsx`, the `attention` prop now means unseen problems. Update the JSDoc-free
 prop by renaming the derived label so the list's accessible name matches the new claim:
@@ -1024,20 +1024,20 @@ prop by renaming the derived label so the list's accessible name matches the new
 Update the matching assertions in `activity-panel.spec.tsx` (around lines 168–184) from
 `'Activity, attention required'` to `'Activity, unread problems'`.
 
-- [ ] **Step 10: Run tests to verify they pass**
+- [x] **Step 10: Run tests to verify they pass**
 
 Run: `npx nx test cockpit`
 Expected: PASS. Any remaining `'Activity, attention required'` string assertions must be
 updated to the new labels.
 
-- [ ] **Step 11: Mutation-check the quiet case**
+- [x] **Step 11: Mutation-check the quiet case**
 
 Temporarily change `countUnseenProblems` to `events.slice(seenCount).length` (dropping the
 severity filter) and confirm "does not flag Activity when nothing has gone wrong" fails
 once a `mode_changed` event exists in the fixture. Revert. Without this check the test
 passes whether or not the filter is wired.
 
-- [ ] **Step 12: Commit**
+- [x] **Step 12: Commit**
 
 ```bash
 git add apps/cockpit/src/lib/runtime/session-activity.ts apps/cockpit/src/lib/runtime/session-activity.spec.ts apps/cockpit/src/components/cockpit-shell.tsx apps/cockpit/src/components/control-plane/cockpit-control-plane.tsx apps/cockpit/src/components/control-plane/cockpit-control-plane.spec.tsx apps/cockpit/src/components/control-plane/activity-panel.tsx apps/cockpit/src/components/control-plane/activity-panel.spec.tsx
@@ -1050,13 +1050,13 @@ git commit -m "feat(cockpit): re-scope the Activity indicator to unseen problems
 
 **Files:** none — verification only.
 
-- [ ] **Step 1: Full suites**
+- [x] **Step 1: Full suites**
 
 Run: `npx nx test ui-react`
 Run: `npx nx test cockpit`
 Expected: both green.
 
-- [ ] **Step 2: Lint**
+- [x] **Step 2: Lint**
 
 `apps/cockpit` has **no** `lint` target — only `ui-react` does. Run:
 
@@ -1073,7 +1073,7 @@ Note on reading test results: `npx nx test <project>` swallows the vitest report
 in this worktree, so it tells you pass/fail but not counts. When you need real numbers, run
 `npx vitest run --root apps/cockpit` (or `--root libs/ui-react`) directly.
 
-- [ ] **Step 3: Confirm in a real browser**
+- [x] **Step 3: Confirm in a real browser**
 
 Start the cockpit dev server via the Browser pane's `preview_start` (never `Bash`), open a
 capability page, and check:
@@ -1084,7 +1084,7 @@ capability page, and check:
 
 Check both themes — the dot tokens are defined per theme.
 
-- [ ] **Step 4: Commit anything the browser pass turned up**
+- [x] **Step 4: Commit anything the browser pass turned up**
 
 ```bash
 git add -A
@@ -1092,3 +1092,40 @@ git commit -m "fix(cockpit): browser-pass corrections for the rail redesign"
 ```
 
 Skip if there is nothing to commit.
+
+---
+
+## Task 6 result (2026-09-01)
+
+Verified against a fresh `nx serve cockpit` build at 1440×900, in both themes.
+
+| Check | Result |
+| --- | --- |
+| Stale `activeMode: "Code"` in localStorage | lands on **Run** (`aria-pressed="true"`), preference untouched in storage |
+| `?mode=code` deep link | lands on Code, `location.search` stripped to `""` |
+| Code → click another capability (client-side `router.push`) | lands on **Run** — the `key={canonicalPath}` fix, confirmed live |
+| Rail inactive contrast | dark `rgb(200,200,200)`, light `rgb(70,70,70)` — `--ds-text-secondary`, not the disabled token |
+| Utilities separator | dark `rgb(60,60,60)` on `rgb(44,44,44)`; light `rgb(200,200,200)` on `rgb(251,251,251)` — visible in both |
+| `VIEW` cap | present, `role="group"` + `aria-labelledby` resolving to "View" |
+| Run status dot | `position: absolute`, 7×7, dark `rgb(76,195,138)` / light `rgb(26,122,64)`, 2px ring matching the rail |
+| Run tooltip | **absent** — no `[data-control-plane-tooltip]`, no `aria-describedby`; status in a visually-hidden span |
+| Activity tooltip | still present (icon-only), no dot with a healthy runtime |
+| Console | no errors, no hydration warnings, across reload and cross-product navigation |
+
+**Not verified by eye:** the Activity dot lighting on a real runtime failure, and the
+`working`/`error` dot colours in situ — all three are covered by unit and integration
+tests, but reproducing them live needs a deliberately broken runtime.
+
+**Two false alarms worth recording**, both caused by testing procedure rather than code:
+
+1. A hydration `useId` mismatch appeared after I edited `page.tsx` under a live dev server.
+   It did not reproduce on a fresh tab against a clean build — it was an HMR artifact.
+2. The status dot briefly computed as `position: static` with a transparent background and
+   the served stylesheet contained neither the dot nor the cap rules. This followed a
+   revert/restore of source files under a running Turbopack server, which left a stale
+   stylesheet. Clearing `.next` and restarting resolved it.
+
+Lesson for future browser passes: **restart the dev server and use a fresh tab after any
+git-level file swap.** The console buffer also persists across navigations, so a stale
+error can be misattributed to the current build — check the DOM to confirm which build you
+are actually looking at.

--- a/docs/superpowers/plans/2026-08-31-cockpit-run-discoverability.md
+++ b/docs/superpowers/plans/2026-08-31-cockpit-run-discoverability.md
@@ -1,0 +1,1073 @@
+# Cockpit Run Discoverability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the cockpit's mode rail read as a switch — Run always the landing view, the four modes visually grouped and legible, and Run carrying a live runtime phase dot — while re-scoping the Activity dot so the two dots make distinct claims.
+
+**Architecture:** Four independent slices over the existing control plane. `activeMode` stops being a persisted preference and becomes local shell state. Rail legibility is pure CSS over DOM hooks that already exist. `ControlPlaneRailItem` in `@threadplane/ui-react` gains a generic status-dot slot, which the cockpit wires to `runtimeSnapshot.phase` for Run and to an unseen-error count for Activity.
+
+**Tech Stack:** Next.js (App Router) + React 19, TypeScript, Nx, Vitest + Testing Library (jsdom), plain CSS with `--ds-*` design tokens.
+
+**Spec:** `docs/superpowers/specs/2026-08-31-cockpit-run-discoverability-design.md`
+
+**Test commands:**
+
+```bash
+npx nx test ui-react
+```
+
+```bash
+npx nx test cockpit
+```
+
+Both must be green before the final task is considered done. If this worktree has never installed dependencies, run `npm ci` once first (never `npm install`, never hand-copy packages).
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+| --- | --- | --- |
+| `libs/ui-react/src/lib/control-plane/control-plane-preferences.ts` | Persisted control-plane preferences | Drop `activeMode` from the stored shape and the hook |
+| `libs/ui-react/src/lib/control-plane/control-plane.tsx` | Presentational control-plane primitives | `ControlPlaneRailItem` gains `status` + `statusLabel` |
+| `apps/cockpit/src/components/cockpit-shell.tsx` | Cockpit page shell, owns mode + activity state | Mode as local state; track the activity seen-marker |
+| `apps/cockpit/src/components/control-plane/cockpit-control-plane.tsx` | Cockpit's rail + pane composition | Map phase → Run dot; map unseen errors → Activity dot |
+| `apps/cockpit/src/components/control-plane/activity-panel.tsx` | Activity log panel | `attention` reinterpreted as unseen errors |
+| `apps/cockpit/src/lib/runtime/runtime-state.ts` | Runtime phase model | Add `runtimeRailStatus(phase)` |
+| `apps/cockpit/src/app/cockpit.css` | Cockpit control-plane styling | Contrast, group rule, `VIEW` cap, dot variants, working token |
+
+---
+
+## Task 1: Mode stops being sticky
+
+Every capability opens in Run. `activeMode` leaves persisted preferences entirely.
+
+**Files:**
+- Modify: `libs/ui-react/src/lib/control-plane/control-plane-preferences.ts`
+- Modify: `apps/cockpit/src/components/cockpit-shell.tsx`
+- Test: `libs/ui-react/src/lib/control-plane/control-plane-preferences.spec.ts`
+- Test: `apps/cockpit/src/components/cockpit-shell.spec.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `libs/ui-react/src/lib/control-plane/control-plane-preferences.spec.ts`:
+
+```ts
+it('ignores a stored activeMode and never writes one back', () => {
+  window.localStorage.setItem(
+    CONTROL_PLANE_STORAGE_KEY,
+    JSON.stringify({
+      version: 1,
+      docs: { expanded: {} },
+      cockpit: { activeMode: 'Code', expanded: { Capability: false } },
+    }),
+  );
+
+  const parsed = readControlPlanePreferences(window.localStorage);
+
+  expect('activeMode' in parsed.cockpit).toBe(false);
+  expect(parsed.cockpit.expanded.Capability).toBe(false);
+});
+```
+
+This spec drives `window.localStorage` directly and clears it in `beforeEach` — there is
+no fake-storage helper to reuse. `CONTROL_PLANE_STORAGE_KEY` and
+`readControlPlanePreferences` are already imported at the top of the file.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx nx test ui-react -- -t "ignores a stored activeMode"`
+Expected: FAIL — `expect(true).toBe(false)`, because `readControlPlanePreferences` still
+copies `activeMode` through.
+
+- [ ] **Step 3: Remove `activeMode` from the persisted shape**
+
+In `control-plane-preferences.ts`:
+
+Change the interface:
+
+```ts
+export interface ControlPlanePreferencesV1 {
+  version: 1;
+  docs: {
+    expanded: Record<string, boolean>;
+  };
+  cockpit: {
+    expanded: Record<string, boolean>;
+  };
+}
+```
+
+Change the defaults:
+
+```ts
+const DEFAULT_PREFERENCES: ControlPlanePreferencesV1 = {
+  version: 1,
+  docs: { expanded: { Learn: true, Environment: false } },
+  cockpit: {
+    expanded: { Capability: true, Environment: true },
+  },
+};
+```
+
+Change `cloneDefaults`:
+
+```ts
+const cloneDefaults = (): ControlPlanePreferencesV1 => ({
+  version: 1,
+  docs: { expanded: { ...DEFAULT_PREFERENCES.docs.expanded } },
+  cockpit: { expanded: { ...DEFAULT_PREFERENCES.cockpit.expanded } },
+});
+```
+
+In `readControlPlanePreferences`, drop the `activeMode` branch from the returned object:
+
+```ts
+      cockpit: {
+        expanded: booleanRecord(cockpit.expanded, defaults.cockpit.expanded),
+      },
+```
+
+Delete the now-unused `isMode` helper. **Keep** `MODES`, `ControlPlaneMode` and
+`parseControlPlaneMode` — the shell still uses them for `?mode=` deep links.
+
+Delete the `setActiveMode` callback entirely, and change the hook's return to:
+
+```ts
+  return {
+    hydrated,
+    expanded: preferences[surface].expanded,
+    setExpanded,
+  };
+```
+
+Note `surface` is still read by `setExpanded`, so it stays a parameter.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx nx test ui-react -- -t "ignores a stored activeMode"`
+Expected: PASS
+
+- [ ] **Step 5: Fix the rest of the preferences suite**
+
+Run: `npx nx test ui-react`
+Expected: several existing assertions fail — they set and read `activeMode`
+(around lines 23, 36, 46, 80, 82, 104, 112, 122, 135, 143, 164 of the spec).
+
+Delete the assertions and fixture fields that concern `activeMode` and
+`setActiveMode`. Keep every `expanded` assertion untouched. The test named for
+docs-surface mode pinning (which asserted `activeMode` is `'Docs'` on the docs surface)
+no longer has a subject — delete it.
+
+Re-run until green.
+
+- [ ] **Step 6: Move mode into the shell**
+
+In `apps/cockpit/src/components/cockpit-shell.tsx`:
+
+Add to the existing `useState` block near `isSidebarOpen`:
+
+```tsx
+  const [activeMode, setActiveMode] = useState<ControlPlaneMode>('Run');
+```
+
+Delete this line further down:
+
+```tsx
+  const activeMode: ControlPlaneMode = preferences.activeMode;
+```
+
+Replace the query-param effect with one that no longer waits on hydration:
+
+```tsx
+  useEffect(() => {
+    if (queryHandled.current) return;
+    queryHandled.current = true;
+    const url = new URL(window.location.href);
+    const rawMode = url.searchParams.get('mode');
+    const requestedMode = parseControlPlaneMode(rawMode);
+    if (requestedMode) setActiveMode(requestedMode);
+    if (rawMode !== null) {
+      url.searchParams.delete('mode');
+      window.history.replaceState(
+        window.history.state,
+        '',
+        url.pathname + url.search + url.hash
+      );
+    }
+  }, []);
+```
+
+The effect runs only on the client after mount, so the server-rendered Run markup and the
+first client render agree — `?mode=code` swaps in on the second render, not during
+hydration.
+
+In `handleModeChange`, swap the setter and drop `preferences` from the dependency array:
+
+```tsx
+  const handleModeChange = useCallback(
+    (mode: ControlPlaneMode) => {
+      if (mode === activeMode) return;
+      setActiveMode(mode);
+      appendActivity(
+        createLocalActivityInput(entry.topic, {
+          kind: 'mode_changed',
+          mode,
+        })
+      );
+      track('cockpit:mode_switched', {
+        capability: entry.topic,
+        from_mode: MODE_ANALYTICS[activeMode],
+        to_mode: MODE_ANALYTICS[mode],
+      });
+    },
+    [activeMode, appendActivity, entry.topic]
+  );
+```
+
+`preferences` is still used for `expanded`, `setExpanded` and `hydrated` — leave the
+`useControlPlanePreferences('cockpit')` call in place.
+
+- [ ] **Step 7: Run the cockpit suite**
+
+Run: `npx nx test cockpit`
+Expected: failures in `cockpit-shell.spec.tsx` around lines 96, 107 and 195, which seed
+and assert `cockpit.activeMode` in `localStorage`.
+
+Rewrite those so that:
+- the seeding helper no longer takes or writes an `activeMode`;
+- a test asserts that a stored `activeMode: 'Code'` does **not** change the landing view —
+  the shell still renders Run;
+- a test asserts `?mode=code` still lands in Code and strips the param from the URL.
+
+Re-run until green.
+
+- [ ] **Step 8: Mutation-check the stickiness test**
+
+Temporarily re-add `activeMode` passthrough in `readControlPlanePreferences` and confirm
+the "stored `activeMode` does not change the landing view" test fails. Revert the
+mutation. This assertion is about an absence and would pass vacuously if mis-wired.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add libs/ui-react/src/lib/control-plane/control-plane-preferences.ts libs/ui-react/src/lib/control-plane/control-plane-preferences.spec.ts apps/cockpit/src/components/cockpit-shell.tsx apps/cockpit/src/components/cockpit-shell.spec.tsx
+git commit -m "fix(cockpit): stop persisting the active mode so every capability opens in Run"
+```
+
+---
+
+## Task 2: Rail legibility
+
+**Files:**
+- Modify: `apps/cockpit/src/app/cockpit.css`
+- Modify: `libs/ui-react/src/lib/control-plane/control-plane.tsx`
+- Test: `apps/cockpit/src/components/control-plane/cockpit-control-plane.spec.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `cockpit-control-plane.spec.tsx`, copying the disk-read preamble that
+`activity-panel.spec.tsx:11-17` already uses (the cwd check matters — Nx runs this suite
+from `apps/cockpit`, not the workspace root):
+
+```tsx
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const workspaceRoot = process.cwd().endsWith('/apps/cockpit')
+  ? resolve(process.cwd(), '../..')
+  : process.cwd();
+const cockpitCss = readFileSync(
+  resolve(workspaceRoot, 'apps/cockpit/src/app/cockpit.css'),
+  'utf8'
+);
+```
+
+```tsx
+it('separates the mode group from the utilities and lifts resting contrast', () => {
+  expect(cockpitCss).toMatch(
+    /\[data-control-plane-rail-group="utilities"\][^}]*border-top/
+  );
+  expect(cockpitCss).not.toMatch(
+    /\[data-control-plane-rail-item\]\s*\{[^}]*--ds-text-muted/
+  );
+});
+
+it('names the mode group without adding a second landmark label', () => {
+  renderControlPlane();
+  const rail = screen.getByRole('navigation', { name: 'Cockpit modes' });
+  const cap = rail.querySelector('[data-control-plane-rail-group-label]');
+  expect(cap?.textContent).toBe('View');
+  expect(cap?.getAttribute('aria-hidden')).toBe('true');
+});
+```
+
+`renderControlPlane` is the existing render helper in this spec file.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx nx test cockpit -- -t "separates the mode group"`
+Expected: FAIL — no `border-top` on the utilities group, and the item rule still sets
+`--ds-text-muted`.
+
+- [ ] **Step 3: Add the group label to the primitive**
+
+In `libs/ui-react/src/lib/control-plane/control-plane.tsx`, extend the rail:
+
+```tsx
+export interface ControlPlaneRailProps extends CommonProps {
+  label: string;
+  primaryLabel?: string;
+  primary: ReactNode;
+  utilities?: ReactNode;
+}
+
+export function ControlPlaneRail({
+  label,
+  primaryLabel,
+  primary,
+  utilities,
+  className,
+}: ControlPlaneRailProps) {
+  return (
+    <nav aria-label={label} className={className} data-control-plane-rail>
+      <div data-control-plane-rail-group="primary">
+        {primaryLabel ? (
+          <span data-control-plane-rail-group-label aria-hidden="true">
+            {primaryLabel}
+          </span>
+        ) : null}
+        {primary}
+      </div>
+      {utilities ? (
+        <div data-control-plane-rail-group="utilities">{utilities}</div>
+      ) : null}
+    </nav>
+  );
+}
+```
+
+It is `aria-hidden` on purpose: the `nav` already carries `aria-label="Cockpit modes"`, and
+a visible duplicate would announce the group twice.
+
+- [ ] **Step 4: Pass the label from the cockpit**
+
+In `apps/cockpit/src/components/control-plane/cockpit-control-plane.tsx`, on the
+`<ControlPlaneRail>` element add:
+
+```tsx
+        primaryLabel="View"
+```
+
+- [ ] **Step 5: Update the CSS**
+
+In `apps/cockpit/src/app/cockpit.css`, change the resting colour of the rail item:
+
+```css
+.cockpit-control-plane [data-control-plane-rail-item] {
+  position: relative;
+  min-height: 48px;
+  padding: 6px 2px;
+  border: 0;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  color: var(--ds-text-secondary);
+  background: transparent;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease;
+}
+```
+
+Then replace the utilities rule and add the cap:
+
+```css
+.cockpit-control-plane [data-control-plane-rail-group="utilities"] {
+  margin-top: auto;
+  padding-top: 8px;
+  border-top: 1px solid var(--ds-border);
+}
+.cockpit-control-plane [data-control-plane-rail-group-label] {
+  display: block;
+  padding-bottom: 4px;
+  color: var(--ds-text-muted);
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  text-align: center;
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `npx nx test cockpit -- -t "separates the mode group"`
+Run: `npx nx test cockpit -- -t "names the mode group"`
+Expected: PASS
+
+- [ ] **Step 7: Run both suites**
+
+Run: `npx nx test ui-react`
+Run: `npx nx test cockpit`
+Expected: green. `control-plane.spec.tsx` may need a case for `primaryLabel` being
+omitted — if a snapshot or structural assertion breaks, update it to reflect the new
+optional wrapper.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add libs/ui-react/src/lib/control-plane/control-plane.tsx apps/cockpit/src/components/control-plane/cockpit-control-plane.tsx apps/cockpit/src/app/cockpit.css apps/cockpit/src/components/control-plane/cockpit-control-plane.spec.tsx
+git commit -m "feat(cockpit): make the mode rail read as a switch"
+```
+
+---
+
+## Task 3: A status-dot slot on rail items
+
+Generic primitive change. No cockpit behaviour yet.
+
+**Files:**
+- Modify: `libs/ui-react/src/lib/control-plane/control-plane.tsx`
+- Modify: `libs/ui-react/src/index.ts`
+- Test: `libs/ui-react/src/lib/control-plane/control-plane.spec.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `control-plane.spec.tsx`:
+
+```tsx
+it('renders a status dot and folds its label into the accessible name', () => {
+  render(
+    <ControlPlaneRailItem
+      label="Run"
+      icon={<svg />}
+      status="error"
+      statusLabel="runtime error"
+    />,
+  );
+  const button = screen.getByRole('button', { name: 'Run, runtime error' });
+  expect(
+    button.querySelector('[data-control-plane-rail-status]')?.getAttribute(
+      'data-control-plane-rail-status',
+    ),
+  ).toBe('error');
+});
+
+it('renders no status dot when status is omitted', () => {
+  render(<ControlPlaneRailItem label="Run" icon={<svg />} />);
+  const button = screen.getByRole('button', { name: 'Run' });
+  expect(button.querySelector('[data-control-plane-rail-status]')).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx nx test ui-react -- -t "renders a status dot"`
+Expected: FAIL — `status` is not a valid prop and no element matches.
+
+- [ ] **Step 3: Implement**
+
+In `control-plane.tsx`, replace `ControlPlaneRailItemProps` and the body of
+`ControlPlaneRailItem`:
+
+```tsx
+export type ControlPlaneRailStatus = 'success' | 'working' | 'error';
+
+export interface ControlPlaneRailItemProps extends CommonProps {
+  label: string;
+  icon: ReactNode;
+  active?: boolean;
+  href?: string;
+  onSelect?: () => void;
+  iconOnly?: boolean;
+  target?: string;
+  rel?: string;
+  status?: ControlPlaneRailStatus;
+  statusLabel?: string;
+}
+
+export function ControlPlaneRailItem({
+  label,
+  icon,
+  active = false,
+  href,
+  onSelect,
+  iconOnly = false,
+  className,
+  target,
+  rel,
+  status,
+  statusLabel,
+}: ControlPlaneRailItemProps) {
+  const tooltipId = useId();
+  const accessibleName = statusLabel ? `${label}, ${statusLabel}` : label;
+  const showTooltip = iconOnly || Boolean(statusLabel);
+  const content = (
+    <>
+      <span data-control-plane-rail-icon>{icon}</span>
+      {iconOnly ? null : <span data-control-plane-rail-label>{label}</span>}
+      {status ? (
+        <span data-control-plane-rail-status={status} aria-hidden="true" />
+      ) : null}
+      {showTooltip ? (
+        <span id={tooltipId} role="tooltip" data-control-plane-tooltip>
+          {accessibleName}
+        </span>
+      ) : null}
+    </>
+  );
+  const shared = {
+    className,
+    'data-control-plane-rail-item': true,
+    'data-control-plane-active': active || undefined,
+    'aria-label': showTooltip ? accessibleName : undefined,
+    'aria-describedby': showTooltip ? tooltipId : undefined,
+  } as const;
+
+  if (href) {
+    return (
+      <a
+        {...shared}
+        href={href}
+        target={target}
+        rel={rel}
+        aria-current={active ? 'page' : undefined}
+        onClick={onSelect}
+      >
+        {content}
+      </a>
+    );
+  }
+
+  return (
+    <button
+      {...shared}
+      type="button"
+      aria-pressed={active}
+      onClick={onSelect}
+    >
+      {content}
+    </button>
+  );
+}
+```
+
+A labelled item with a status now gets a hover tooltip too, so the state has a
+non-colour, non-screen-reader home.
+
+- [ ] **Step 4: Export the new type**
+
+In `libs/ui-react/src/index.ts`, add `ControlPlaneRailStatus` alongside the existing
+`ControlPlaneRailItem` / `ControlPlaneMode` exports, matching the file's existing export
+style.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npx nx test ui-react`
+Expected: PASS, whole suite green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add libs/ui-react/src/lib/control-plane/control-plane.tsx libs/ui-react/src/lib/control-plane/control-plane.spec.tsx libs/ui-react/src/index.ts
+git commit -m "feat(ui-react): add a status dot slot to control plane rail items"
+```
+
+---
+
+## Task 4: The runtime phase dot on Run
+
+**Files:**
+- Modify: `apps/cockpit/src/lib/runtime/runtime-state.ts`
+- Modify: `apps/cockpit/src/components/control-plane/cockpit-control-plane.tsx`
+- Modify: `apps/cockpit/src/app/cockpit.css`
+- Test: `apps/cockpit/src/lib/runtime/runtime-state.spec.ts`
+- Test: `apps/cockpit/src/components/control-plane/cockpit-control-plane.spec.tsx`
+
+- [ ] **Step 1: Write the failing test for the mapping**
+
+Add to `apps/cockpit/src/lib/runtime/runtime-state.spec.ts`:
+
+```ts
+describe('runtimeRailStatus', () => {
+  it('maps every phase to a rail status', () => {
+    expect(runtimeRailStatus('ready')).toEqual({
+      status: 'success',
+      label: 'runtime ready',
+    });
+    expect(runtimeRailStatus('connecting')).toEqual({
+      status: 'working',
+      label: 'runtime starting',
+    });
+    expect(runtimeRailStatus('checking')).toEqual({
+      status: 'working',
+      label: 'runtime starting',
+    });
+    expect(runtimeRailStatus('reloading')).toEqual({
+      status: 'working',
+      label: 'runtime starting',
+    });
+    expect(runtimeRailStatus('unresponsive')).toEqual({
+      status: 'error',
+      label: 'runtime error',
+    });
+    expect(runtimeRailStatus('error')).toEqual({
+      status: 'error',
+      label: 'runtime error',
+    });
+    expect(runtimeRailStatus('invalid_configuration')).toEqual({
+      status: 'error',
+      label: 'runtime error',
+    });
+  });
+
+  it('reports no status when there is no runtime to report on', () => {
+    expect(runtimeRailStatus('not_configured')).toBeNull();
+  });
+});
+```
+
+Add `runtimeRailStatus` to the file's existing import from `./runtime-state`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx nx test cockpit -- -t "runtimeRailStatus"`
+Expected: FAIL — `runtimeRailStatus is not a function`.
+
+- [ ] **Step 3: Implement the mapping**
+
+Append to `apps/cockpit/src/lib/runtime/runtime-state.ts`:
+
+```ts
+export interface RuntimeRailStatus {
+  status: 'success' | 'working' | 'error';
+  label: string;
+}
+
+export function runtimeRailStatus(
+  phase: RuntimePhase
+): RuntimeRailStatus | null {
+  switch (phase) {
+    case 'ready':
+      return { status: 'success', label: 'runtime ready' };
+    case 'connecting':
+    case 'checking':
+    case 'reloading':
+      return { status: 'working', label: 'runtime starting' };
+    case 'unresponsive':
+    case 'error':
+    case 'invalid_configuration':
+      return { status: 'error', label: 'runtime error' };
+    case 'not_configured':
+      return null;
+  }
+}
+```
+
+The exhaustive `switch` over `RuntimePhase` with no `default` means a future phase is a
+compile error rather than a silently missing dot.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx nx test cockpit -- -t "runtimeRailStatus"`
+Expected: PASS
+
+- [ ] **Step 5: Write the failing wiring test**
+
+Add to `cockpit-control-plane.spec.tsx`:
+
+```tsx
+it('puts the runtime phase on the Run rail item', () => {
+  renderControlPlane({ runtimeSnapshot: runtimeSnapshot('unresponsive') });
+  const run = screen.getByRole('button', { name: 'Run, runtime error' });
+  expect(
+    run
+      .querySelector('[data-control-plane-rail-status]')
+      ?.getAttribute('data-control-plane-rail-status')
+  ).toBe('error');
+});
+
+it('shows no dot on Run when no runtime is configured', () => {
+  renderControlPlane({
+    runtimeSnapshot: runtimeSnapshot('not_configured'),
+  });
+  const run = screen.getByRole('button', { name: 'Run' });
+  expect(run.querySelector('[data-control-plane-rail-status]')).toBeNull();
+});
+```
+
+- [ ] **Step 6: Run test to verify it fails**
+
+Run: `npx nx test cockpit -- -t "puts the runtime phase"`
+Expected: FAIL — no button named `Run, runtime error`.
+
+- [ ] **Step 7: Wire it**
+
+In `cockpit-control-plane.tsx`, add `runtimeRailStatus` to the existing import from
+`../../lib/runtime/runtime-state`, then compute it next to `attention`:
+
+```tsx
+  const railStatus = runtimeRailStatus(runtimeSnapshot.phase);
+```
+
+and change the `primary` mapping so only Run carries it:
+
+```tsx
+        primary={MODES.map(({ label, icon: Icon }) => (
+          <ControlPlaneRailItem
+            key={label}
+            label={label}
+            icon={<Icon size={18} aria-hidden="true" />}
+            active={label === activeMode}
+            onSelect={() => selectMode(label)}
+            status={label === 'Run' ? railStatus?.status : undefined}
+            statusLabel={label === 'Run' ? railStatus?.label : undefined}
+          />
+        ))}
+```
+
+- [ ] **Step 8: Add the dot styling**
+
+In `apps/cockpit/src/app/cockpit.css`, add the working token to both blocks:
+
+```css
+.cockpit-control-plane {
+  --cockpit-state-error: #b42318;
+  --cockpit-state-success: #1a7a40;
+  --cockpit-state-working: #9a6700;
+```
+
+```css
+[data-theme="dark"] .cockpit-control-plane {
+  --cockpit-state-error: #ff6369;
+  --cockpit-state-success: #4cc38a;
+  --cockpit-state-working: #e0a02f;
+}
+```
+
+Then add the dot itself, after the rail-label rule:
+
+```css
+.cockpit-control-plane [data-control-plane-rail-status] {
+  position: absolute;
+  top: 7px;
+  right: 11px;
+  width: 7px;
+  height: 7px;
+  border: 2px solid var(--ds-surface-tinted);
+  border-radius: 999px;
+}
+.cockpit-control-plane [data-control-plane-rail-status="success"] {
+  background: var(--cockpit-state-success);
+}
+.cockpit-control-plane [data-control-plane-rail-status="working"] {
+  background: var(--cockpit-state-working);
+}
+.cockpit-control-plane [data-control-plane-rail-status="error"] {
+  background: var(--cockpit-state-error);
+}
+```
+
+Steady fills — no `animation`, deliberately.
+
+- [ ] **Step 9: Run tests to verify they pass**
+
+Run: `npx nx test cockpit`
+Expected: PASS. Existing tests that query `screen.getByRole('button', { name: 'Run' })`
+will now fail wherever the fixture snapshot has a phase other than `not_configured`,
+because Run's accessible name has changed. Update those queries to the new name — this is
+the intended contract change, not a regression.
+
+- [ ] **Step 10: Mutation-check the no-dot case**
+
+Temporarily change `runtimeRailStatus('not_configured')` to return
+`{ status: 'success', label: 'runtime ready' }` and confirm "shows no dot on Run when no
+runtime is configured" fails. Revert. The assertion is an absence and would otherwise pass
+vacuously.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add apps/cockpit/src/lib/runtime/runtime-state.ts apps/cockpit/src/lib/runtime/runtime-state.spec.ts apps/cockpit/src/components/control-plane/cockpit-control-plane.tsx apps/cockpit/src/components/control-plane/cockpit-control-plane.spec.tsx apps/cockpit/src/app/cockpit.css
+git commit -m "feat(cockpit): show runtime phase on the Run rail item"
+```
+
+---
+
+## Task 5: Re-scope the Activity dot to unseen problems
+
+Run owns "what the runtime is doing now". Activity owns "there are problems you haven't
+read".
+
+**Files:**
+- Modify: `apps/cockpit/src/lib/runtime/session-activity.ts`
+- Modify: `apps/cockpit/src/components/cockpit-shell.tsx`
+- Modify: `apps/cockpit/src/components/control-plane/cockpit-control-plane.tsx`
+- Modify: `apps/cockpit/src/components/control-plane/activity-panel.tsx`
+- Test: `apps/cockpit/src/lib/runtime/session-activity.spec.ts`
+- Test: `apps/cockpit/src/components/control-plane/cockpit-control-plane.spec.tsx`
+
+- [ ] **Step 1: Write the failing selector test**
+
+Add to `apps/cockpit/src/lib/runtime/session-activity.spec.ts`:
+
+```ts
+describe('countUnseenProblems', () => {
+  const event = (
+    id: string,
+    kind: ActivityKind,
+    severity: ActivitySeverity
+  ): SessionActivityEvent => ({
+    id,
+    at: '2026-08-31T17:00:00.000Z',
+    kind,
+    severity,
+    capability: 'streaming',
+    summary: kind,
+  });
+
+  it('counts only error events beyond the seen marker', () => {
+    const events = [
+      event('a', 'runtime_ready', 'success'),
+      event('b', 'mode_changed', 'neutral'),
+      event('c', 'runtime_unresponsive', 'error'),
+    ];
+    expect(countUnseenProblems(events, 0)).toBe(1);
+  });
+
+  it('ignores routine activity entirely', () => {
+    const events = [
+      event('a', 'runtime_ready', 'success'),
+      event('b', 'mode_changed', 'neutral'),
+    ];
+    expect(countUnseenProblems(events, 0)).toBe(0);
+  });
+
+  it('ignores errors the user has already seen', () => {
+    const events = [
+      event('a', 'runtime_unresponsive', 'error'),
+      event('b', 'mode_changed', 'neutral'),
+    ];
+    expect(countUnseenProblems(events, 2)).toBe(0);
+  });
+});
+```
+
+Import `countUnseenProblems`, `ActivityKind`, `ActivitySeverity` and
+`SessionActivityEvent` from `./session-activity`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx nx test cockpit -- -t "countUnseenProblems"`
+Expected: FAIL — `countUnseenProblems is not a function`.
+
+- [ ] **Step 3: Implement the selector**
+
+Append to `apps/cockpit/src/lib/runtime/session-activity.ts`:
+
+```ts
+/**
+ * Problems the user has not looked at yet.
+ *
+ * Errors only: `mode_changed` and `runtime_ready` fire during ordinary use, so
+ * counting every unread event would light the indicator from the user's own
+ * actions. `seenCount` is a prefix marker over the append-ordered log.
+ */
+export function countUnseenProblems(
+  events: readonly SessionActivityEvent[],
+  seenCount: number,
+): number {
+  return events
+    .slice(seenCount)
+    .filter((event) => event.severity === 'error').length;
+}
+```
+
+The reducer appends, so index order is arrival order and a prefix count is a valid marker.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx nx test cockpit -- -t "countUnseenProblems"`
+Expected: PASS
+
+- [ ] **Step 5: Track the seen marker in the shell**
+
+In `cockpit-shell.tsx`, add state beside `activityOpenCycle`:
+
+```tsx
+  const [seenActivityCount, setSeenActivityCount] = useState(0);
+```
+
+Mark everything seen when the Activity utility opens, inside the existing
+`handleActiveUtilityChange`:
+
+```tsx
+  const handleActiveUtilityChange = useCallback(
+    (utility: CockpitUtility) => {
+      if (utility === 'activity' && activeUtility !== 'activity') {
+        setActivityOpenCycle((cycle) => cycle + 1);
+        setSeenActivityCount(events.length);
+      }
+      setActiveUtility(utility);
+    },
+    [activeUtility, events.length]
+  );
+```
+
+Reset the marker when the log is cleared:
+
+```tsx
+  const handleClearActivity = useCallback(() => {
+    dispatchActivity({ type: 'clear' });
+    setSeenActivityCount(0);
+  }, []);
+```
+
+Compute the count and pass it through. Add `countUnseenProblems` to the existing import
+from `../lib/runtime/session-activity`, then inside `controlPlaneProps`:
+
+```tsx
+      unseenProblems: countUnseenProblems(events, seenActivityCount),
+```
+
+and add `seenActivityCount` to that `useMemo` dependency array.
+
+- [ ] **Step 6: Write the failing behaviour test**
+
+In `cockpit-control-plane.spec.tsx`, **replace** the existing test named
+`'renders Activity above Settings with a nonnumeric attention indicator that opening does not clear'`
+— its "opening does not clear" premise is exactly what this task inverts:
+
+```tsx
+it('flags unseen problems on Activity and clears them when the panel opens', () => {
+  renderControlPlane({ unseenProblems: 1 });
+  const rail = screen.getByRole('navigation', { name: 'Cockpit modes' });
+  const utilities = within(rail).getAllByRole('button').slice(4);
+  expect(
+    utilities.map((button) => button.getAttribute('aria-label'))
+  ).toEqual(['Activity, 1 unread problem', 'Settings']);
+  expect(
+    document.querySelector('[data-cockpit-activity-attention]')?.textContent
+  ).toBe('');
+});
+
+it('does not flag Activity when nothing has gone wrong', () => {
+  renderControlPlane({ unseenProblems: 0 });
+  expect(screen.getByRole('button', { name: 'Activity' })).toBeTruthy();
+  expect(
+    document.querySelector('[data-cockpit-activity-attention]')
+  ).toBeNull();
+});
+```
+
+`renderControlPlane` builds props from a defaults object in this spec — add
+`unseenProblems: 0` to those defaults so every other test keeps compiling.
+
+- [ ] **Step 7: Run test to verify it fails**
+
+Run: `npx nx test cockpit -- -t "flags unseen problems"`
+Expected: FAIL — `unseenProblems` is not a prop and the label is still phase-derived.
+
+- [ ] **Step 8: Wire the control plane**
+
+In `cockpit-control-plane.tsx`:
+
+Add to `CockpitControlPlaneProps`:
+
+```tsx
+  unseenProblems: number;
+```
+
+Destructure `unseenProblems` in the component signature.
+
+Replace the `attention` derivation:
+
+```tsx
+  const attention = unseenProblems > 0;
+  const activityLabel = attention
+    ? `Activity, ${unseenProblems} unread problem${unseenProblems === 1 ? '' : 's'}`
+    : 'Activity';
+```
+
+Remove `runtimeNeedsAttention` from the import list — `runtimeRailStatus` now covers the
+Run dot and nothing else in this file uses it. Leave the function exported from
+`runtime-state.ts`; `use-runtime-controller.ts` still uses it.
+
+Everything downstream (`attention` passed to `ActivityPanel`, the
+`[data-cockpit-activity-attention]` marker) keeps working unchanged.
+
+- [ ] **Step 9: Update the panel's wording**
+
+In `activity-panel.tsx`, the `attention` prop now means unseen problems. Update the JSDoc-free
+prop by renaming the derived label so the list's accessible name matches the new claim:
+
+```tsx
+  const label = attention ? 'Activity, unread problems' : 'Activity';
+```
+
+Update the matching assertions in `activity-panel.spec.tsx` (around lines 168–184) from
+`'Activity, attention required'` to `'Activity, unread problems'`.
+
+- [ ] **Step 10: Run tests to verify they pass**
+
+Run: `npx nx test cockpit`
+Expected: PASS. Any remaining `'Activity, attention required'` string assertions must be
+updated to the new labels.
+
+- [ ] **Step 11: Mutation-check the quiet case**
+
+Temporarily change `countUnseenProblems` to `events.slice(seenCount).length` (dropping the
+severity filter) and confirm "does not flag Activity when nothing has gone wrong" fails
+once a `mode_changed` event exists in the fixture. Revert. Without this check the test
+passes whether or not the filter is wired.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add apps/cockpit/src/lib/runtime/session-activity.ts apps/cockpit/src/lib/runtime/session-activity.spec.ts apps/cockpit/src/components/cockpit-shell.tsx apps/cockpit/src/components/control-plane/cockpit-control-plane.tsx apps/cockpit/src/components/control-plane/cockpit-control-plane.spec.tsx apps/cockpit/src/components/control-plane/activity-panel.tsx apps/cockpit/src/components/control-plane/activity-panel.spec.tsx
+git commit -m "feat(cockpit): re-scope the Activity indicator to unseen problems"
+```
+
+---
+
+## Task 6: Verify the whole thing
+
+**Files:** none — verification only.
+
+- [ ] **Step 1: Full suites**
+
+Run: `npx nx test ui-react`
+Run: `npx nx test cockpit`
+Expected: both green.
+
+- [ ] **Step 2: Lint**
+
+Run: `npx nx lint cockpit 2>&1 | sed $'s/\033\\[[0-9;]*m//g' | grep -cE ' error '`
+Expected: `0`.
+
+CI tolerates warnings but fails on errors. Strip ANSI before grepping — a bare
+`grep -cE ' error '` silently returns 0 against coloured output. Repeat for `ui-react`.
+
+- [ ] **Step 3: Confirm in a real browser**
+
+Start the cockpit dev server via the Browser pane's `preview_start` (never `Bash`), open a
+capability page, and check:
+- it lands on Run even though `localStorage` still holds an old `activeMode: "Code"`;
+- the rail shows the `VIEW` cap, a rule above Activity/Settings, and legible inactive items;
+- Run carries a green dot once the runtime is ready;
+- `?mode=code` still deep-links to Code and strips the param.
+
+Check both themes — the dot tokens are defined per theme.
+
+- [ ] **Step 4: Commit anything the browser pass turned up**
+
+```bash
+git add -A
+git commit -m "fix(cockpit): browser-pass corrections for the rail redesign"
+```
+
+Skip if there is nothing to commit.

--- a/docs/superpowers/plans/2026-08-31-cockpit-run-discoverability.md
+++ b/docs/superpowers/plans/2026-08-31-cockpit-run-discoverability.md
@@ -1005,8 +1005,9 @@ Replace the `attention` derivation:
 ```
 
 Remove `runtimeNeedsAttention` from the import list — `runtimeRailStatus` now covers the
-Run dot and nothing else in this file uses it. Leave the function exported from
-`runtime-state.ts`; `use-runtime-controller.ts` still uses it.
+Run dot. This removes its LAST caller repo-wide (`use-runtime-controller.ts` does not
+reference it, contrary to an earlier draft of this plan), so delete the function and its
+test table rather than leaving a tested, uncalled predicate behind.
 
 Everything downstream (`attention` passed to `ActivityPanel`, the
 `[data-cockpit-activity-attention]` marker) keeps working unchanged.

--- a/docs/superpowers/plans/2026-08-31-cockpit-run-discoverability.md
+++ b/docs/superpowers/plans/2026-08-31-cockpit-run-discoverability.md
@@ -1046,11 +1046,20 @@ Expected: both green.
 
 - [ ] **Step 2: Lint**
 
-Run: `npx nx lint cockpit 2>&1 | sed $'s/\033\\[[0-9;]*m//g' | grep -cE ' error '`
+`apps/cockpit` has **no** `lint` target — only `ui-react` does. Run:
+
+```bash
+npx nx lint ui-react 2>&1 | sed $'s/\033\\[[0-9;]*m//g' | grep -cE ' error '
+```
+
 Expected: `0`.
 
 CI tolerates warnings but fails on errors. Strip ANSI before grepping — a bare
-`grep -cE ' error '` silently returns 0 against coloured output. Repeat for `ui-react`.
+`grep -cE ' error '` silently returns 0 against coloured output.
+
+Note on reading test results: `npx nx test <project>` swallows the vitest reporter output
+in this worktree, so it tells you pass/fail but not counts. When you need real numbers, run
+`npx vitest run --root apps/cockpit` (or `--root libs/ui-react`) directly.
 
 - [ ] **Step 3: Confirm in a real browser**
 

--- a/docs/superpowers/specs/2026-08-31-cockpit-run-discoverability-design.md
+++ b/docs/superpowers/specs/2026-08-31-cockpit-run-discoverability-design.md
@@ -1,0 +1,174 @@
+# Cockpit: making Run discoverable from Code
+
+**Date:** 2026-08-31
+**Status:** Approved, ready for planning
+
+## Problem
+
+On a capability page in Code view, nothing tells the user they can run the example. The
+mode rail exists and works, but it does not read as a switch.
+
+Three failures, observed on the live page at 1440×900
+(`/ag-ui/core-capabilities/streaming/overview/python`):
+
+1. **The rail reads as chrome.** `Docs / Run / Code / API` sit in a 66px column at the far
+   left edge, at the same visual weight as the `Activity` and `Settings` utilities beneath
+   them. Nothing groups the four as views of one capability. Inactive items are painted
+   with `--ds-text-muted` — the token also used for disabled text — so they read as
+   unavailable rather than clickable.
+
+2. **Code view has no exit affordance.** Roughly 1250px of the viewport is file tree, tabs
+   and source. The only route back to Run is a 48px target ~1200px away, with no
+   in-context prompt.
+
+3. **Runtime controls sit below the fold.** The `Runtime` section renders after the full
+   capability nav list. Measured on the live page: the heading lands at `y=1860` inside a
+   900px viewport, in a pane with 1997px of scroll height. The one surface that says a
+   live runtime exists is unreachable without scrolling past ~30 nav links.
+
+**Amplifier.** `activeMode` is persisted in `localStorage` under a single global key
+(`libs/ui-react/src/lib/control-plane/control-plane-preferences.ts`), not scoped per
+capability. Verified live: a single Code click persisted for the rest of the session and
+across navigations. One exploratory click therefore makes Code the landing view for *every*
+capability, on *every* future visit. The `'Run'` default only ever applies to a first-time
+visitor.
+
+## Non-goals
+
+- No in-content affordance inside the Code pane (a header "run this" pill, a live peek at
+  the running app). Both were considered and deliberately deferred; see Alternatives.
+- No change to Docs, API or narrative content.
+- No change to the mobile overlay beyond what falls out of shared components.
+
+**Accepted tradeoff:** this design does not address failure 2. Nothing lands in the 1250px
+where the user's eye is while reading code. The rail becomes legible; it does not become
+close. This is a deliberate first step, to be evaluated before deciding whether the header
+pill is still needed.
+
+## Design
+
+### 1. Mode is no longer sticky
+
+Every capability opens in Run. Mode becomes per-page state, not a preference.
+
+- Remove `activeMode` / `setActiveMode` from `ControlPlanePreferencesV1['cockpit']` and
+  from `useControlPlanePreferences`. The hook retains `expanded` only.
+- `CockpitShell` holds the mode in `useState<ControlPlaneMode>('Run')`.
+- The `?mode=` deep link keeps working. It currently waits on `preferences.hydrated`;
+  with mode as local state it instead applies in a mount effect, so the server-rendered
+  Run markup and the first client render agree and hydration stays clean.
+- No storage version bump. `activeMode` in existing stored blobs is simply no longer read;
+  a stale ignored key is harmless. The `docs` surface does not use this field.
+
+Rationale: the cockpit's value is the running example; the code is supporting evidence. A
+preference that quietly demotes the demo to a code dump is the wrong thing to remember —
+and it is remembered from a single exploratory click, which is weak evidence of intent.
+
+### 2. Rail legibility
+
+In `apps/cockpit/src/app/cockpit.css`:
+
+- **Resting contrast:** inactive `[data-control-plane-rail-item]` moves from
+  `--ds-text-muted` to `--ds-text-secondary`.
+- **Group rule:** a hairline above `[data-control-plane-rail-group="utilities"]`. The DOM
+  already separates `primary` from `utilities`
+  (`libs/ui-react/src/lib/control-plane/control-plane.tsx`); only the CSS is missing.
+- **Set label:** a small `VIEW` cap above the primary group, so the switch is named rather
+  than inferred. Decorative, `aria-hidden` — the rail's `nav` already carries
+  `aria-label="Cockpit modes"`.
+
+### 3. A runtime phase dot on Run
+
+The `Run` rail item carries a dot driven by `runtimeSnapshot.phase`, already available in
+`CockpitShell` via `controller.snapshot`.
+
+| Phase | Dot |
+| --- | --- |
+| `ready` | success |
+| `connecting`, `checking`, `reloading` | working |
+| `unresponsive`, `error`, `invalid_configuration` | error |
+| `not_configured` | none |
+
+`not_configured` renders no dot: there is no runtime, so absence is the honest signal.
+
+`.cockpit-control-plane` already defines `--cockpit-state-success` and
+`--cockpit-state-error` (with dark-theme overrides). The success and error buckets use
+those; the working bucket needs one new sibling token defined the same way.
+
+Constraints:
+
+- **Colour is not the only channel.** The state goes into the Run item's accessible name
+  ("Run, runtime ready" / "Run, runtime error"), reusing the existing rail tooltip for the
+  hover affordance.
+- **Steady fills, no pulse.** A blinking dot in permanent peripheral vision costs
+  attention without carrying information.
+- Reuses the existing dot treatment established by `[data-cockpit-activity-attention]`.
+
+### 4. Activity's dot is re-scoped to unseen problems
+
+Adding a phase dot to Run collides with the Activity dot: today
+`runtimeNeedsAttention(phase)` fires on exactly `invalid_configuration`, `unresponsive`
+and `error` — the same three phases where Run now goes red. Left alone, one fault paints
+two red dots in one 66px column and neither says which to click.
+
+The two dots are re-scoped to make two distinct claims:
+
+- **Run** — what the runtime is doing *right now*.
+- **Activity** — there are problems in the log you have not read.
+
+Definition: the Activity dot shows when there is at least one event with
+`severity === 'error'` that arrived since the panel was last opened. `severity` is already
+assigned in `createSessionActivityEvent`, so this needs no new event plumbing. It covers
+`runtime_unresponsive`, `runtime_initialization_error`, `configuration_invalid` and
+`diagnostics_copy_failed`.
+
+- Seen-marker: opening the Activity utility marks all current events seen. `CockpitShell`
+  already tracks `activityOpenCycle` on open, which is the natural hook.
+- Clearing the log clears the marker.
+- Deriving from `severity === 'error'` rather than "any unread event" matters: `mode_changed`
+  and `runtime_ready` fire during ordinary use, and counting them would light the dot
+  constantly from the user's own actions.
+
+This is strictly better than today's behaviour on one case: a runtime that failed and then
+self-recovered currently leaves no trace once the phase clears, because the dot tracks
+live phase. Under the new rule the unread error survives the recovery until someone looks.
+
+`runtimeNeedsAttention` remains exported and still drives the Run dot's error bucket; only
+the Activity dot stops calling it.
+
+## Components touched
+
+| Unit | Change |
+| --- | --- |
+| `control-plane-preferences.ts` | Drop `activeMode` from the persisted shape and the hook |
+| `control-plane.tsx` | Rail item gains optional status-dot + accessible-name support |
+| `cockpit-control-plane.tsx` | Pass phase to Run; switch Activity's dot to unseen-errors |
+| `cockpit-shell.tsx` | Mode as local state; `?mode=` on mount; track seen-marker |
+| `activity-panel.tsx` | `attention` prop reinterpreted as unseen-errors |
+| `cockpit.css` | Contrast, group rule, `VIEW` cap, dot variants |
+
+## Testing
+
+- **Preferences:** stored `activeMode` is ignored; a fresh capability opens in Run;
+  `?mode=code` still lands in Code without a hydration mismatch.
+- **Phase mapping:** all eight phases map to the right dot, `not_configured` renders none,
+  and the accessible name changes with phase.
+- **Activity dot:** does not fire on `mode_changed` or `runtime_ready`; fires on an error
+  event; clears on panel open; survives a fault that recovers before the panel is opened.
+- **Mutation check.** The Activity-dot rule and the `not_configured` no-dot case both fail
+  silently if wired wrong — the assertion is an absence. Each needs a deliberate mutation
+  to confirm the test actually fails, per prior experience with tests that pass vacuously.
+- Existing rail, overflow-menu and mobile-overlay suites must stay green.
+
+## Alternatives considered
+
+- **Header runtime pill** (`● Running ›› See it run` in the workspace header). Hits all
+  three failures, lands where the eye is, and covers Docs and API with one affordance.
+  Recommended, not chosen — deferred so the cheaper rail work can be evaluated first.
+- **Live peek** — the running app kept on screen beneath the code. Architecturally cheap,
+  because `RunMode` never unmounts (`invisible absolute inset-0`) and the iframe is already
+  warm. Deferred: these demos are chat UIs that want vertical room, and at laptop height it
+  risks leaving both panes unusable. Wants a real-size prototype before committing.
+- **Presence-only dot on Run** (one colour, "a runtime is live"). Avoids the Activity
+  collision entirely. Not chosen: full phase is more informative, and the collision turned
+  out to have a resolution that improves Activity independently.

--- a/docs/superpowers/specs/2026-08-31-cockpit-run-discoverability-design.md
+++ b/docs/superpowers/specs/2026-08-31-cockpit-run-discoverability-design.md
@@ -124,6 +124,14 @@ assigned in `createSessionActivityEvent`, so this needs no new event plumbing. I
 
 - Seen-marker: opening the Activity utility marks all current events seen. `CockpitShell`
   already tracks `activityOpenCycle` on open, which is the natural hook.
+- **Direction matters.** `activityReducer` *prepends* (`[action.event, ...state]`), so the
+  log is newest-first: the seen events are the array's tail and the unseen window runs from
+  index 0. A naive `slice(seenCount)` is exactly inverted and still passes the obvious
+  tests, so the selector needs a case that pins the direction.
+- Known limitation: the marker is a count, and the log is capped at `MAX_ACTIVITY_EVENTS`
+  (50). Once the cap is reached, `length - seenCount` saturates at 0 and further errors
+  would not flag. Keying the marker on the newest seen event id would be robust; the count
+  is kept because the cap is far outside ordinary use. Revisit if the cap ever drops.
 - Clearing the log clears the marker.
 - Deriving from `severity === 'error'` rather than "any unread event" matters: `mode_changed`
   and `runtime_ready` fire during ordinary use, and counting them would light the dot

--- a/docs/superpowers/specs/2026-08-31-cockpit-run-discoverability-design.md
+++ b/docs/superpowers/specs/2026-08-31-cockpit-run-discoverability-design.md
@@ -141,8 +141,9 @@ This is strictly better than today's behaviour on one case: a runtime that faile
 self-recovered currently leaves no trace once the phase clears, because the dot tracks
 live phase. Under the new rule the unread error survives the recovery until someone looks.
 
-`runtimeNeedsAttention` remains exported and still drives the Run dot's error bucket; only
-the Activity dot stops calling it.
+`runtimeNeedsAttention` becomes dead once the Activity dot stops calling it: the Run dot
+goes through `runtimeRailStatus`, not through it. It is deleted along with its test table
+rather than left as an exported, tested, uncalled predicate.
 
 ## Components touched
 

--- a/libs/ui-react/src/index.ts
+++ b/libs/ui-react/src/index.ts
@@ -19,6 +19,7 @@ export {
   type ControlPlanePaneProps,
   type ControlPlaneRailItemProps,
   type ControlPlaneRailProps,
+  type ControlPlaneRailItemStatus,
   type ControlPlaneRailStatus,
   type ControlPlaneSectionProps,
 } from './lib/control-plane/control-plane';

--- a/libs/ui-react/src/index.ts
+++ b/libs/ui-react/src/index.ts
@@ -19,6 +19,7 @@ export {
   type ControlPlanePaneProps,
   type ControlPlaneRailItemProps,
   type ControlPlaneRailProps,
+  type ControlPlaneRailStatus,
   type ControlPlaneSectionProps,
 } from './lib/control-plane/control-plane';
 export {

--- a/libs/ui-react/src/lib/control-plane/control-plane-preferences.spec.ts
+++ b/libs/ui-react/src/lib/control-plane/control-plane-preferences.spec.ts
@@ -136,6 +136,24 @@ describe('control-plane preferences', () => {
     });
   });
 
+  it('writes docs disclosure state into docs.expanded, leaving cockpit untouched', async () => {
+    const { result } = renderHook(() => useControlPlanePreferences('docs'));
+    await waitFor(() => expect(result.current.hydrated).toBe(true));
+
+    act(() => result.current.setExpanded('Environment', true));
+
+    expect(result.current.expanded.Environment).toBe(true);
+    const stored = window.localStorage.getItem(CONTROL_PLANE_STORAGE_KEY);
+    expect(stored).not.toBeNull();
+    expect(JSON.parse(stored ?? '{}')).toEqual({
+      version: 1,
+      docs: { expanded: { Learn: true, Environment: true } },
+      cockpit: {
+        expanded: { Capability: true, Environment: true },
+      },
+    });
+  });
+
   it('merges writes from concurrent hook instances without reverting newer preferences', async () => {
     const shell = renderHook(() => useControlPlanePreferences('cockpit'));
     const pane = renderHook(() => useControlPlanePreferences('cockpit'));

--- a/libs/ui-react/src/lib/control-plane/control-plane-preferences.spec.ts
+++ b/libs/ui-react/src/lib/control-plane/control-plane-preferences.spec.ts
@@ -20,10 +20,25 @@ describe('control-plane preferences', () => {
       version: 1,
       docs: { expanded: { Learn: true, Environment: false } },
       cockpit: {
-        activeMode: 'Run',
         expanded: { Capability: true, Environment: true },
       },
     });
+  });
+
+  it('ignores a stored activeMode and never writes one back', () => {
+    window.localStorage.setItem(
+      CONTROL_PLANE_STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        docs: { expanded: {} },
+        cockpit: { activeMode: 'Code', expanded: { Capability: false } },
+      }),
+    );
+
+    const parsed = readControlPlanePreferences(window.localStorage);
+
+    expect('activeMode' in parsed.cockpit).toBe(false);
+    expect(parsed.cockpit.expanded.Capability).toBe(false);
   });
 
   it('validates persisted values and falls back only for invalid fields', () => {
@@ -33,7 +48,6 @@ describe('control-plane preferences', () => {
         version: 1,
         docs: { expanded: { Learn: false, Environment: 'yes' } },
         cockpit: {
-          activeMode: 'Preview',
           expanded: { Capability: false, Environment: true, Extra: 'no' },
         },
       }),
@@ -43,7 +57,6 @@ describe('control-plane preferences', () => {
       version: 1,
       docs: { expanded: { Learn: false, Environment: false } },
       cockpit: {
-        activeMode: 'Run',
         expanded: { Capability: false, Environment: true },
       },
     });
@@ -77,9 +90,9 @@ describe('control-plane preferences', () => {
     try {
       const { result } = renderHook(() => useControlPlanePreferences('cockpit'));
       await waitFor(() => expect(result.current.hydrated).toBe(true));
-      expect(result.current.activeMode).toBe('Run');
-      expect(() => act(() => result.current.setActiveMode('Code'))).not.toThrow();
-      expect(result.current.activeMode).toBe('Code');
+      expect(result.current.expanded.Capability).toBe(true);
+      expect(() => act(() => result.current.setExpanded('Capability', false))).not.toThrow();
+      expect(result.current.expanded.Capability).toBe(false);
     } finally {
       if (descriptor) Object.defineProperty(window, 'localStorage', descriptor);
     }
@@ -94,14 +107,13 @@ describe('control-plane preferences', () => {
     expect(parseControlPlaneMode(null)).toBeNull();
   });
 
-  it('hydrates Cockpit mode and persists mode changes without erasing Docs', async () => {
+  it('hydrates Cockpit disclosure state and persists changes without erasing Docs', async () => {
     window.localStorage.setItem(
       CONTROL_PLANE_STORAGE_KEY,
       JSON.stringify({
         version: 1,
         docs: { expanded: { Learn: false, Environment: true } },
         cockpit: {
-          activeMode: 'Code',
           expanded: { Capability: true, Environment: false },
         },
       }),
@@ -109,9 +121,9 @@ describe('control-plane preferences', () => {
 
     const { result } = renderHook(() => useControlPlanePreferences('cockpit'));
     await waitFor(() => expect(result.current.hydrated).toBe(true));
-    expect(result.current.activeMode).toBe('Code');
+    expect(result.current.expanded).toEqual({ Capability: true, Environment: false });
 
-    act(() => result.current.setActiveMode('API'));
+    act(() => result.current.setExpanded('Environment', true));
 
     const stored = window.localStorage.getItem(CONTROL_PLANE_STORAGE_KEY);
     expect(stored).not.toBeNull();
@@ -119,28 +131,6 @@ describe('control-plane preferences', () => {
       version: 1,
       docs: { expanded: { Learn: false, Environment: true } },
       cockpit: {
-        activeMode: 'API',
-        expanded: { Capability: true, Environment: false },
-      },
-    });
-  });
-
-  it('keeps Docs active and persists only its disclosure state', async () => {
-    const { result } = renderHook(() => useControlPlanePreferences('docs'));
-    await waitFor(() => expect(result.current.hydrated).toBe(true));
-
-    act(() => result.current.setActiveMode('Code'));
-    act(() => result.current.setExpanded('Environment', true));
-
-    expect(result.current.activeMode).toBe('Docs');
-    expect(result.current.expanded.Environment).toBe(true);
-    const stored = window.localStorage.getItem(CONTROL_PLANE_STORAGE_KEY);
-    expect(stored).not.toBeNull();
-    expect(JSON.parse(stored ?? '{}')).toEqual({
-      version: 1,
-      docs: { expanded: { Learn: true, Environment: true } },
-      cockpit: {
-        activeMode: 'Run',
         expanded: { Capability: true, Environment: true },
       },
     });
@@ -154,15 +144,14 @@ describe('control-plane preferences', () => {
       expect(pane.result.current.hydrated).toBe(true);
     });
 
-    act(() => shell.result.current.setActiveMode('Code'));
+    act(() => shell.result.current.setExpanded('Capability', false));
     act(() => pane.result.current.setExpanded('Environment', false));
 
     expect(JSON.parse(window.localStorage.getItem(CONTROL_PLANE_STORAGE_KEY) ?? '{}')).toEqual({
       version: 1,
       docs: { expanded: { Learn: true, Environment: false } },
       cockpit: {
-        activeMode: 'Code',
-        expanded: { Capability: true, Environment: false },
+        expanded: { Capability: false, Environment: false },
       },
     });
   });

--- a/libs/ui-react/src/lib/control-plane/control-plane-preferences.ts
+++ b/libs/ui-react/src/lib/control-plane/control-plane-preferences.ts
@@ -11,7 +11,6 @@ export interface ControlPlanePreferencesV1 {
     expanded: Record<string, boolean>;
   };
   cockpit: {
-    activeMode: ControlPlaneMode;
     expanded: Record<string, boolean>;
   };
 }
@@ -22,7 +21,6 @@ const DEFAULT_PREFERENCES: ControlPlanePreferencesV1 = {
   version: 1,
   docs: { expanded: { Learn: true, Environment: false } },
   cockpit: {
-    activeMode: 'Run',
     expanded: { Capability: true, Environment: true },
   },
 };
@@ -32,10 +30,7 @@ const MODES: readonly ControlPlaneMode[] = ['Docs', 'Run', 'Code', 'API'];
 const cloneDefaults = (): ControlPlanePreferencesV1 => ({
   version: 1,
   docs: { expanded: { ...DEFAULT_PREFERENCES.docs.expanded } },
-  cockpit: {
-    activeMode: DEFAULT_PREFERENCES.cockpit.activeMode,
-    expanded: { ...DEFAULT_PREFERENCES.cockpit.expanded },
-  },
+  cockpit: { expanded: { ...DEFAULT_PREFERENCES.cockpit.expanded } },
 });
 
 const getBrowserStorage = (): Storage | null => {
@@ -61,9 +56,6 @@ const booleanRecord = (
   return result;
 };
 
-const isMode = (value: unknown): value is ControlPlaneMode =>
-  typeof value === 'string' && MODES.includes(value as ControlPlaneMode);
-
 export const parseControlPlaneMode = (value: string | null): ControlPlaneMode | null => {
   if (!value) return null;
   const normalized = value.toLowerCase();
@@ -88,9 +80,6 @@ export const readControlPlanePreferences = (
         expanded: booleanRecord(docs.expanded, defaults.docs.expanded),
       },
       cockpit: {
-        activeMode: isMode(cockpit.activeMode)
-          ? cockpit.activeMode
-          : defaults.cockpit.activeMode,
         expanded: booleanRecord(cockpit.expanded, defaults.cockpit.expanded),
       },
     };
@@ -135,17 +124,6 @@ export function useControlPlanePreferences(surface: ControlPlaneSurface) {
     [hydrated],
   );
 
-  const setActiveMode = useCallback(
-    (activeMode: ControlPlaneMode) => {
-      if (surface === 'docs') return;
-      update((current) => ({
-        ...current,
-        cockpit: { ...current.cockpit, activeMode },
-      }));
-    },
-    [surface, update],
-  );
-
   const setExpanded = useCallback(
     (section: string, open: boolean) => {
       update((current) =>
@@ -171,9 +149,7 @@ export function useControlPlanePreferences(surface: ControlPlaneSurface) {
 
   return {
     hydrated,
-    activeMode: surface === 'docs' ? ('Docs' as const) : preferences.cockpit.activeMode,
     expanded: preferences[surface].expanded,
-    setActiveMode,
     setExpanded,
   };
 }

--- a/libs/ui-react/src/lib/control-plane/control-plane.spec.tsx
+++ b/libs/ui-react/src/lib/control-plane/control-plane.spec.tsx
@@ -70,6 +70,20 @@ describe('control-plane structure', () => {
     ).toBe('error');
   });
 
+  it('gives a labeled status item the accessible name without a tooltip', () => {
+    render(
+      <ControlPlaneRailItem
+        label="Run"
+        icon={<svg />}
+        status={{ kind: 'error', label: 'runtime error' }}
+      />,
+    );
+    const button = screen.getByRole('button', { name: 'Run, runtime error' });
+    expect(button.querySelector('[data-control-plane-tooltip]')).toBeNull();
+    expect(button.getAttribute('aria-describedby')).toBeNull();
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
   it('renders no status dot when status is omitted', () => {
     render(<ControlPlaneRailItem label="Run" icon={<svg />} />);
     const button = screen.getByRole('button', { name: 'Run' });

--- a/libs/ui-react/src/lib/control-plane/control-plane.spec.tsx
+++ b/libs/ui-react/src/lib/control-plane/control-plane.spec.tsx
@@ -54,6 +54,29 @@ describe('control-plane structure', () => {
     expect(screen.getByRole('button', { name: 'Run' }).getAttribute('aria-pressed')).toBe('true');
   });
 
+  it('renders a status dot and folds its label into the accessible name', () => {
+    render(
+      <ControlPlaneRailItem
+        label="Run"
+        icon={<svg />}
+        status="error"
+        statusLabel="runtime error"
+      />,
+    );
+    const button = screen.getByRole('button', { name: 'Run, runtime error' });
+    expect(
+      button.querySelector('[data-control-plane-rail-status]')?.getAttribute(
+        'data-control-plane-rail-status',
+      ),
+    ).toBe('error');
+  });
+
+  it('renders no status dot when status is omitted', () => {
+    render(<ControlPlaneRailItem label="Run" icon={<svg />} />);
+    const button = screen.getByRole('button', { name: 'Run' });
+    expect(button.querySelector('[data-control-plane-rail-status]')).toBeNull();
+  });
+
   it('renders a labeled contextual pane and environment facts', () => {
     render(
       <ControlPlanePane label="Docs context">

--- a/libs/ui-react/src/lib/control-plane/control-plane.spec.tsx
+++ b/libs/ui-react/src/lib/control-plane/control-plane.spec.tsx
@@ -59,8 +59,7 @@ describe('control-plane structure', () => {
       <ControlPlaneRailItem
         label="Run"
         icon={<svg />}
-        status="error"
-        statusLabel="runtime error"
+        status={{ kind: 'error', label: 'runtime error' }}
       />,
     );
     const button = screen.getByRole('button', { name: 'Run, runtime error' });

--- a/libs/ui-react/src/lib/control-plane/control-plane.tsx
+++ b/libs/ui-react/src/lib/control-plane/control-plane.tsx
@@ -99,13 +99,21 @@ export function ControlPlaneRailItem({
 }: ControlPlaneRailItemProps) {
   const tooltipId = useId();
   const accessibleName = status ? `${label}, ${status.label}` : label;
-  const showTooltip = iconOnly || Boolean(status);
+  // An icon-only item needs a tooltip because it has no visible label. A
+  // status item needs its status in the accessible name, which `aria-label`
+  // already supplies -- it must not also get the rail tooltip, whose
+  // positioning is authored for the narrow icon rail.
+  const needsAccessibleName = iconOnly || Boolean(status);
+  const showTooltip = iconOnly;
   const content = (
     <>
       <span data-control-plane-rail-icon>{icon}</span>
       {iconOnly ? null : <span data-control-plane-rail-label>{label}</span>}
       {status ? (
         <span data-control-plane-rail-status={status.kind} aria-hidden="true" />
+      ) : null}
+      {status && !iconOnly ? (
+        <span style={visuallyHidden}>{status.label}</span>
       ) : null}
       {showTooltip ? (
         <span id={tooltipId} role="tooltip" data-control-plane-tooltip>
@@ -118,7 +126,7 @@ export function ControlPlaneRailItem({
     className,
     'data-control-plane-rail-item': true,
     'data-control-plane-active': active || undefined,
-    'aria-label': showTooltip ? accessibleName : undefined,
+    'aria-label': needsAccessibleName ? accessibleName : undefined,
     'aria-describedby': showTooltip ? tooltipId : undefined,
   } as const;
 

--- a/libs/ui-react/src/lib/control-plane/control-plane.tsx
+++ b/libs/ui-react/src/lib/control-plane/control-plane.tsx
@@ -44,11 +44,16 @@ export function ControlPlaneRail({
   utilities,
   className,
 }: ControlPlaneRailProps) {
+  const primaryLabelId = useId();
   return (
     <nav aria-label={label} className={className} data-control-plane-rail>
-      <div data-control-plane-rail-group="primary">
+      <div
+        data-control-plane-rail-group="primary"
+        role={primaryLabel ? 'group' : undefined}
+        aria-labelledby={primaryLabel ? primaryLabelId : undefined}
+      >
         {primaryLabel ? (
-          <span data-control-plane-rail-group-label aria-hidden="true">
+          <span id={primaryLabelId} data-control-plane-rail-group-label>
             {primaryLabel}
           </span>
         ) : null}

--- a/libs/ui-react/src/lib/control-plane/control-plane.tsx
+++ b/libs/ui-react/src/lib/control-plane/control-plane.tsx
@@ -32,19 +32,28 @@ const visuallyHidden: CSSProperties = {
 
 export interface ControlPlaneRailProps extends CommonProps {
   label: string;
+  primaryLabel?: string;
   primary: ReactNode;
   utilities?: ReactNode;
 }
 
 export function ControlPlaneRail({
   label,
+  primaryLabel,
   primary,
   utilities,
   className,
 }: ControlPlaneRailProps) {
   return (
     <nav aria-label={label} className={className} data-control-plane-rail>
-      <div data-control-plane-rail-group="primary">{primary}</div>
+      <div data-control-plane-rail-group="primary">
+        {primaryLabel ? (
+          <span data-control-plane-rail-group-label aria-hidden="true">
+            {primaryLabel}
+          </span>
+        ) : null}
+        {primary}
+      </div>
       {utilities ? (
         <div data-control-plane-rail-group="utilities">{utilities}</div>
       ) : null}

--- a/libs/ui-react/src/lib/control-plane/control-plane.tsx
+++ b/libs/ui-react/src/lib/control-plane/control-plane.tsx
@@ -68,6 +68,11 @@ export function ControlPlaneRail({
 
 export type ControlPlaneRailStatus = 'success' | 'working' | 'error';
 
+export interface ControlPlaneRailItemStatus {
+  kind: ControlPlaneRailStatus;
+  label: string;
+}
+
 export interface ControlPlaneRailItemProps extends CommonProps {
   label: string;
   icon: ReactNode;
@@ -77,8 +82,7 @@ export interface ControlPlaneRailItemProps extends CommonProps {
   iconOnly?: boolean;
   target?: string;
   rel?: string;
-  status?: ControlPlaneRailStatus;
-  statusLabel?: string;
+  status?: ControlPlaneRailItemStatus;
 }
 
 export function ControlPlaneRailItem({
@@ -92,17 +96,16 @@ export function ControlPlaneRailItem({
   target,
   rel,
   status,
-  statusLabel,
 }: ControlPlaneRailItemProps) {
   const tooltipId = useId();
-  const accessibleName = statusLabel ? `${label}, ${statusLabel}` : label;
-  const showTooltip = iconOnly || Boolean(statusLabel);
+  const accessibleName = status ? `${label}, ${status.label}` : label;
+  const showTooltip = iconOnly || Boolean(status);
   const content = (
     <>
       <span data-control-plane-rail-icon>{icon}</span>
       {iconOnly ? null : <span data-control-plane-rail-label>{label}</span>}
       {status ? (
-        <span data-control-plane-rail-status={status} aria-hidden="true" />
+        <span data-control-plane-rail-status={status.kind} aria-hidden="true" />
       ) : null}
       {showTooltip ? (
         <span id={tooltipId} role="tooltip" data-control-plane-tooltip>

--- a/libs/ui-react/src/lib/control-plane/control-plane.tsx
+++ b/libs/ui-react/src/lib/control-plane/control-plane.tsx
@@ -66,6 +66,8 @@ export function ControlPlaneRail({
   );
 }
 
+export type ControlPlaneRailStatus = 'success' | 'working' | 'error';
+
 export interface ControlPlaneRailItemProps extends CommonProps {
   label: string;
   icon: ReactNode;
@@ -75,6 +77,8 @@ export interface ControlPlaneRailItemProps extends CommonProps {
   iconOnly?: boolean;
   target?: string;
   rel?: string;
+  status?: ControlPlaneRailStatus;
+  statusLabel?: string;
 }
 
 export function ControlPlaneRailItem({
@@ -87,15 +91,22 @@ export function ControlPlaneRailItem({
   className,
   target,
   rel,
+  status,
+  statusLabel,
 }: ControlPlaneRailItemProps) {
   const tooltipId = useId();
+  const accessibleName = statusLabel ? `${label}, ${statusLabel}` : label;
+  const showTooltip = iconOnly || Boolean(statusLabel);
   const content = (
     <>
       <span data-control-plane-rail-icon>{icon}</span>
       {iconOnly ? null : <span data-control-plane-rail-label>{label}</span>}
-      {iconOnly ? (
+      {status ? (
+        <span data-control-plane-rail-status={status} aria-hidden="true" />
+      ) : null}
+      {showTooltip ? (
         <span id={tooltipId} role="tooltip" data-control-plane-tooltip>
-          {label}
+          {accessibleName}
         </span>
       ) : null}
     </>
@@ -104,8 +115,8 @@ export function ControlPlaneRailItem({
     className,
     'data-control-plane-rail-item': true,
     'data-control-plane-active': active || undefined,
-    'aria-label': iconOnly ? label : undefined,
-    'aria-describedby': iconOnly ? tooltipId : undefined,
+    'aria-label': showTooltip ? accessibleName : undefined,
+    'aria-describedby': showTooltip ? tooltipId : undefined,
   } as const;
 
   if (href) {


### PR DESCRIPTION
## Why

On a capability page in **Code** view, nothing tells you the example can be run. The mode rail exists and works, but it doesn't read as a switch.

Three failures, measured on the live page at 1440×900:

1. **The rail reads as chrome.** The four mode buttons sat at the same visual weight as the Activity/Settings utilities below them, nothing grouped them, and inactive items used `--ds-text-muted` — the same token as *disabled* text, so they read as unavailable.
2. **Code view has no exit affordance.** ~1250px of the viewport is tree + tabs + source; the only route back to Run is a 48px target ~1200px away.
3. **Runtime controls sat ~1000px below the fold.** The `Runtime` heading rendered at `y=1860` in a 900px viewport, unreachable without scrolling past ~30 nav links.

**Amplifier:** `activeMode` was persisted under one global localStorage key, not scoped per capability. One exploratory click into Code made Code the landing view for *every* capability on *every* future visit — verified live on production.

## What changed

| | |
|---|---|
| **1** | Mode is no longer sticky — every capability opens in Run; `?mode=` deep links still work |
| **2** | Rail reads as a switch — resting contrast off the disabled token, a visible rule separating modes from utilities, a `VIEW` group label |
| **3** | Generic `status?: { kind, label }` slot on `ControlPlaneRailItem` |
| **4** | Run carries a live runtime phase dot — 8 phases → 4 buckets, state in the accessible name |
| **5** | Activity re-scoped to *unread problems*, so the two dots make distinct claims |

Run now says **what the runtime is doing**; Activity says **there are problems you haven't read**. That's also strictly better on one case: a runtime that fails and self-recovers previously left no trace once the phase cleared — now the unread error survives until someone looks.

## Scope note

This deliberately does **not** address failure 2. Nothing lands in the 1250px where your eye is while reading code. The rail becomes legible; it does not become close. This was chosen as a first step, to evaluate before deciding whether an in-content affordance is still needed.

## Verification

cockpit **433/433**, ui-react **33/33**, `nx lint ui-react` 0 errors.

Browser-verified against a fresh build at 1440×900, **both themes**:

- Stale `activeMode: "Code"` in storage → lands on **Run**
- `?mode=code` → lands on Code, `search` stripped to `""`
- Code → click another capability → lands on **Run** (the `key={canonicalPath}` fix)
- Rail inactive `rgb(200,200,200)` dark / `rgb(70,70,70)` light; separator visible in both
- Run dot `position: absolute`, 7×7, `rgb(76,195,138)` dark / `rgb(26,122,64)` light
- Run has no stray tooltip; status lives in a visually-hidden span
- No console or hydration errors

Not verified by eye (covered by tests; live repro needs a deliberately broken runtime): the Activity dot on a real failure, and the `working`/`error` dot colours in situ.

## Notable during review

- **The separator initially shipped invisible.** It used `--ds-border` — `rgb(45,45,45)` on a `rgb(44,44,44)` rail in dark, a one-value difference — while every test passed. Fixed to `--ds-border-strong`, with a comment recording why.
- **A test guarding the route `key` was circular** — deleting the `key` from `page.tsx` left the suite fully green. Replaced with a route-module test that actually fails.
- **The plan I wrote had two errors**, both caught by reading the code rather than trusting the prose: `activityReducer` *prepends* (the specified selector was inverted, and all three specified tests passed either way), and `runtimeNeedsAttention` had no remaining caller (now deleted). Spec and plan corrected.

Design: `docs/superpowers/specs/2026-08-31-cockpit-run-discoverability-design.md`
Plan: `docs/superpowers/plans/2026-08-31-cockpit-run-discoverability.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
