### PR TITLE
fix(ci): bump scorecard-action to v2.4.4 so the image pulls again

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -23,8 +23,15 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      # v2.4.0 runs from `gcr.io/openssf/scorecard-action`, and OpenSSF's GCP
+      # project lost billing: every pull since 2026-09-01 fails with
+      # "denied: This API method requires billing to be enabled ... project
+      # #367732848534". Six consecutive main runs went red for that reason
+      # alone — nothing in this repo. v2.4.1 moved the image to
+      # ghcr.io/ossf/scorecard-action, which pulls anonymously; v2.4.4 is the
+      # current release.
       - name: Run analysis
-        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
`.github/workflows/scorecard.yml` has failed on **every** recent push to `main` — six consecutive runs. The cause is upstream, not this repo.

v2.4.0's action image lives at `gcr.io/openssf/scorecard-action`, and pulls now fail:

```
Error response from daemon: Head "https://gcr.io/v2/openssf/scorecard-action/manifests/v2.4.0":
denied: This API method requires billing to be enabled.
Please enable billing on project #367732848534
```

That is OpenSSF's own GCP project. Nothing here can fix it, and a workflow that is red on every commit trains everyone to stop reading red — so this is worth fixing rather than muting.

## Fix

**v2.4.1 moved the image to GitHub Container Registry.** Diffing `action.yaml` across tags:

| tag | image |
| --- | --- |
| v2.4.0 | `docker://gcr.io/openssf/scorecard-action:v2.4.0` |
| v2.4.1 – v2.4.4 | `docker://ghcr.io/ossf/scorecard-action:<tag>` |

Bumping to v2.4.4 (current release) therefore sidesteps the dead registry entirely, without changing the job's shape, its container-vs-composite form, or making it non-blocking.

## Verification

- ghcr manifest for v2.4.4 is **anonymously pullable** — requested a pull-scoped token and fetched the manifest: `HTTP 200`.
- The three inputs this workflow passes (`results_file`, `results_format`, `publish_results`) all still exist in v2.4.4's `action.yaml`.
- No release note between v2.4.0 and v2.4.4 flags a breaking change affecting this usage.
- `2d1146689b8cda280b9bc96326124645441f03bc` is the commit that tag `v2.4.4` dereferences to (the tag is annotated; `git/ref/tags/v2.4.4` returns the tag object, not the commit).

## Pin safety

Grepped the old SHA `62b2cac7ed8198b15735ed49ab1e5cf35480ba46` across the repo: **this workflow is the only occurrence**. This repo has no independent action-pin validator (no `scripts/release/preflight.mjs`), so there is no second site to keep in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)