### PR TITLE
fix(examples/chat): hero walkthrough keeps reading pauses under reduced motion

### DIFF
--- a/examples/chat/angular/src/app/hero/hero-mode.component.spec.ts
+++ b/examples/chat/angular/src/app/hero/hero-mode.component.spec.ts
@@ -137,6 +137,28 @@ describe('HeroMode', () => {
     expect(fx.componentInstance.mode()).toBe('live');
   });
 
+  it('reduced motion: typeInto sets the value instantly but keeps a reading pause before resolving', async () => {
+    fx.componentInstance.reducedMotion = true;
+    const el = fx.nativeElement as HTMLElement;
+    const textarea = el.querySelector<HTMLTextAreaElement>('textarea[aria-label="Type a message"]')!;
+
+    const started = performance.now();
+    const typing = fx.componentInstance.typeInto('abc');
+    // Instant: the value is set synchronously, before any timer fires.
+    expect(textarea.value).toBe('abc');
+
+    await typing;
+    expect(performance.now() - started).toBeGreaterThanOrEqual(1200);
+  });
+
+  it('reduced motion: moveCursor holds for a reading pause instead of resolving instantly', async () => {
+    fx.componentInstance.reducedMotion = true;
+
+    const started = performance.now();
+    await fx.componentInstance.moveCursor('composer');
+    expect(performance.now() - started).toBeGreaterThanOrEqual(600);
+  });
+
   it('clears the half-typed composer on takeover', async () => {
     const el = fx.nativeElement as HTMLElement;
     await fx.componentInstance.typeInto('hello');

--- a/examples/chat/angular/src/app/hero/hero-mode.component.ts
+++ b/examples/chat/angular/src/app/hero/hero-mode.component.ts
@@ -47,6 +47,12 @@ import { HeroScriptRunner, type CursorTarget, type HeroScriptHost } from './hero
 
 export type HeroModeKind = 'replay' | 'live';
 const TYPE_DELAY_MS = 40;
+/**
+ * Reduced motion removes animation, not reading time: a visitor who never
+ * sees the cursor glide or the prompt type out still needs a moment to read
+ * what just appeared before the walkthrough moves on.
+ */
+const READ_PAUSE_MS = 1200;
 
 /**
  * The live agent's thread id, held per component instance (NOT at module
@@ -216,7 +222,8 @@ export class HeroMode implements HeroScriptHost {
     typeof window === 'undefined'
       ? { postState: () => undefined, onVisibility: () => () => undefined }
       : browserHeroBridge();
-  readonly reducedMotion =
+  /** TEST SEAM. Overridable the same way `bridge` is, instead of mocking matchMedia globally. */
+  reducedMotion =
     typeof matchMedia === 'function' && matchMedia('(prefers-reduced-motion: reduce)').matches;
 
   private runner: HeroScriptRunner | null = null;
@@ -389,9 +396,13 @@ export class HeroMode implements HeroScriptHost {
 
   async typeInto(text: string): Promise<void> {
     // Deliberately does NOT focus the textarea: that would trip the takeover.
-    await this.driving(() =>
-      typeIntoTextarea(composerOf(this.surface()), text, TYPE_DELAY_MS, this.reducedMotion),
-    );
+    await this.driving(async () => {
+      await typeIntoTextarea(composerOf(this.surface()), text, TYPE_DELAY_MS, this.reducedMotion);
+      // Reduced motion writes the whole prompt in one tick; without a pause
+      // here it would be typed and sent in the same tick and a reduced-motion
+      // visitor would never get to read it.
+      if (this.reducedMotion) await sleep(READ_PAUSE_MS);
+    });
   }
 
   async send(): Promise<void> {
@@ -420,7 +431,9 @@ export class HeroMode implements HeroScriptHost {
     this.cursorX.set(point.x);
     this.cursorY.set(point.y);
     this.cursorVisible.set(true);
-    await sleep(this.reducedMotion ? 0 : 650);
+    // Reduced motion skips the glide (the cursor jumps) but still holds
+    // briefly so the target is readable before the next scripted action.
+    await sleep(this.reducedMotion ? READ_PAUSE_MS / 2 : 650);
   }
 
   hasInterrupt(): boolean {


### PR DESCRIPTION
## Problem (verified on production)

Under `prefers-reduced-motion: reduce`, `HeroMode` zeroed every scripted pause: `moveCursor` slept 0, `press` slept 0, and `typeInto` wrote the whole prompt in one shot — so the first prompt was typed and sent in the same tick, and a reduced-motion visitor never got a chance to read it. The spec intent for reduced motion is "typing is instant and the cursor jumps," not "no pacing at all."

## Fix

In `hero-mode.component.ts`:
- Added `READ_PAUSE_MS = 1200` ("reduced motion removes animation, not reading time").
- `typeInto`: under reduced motion, after the instant set, waits `READ_PAUSE_MS` so the prompt is visible before the cursor moves on.
- `moveCursor`: under reduced motion, waits `READ_PAUSE_MS / 2` (600ms) instead of 0 — the cursor jumps, then holds briefly so the target is readable.
- `press` stays instant (0ms) under reduced motion.
- Made `reducedMotion` an overridable public field (test seam, same pattern as `bridge`) instead of a readonly value computed once from `matchMedia`, so specs can flip it without mocking `matchMedia` globally.

The pauses run inside the existing `driving()` wrapper, so `scriptDriving` window semantics are unchanged.

## Test evidence

Two new specs in `hero-mode.component.spec.ts` (real timers, timestamped):
- reduced motion `typeInto('abc')` sets the textarea value synchronously but the returned promise takes ≥1200ms to resolve.
- reduced motion `moveCursor('composer')` takes ≥600ms to resolve (not 0).

`npx nx test examples-chat-angular`: 177 passed (23 files), 0 failed.
`npx nx lint examples-chat-angular`: 0 errors (47 pre-existing warnings, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)