### PR TITLE
fix(examples): sync requirements.txt with uv.lock; guard drift in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -458,6 +458,14 @@ jobs:
           key: uv-venv-${{ runner.os }}-py3.12-${{ hashFiles('examples/ag-ui/python/uv.lock') }}
       - working-directory: examples/ag-ui/python
         run: uv sync
+      - name: Check requirements.txt matches uv.lock
+        working-directory: examples/ag-ui/python
+        run: |
+          uv export --no-hashes -o /tmp/requirements.check.txt
+          if ! diff -u requirements.txt /tmp/requirements.check.txt; then
+            echo "::error::examples/ag-ui/python/requirements.txt is stale — the Railway image installs from this file, not uv.lock. Run 'uv export --no-hashes -o requirements.txt' in examples/ag-ui/python and commit the result."
+            exit 1
+          fi
       - name: Cache Playwright browsers
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
@@ -548,6 +556,22 @@ jobs:
         if: matrix.cap.python != ''
         working-directory: ${{ matrix.cap.python }}
         run: uv sync
+      - name: Check requirements.txt matches uv.lock
+        if: matrix.cap.python != ''
+        working-directory: ${{ matrix.cap.python }}
+        run: |
+          # Only a handful of caps (the ones deployed via a Railway/Docker
+          # image, e.g. cockpit/ag-ui/*) check in a requirements.txt export
+          # alongside pyproject.toml/uv.lock. Skip caps that don't have one.
+          if [ ! -f requirements.txt ]; then
+            echo "No requirements.txt in ${{ matrix.cap.python }} — skipping drift check."
+            exit 0
+          fi
+          uv export --no-hashes -o /tmp/requirements.check.txt
+          if ! diff -u requirements.txt /tmp/requirements.check.txt; then
+            echo "::error::${{ matrix.cap.python }}/requirements.txt is stale relative to uv.lock — deployments/ag-ui-dev is generated from this file. Run 'uv export --no-hashes -o requirements.txt' in ${{ matrix.cap.python }} and commit the result."
+            exit 1
+          fi
       - name: Cache Playwright browsers
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:

--- a/examples/ag-ui/python/requirements.txt
+++ b/examples/ag-ui/python/requirements.txt
@@ -5,8 +5,10 @@ ag-ui-a2ui-toolkit==0.0.2
     # via ag-ui-langgraph
 ag-ui-langgraph==0.0.40
     # via examples-ag-ui-python
-ag-ui-protocol==0.1.19
-    # via ag-ui-langgraph
+ag-ui-protocol==0.1.22
+    # via
+    #   ag-ui-langgraph
+    #   examples-ag-ui-python
 annotated-doc==0.0.4
     # via fastapi
 annotated-types==0.7.0


### PR DESCRIPTION
## Problem

`examples/ag-ui/python/Dockerfile` installs from `requirements.txt` (a `uv export --no-hashes` snapshot), not from `uv.lock` directly. PR #964 bumped `pyproject.toml`/`uv.lock` to `ag-ui-protocol>=0.1.22` and added a `SubagentStartedEvent` import that only exists in 0.1.22+, but left `requirements.txt` pinned to `ag-ui-protocol==0.1.19`.

Chain of failure:
1. `requirements.txt` drifts from `uv.lock` (nothing catches this).
2. The Railway `ag-ui-demo` image builds fine (pip installs the stale pins) but the container fails to import at boot (`ImportError: cannot import name 'SubagentStartedEvent'`).
3. The `/ok` healthcheck never comes up.
4. The deploy job runs `railway up --detach`, which reports success regardless of whether the new deployment actually became healthy — so the OLD deployment stays live and the break is silent.

## Fix

- Re-ran `uv sync && uv export --no-hashes -o requirements.txt` in `examples/ag-ui/python`. The only substantive change is `ag-ui-protocol==0.1.19` → `0.1.22` (plus its `# via` comment picking up the direct `pyproject.toml` pin). Autogenerated header preserved.
- Verified the fix outside Docker: built a scratch venv from the exported `requirements.txt` (stripping the local `-e .` line exactly like the Dockerfile does) and imported `src.server:app` (and the narrower `src.streaming.subagent_emitting_agent.SubagentEmittingAgent`) from `examples/ag-ui/python` — both import cleanly now.
- Checked the sibling lane, `cockpit/ag-ui/subagents/python/requirements.txt` — it already pins `ag-ui-protocol==0.1.22` (landed via #962), so no change needed there.
- Added a CI drift guard so this can't recur silently: a `uv export --no-hashes` + `diff` step in the `examples/ag-ui — e2e` job, and in the per-cap `Cockpit — e2e` matrix job (skipped for caps that don't check in a `requirements.txt`, since most cockpit python caps aren't Docker-deployed). Both fail with an `::error::` pointing at the exact `uv export` command to fix it.

## Test plan

- [x] `uv export --no-hashes -o requirements.txt` diff reviewed — only the expected version bump
- [x] Scratch-venv install from the exported `requirements.txt` + `import src.server` succeeds
- [x] `cockpit/ag-ui/subagents/python/requirements.txt` confirmed already at 0.1.22
- [x] `.github/workflows/ci.yml` YAML validated with `yaml.safe_load`
- [ ] CI green on this PR (exercises the new drift-check step for real)

🤖 Generated with [Claude Code](https://claude.com/claude-code)