### PR TITLE
ci: wire the two dead cockpit spec files into targets CI actually runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,7 +226,12 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npx nx build cockpit --skip-nx-cache
-      - run: npx nx test cockpit --skip-nx-cache
+      # cockpit-docs and cockpit-registry carry `test` targets that nothing in
+      # CI invoked: `nx test` does not walk `^test`, and the `library` job runs
+      # a hardcoded LIBS list that excludes both. Name them here so their specs
+      # actually execute. All three share the `scope:cockpit` tag, so ci-scope
+      # already gates this job correctly for changes under either library.
+      - run: npx nx run-many -t test --projects=cockpit,cockpit-docs,cockpit-registry --skip-nx-cache
 
   cockpit-examples-build:
     name: Cockpit — build all examples

--- a/apps/cockpit/vite.config.mts
+++ b/apps/cockpit/vite.config.mts
@@ -25,6 +25,13 @@ export default defineConfig({
       // docsPath assertion drifted into asserting a URL shape the website has
       // never served. Run them here so `nx test cockpit` covers them.
       '../../cockpit/*/matrix.spec.ts',
+      // Same story for the per-product footprint specs (chat, deep-agents,
+      // render): they sit outside any project root, so no `test` target owned
+      // them and the deep-agents one drifted into asserting a website docs
+      // library that does not exist. Glob the whole family rather than naming
+      // files, so a new `cockpit/<product>/footprint.spec.ts` is covered the
+      // day it lands instead of joining the unrun pile.
+      '../../cockpit/*/footprint.spec.ts',
     ],
     setupFiles: ['./test-setup.ts'],
   },

