### PR TITLE
test(chat,cockpit): fence streaming regression guards; retire stale parser-workaround comment

### DIFF
--- a/cockpit/chat/messages/angular/e2e/c-messages.spec.ts
+++ b/cockpit/chat/messages/angular/e2e/c-messages.spec.ts
@@ -21,3 +21,13 @@ test('c-messages: chat-message-list renders both turns', async ({ page }) => {
   // list renders one bubble per message. Regression coverage for that fix.
   await expect(page.locator('chat-message-list chat-message')).toHaveCount(2);
 });
+
+test('c-messages: a code fence streamed in 3-char chunks renders as a code block', async ({ page }) => {
+  const bubble = await submitAndWaitForResponse(page, 'Stream a TypeScript code fence');
+
+  // Final-state invariant driven through REAL small-chunk streaming: the
+  // fence opener arrives split mid-token and must still commit as a block.
+  await expect(bubble.locator('pre code')).toHaveCount(1);
+  await expect(bubble.locator('pre code')).toContainText('const answer = 42;');
+  await expect(bubble).not.toContainText('```');
+});

--- a/cockpit/chat/messages/angular/e2e/fixtures/c-messages.json
+++ b/cockpit/chat/messages/angular/e2e/fixtures/c-messages.json
@@ -5,6 +5,14 @@
       "response": {
         "content": "Hi! I'm the chat-messages capability demo. I show how ChatMessageListComponent, ChatInputComponent, and ChatTypingIndicatorComponent render together. Try sending a few messages to see the bubbles and typing indicator in action."
       }
+    },
+    {
+      "match": { "userMessage": "Stream a TypeScript code fence" },
+      "response": {
+        "content": "Here is the snippet:\n\n```typescript\nconst answer = 42;\n```\n\nThe constant is available for later use."
+      },
+      "chunkSize": 3,
+      "latency": 25
     }
   ]
 }

--- a/libs/chat/src/lib/markdown/streaming-fence.spec.ts
+++ b/libs/chat/src/lib/markdown/streaming-fence.spec.ts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+//
+// Consumer-side guarantee: with the partial-markdown version chat depends on,
+// a triple-backtick fence whose opener is split across streamed chunks still
+// materializes as a code block — never as a paragraph with inline code.
+// Fixed upstream in 0.5.6 (opener-marker tracking); this spec guards against
+// a dependency downgrade reintroducing it. The e2e harnesses' large default
+// chunkSize is a determinism choice, not a workaround for this — see
+// libs/e2e-harness/src/aimock-runner.ts.
+import { describe, it, expect } from 'vitest';
+import { createPartialMarkdownParser, materialize } from '@cacheplane/partial-markdown';
+
+function finalTypes(chunks: string[]): string[] {
+  const p = createPartialMarkdownParser();
+  for (const chunk of chunks) p.push(chunk);
+  p.finish();
+  const doc = materialize(p.root) as { children?: Array<{ type: string }> } | null;
+  return (doc?.children ?? []).map((c) => c.type);
+}
+
+describe('libs/chat consumes streamed code fences', () => {
+  it('recovers an opener split one backtick at a time', () => {
+    expect(finalTypes(['`', '`', '`ts\n', 'const x = 1;\n', '```\n']))
+      .toEqual(['code-block']);
+  });
+
+  it('recovers a closer split one backtick at a time', () => {
+    expect(finalTypes(['```ts\nconst x = 1;\n', '`', '`', '`\n']))
+      .toEqual(['code-block']);
+  });
+
+  it('survives arbitrary small chunkings of fenced content after prose', () => {
+    const text = 'Here is the snippet:\n\n```typescript\nconst answer = 42;\n```\n\nDone.\n';
+    for (let chunkSize = 1; chunkSize <= 7; chunkSize++) {
+      const chunks: string[] = [];
+      for (let i = 0; i < text.length; i += chunkSize) chunks.push(text.slice(i, i + chunkSize));
+      const types = finalTypes(chunks);
+      expect(types, `chunkSize ${chunkSize}`).toEqual(['paragraph', 'code-block', 'paragraph']);
+    }
+  });
+
+  it('keeps genuine inline code inline', () => {
+    expect(finalTypes(['Use `npm', ' i` first.\n'])).toEqual(['paragraph']);
+  });
+});


### PR DESCRIPTION
## Summary

- New consumer-guarantee spec `streaming-fence.spec.ts`: a triple-backtick fence whose opener/closer is split across streamed chunks (down to 1-char chunks) must materialize as a code block. The bug this guards was fixed upstream in `@cacheplane/partial-markdown` 0.5.6 (opener-marker tracking); this pins the pinned 0.5.8 behavior against downgrades.
- Cockpit tier's first small-chunk streaming fixture: c-messages streams a code fence at `chunkSize: 3` / `latency: 25` and asserts the final DOM renders exactly one `pre code` with no raw fence markers — exercising the in-repo mock's per-fixture chunking.

## Testing

- `streaming-fence.spec.ts`: 4/4 green against partial-markdown 0.5.8.
- New c-messages fence spec: green against the in-repo mock server.
- Note: the pre-existing `c-messages: chat-message-list renders both turns` spec fails on origin/main itself (3 bubbles where 2 expected, reproduced on a pristine detached checkout) — unrelated to this PR and tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)