### PR TITLE
fix(ci): stop fanning out the whole cockpit e2e matrix for unrelated changes

### DIFF
--- a/apps/cockpit/project.json
+++ b/apps/cockpit/project.json
@@ -6,7 +6,6 @@
   "tags": [
     "scope:cockpit",
     "scope:cockpit-deploy-smoke",
-    "scope:cockpit-e2e",
     "scope:cockpit-examples",
     "type:app"
   ],

--- a/scripts/ci-scope.spec.mjs
+++ b/scripts/ci-scope.spec.mjs
@@ -413,3 +413,52 @@ describe('SCOPE_KEYS export', () => {
     ]);
   });
 });
+
+describe('classifyFromAffected — cockpit shell does not own the e2e matrix', () => {
+  // The cockpit-e2e matrix dispatches `nx e2e` for the standalone Angular cap
+  // apps under cockpit/**; none of them depends on the apps/cockpit Next.js
+  // shell, and no workflow runs the shell's own `e2e` target. A
+  // `scope:cockpit-e2e` tag on the shell therefore cannot select any real
+  // work — it can only over-select. It used to: apps/cockpit imports from
+  // apps/website, so a website-only PR made the shell nx-affected, flipped
+  // cockpit_e2e true, and (with no cap affected) hit the dispatcher's
+  // full-fleet fallback. PR #932 changed three apps/website/src files and ran
+  // the whole cap matrix.
+  it('apps/cockpit is not tagged scope:cockpit-e2e', async () => {
+    const project = JSON.parse(
+      await readFile('apps/cockpit/project.json', 'utf8')
+    );
+
+    assert.ok(
+      !project.tags.includes('scope:cockpit-e2e'),
+      'the cockpit shell must not select the cockpit-e2e cap matrix'
+    );
+  });
+
+  it('a website-only change leaves cockpit_e2e false', async () => {
+    const cockpit = JSON.parse(
+      await readFile('apps/cockpit/project.json', 'utf8')
+    );
+    const website = JSON.parse(
+      await readFile('apps/website/project.json', 'utf8')
+    );
+
+    // The real nx-affected set for PR #932 was [website, cockpit, scripts]:
+    // apps/cockpit statically depends on apps/website.
+    const scope = classifyFromAffected(
+      [
+        'apps/website/src/app/layout.tsx',
+        'apps/website/src/components/shared/SiteFooter.tsx',
+      ],
+      [
+        { name: 'website', tags: website.tags },
+        { name: 'cockpit', tags: cockpit.tags },
+      ]
+    );
+
+    assert.equal(scope.cockpit_e2e, false);
+    // The shell still builds and tests — it consumes the changed website code.
+    assert.equal(scope.cockpit, true);
+    assert.equal(scope.website, true);
+  });
+});

--- a/scripts/cockpit-matrix.mjs
+++ b/scripts/cockpit-matrix.mjs
@@ -2,12 +2,31 @@
 // SPDX-License-Identifier: MIT
 
 /**
+ * Does this cap own one of the nx-affected projects?
+ *
+ * A cap is two independent nx projects — the Angular app that owns the `e2e`
+ * target and the python backend it talks to — with no edge between them in the
+ * project graph. Matching only on the Angular name made a python-only change
+ * look unattributed, which main() answers with the full fleet.
+ *
+ * @param {{angular: string, pythonName?: string}} cap
+ * @param {Set<string>} affectedNames
+ * @returns {boolean}
+ */
+export function isCapAffected(cap, affectedNames) {
+  if (affectedNames.has(cap.angular)) return true;
+  // Guard the falsy case: caps with a Node-hosted backend carry '' here, and
+  // `affectedNames` must never be probed with an empty key.
+  return Boolean(cap.pythonName) && affectedNames.has(cap.pythonName);
+}
+
+/**
  * Pure-function classifier for the cockpit-e2e matrix.
  *
- * @param {Array<{angular: string, python: string}>} allCockpitCaps
+ * @param {Array<{angular: string, python: string, pythonName: string}>} allCockpitCaps
  *        All cockpit angular projects with an e2e target, paired with
- *        their python sibling path. Derived from the project graph by
- *        the CLI wrapper (or hard-coded in tests).
+ *        their python sibling path and project name. Derived from the
+ *        project graph by the CLI wrapper (or hard-coded in tests).
  * @param {Set<string>} affectedNames
  *        Set of project names nx-affected returned for this diff.
  * @param {{fullFleet: boolean}} opts
@@ -19,7 +38,7 @@
  */
 export function selectCockpitCaps(allCockpitCaps, affectedNames, { fullFleet }) {
   if (fullFleet) return allCockpitCaps;
-  return allCockpitCaps.filter((cap) => affectedNames.has(cap.angular));
+  return allCockpitCaps.filter((cap) => isCapAffected(cap, affectedNames));
 }
 
 // ── CLI wrapper ────────────────────────────────────────────────────────────
@@ -100,7 +119,29 @@ function deriveCockpitCaps() {
               return false;
             }
           })();
