### PR TITLE
fix(workspace): keep utility panel focus when the drawer opens in one commit

### DIFF
--- a/libs/workspace-react/src/lib/components/mobile-nav-overlay.spec.tsx
+++ b/libs/workspace-react/src/lib/components/mobile-nav-overlay.spec.tsx
@@ -32,6 +32,7 @@ const snapshot = createRuntimeSnapshot(parseRuntimeTarget(null), entry.topic);
 
 const renderOverlay = ({
   initialOpen = true,
+  initialActiveUtility = null,
   onPresenceChange = vi.fn(),
   strict = false,
   variant = 'mobile',
@@ -41,6 +42,7 @@ const renderOverlay = ({
   onContextAction = vi.fn(),
 }: {
   initialOpen?: boolean;
+  initialActiveUtility?: CockpitUtility;
   onPresenceChange?: ReturnType<typeof vi.fn>;
   strict?: boolean;
   variant?: 'mobile' | 'tablet';
@@ -65,7 +67,8 @@ const renderOverlay = ({
 
   function Harness() {
     const [isOpen, setIsOpen] = useState(initialOpen);
-    const [activeUtility, setActiveUtility] = useState<CockpitUtility>(null);
+    const [activeUtility, setActiveUtility] =
+      useState<CockpitUtility>(initialActiveUtility);
     const [, setSharedState] = useState(0);
     setOpen = setIsOpen;
     bumpSharedState = () => setSharedState((value) => value + 1);
@@ -263,6 +266,43 @@ describe('MobileNavOverlay', () => {
       expect(document.activeElement).toBe(invoker);
     }
   );
+
+  it.each([
+    ['Activity', 'activity'],
+    ['Settings', 'settings'],
+  ] as const)(
+    'leaves the %s panel heading focused when the utility opens the drawer',
+    (heading, utility) => {
+      // The tablet rail selects the utility and opens the context surface in
+      // one batch, so the panel mounts in the same commit that opens the
+      // dialog. The panel focuses its own heading; the drawer must not then
+      // pull focus back to its first tabbable control.
+      const result = renderOverlay({
+        initialOpen: false,
+        initialActiveUtility: utility,
+        variant: 'tablet',
+        controlPlaneLayout: 'pane',
+      });
+
+      result.reopen();
+
+      expect(document.activeElement).toBe(
+        within(dialog()).getByRole('heading', { name: heading })
+      );
+    }
+  );
+
+  it('still claims drawer focus when no panel claims it first', () => {
+    const result = renderOverlay({ initialOpen: false });
+
+    result.reopen();
+
+    // Which control wins is the document-order first tabbable, and jsdom
+    // groups a selector list by selector instead of document order -- so
+    // assert the drawer took focus rather than naming the element.
+    expect(document.activeElement).not.toBe(document.body);
+    expect(dialog().contains(document.activeElement)).toBe(true);
+  });
 
   it.each([
     ['Escape', () => fireEvent.keyDown(document, { key: 'Escape' })],

--- a/libs/workspace-react/src/lib/components/mobile-nav-overlay.tsx
+++ b/libs/workspace-react/src/lib/components/mobile-nav-overlay.tsx
@@ -327,7 +327,10 @@ export function MobileNavOverlay({
           'a[href], button:not(:disabled), [tabindex]:not([tabindex="-1"])'
         ) ?? []
       );
-    focusable()[0]?.focus();
+    // A utility panel mounting in the same commit that opens the drawer
+    // focuses its own heading first, and child effects run before this one.
+    // Claiming the first tabbable control unconditionally would undo that.
+    if (!dialog?.contains(document.activeElement)) focusable()[0]?.focus();
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         event.preventDefault();


### PR DESCRIPTION
## Why

`main` is currently blocked: the **Deploy → Vercel** job fails at "Verify deployed website" on the website e2e `workspace-shell … and restores utility focus`, which stops `refs/deploy/last-promoted` from advancing and skips Production smoke. Every subsequent main deploy re-verifies and re-fails until this lands. First seen on c2bc3f91 ([run 33684113829](https://github.com/cacheplane/angular-agent-framework/actions/runs/33684113829)), still failing on df910420.

This is a real production a11y regression, not a flaky assertion — the expected focus target is correct and was not loosened.

## Root cause

Opening the tablet context surface (800px) from the rail's **Activity** button mounts `ControlPlaneUtilityPanel` and flips `MobileNavOverlay` to `open` **in the same commit**. The panel focuses its own `<h2 tabindex="-1">`; the overlay's open effect then ran `focusable()[0]?.focus()` — a selector that explicitly excludes `tabindex="-1"` — sending focus to the **Close navigation** button. React runs child passive effects before parent ones, so the drawer always won.

Confirmed against the deployed site: after clicking Activity, `document.activeElement` was `button[Close navigation]` with the heading present, visible, and unfocused.

### Why CI's own e2e job passed on the same commit

`Website — e2e` runs against `next dev` with React StrictMode, which double-invokes effects of *newly mounted* components only. `MobileNavOverlay` stays mounted and returns `null` while closed, so its steal fires once while the fresh panel fires twice — the panel's second invocation lands last and masks the bug. A focus-event log on the dev server showed exactly `h2[Activity]` → `button[Close navigation]` → `h2[Activity]`. Production has no second invocation.

## The fix

Claim initial drawer focus only when nothing inside the dialog already holds it. The Tab-trap registration and all other paths are untouched; when the drawer opens with no panel, focus is still on the trigger (outside the dialog), so default behavior is unchanged.

New regression tests cover the real sequence — panel mounting in the same commit that opens the drawer. The existing utility test missed this because it clicks the invoker while the drawer is *already* open, a commit where the overlay's state doesn't change. Both new cases fail without the fix.

## Verification

- Reproduced the exact CI failure locally (`Received: inactive`, same locator) under production semantics, confirmed it passes with the fix and fails again with the fix reverted — the fix is causal.
- **Full e2e against a real production build: all 13 workspace-shell tests pass**, including the 5 that never ran in CI because serial mode skipped them after the failure, and lines 259–282 of the failing test which had never been exercised against production.
- `nx e2e website` 85/85 · `nx test workspace-react` · `nx test ui-react` · `nx test cockpit` · `nx lint workspace-react` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)