### PR TITLE
ci: run CI in a merge queue so promotions stop deferring forever

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # A merge queue runs each candidate on a gh-readonly-queue/* ref. Every
+  # verification job already falls through to the ci-scope outputs when the
+  # event is not `push`, so they scope themselves here exactly as they do on a
+  # pull request. The deploy jobs additionally require
+  # `github.ref == 'refs/heads/main'`, which a queue ref never matches, so a
+  # queued candidate can never promote to production.
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
@@ -60,6 +67,15 @@ jobs:
           if [ "${{ github.event_name }}" = "push" ]; then
             node scripts/ci-scope.mjs \
               --event push \
+              --output "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "${{ github.event_name }}" = "merge_group" ]; then
+            node scripts/ci-scope.mjs \
+              --event pull_request \
+              --base "${{ github.event.merge_group.base_sha }}" \
+              --head "${{ github.event.merge_group.head_sha }}" \
               --output "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -676,7 +692,10 @@ jobs:
       - scripts-tests
       - growth-lifecycle
       - lifecycle
-    if: ${{ always() && github.event_name == 'pull_request' }}
+    # `CI — required` is the only required status context. A merge queue
+    # waits on it for each candidate, so it must report on merge_group too —
+    # otherwise every queued merge blocks forever on a check that never runs.
+    if: ${{ always() && (github.event_name == 'pull_request' || github.event_name == 'merge_group') }}
     runs-on: ubuntu-latest
     steps:
       - name: Verify scoped CI jobs

--- a/scripts/ci-workflow.spec.mjs
+++ b/scripts/ci-workflow.spec.mjs
@@ -77,6 +77,53 @@ function readNamedStep(job, name) {
 }
 
 describe('CI workflow', () => {
+  it('runs in a merge queue and reports the required context there', async () => {
+    const workflow = await readFile('.github/workflows/ci.yml', 'utf8');
+
+    assert.match(
+      workflow,
+      /^  merge_group:\s*$/m,
+      'ci.yml must trigger on merge_group or a merge queue blocks forever'
+    );
+
+    const required = readJobBlock(workflow, 'required-pr-checks');
+    assert.match(
+      required,
+      /github\.event_name == 'merge_group'/,
+      'CI — required is the only required context; it must report inside the queue'
+    );
+  });
+
+  it('never lets a merge-queue candidate promote to production', async () => {
+    const workflow = await readFile('.github/workflows/ci.yml', 'utf8');
+
+    // A queue candidate builds on refs/heads/gh-readonly-queue/*, so every job
+    // that touches production must be pinned to refs/heads/main. Without this
+    // the queue would deploy unmerged candidates.
+    for (const job of [
+      'deploy',
+      'demo-deploy',
+      'ag-ui-demo-deploy',
+      'production-smoke',
+    ]) {
+      const block = readJobBlock(workflow, job);
+      assert.match(
+        block,
+        /github\.ref == 'refs\/heads\/main'/,
+        `${job} must be pinned to refs/heads/main so a queue ref cannot deploy`
+      );
+    }
+  });
+
+  it('scopes a merge-queue candidate from the merge group range', async () => {
+    const workflow = await readFile('.github/workflows/ci.yml', 'utf8');
+    const scope = readJobBlock(workflow, 'ci-scope');
+
+    assert.match(scope, /github\.event\.merge_group\.base_sha/);
+    assert.match(scope, /github\.event\.merge_group\.head_sha/);
+  });
+
+
   async function readWorkflow() {
     return readFile('.github/workflows/ci.yml', 'utf8');
   }
@@ -908,7 +955,7 @@ describe('CI workflow', () => {
     assert.match(requiredPrChecksJob, /name:\s*CI — required/);
     assert.match(
       requiredPrChecksJob,
-      /if:\s*\$\{\{\s*always\(\)\s*&&\s*github\.event_name == 'pull_request'\s*\}\}/
+      /if:\s*\$\{\{\s*always\(\)\s*&&\s*\(github\.event_name == 'pull_request'\s*\|\|\s*github\.event_name == 'merge_group'\)\s*\}\}/
     );
 
     assert.deepEqual(readJobNeeds(requiredPrChecksJob), expectedNeeds);


### PR DESCRIPTION
> **Land this before enabling the merge queue in settings.** Turning the queue on first would hang every merge on a required check that never runs.

## Why

Merges arrive faster than CI completes (~25 min apart vs ~30 min runs), so the deploy job's staleness gate defers to a newer commit — which then defers itself. Tonight that ran **five rounds** and production never advanced past the pre-#963 build. The gate is correct in isolation; it just has no way to eventually win.

A merge queue serialises `main` so each candidate gets a clean window.

## What this changes

GitHub runs queue candidates on the `merge_group` event. Three things are required:

1. **Trigger CI on `merge_group`.**
2. **Scope a candidate from the merge group's base/head range**, so queued runs stay as narrow as pull requests instead of running the full matrix every time.
3. **Report `CI — required` on `merge_group`.** It is the only required status context and the queue waits on it per candidate — this is the one that would hang merges if missed.

## What deliberately does not change

- **The 18 verification jobs.** They already read `github.event_name == 'push' || needs.ci-scope.outputs.X`, so on `merge_group` they fall through to the scope outputs and behave exactly as they do on a PR.
- **The 4 deploy jobs.** They additionally require `github.ref == 'refs/heads/main'`, and a candidate builds on `refs/heads/gh-readonly-queue/*`. **A queued candidate therefore cannot promote to production.** This is the safety-critical property, and it is now pinned by a test rather than left implicit.

## Verification

- `ci-workflow.spec.mjs`: 36/36, including three new guards — the `merge_group` trigger exists, the required context reports there, and all four production jobs stay pinned to `refs/heads/main`.
- Mutation-probed: removing the `merge_group` trigger fails a guard.
- Re-pinned the existing `CI — required` `if:` assertion to the new expression rather than loosening it.

## After merging

Enable the merge queue on `main` in branch protection. Worth doing in the same sitting — the two halves are only useful together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)