-          caps.push({ angular: angularName, python: hasPython ? relPython : '' });
+          // Read the python sibling's own project.json for its nx name rather
+          // than deriving one from the path — the name is what nx-affected
+          // reports, and a convention-derived guess would fail open (no match
+          // → full fleet) without ever saying so.
+          const pythonName = (() => {
+            if (!hasPython) return '';
+            try {
+              const sibling = JSON.parse(
+                readFileSync(
+                  path.join(repoRoot, relPython, 'project.json'),
+                  'utf8',
+                ),
+              );
+              return typeof sibling.name === 'string' ? sibling.name : '';
+            } catch {
+              return '';
+            }
+          })();
+          caps.push({
+            angular: angularName,
+            python: hasPython ? relPython : '',
+            pythonName,
+          });
         } catch {
           // No project.json or invalid JSON — skip silently.
         }
@@ -135,14 +176,18 @@ function main() {
 
   // Empty-affected fallback: when scope says e2e is required but nx
   // didn't attribute any cap (lib fanout), run all caps.
-  const haveAnyCockpitAffected = allCaps.some((c) => affected.has(c.angular));
+  const haveAnyCockpitAffected = allCaps.some((c) => isCapAffected(c, affected));
   const effectiveFullFleet = args.fullFleet || !haveAnyCockpitAffected;
 
   const selected = selectCockpitCaps(allCaps, affected, {
     fullFleet: effectiveFullFleet,
   });
 
-  const json = JSON.stringify(selected);
+  // ci.yml reads matrix.cap.angular / matrix.cap.python; pythonName is an
+  // internal attribution detail, so keep it out of the emitted matrix.
+  const json = JSON.stringify(
+    selected.map(({ angular, python }) => ({ angular, python })),
+  );
 
   const ghOutput = process.env.GITHUB_OUTPUT;
   if (ghOutput) {

--- a/scripts/cockpit-matrix.spec.mjs
+++ b/scripts/cockpit-matrix.spec.mjs
@@ -1,11 +1,25 @@
 import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
-import { selectCockpitCaps } from './cockpit-matrix.mjs';
+import { isCapAffected, selectCockpitCaps } from './cockpit-matrix.mjs';
 
 const ALL_CAPS = [
-  { angular: 'cockpit-chat-messages-angular', python: 'cockpit/chat/messages/python' },
-  { angular: 'cockpit-chat-input-angular',    python: 'cockpit/chat/input/python' },
-  { angular: 'cockpit-langgraph-streaming-angular', python: 'cockpit/langgraph/streaming/python' },
+  {
+    angular: 'cockpit-chat-messages-angular',
+    python: 'cockpit/chat/messages/python',
+    pythonName: 'cockpit-chat-messages-python',
+  },
+  {
+    angular: 'cockpit-chat-input-angular',
+    python: 'cockpit/chat/input/python',
+    pythonName: 'cockpit-chat-input-python',
+  },
+  {
+    angular: 'cockpit-langgraph-streaming-angular',
+    python: 'cockpit/langgraph/streaming/python',
+    pythonName: 'cockpit-langgraph-streaming-python',
+  },
+  // Node-hosted backend: no python sibling on disk.
+  { angular: 'cockpit-runtimes-mastra-angular', python: '', pythonName: '' },
 ];
 
 describe('selectCockpitCaps', () => {
@@ -15,9 +29,7 @@ describe('selectCockpitCaps', () => {
       new Set(['cockpit-chat-messages-angular']),
       { fullFleet: false },
     );
-    assert.deepEqual(result, [
-      { angular: 'cockpit-chat-messages-angular', python: 'cockpit/chat/messages/python' },
-    ]);
+    assert.deepEqual(result, [ALL_CAPS[0]]);
   });
 
   test('returns multiple affected caps preserving input order', () => {
@@ -26,10 +38,7 @@ describe('selectCockpitCaps', () => {
       new Set(['cockpit-langgraph-streaming-angular', 'cockpit-chat-messages-angular']),
       { fullFleet: false },
     );
-    assert.deepEqual(result, [
-      { angular: 'cockpit-chat-messages-angular', python: 'cockpit/chat/messages/python' },
-      { angular: 'cockpit-langgraph-streaming-angular', python: 'cockpit/langgraph/streaming/python' },
-    ]);
+    assert.deepEqual(result, [ALL_CAPS[0], ALL_CAPS[2]]);
   });
 
   test('returns all caps when fullFleet=true regardless of affected', () => {
@@ -67,5 +76,65 @@ describe('selectCockpitCaps', () => {
       { fullFleet: false },
     );
     assert.deepEqual(JSON.parse(JSON.stringify(result)), result);
+  });
+});
+
+describe('selectCockpitCaps — python sibling attribution', () => {
+  // A cap's python project is a separate nx project from its Angular app, and
+  // the two are not linked in the project graph. Matching only on `cap.angular`
+  // meant a python-only cap change produced an empty selection, which
+  // cockpit-matrix's main() reads as "nx attributed nothing" and answers with
+  // the full fleet — ~40 lanes to cover a one-cap change.
+  test('selects the cap when only its python project is affected', () => {
+    const result = selectCockpitCaps(
+      ALL_CAPS,
+      new Set(['cockpit-chat-messages-python']),
+      { fullFleet: false },
+    );
+    assert.deepEqual(result, [ALL_CAPS[0]]);
+  });
+
+  test('does not double-select when both siblings are affected', () => {
+    const result = selectCockpitCaps(
+      ALL_CAPS,
+      new Set(['cockpit-chat-messages-python', 'cockpit-chat-messages-angular']),
+      { fullFleet: false },
+    );
+    assert.deepEqual(result, [ALL_CAPS[0]]);
+  });
+
+  test('mixes angular- and python-attributed caps', () => {
+    const result = selectCockpitCaps(
+      ALL_CAPS,
+      new Set(['cockpit-langgraph-streaming-python', 'cockpit-chat-input-angular']),
+      { fullFleet: false },
+    );
+    assert.deepEqual(result, [ALL_CAPS[1], ALL_CAPS[2]]);
+  });
+});
+
+describe('isCapAffected', () => {
+  test('matches on the angular project name', () => {
+    assert.equal(
+      isCapAffected(ALL_CAPS[0], new Set(['cockpit-chat-messages-angular'])),
+      true,
+    );
+  });
+
+  test('matches on the python project name', () => {
+    assert.equal(
+      isCapAffected(ALL_CAPS[0], new Set(['cockpit-chat-messages-python'])),
+      true,
+    );
+  });
+
+  test('an empty pythonName never matches an empty-string entry', () => {
+    // cockpit-runtimes-mastra has no python sibling; a falsy pythonName must
+    // not turn `affectedNames.has('')` into a match.
+    assert.equal(isCapAffected(ALL_CAPS[3], new Set([''])), false);
+  });
+
+  test('unrelated affected names do not match', () => {
+    assert.equal(isCapAffected(ALL_CAPS[0], new Set(['chat', 'website'])), false);
   });
 });


### PR DESCRIPTION
PR #932 changed exactly three files under `apps/website/src` and ran **41** `Cockpit — e2e` lanes. Two independent scoping defects stacked.

## 1. The cockpit shell claimed the e2e matrix

`apps/cockpit/project.json` carried `scope:cockpit-e2e`. But the matrix dispatches `nx e2e` for the standalone Angular cap apps under `cockpit/**`, and:

- **0 of 40** caps depend on the `apps/cockpit` Next.js shell (checked against the nx project graph)
- no workflow anywhere runs the shell's own `e2e` target

So the tag could never select real work — only over-select. And it did: `apps/cockpit` statically depends on `apps/website`, so a website-only PR made the shell nx-affected and flipped `cockpit_e2e` true. From that run's `CI scope` log:

```
Affected projects (3):
  website [scope:website, scope:website-e2e, type:app]
  cockpit [scope:cockpit, scope:cockpit-deploy-smoke, scope:cockpit-e2e, scope:cockpit-examples, type:app]
  scripts [scope:scripts-tests, type:tooling]
cockpit_e2e=true
```

## 2. A cap was only matchable by its Angular name

A cap is two independent nx projects — the Angular app that owns the `e2e` target and the python backend — with no edge between them. `cockpit-matrix.mjs` matched affected projects on `cap.angular` only, so a python-only cap change attributed nothing, which `main()` reads as "nx found no cap" and answers with the full fleet.

## Measured, before → after

| change | lanes before | lanes after |
| --- | --- | --- |
| website-only (#932 `base..head`) | 41 | **0** — the dispatcher's `if:` gate is now false |
| python-only cap change | 40 | **1** — the cap that changed |
| `libs/chat` change | 40 | **40** — unchanged, no coverage lost |

(40 vs 41 is drift in the cap count since that run, not an effect of this change.)

## Notes

- The python sibling's nx name is read from its own `project.json` rather than derived from the path. A convention-derived guess would fail open to the full fleet without ever reporting that it guessed.
- The emitted matrix JSON keeps its exact `{angular, python}` shape; `pythonName` is internal to attribution.
- The shell still builds and tests on a website change — it consumes that code. Only the cap e2e matrix is descoped.

## Tests

Both new spec groups were confirmed **failing before** the fix:

```
not ok 1 - apps/cockpit is not tagged scope:cockpit-e2e
not ok 2 - a website-only change leaves cockpit_e2e false
# SyntaxError: ... does not provide an export named 'isCapAffected'
```

After: `node --test` over all six suites 125/125, `nx test scripts` vitest 71/71 (baseline), `nx lint scripts` clean. No new spec *file*, so `scripts/vite.config.mts` `exclude` and the ci.yml `node --test` invocation need no change.

## Left alone deliberately

`scope:cockpit-examples` and `scope:cockpit-deploy-smoke` on the shell are also broad, but those jobs are cheap and already self-scope (`Cockpit — build all examples` correctly logged "No affected cockpit angular projects" on #932). Separately: `apps/cockpit` has an `e2e` target that no workflow runs — worth a look, but not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)