--- a/cockpit/chat/footprint.spec.ts
+++ b/cockpit/chat/footprint.spec.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 const topicNames = [
@@ -15,41 +16,33 @@ const topicNames = [
   'theming',
 ] as const;
 
-const pageNames = ['overview', 'build', 'prompts', 'code', 'testing'] as const;
+// Resolve from this file, not process.cwd(). These specs run under
+// `nx test cockpit`, whose cwd is apps/cockpit — a cwd-relative root silently
+// points at apps/cockpit/cockpit/... and turns every existence assertion into
+// a vacuous pass (or an unrelated ENOENT).
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const chatRoot = path.join(repoRoot, 'cockpit', 'chat');
 
-const chatRoot = path.join(process.cwd(), 'cockpit', 'chat');
-const websiteDocsRoot = path.join(
-  process.cwd(), 'apps', 'website', 'content', 'docs', 'chat'
-);
-
+// The per-topic website .mdx assertions this spec used to carry asserted the
+// five-segment docs shape #918 removed (see
+// libs/cockpit-registry/src/lib/docs-links.ts: it "produced a URL that 404s for
+// every product"). The website tree is organised by guide, not by cockpit
+// topic. That coupling is now a table checked against the website's real
+// content tree by apps/cockpit/src/lib/docs-links.spec.ts.
 describe('Chat footprint', () => {
-  it('keeps the getting-started overview in place', () => {
-    expect(
-      fs.existsSync(
-        path.join(websiteDocsRoot, 'getting-started', 'overview', 'python', 'overview.mdx')
-      )
-    ).toBe(true);
-  });
-
-  it('creates the approved topic modules and docs pages', () => {
+  it('creates the approved topic modules', () => {
     for (const topic of topicNames) {
       const moduleRoot = path.join(chatRoot, topic, 'python');
       const projectJsonPath = path.join(chatRoot, topic, 'angular', 'project.json');
 
       expect(fs.existsSync(path.join(moduleRoot, 'src', 'index.ts'))).toBe(true);
-      expect(fs.existsSync(path.join(moduleRoot, 'prompts', `${topic}.md`))).toBe(true);
+      expect(fs.existsSync(path.join(moduleRoot, 'prompts', `${topic}.md`))).toBe(
+        true
+      );
       expect(fs.existsSync(projectJsonPath)).toBe(true);
 
       const projectJson = JSON.parse(fs.readFileSync(projectJsonPath, 'utf8'));
       expect(projectJson.targets?.smoke?.executor).toBe('nx:run-commands');
-
-      for (const page of pageNames) {
-        expect(
-          fs.existsSync(
-            path.join(websiteDocsRoot, 'core-capabilities', topic, 'python', `${page}.mdx`)
-          )
-        ).toBe(true);
-      }
     }
   });
 

--- a/cockpit/deep-agents/footprint.spec.ts
+++ b/cockpit/deep-agents/footprint.spec.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 const topicNames = [
@@ -10,34 +11,24 @@ const topicNames = [
   'skills',
 ] as const;
 
-const pageNames = ['overview', 'build', 'prompts', 'code', 'testing'] as const;
+// Resolve from this file, not process.cwd(). These specs run under
+// `nx test cockpit`, whose cwd is apps/cockpit — a cwd-relative root silently
+// points at apps/cockpit/cockpit/... and turns every existence assertion into
+// a vacuous pass (or an unrelated ENOENT).
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const deepAgentsRoot = path.join(repoRoot, 'cockpit', 'deep-agents');
 
-const deepAgentsRoot = path.join(process.cwd(), 'cockpit', 'deep-agents');
-const websiteDocsRoot = path.join(
-  process.cwd(),
-  'apps',
-  'website',
-  'content',
-  'docs',
-  'deep-agents'
-);
-
-describe('Deep Agents Phase 5 footprint', () => {
-  it('keeps the getting-started overview in place', () => {
-    expect(
-      fs.existsSync(
-        path.join(
-          websiteDocsRoot,
-          'getting-started',
-          'overview',
-          'python',
-          'overview.mdx'
-        )
-      )
-    ).toBe(true);
-  });
-
-  it('creates the approved topic modules and docs pages', () => {
+// This spec used to also assert a website docs page per topic at
+// content/docs/deep-agents/core-capabilities/<topic>/python/<page>.mdx. That
+// five-segment shape is the formula #918 removed: as
+// libs/cockpit-registry/src/lib/docs-links.ts records, it "produced a URL that
+// 404s for every product", and no `deep-agents` docs library exists on the
+// website at all. The real website coupling now lives in the docs-links table
+// and is checked against the website's actual content tree and nav config by
+// apps/cockpit/src/lib/docs-links.spec.ts. What is left here is what
+// "footprint" actually means: the cockpit modules exist and are runnable.
+describe('Deep Agents footprint', () => {
+  it('creates the approved topic modules', () => {
     for (const topic of topicNames) {
       const moduleRoot = path.join(deepAgentsRoot, topic, 'python');
       const projectJson = JSON.parse(
@@ -45,28 +36,15 @@ describe('Deep Agents Phase 5 footprint', () => {
       );
 
       expect(fs.existsSync(path.join(moduleRoot, 'package.json'))).toBe(true);
-      expect(fs.existsSync(path.join(moduleRoot, 'project.json'))).toBe(true);
       expect(fs.existsSync(path.join(moduleRoot, 'tsconfig.json'))).toBe(true);
       expect(fs.existsSync(path.join(moduleRoot, 'src', 'index.ts'))).toBe(true);
-      expect(fs.existsSync(path.join(moduleRoot, 'prompts', `${topic}.md`))).toBe(true);
+      expect(fs.existsSync(path.join(moduleRoot, 'prompts', `${topic}.md`))).toBe(
+        true
+      );
       expect(projectJson.targets?.smoke?.executor).toBe('nx:run-commands');
       expect(projectJson.targets?.smoke?.options?.command).toContain(
         'src/index.ts'
       );
-
-      for (const page of pageNames) {
-        expect(
-          fs.existsSync(
-            path.join(
-              websiteDocsRoot,
-              'core-capabilities',
-              topic,
-              'python',
-              `${page}.mdx`
-            )
-          )
-        ).toBe(true);
-      }
     }
   });
 });

--- a/cockpit/render/footprint.spec.ts
+++ b/cockpit/render/footprint.spec.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 const topicNames = [
@@ -11,41 +12,38 @@ const topicNames = [
   'computed-functions',
 ] as const;
 
-const pageNames = ['overview', 'build', 'prompts', 'code', 'testing'] as const;
+// Resolve from this file, not process.cwd(). These specs run under
+// `nx test cockpit`, whose cwd is apps/cockpit — a cwd-relative root silently
+// points at apps/cockpit/cockpit/... and turns every existence assertion into
+// a vacuous pass (or an unrelated ENOENT).
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const renderRoot = path.join(repoRoot, 'cockpit', 'render');
 
-const renderRoot = path.join(process.cwd(), 'cockpit', 'render');
-const websiteDocsRoot = path.join(
-  process.cwd(), 'apps', 'website', 'content', 'docs', 'render'
-);
-
+// The per-topic website .mdx assertions this spec used to carry asserted the
+// five-segment docs shape #918 removed (see
+// libs/cockpit-registry/src/lib/docs-links.ts: it "produced a URL that 404s for
+// every product"). The website tree is organised by guide, not by cockpit
+// topic. That coupling is now a table checked against the website's real
+// content tree by apps/cockpit/src/lib/docs-links.spec.ts.
 describe('Render footprint', () => {
-  it('keeps the getting-started overview in place', () => {
-    expect(
-      fs.existsSync(
-        path.join(websiteDocsRoot, 'getting-started', 'overview', 'python', 'overview.mdx')
-      )
-    ).toBe(true);
-  });
-
-  it('creates the approved topic modules and docs pages', () => {
+  it('creates the approved topic modules', () => {
     for (const topic of topicNames) {
       const moduleRoot = path.join(renderRoot, topic, 'python');
-      const projectJsonPath = path.join(renderRoot, topic, 'angular', 'project.json');
+      const projectJsonPath = path.join(
+        renderRoot,
+        topic,
+        'angular',
+        'project.json'
+      );
 
       expect(fs.existsSync(path.join(moduleRoot, 'src', 'index.ts'))).toBe(true);
-      expect(fs.existsSync(path.join(moduleRoot, 'prompts', `${topic}.md`))).toBe(true);
+      expect(fs.existsSync(path.join(moduleRoot, 'prompts', `${topic}.md`))).toBe(
+        true
+      );
       expect(fs.existsSync(projectJsonPath)).toBe(true);
 
       const projectJson = JSON.parse(fs.readFileSync(projectJsonPath, 'utf8'));
       expect(projectJson.targets?.smoke?.executor).toBe('nx:run-commands');
-
-      for (const page of pageNames) {
-        expect(
-          fs.existsSync(
-            path.join(websiteDocsRoot, 'core-capabilities', topic, 'python', `${page}.mdx`)
-          )
-        ).toBe(true);
-      }
     }
   });
 });

--- a/libs/cockpit-docs/project.json
+++ b/libs/cockpit-docs/project.json
@@ -17,6 +17,12 @@
         "main": "libs/cockpit-docs/src/index.ts",
         "tsConfig": "libs/cockpit-docs/tsconfig.lib.json"
       }
+    },
+    "test": {
+      "executor": "@nx/vitest:test",
+      "options": {
+        "configFile": "libs/cockpit-docs/vite.config.mts"
+      }
     }
   },
   "tags": [

--- a/libs/cockpit-docs/vite.config.mts
+++ b/libs/cockpit-docs/vite.config.mts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite';
+import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+
+export default defineConfig({
+  plugins: [nxViteTsPaths()],
+  test: {
+    environment: 'node',
+    globals: true,
+    include: ['src/**/*.spec.ts'],
+  },
+});

--- a/scripts/ci-scope.mjs
+++ b/scripts/ci-scope.mjs
@@ -69,6 +69,15 @@ const LINT_ONLY_FILES = new Set(['eslint.config.mjs']);
  *  when a LINT_ONLY_FILES entry changes. */
 const LINT_SCOPE_KEYS = ['library', 'cockpit', 'website', 'examples_chat'];
 
+/** The per-product `matrix.spec.ts` / `footprint.spec.ts` files sit at
+ *  cockpit/<product>/, which is outside every project root. `nx affected`
+ *  therefore attributes them to the `root` project, and `root` carries no
+ *  `scope:` tag — so a PR touching only these specs produced an empty scope
+ *  and skipped the very job that runs them. They execute under
+ *  `nx test cockpit` (see apps/cockpit/vite.config.mts), so map them onto the
+ *  cockpit scope by path. */
+const COCKPIT_ROOTLESS_SPEC = /^cockpit\/[^/]+\/[^/]+\.spec\.ts$/;
+
 export function emptyScope() {
   return Object.fromEntries(SCOPE_KEYS.map((k) => [k, false]));
 }
@@ -124,6 +133,9 @@ export function classifyFromAffected(changedFiles, affectedProjects) {
   }
   if (changedFiles.some((f) => LINT_ONLY_FILES.has(f))) {
     for (const key of LINT_SCOPE_KEYS) scope[key] = true;
+  }
+  if (changedFiles.some((f) => COCKPIT_ROOTLESS_SPEC.test(f))) {
+    scope.cockpit = true;
   }
   if (isAngularCompatibilityChange(changedFiles)) {
     scope.angular_compatibility = true;

--- a/scripts/ci-scope.spec.mjs
+++ b/scripts/ci-scope.spec.mjs
@@ -125,6 +125,47 @@ describe('classifyFromAffected — lint-only files', () => {
   });
 });
 
+describe('classifyFromAffected — rootless cockpit specs', () => {
+  // These specs live at cockpit/<product>/ — outside every project root — so
+  // `nx affected` reports only the untagged `root` project for them. Without
+  // the path rule they produced an empty scope and skipped the cockpit job
+  // that actually runs them.
+  for (const file of [
+    'cockpit/deep-agents/footprint.spec.ts',
+    'cockpit/chat/footprint.spec.ts',
+    'cockpit/render/footprint.spec.ts',
+    'cockpit/chat/matrix.spec.ts',
+    'cockpit/langgraph/matrix.spec.ts',
+  ]) {
+    it(`${file} flips the cockpit scope even when nx reports only \`root\``, () => {
+      const scope = classifyFromAffected(
+        [file],
+        [{ name: 'root', tags: ['npm:private'] }]
+      );
+      assert.equal(scope.cockpit, true);
+    });
+  }
+
+  it('does not flip cockpit for specs that already live inside a project root', () => {
+    const scope = classifyFromAffected(
+      ['cockpit/chat/messages/angular/e2e/c-messages.spec.ts'],
+      [{ name: 'root', tags: ['npm:private'] }]
+    );
+    assert.equal(scope.cockpit, false);
+  });
+
+  it('leaves the e2e / smoke / deploy scopes alone', () => {
+    const scope = classifyFromAffected(
+      ['cockpit/deep-agents/footprint.spec.ts'],
+      [{ name: 'root', tags: ['npm:private'] }]
+    );
+    assert.equal(scope.cockpit_e2e, false);
+    assert.equal(scope.cockpit_smoke, false);
+    assert.equal(scope.cockpit_deploy_smoke, false);
+    assert.equal(scope.cockpit_examples, false);
+  });
+});
+
 describe('classifyFromAffected — publishable lib broadcast', () => {
   it('publishable lib triggers its existing scopes plus angular compatibility', () => {
     const scope = classifyFromAffected(

--- a/scripts/ci-workflow.spec.mjs
+++ b/scripts/ci-workflow.spec.mjs
@@ -368,6 +368,24 @@ describe('CI workflow', () => {
     }
   });
 
+  it('runs the cockpit sibling libraries that own vitest specs', async () => {
+    // `nx test cockpit` does not walk `^test`, and the `library` job runs a
+    // hardcoded LIBS list that excludes both of these. If they are dropped
+    // from this run-many their specs stop executing silently.
+    const cockpitJob = readJobBlock(await readWorkflow(), 'cockpit');
+    const runMany = cockpitJob.match(/npx nx run-many -t test --projects=(\S+)/);
+
+    assert.ok(runMany, 'cockpit job should run tests via nx run-many');
+
+    const projects = runMany[1].split(',');
+    for (const project of ['cockpit', 'cockpit-docs', 'cockpit-registry']) {
+      assert.ok(
+        projects.includes(project),
+        `cockpit job should run \`nx test ${project}\``
+      );
+    }
+  });
+
   it('lets the cockpit e2e summary inspect CI scope outputs', async () => {
     const cockpitE2eSummaryJob = await readCockpitE2eSummaryJob();
 


### PR DESCRIPTION
Two spec files were executed by nothing. Both are wired in — neither deleted.

| Spec | Verdict | Now runs under |
|---|---|---|
| `cockpit/deep-agents/footprint.spec.ts` | **wire in** | `nx test cockpit` (glob, per #918) |
| `libs/cockpit-docs/src/lib/docs-bundle.spec.ts` | **wire in** | `nx test cockpit-docs` (new target, per #916) |

### On `/docs/deep-agents`

When I opened this PR the library did not exist. **#937 landed it while this PR was in CI**, so this branch is rebased onto it — and it confirms the call below rather than overturning it.

The new library is six pages shaped `deep-agents/capabilities/<topic>.mdx` and `deep-agents/getting-started/introduction.mdx` — the three-segment guide shape. The spec asserted `deep-agents/core-capabilities/<topic>/python/<page>.mdx`. **Those assertions would still fail against main today**, now for the same reason as chat and render: the website is organised by guide, not by cockpit topic.

#937 also rewired the six deep-agents sentinels to real targets, leaving `COCKPIT_TOPICS_WITHOUT_DOCS` empty so that blanking anything now fails. Worth recording that I had drafted an inverted "no docs library yet" tripwire and dropped it before pushing — it would be red on main today. The generic guard #937 strengthened is the right home for this, not a footprint spec.

## Three further gaps surfaced while wiring

**1. `cockpit-docs` and `cockpit-registry` were both unreachable.** Adding a `test` target to `cockpit-docs` mirroring its `cockpit-registry` sibling would have been dead on arrival: `nx test` does not walk `^test`, and the `library` job runs a hardcoded `LIBS: chat,langgraph,ag-ui,render,a2ui,telemetry`. `npx nx test cockpit-registry` appears **nowhere** in any workflow, so its three specs (`manifest`, `validate-manifest`, `resolve-language`) had never run either. The cockpit job now uses `nx run-many -t test --projects=cockpit,cockpit-docs,cockpit-registry`.

**2. The footprint specs would have passed vacuously.** They resolved paths from `process.cwd()`, which under `nx test cockpit` is `apps/cockpit`, not the repo root. Wired in unchanged, the new deep-agents assertion pointed at `apps/cockpit/apps/website/...` and passed green while asserting nothing. They now resolve from `import.meta.url`.

**3. ci-scope could not see them.** `cockpit/<product>/*.spec.ts` sits outside every project root, so `nx affected` attributes it to `root`, which carries only `npm:private` — no `scope:` tag. A PR touching only these specs produced an empty scope and skipped the job that runs them (inherited from #918, which affected the matrix specs too). `ci-scope.mjs` now maps them onto the `cockpit` scope by path.

## The stale assertions, and why removing them is not weakening

All three footprint specs (chat, render, deep-agents — the latter two were also unwired) asserted a website page per topic at `content/docs/<product>/core-capabilities/<topic>/python/<page>.mdx`. That is the five-segment shape **#918 deleted**. From `libs/cockpit-registry/src/lib/docs-links.ts`:

> An earlier five-segment formula (`/docs/<product>/core-capabilities/<topic>/overview/<language>`) produced a URL that 404s for every product.

The website tree is organised by guide (`chat/{components,guides,getting-started}/*.mdx`), not by cockpit topic. Every one of those ~90 assertions was describing a layout the website has never served. For deep-agents specifically, `docs-links.ts` mapped all six topics to `NO_COCKPIT_DOCS_LINK`; #937 has since pointed them at real pages — at the guide-shaped URLs, not the five-segment ones.

I removed them rather than inverting them into a tripwire, because the coverage already exists and is stronger: `apps/cockpit/src/lib/docs-links.spec.ts` (7 tests, already running) checks every non-sentinel link against the website's **actual** content tree and nav config, and asserts the blanked set equals `COCKPIT_TOPICS_WITHOUT_DOCS` so nobody can silently blank an entry. What remains in the footprint specs is what "footprint" means: the cockpit modules exist and are runnable. Those assertions were already true on main and are unchanged.

**Coverage lost:** nothing that was running, and nothing another running spec does not cover better.

## Verification

Mutation-tested — each broken, observed red through the CI-visible target, restored:

| Mutation | Target | Result |
|---|---|---|
| `'planning'` → `'planning-BROKEN'` | `nx test cockpit` | exit 1, `ENOENT .../planning-BROKEN/python/project.json` (path proves root resolution) |
| page count `5` → `6` | `nx run-many` (exact CI cmd) | exit 1, `Failed tasks: cockpit-docs:test` |
| drop `cockpit-docs` from ci.yml | `node --test ci-workflow.spec.mjs` | `not ok 15 - runs the cockpit sibling libraries…` |
| neuter `COCKPIT_ROOTLESS_SPEC` | `node --test ci-scope.spec.mjs` | 5 failures |

Green after restore:
- `nx test cockpit` — **45 files / 426 tests**, up from 42 / 421 (re-run after the rebase onto #937, which touched `cockpit-shell.spec.tsx`, `route-resolution.spec.ts` and all five deep-agents `src/index.ts`)
- `nx test cockpit-docs` — 1 file / **4 tests** (confirmed non-vacuous by direct vitest count)
- `nx test cockpit-registry` — passes
- `node --test ci-scope.spec.mjs ci-workflow.spec.mjs` — 85 pass / 0 fail
- `nx build cockpit-docs` — passes (spec still excluded from `tsconfig.lib.json`)

Reachability traced through the real classifier: footprint-only PR → `cockpit=true` (`cockpit_e2e` stays false); docs-bundle PR → `cockpit=true`.

**Pre-existing, unrelated:** `cockpit-shell.spec.tsx` "copies sanitized diagnostics…" times out at 5000 ms on my machine (needs ~7.5 s). It fails identically on unmodified main, and passes 19/19 with `--testTimeout=30000`. Not touched — that is a separate call about the timeout.

## Follow-up: a structural guard against this whole class

This repo has now yielded **eight** unwired suites (website e2e drift, root generator specs, mit-cutover, cockpit matrix specs, these two, the deploy gates measuring at the wrong layer, and cockpit-registry found here). Each was repaired one at a time, after drifting silently.

Proposing as a **follow-up, not built here**: a meta-spec that enumerates every `*.spec.*` in the repo and asserts each is matched by some project's vitest `include` globs (or an explicit, commented allowlist for the `node --test` suites, which `scripts/vite.config.mts` already models). It would run in `ci-scope`, cost seconds, and fail loudly the day a spec lands unowned instead of years later. The allowlist is the design question worth settling before building it — it must be narrow enough that "add it to the allowlist" is not the path of least resistance.
