### PR TITLE
fix(website): production-smoke spec must not use import.meta.url

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -640,6 +640,17 @@ jobs:
             playwright-${{ runner.os }}-
       - run: npx playwright install --with-deps chromium
       - run: npx nx e2e website --skip-nx-cache
+      # The production-smoke spec is testIgnore'd outside PRODUCTION_SMOKE mode,
+      # so a module-load error in it is invisible until the post-merge Production
+      # smoke job runs against main — too late to gate a PR. Collect it here:
+      # --list loads every spec without hitting production.
+      - name: Production-smoke spec must load
+        env:
+          PRODUCTION_SMOKE: 'true'
+          BASE_URL: https://threadplane.ai
+        run: |
+          npx playwright test apps/website/e2e/platform-production-smoke.spec.ts \
+            --config apps/website/playwright.config.ts --list
 
   required-pr-checks:
     name: CI — required

--- a/apps/website/e2e/platform-production-smoke.spec.ts
+++ b/apps/website/e2e/platform-production-smoke.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { validateRuntimeParentOrigins } from '@threadplane/cockpit-runtime-bridge';
 import {
   cockpitManifest,
@@ -30,11 +31,12 @@ const EXAMPLES_URL =
   process.env['EXAMPLES_URL'] ?? 'https://examples.threadplane.ai';
 const DEMO_URL = process.env['DEMO_URL'] ?? 'https://demo.threadplane.ai';
 const WEBSITE_URL = process.env['WEBSITE_URL'] ?? 'https://threadplane.ai';
+// Playwright transpiles specs to CJS, so `import.meta.url` here compiles to a
+// `require` the ESM-loaded output cannot resolve and the whole file fails to
+// load. `__dirname` is what the emitted module actually has. Don't "modernise"
+// this back to import.meta.url.
 const runtimeParentOriginSource = JSON.parse(
-  readFileSync(
-    new URL('../../../runtime-parent-origins.json', import.meta.url),
-    'utf8'
-  )
+  readFileSync(join(__dirname, '../../../runtime-parent-origins.json'), 'utf8')
 ) as { readonly baseOrigins?: unknown };
 const runtimeParentPreviewOrigins = (
   process.env['RUNTIME_PARENT_PREVIEW_ORIGINS'] ?? ''


### PR DESCRIPTION
## Summary

The production-smoke spec added in #963 **has never loaded**. Playwright transpiles specs to CJS (`var _test = require("@playwright/test")`), so `import.meta.url` compiles to a `require` the loaded module cannot resolve:

```
ReferenceError: require is not defined in ES module scope
   at platform-production-smoke.spec.ts:1
Error: No tests found.
```

The `Production smoke` job has been reporting *"No tests found"* rather than running, so it has verified nothing since it landed. Resolving the repo-root policy file from `__dirname` — what the emitted CJS module actually has — fixes it.

### Why nothing caught this

The spec is `testIgnore`'d outside `PRODUCTION_SMOKE` mode, so no PR ever loaded it; the failure only appeared post-merge on `main`, where it's too late to gate anything. This PR adds a Website e2e step that collects the spec with `--list`, which loads every spec without touching production.

## Verification

- Before: the exact CI command exits 1 with `No tests found`.
- After: the spec collects **104 tests**.
- Ran the suite against production: **98 passed, 5 failed, 1 skipped**.

## The 5 failures are real production findings, not caused by this change

Reported separately so this fix isn't blocked on them:

1. **Legacy Cockpit redirect service** (4 tests) — `cockpit.threadplane.ai` answers `200` where `308` is expected, for the root, Docs-backed and workspace-only cases, and does not `404` unknown paths. The Cockpit surface retirement is not live in production.
2. **Unified runtime embedding policy** — the assembled `frame-ancestors` policy does not validate (`validateRuntimeParentOrigins` returns `null`).

Both look like the cockpit surface not having promoted rather than defects in the merged code, but they need confirming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)