### PR TITLE
fix(ci): give the Website Vercel build its growth form policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1005,6 +1005,14 @@ jobs:
       - name: Deploy immutable Website preview
         if: steps.freshness.outputs.stale != 'true' && steps.affected.outputs.website == 'true'
         id: deploy_website
+        env:
+          # Server pages read the growth form policy while rendering, so this
+          # build needs it exactly as the `website` job does. It cannot come
+          # from `vercel pull`: the project marks GROWTH_FORM_POLICY sensitive
+          # for preview/production, and Vercel never returns a sensitive value,
+          # so the pulled .env omits it and `vercel build` throws
+          # "GROWTH_FORM_POLICY must be growth_v1". It is not a secret.
+          GROWTH_FORM_POLICY: growth_v1
         run: |
           npx vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
           url=$(npx vercel deploy --prebuilt --archive=tgz --prod --skip-domain --yes --token=${{ secrets.VERCEL_TOKEN }} | tail -n 1)


### PR DESCRIPTION
## Summary

The deploy job's `npx vercel build` fails on `main`:

```
Error: GROWTH_FORM_POLICY must be growth_v1
Error: Command "npx nx build website" exited with 1
```

The Website preview is therefore never built, **every later step skips** — embedding-policy verification, Website promotion, the cockpit redirect build, cockpit promotion — and production has not promoted since the control-plane arc landed.

## Root cause

#968 added the assertion in `apps/website/src/lib/growth/form-policy.ts:35` and set `GROWTH_FORM_POLICY` for the `website` job, but not for the deploy job's build.

It cannot come from `vercel pull`. The project marks `GROWTH_FORM_POLICY` **sensitive** for preview and production:

```
target=preview      type=sensitive  value=''
target=production   type=sensitive  value=''
```

Vercel never returns a sensitive value, so the pulled `.env` omits it and the runner-side `vercel build` throws. A Vercel-side cloud build would have it; our `--prebuilt` flow does not. That is why #968's own CI was green — the `website` job hardcodes the value.

## Fix

Set it on the build step, mirroring the `website` job. It is not a secret (the existing comment in that job says so), and **runtime is unaffected** — Vercel still injects the sensitive value into the deployed function.

## Verification

- The CI log shows that exact error string from `form-policy.ts:35`.
- `GROWTH_FORM_POLICY` is confirmed `type=sensitive` with an empty readback via the Vercel API.
- The `website` job, which sets the same value, builds green every run.
- `ci-workflow.spec.mjs`: 36/36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)