### PR TITLE
feat(website): whitepaper block and toast on the form kit; old form CSS removed

### DIFF
--- a/apps/website/e2e/website.spec.ts
+++ b/apps/website/e2e/website.spec.ts
@@ -213,8 +213,8 @@ test('whitepaper signup form posts to /api/whitepaper-signup and renders success
   });
 
   await page.goto('/chat');
-  await page.locator('#whitepaper-block').getByLabel('Email address').fill('reader@acme.com');
-  await page.locator('#whitepaper-block').getByRole('button', { name: 'Download (free)' }).click();
+  await page.locator('#whitepaper-block').getByLabel('Work email').fill('reader@acme.com');
+  await page.locator('#whitepaper-block').getByRole('button', { name: 'Get the field report' }).click();
 
   await expect(page.getByText(/check your inbox/i)).toBeVisible();
   expect(payload).toMatchObject({

--- a/apps/website/src/components/landing/TeamsBlock.spec.tsx
+++ b/apps/website/src/components/landing/TeamsBlock.spec.tsx
@@ -24,7 +24,7 @@ describe('TeamsBlock', () => {
     expect(screen.getByRole('link', { name: 'Talk to an engineer' }).getAttribute('href')).toBe('/contact?source=home_enterprise&track=enterprise');
     expect(screen.getByRole('link', { name: 'See the pilot program' }).getAttribute('href')).toBe('/pilot-to-prod');
     expect(container.querySelectorAll('form')).toHaveLength(1);
-    expect(screen.getByLabelText('Email address')).toBeTruthy();
+    expect(screen.getByLabelText('Work email')).toBeTruthy();
     expect(screen.getByText('Whitepaper disclosure')).toBeTruthy();
   });
 

--- a/apps/website/src/components/landing/WhitePaperBlock.spec.tsx
+++ b/apps/website/src/components/landing/WhitePaperBlock.spec.tsx
@@ -28,10 +28,10 @@ const UUID_V4 =
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu;
 
 function submit(email: string): void {
-  fireEvent.change(screen.getByLabelText(/email address/i), {
+  fireEvent.change(screen.getByLabelText('Work email'), {
     target: { value: email },
   });
-  fireEvent.click(screen.getByRole('button', { name: /download \(free\)/i }));
+  fireEvent.click(screen.getByRole('button', { name: 'Get the field report' }));
 }
 
 function sentBody(fetchMock: ReturnType<typeof vi.fn>, call: number) {
@@ -57,11 +57,34 @@ describe('WhitePaperBlock', () => {
     submit('dev@example.com');
 
     await waitFor(() =>
-      expect(screen.getByText(/Check your inbox/i)).toBeTruthy()
+      expect(screen.getByRole('status').textContent).toContain('Check your inbox.')
     );
     const events = trackMock.mock.calls.map((call) => call[0]);
     expect(events).toContain('marketing:whitepaper_signup_submit');
     expect(events).toContain('marketing:whitepaper_signup_success');
+  });
+
+  it('shows the direct PDF link in the failure block', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+    render(<WhitePaperBlock formPolicy={formPolicy} paper="chat" />);
+    fireEvent.change(screen.getByLabelText('Work email'), { target: { value: 'reader@acme.com' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Get the field report' }));
+    await waitFor(() => expect(screen.getByRole('alert')).toBeTruthy());
+    expect(screen.getByRole('link', { name: 'Download the PDF directly' }).getAttribute('href')).toBe('/whitepapers/chat.pdf');
+  });
+
+  it('validates on blur, focuses the field on an invalid submit, and clears once valid', () => {
+    vi.stubGlobal('fetch', vi.fn());
+    render(<WhitePaperBlock formPolicy={formPolicy} />);
+    const input = screen.getByLabelText('Work email');
+    fireEvent.click(screen.getByRole('button', { name: 'Get the field report' }));
+    expect(screen.getByText('Enter your email address.')).toBeTruthy();
+    expect(document.activeElement).toBe(input);
+    fireEvent.change(input, { target: { value: 'reader@acme' } });
+    fireEvent.blur(input);
+    expect(screen.getByText('Enter a full address, like jordan@acme.dev.')).toBeTruthy();
+    fireEvent.change(input, { target: { value: 'reader@acme.dev' } });
+    expect(screen.queryByText(/full address/)).toBeNull();
   });
 });
 
@@ -70,7 +93,7 @@ describe('WhitePaperBlock growth policy', () => {
     render(<WhitePaperBlock formPolicy={formPolicy} />);
 
     const disclosure = screen.getByText(formPolicy.disclosures.whitepaper);
-    const button = screen.getByRole('button', { name: /download \(free\)/i });
+    const button = screen.getByRole('button', { name: 'Get the field report' });
 
     expect(disclosure.id).toBeTruthy();
     expect(button.getAttribute('aria-describedby')).toBe(disclosure.id);
@@ -103,7 +126,7 @@ describe('WhitePaperBlock growth policy', () => {
 
     submit('reader@example.com');
     await waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
-    fireEvent.click(screen.getByRole('button', { name: /download \(free\)/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Get the field report' }));
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
 
     expect(sentBody(fetchMock, 1).submission_id).toBe(

--- a/apps/website/src/components/landing/WhitePaperBlock.spec.tsx
+++ b/apps/website/src/components/landing/WhitePaperBlock.spec.tsx
@@ -74,12 +74,14 @@ describe('WhitePaperBlock', () => {
   });
 
   it('validates on blur, focuses the field on an invalid submit, and clears once valid', () => {
-    vi.stubGlobal('fetch', vi.fn());
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
     render(<WhitePaperBlock formPolicy={formPolicy} />);
     const input = screen.getByLabelText('Work email');
     fireEvent.click(screen.getByRole('button', { name: 'Get the field report' }));
     expect(screen.getByText('Enter your email address.')).toBeTruthy();
     expect(document.activeElement).toBe(input);
+    expect(fetchMock).not.toHaveBeenCalled();
     fireEvent.change(input, { target: { value: 'reader@acme' } });
     fireEvent.blur(input);
     expect(screen.getByText('Enter a full address, like jordan@acme.dev.')).toBeTruthy();

--- a/apps/website/src/components/landing/WhitePaperForm.tsx
+++ b/apps/website/src/components/landing/WhitePaperForm.tsx
@@ -1,18 +1,16 @@
 'use client';
-import { useRef, useState } from 'react';
+import { useState } from 'react';
+import type { FormEvent } from 'react';
 import type { PublicFormPolicy } from '../../lib/growth/form-policy';
-import {
-  FORM_POLICY_REFRESH_MESSAGE,
-  growthFormRequestSnapshot,
-  type GrowthFormRequestSnapshot,
-} from '../../lib/growth/form-client';
+import { FORM_POLICY_REFRESH_MESSAGE } from '../../lib/growth/form-client';
 import { Button } from '../ui/Button';
 import {
   analyticsEvents,
   type AnalyticsSurface,
   type WhitepaperId,
 } from '../../lib/analytics/events';
-import { track, trackWhitepaperDownloadClick } from '../../lib/analytics/client';
+import { trackWhitepaperDownloadClick } from '../../lib/analytics/client';
+import { Field, FormStatus, SubmitButton, TextInput, emailError, useGrowthForm } from '../form';
 
 export type { WhitepaperId };
 
@@ -33,6 +31,7 @@ interface WhitePaperFormProps {
   idPrefix: string;
 }
 
+/** The whitepaper signup on the form kit: label above the field, inline submit, validation on blur. */
 export function WhitePaperForm({
   paper,
   formPolicy,
@@ -42,156 +41,88 @@ export function WhitePaperForm({
 }: WhitePaperFormProps) {
   const pdf = PDF_PATHS[paper];
   const [email, setEmail] = useState('');
-  const [state, setState] = useState<
-    'idle' | 'submitting' | 'done' | 'error' | 'stale'
-  >('idle');
-  const submissionSnapshot = useRef<GrowthFormRequestSnapshot<{
-    email: string;
-    paper: WhitepaperId;
-  }> | null>(null);
+  const [emailMessage, setEmailMessage] = useState<string | null>(null);
+  const form = useGrowthForm<{ email: string; paper: WhitepaperId }>({
+    route: '/api/whitepaper-signup',
+    formPolicy,
+    events: {
+      submit: analyticsEvents.marketingWhitepaperSignupSubmit,
+      success: analyticsEvents.marketingWhitepaperSignupSuccess,
+      fail: analyticsEvents.marketingWhitepaperSignupFail,
+    },
+    analytics: { surface, source_section: sourceSection, paper },
+  });
   const inputId = `${idPrefix}-email`;
   const disclosureId = `${idPrefix}-growth-disclosure`;
 
-  const submit = async (e: React.FormEvent) => {
+  const directLink = (ctaId: 'home_whitepaper_direct' | 'home_whitepaper_direct_inline', label: string) => (
+    <a
+      href={pdf.href}
+      download={pdf.download}
+      onClick={() => trackWhitepaperDownloadClick(paper, { surface, source_section: sourceSection, cta_id: ctaId })}
+    >
+      {label}
+    </a>
+  );
+
+  const submit = (e: FormEvent) => {
     e.preventDefault();
-    if (!email) return;
-    setState('submitting');
-    track(analyticsEvents.marketingWhitepaperSignupSubmit, {
-      surface,
-      source_section: sourceSection,
-      paper,
-    });
-    try {
-      const snapshot = growthFormRequestSnapshot(submissionSnapshot.current, {
-        email,
-        paper,
-      });
-      submissionSnapshot.current = snapshot;
-      const res = await fetch('/api/whitepaper-signup', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          ...snapshot.facts,
-          acquisition_session_id: snapshot.acquisition_session_id,
-          submission_id: snapshot.submission_id,
-          policy_version: formPolicy.version,
-        }),
-      });
-      if (res.status === 409) {
-        submissionSnapshot.current = null;
-        setState('stale');
-        return;
-      }
-      if (res.status >= 400 && res.status < 500) {
-        submissionSnapshot.current = null;
-      }
-      if (!res.ok) throw new Error('whitepaper_signup_failed');
-      submissionSnapshot.current = null;
-      track(analyticsEvents.marketingWhitepaperSignupSuccess, {
-        surface,
-        source_section: sourceSection,
-        paper,
-      });
-      setState('done');
-    } catch {
-      track(analyticsEvents.marketingWhitepaperSignupFail, {
-        surface,
-        source_section: sourceSection,
-        paper,
-        error_reason: 'api_error',
-      });
-      setState('error');
+    const problem = emailError(email);
+    setEmailMessage(problem);
+    if (problem) {
+      document.getElementById(inputId)?.focus();
+      return;
     }
+    void form.submit({ email: email.trim(), paper });
   };
 
+  if (form.status === 'sent') {
+    return (
+      <FormStatus tone="success" title="Check your inbox." detail="The guide is on its way, and the PDF is here too.">
+        {directLink('home_whitepaper_direct', 'Download the PDF directly')}
+      </FormStatus>
+    );
+  }
+  if (form.status === 'stale') {
+    return (
+      <FormStatus tone="stale" title="This page is out of date." detail={FORM_POLICY_REFRESH_MESSAGE}>
+        <Button type="button" variant="primary" size="lg" onClick={() => window.location.reload()}>
+          Refresh page
+        </Button>
+      </FormStatus>
+    );
+  }
   return (
-    <>
-      {state === 'done' ? (
-        <div className="wp-success">
-          ✓ Check your inbox — the guide is on its way.{' '}
-          <a
-            href={pdf.href}
-            download={pdf.download}
-            onClick={() =>
-              trackWhitepaperDownloadClick(paper, {
-                surface,
-                source_section: sourceSection,
-                cta_id: 'home_whitepaper_direct',
-              })
-            }
-            className="wp-success-link"
-          >
-            Or download directly.
-          </a>
-        </div>
-      ) : state === 'stale' ? (
-        <div role="alert" className="wp-form">
-          <p className="wp-disclosure">{FORM_POLICY_REFRESH_MESSAGE}</p>
-          <Button
-            type="button"
-            variant="primary"
-            size="lg"
-            onClick={() => window.location.reload()}
-          >
-            Refresh page
-          </Button>
-        </div>
-      ) : (
-        <form onSubmit={submit} className="wp-form">
-          <label htmlFor={inputId} className="sr-only">Email address</label>
-          <input
-            id={inputId}
+    <form onSubmit={submit} className="wp-form" data-ui="form" noValidate>
+      <Field id={inputId} label="Work email" error={emailMessage}>
+        <div data-ui="form-row">
+          <TextInput
             type="email"
             autoComplete="email"
+            inputMode="email"
             placeholder="you@company.com"
             value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-            disabled={state === 'submitting'}
-            className="wp-email-input"
+            onChange={(e) => {
+              setEmail(e.target.value);
+              if (emailMessage) setEmailMessage(emailError(e.target.value));
+            }}
+            onBlur={() => setEmailMessage(emailError(email))}
+            disabled={form.status === 'pending'}
           />
-          <p id={disclosureId} className="wp-disclosure">
-            {formPolicy.disclosures.whitepaper}
-          </p>
-          <Button
-            type="submit"
-            variant="primary"
-            size="lg"
-            disabled={state === 'submitting' || !email}
-            aria-describedby={disclosureId}
-          >
-            {state === 'submitting' ? 'Sending…' : 'Download (free)'}
-          </Button>
-        </form>
-      )}
-      {state === 'error' && (
-        <p className="wp-error">
-          Something went wrong — please try again or{' '}
-          <a href={pdf.href} download={pdf.download} className="wp-error-link">
-            download directly
-          </a>
-          .
-        </p>
-      )}
-      {state !== 'done' && (
-        <p className="wp-already">
-          Already on the list?{' '}
-          <a
-            href={pdf.href}
-            download={pdf.download}
-            onClick={() =>
-              trackWhitepaperDownloadClick(paper, {
-                surface,
-                source_section: sourceSection,
-                cta_id: 'home_whitepaper_direct_inline',
-              })
-            }
-            className="wp-already-link"
-          >
-            Download the PDF directly.
-          </a>
-        </p>
-      )}
-    </>
+          <SubmitButton variant="primary" size="lg" pending={form.status === 'pending'} pendingLabel="Sending the guide…" aria-describedby={disclosureId}>
+            Get the field report
+          </SubmitButton>
+        </div>
+      </Field>
+      <p id={disclosureId} data-ui="form-disclosure">
+        {formPolicy.disclosures.whitepaper}
+      </p>
+      {form.status === 'failed' ? (
+        <FormStatus tone="failure" title="That did not send." detail="You can still get the guide.">
+          {directLink('home_whitepaper_direct', 'Download the PDF directly')}
+        </FormStatus>
+      ) : null}
+      <p className="wp-already">Already on the list? {directLink('home_whitepaper_direct_inline', 'Download the PDF directly.')}</p>
+    </form>
   );
 }

--- a/apps/website/src/components/shared/AnnouncementToast.spec.tsx
+++ b/apps/website/src/components/shared/AnnouncementToast.spec.tsx
@@ -83,10 +83,10 @@ function openForm(): void {
 }
 
 function fillAndSubmit(email: string): void {
-  fireEvent.change(screen.getByLabelText(/email address/i), {
+  fireEvent.change(screen.getByLabelText('Work email'), {
     target: { value: email },
   });
-  fireEvent.click(screen.getByRole('button', { name: /send me the guide/i }));
+  fireEvent.click(screen.getByRole('button', { name: 'Get the field report' }));
 }
 
 async function flush(): Promise<void> {
@@ -120,7 +120,7 @@ describe('AnnouncementToast growth policy', () => {
     openForm();
 
     const disclosure = screen.getByText(formPolicy.disclosures.whitepaper);
-    const submit = screen.getByRole('button', { name: /send me the guide/i });
+    const submit = screen.getByRole('button', { name: 'Get the field report' });
 
     expect(disclosure.id).toBeTruthy();
     expect(submit.getAttribute('aria-describedby')).toBe(disclosure.id);
@@ -156,5 +156,39 @@ describe('AnnouncementToast growth policy', () => {
     await flush();
     expect(screen.getByRole('button', { name: /refresh page/i })).toBeTruthy();
     expect(screen.queryByText(/check your inbox/i)).toBeNull();
+  });
+
+  it('reports a failed send instead of pretending it succeeded', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+    openForm();
+
+    fillAndSubmit('reader@acme.com');
+
+    await flush();
+    expect(screen.getByRole('alert').textContent).toContain('That did not send.');
+  });
+
+  it('validates on blur and focuses the field on an invalid submit', () => {
+    vi.stubGlobal('fetch', vi.fn());
+    openForm();
+
+    const input = screen.getByLabelText('Work email');
+    fireEvent.click(screen.getByRole('button', { name: 'Get the field report' }));
+    expect(screen.getByText('Enter your email address.')).toBeTruthy();
+    expect(document.activeElement).toBe(input);
+
+    fireEvent.change(input, { target: { value: 'reader@acme' } });
+    fireEvent.blur(input);
+    expect(screen.getByText('Enter a full address, like jordan@acme.dev.')).toBeTruthy();
+  });
+
+  it('shows the sent confirmation on success', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, status: 200 }));
+    openForm();
+
+    fillAndSubmit('reader@example.com');
+
+    await flush();
+    expect(screen.getByRole('status').textContent).toContain('Check your inbox.');
   });
 });

--- a/apps/website/src/components/shared/AnnouncementToast.spec.tsx
+++ b/apps/website/src/components/shared/AnnouncementToast.spec.tsx
@@ -173,6 +173,8 @@ describe('AnnouncementToast growth policy', () => {
     openForm();
 
     const input = screen.getByLabelText('Work email');
+    act(() => { (document.activeElement as HTMLElement | null)?.blur(); });
+    expect(document.activeElement).not.toBe(input);
     fireEvent.click(screen.getByRole('button', { name: 'Get the field report' }));
     expect(screen.getByText('Enter your email address.')).toBeTruthy();
     expect(document.activeElement).toBe(input);

--- a/apps/website/src/components/shared/AnnouncementToast.tsx
+++ b/apps/website/src/components/shared/AnnouncementToast.tsx
@@ -1,17 +1,21 @@
 'use client';
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import type { PublicFormPolicy } from '../../lib/growth/form-policy';
-import {
-  FORM_POLICY_REFRESH_MESSAGE,
-  growthFormRequestSnapshot,
-  type GrowthFormRequestSnapshot,
-} from '../../lib/growth/form-client';
+import { FORM_POLICY_REFRESH_MESSAGE } from '../../lib/growth/form-client';
 import { analyticsEvents } from '../../lib/analytics/events';
 import {
   track,
   trackWhitepaperDownloadClick,
 } from '../../lib/analytics/client';
 import { Button } from '../ui/Button';
+import {
+  Field,
+  FormStatus,
+  SubmitButton,
+  TextInput,
+  emailError,
+  useGrowthForm,
+} from '../form';
 
 /**
  * Bump this date to re-show the toast for all users.
@@ -32,12 +36,23 @@ export function AnnouncementToast({
   const [mounted, setMounted] = useState(false);
   const [step, setStep] = useState<Step>('cta');
   const [email, setEmail] = useState('');
-  const [submitting, setSubmitting] = useState(false);
-  const submissionSnapshot = useRef<GrowthFormRequestSnapshot<{
-    email: string;
-    paper: 'overview';
-  }> | null>(null);
+  const [emailMessage, setEmailMessage] = useState<string | null>(null);
   const disclosureId = 'toast-whitepaper-growth-disclosure';
+
+  const form = useGrowthForm<{ email: string; paper: 'overview' }>({
+    route: '/api/whitepaper-signup',
+    formPolicy,
+    events: {
+      submit: analyticsEvents.marketingWhitepaperSignupSubmit,
+      success: analyticsEvents.marketingWhitepaperSignupSuccess,
+      fail: analyticsEvents.marketingWhitepaperSignupFail,
+    },
+    analytics: {
+      surface: 'toast',
+      source_section: 'announcement-toast',
+      paper: 'overview',
+    },
+  });
 
   const [timerDone, setTimerDone] = useState(false);
   const [scrolledEnough, setScrolledEnough] = useState(false);
@@ -99,58 +114,27 @@ export function AnnouncementToast({
     }
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!email) return;
-    setSubmitting(true);
-    track(analyticsEvents.marketingWhitepaperSignupSubmit, {
-      surface: 'toast',
-      source_section: 'announcement-toast',
-      paper: 'overview',
-    });
-    try {
-      const snapshot = growthFormRequestSnapshot(submissionSnapshot.current, {
-        email,
-        paper: 'overview' as const,
-      });
-      submissionSnapshot.current = snapshot;
-      const response = await fetch('/api/whitepaper-signup', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          ...snapshot.facts,
-          acquisition_session_id: snapshot.acquisition_session_id,
-          submission_id: snapshot.submission_id,
-          policy_version: formPolicy.version,
-        }),
-      });
-      if (response.status === 409) {
-        submissionSnapshot.current = null;
-        setStep('stale');
-        setSubmitting(false);
-        return;
-      }
-      if (response.status >= 400 && response.status < 500) {
-        submissionSnapshot.current = null;
-      }
-      submissionSnapshot.current = null;
-      track(analyticsEvents.marketingWhitepaperSignupSuccess, {
-        surface: 'toast',
-        source_section: 'announcement-toast',
-        paper: 'overview',
-      });
-    } catch {
-      track(analyticsEvents.marketingWhitepaperSignupFail, {
-        surface: 'toast',
-        source_section: 'announcement-toast',
-        paper: 'overview',
-        error_reason: 'api_error',
-      });
+  // Mirror the hook's terminal states onto the toast's step machine.
+  useEffect(() => {
+    if (form.status === 'sent') {
+      setStep('sent');
+      const id = setTimeout(dismiss, 4000);
+      return () => clearTimeout(id);
     }
-    setStep('sent');
-    setSubmitting(false);
-    // Auto-dismiss after showing success
-    setTimeout(dismiss, 4000);
+    if (form.status === 'stale') setStep('stale');
+    return undefined;
+    // dismiss is stable for the component's lifetime; intentionally omitted.
+  }, [form.status]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const problem = emailError(email);
+    setEmailMessage(problem);
+    if (problem) {
+      document.getElementById('toast-email')?.focus();
+      return;
+    }
+    void form.submit({ email: email.trim(), paper: 'overview' });
   };
 
   if (!visible) return null;
@@ -212,35 +196,65 @@ export function AnnouncementToast({
       )}
 
       {step === 'form' && (
-        <form onSubmit={handleSubmit} className="toast-mt-section">
-          <label htmlFor="toast-email" className="sr-only">
-            Email address
-          </label>
-          <input
-            id="toast-email"
-            type="email"
-            placeholder="Email address"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-            disabled={submitting}
-            autoFocus
-            className="toast-input"
-          />
-          <p id={disclosureId} className="toast-disclosure">
+        <form
+          onSubmit={handleSubmit}
+          className="toast-mt-section"
+          data-ui="form"
+          data-compact=""
+          noValidate
+        >
+          <Field id="toast-email" label="Work email" error={emailMessage}>
+            <TextInput
+              compact
+              type="email"
+              autoComplete="email"
+              inputMode="email"
+              value={email}
+              onChange={(e) => {
+                setEmail(e.target.value);
+                if (emailMessage) setEmailMessage(emailError(e.target.value));
+              }}
+              onBlur={() => setEmailMessage(emailError(email))}
+              disabled={form.status === 'pending'}
+              autoFocus
+            />
+          </Field>
+          <p id={disclosureId} data-ui="form-disclosure">
             {formPolicy.disclosures.whitepaper}
           </p>
           <div className="toast-button-row">
-            <Button
-              type="submit"
+            <SubmitButton
               variant="primary"
               size="md"
-              disabled={submitting || !email}
+              pending={form.status === 'pending'}
+              pendingLabel="Sending the guide…"
               aria-describedby={disclosureId}
             >
-              {submitting ? 'Sending...' : '↓ Send me the guide'}
-            </Button>
+              Get the field report
+            </SubmitButton>
           </div>
+          {form.status === 'failed' ? (
+            <FormStatus
+              tone="failure"
+              title="That did not send."
+              detail="You can still get the guide."
+            >
+              <a
+                href="/whitepaper.pdf"
+                download="angular-agent-readiness-guide.pdf"
+                onClick={() => {
+                  trackWhitepaperDownloadClick('overview', {
+                    surface: 'toast',
+                    source_section: 'announcement-toast',
+                    cta_id: 'toast_direct_download',
+                  });
+                  dismiss();
+                }}
+              >
+                Download the PDF directly
+              </a>
+            </FormStatus>
+          ) : null}
           <a
             href="/whitepaper.pdf"
             download="angular-agent-readiness-guide.pdf"
@@ -260,9 +274,12 @@ export function AnnouncementToast({
       )}
 
       {step === 'stale' && (
-        <div className="toast-mt-section" role="alert">
-          <p className="toast-disclosure">{FORM_POLICY_REFRESH_MESSAGE}</p>
-          <div className="toast-button-row">
+        <div className="toast-mt-section">
+          <FormStatus
+            tone="stale"
+            title="This page is out of date."
+            detail={FORM_POLICY_REFRESH_MESSAGE}
+          >
             <Button
               type="button"
               variant="primary"
@@ -271,16 +288,17 @@ export function AnnouncementToast({
             >
               Refresh page
             </Button>
-          </div>
+          </FormStatus>
         </div>
       )}
 
       {step === 'sent' && (
         <div className="toast-mt-section">
-          {/* role=status: the step swap is announced without stealing focus. */}
-          <p role="status" className="toast-success-text">
-            ✓ Check your inbox — the guide is on its way!
-          </p>
+          <FormStatus
+            tone="success"
+            title="Check your inbox."
+            detail="The guide is on its way."
+          />
         </div>
       )}
     </div>

--- a/apps/website/src/styles/chrome.css
+++ b/apps/website/src/styles/chrome.css
@@ -457,7 +457,7 @@
   display: inline-flex;
   align-items: center;
   min-height: 24px;
-  margin-top: 10px;
+  margin-top: 0;
   font-size: 12px;
   color: var(--color-text-muted);
   text-decoration: underline;

--- a/apps/website/src/styles/chrome.css
+++ b/apps/website/src/styles/chrome.css
@@ -447,38 +447,21 @@
   font-size: 0.68rem;
   color: var(--color-text-muted);
   text-decoration: underline;
-  padding: 8px 4px;
+  padding: 8px 6px;
+  min-height: 24px;
 }
 .toast-mt-section {
   margin-top: 8px;
 }
-.toast-input {
-  width: 100%;
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  padding: 8px 12px;
-  font-size: 0.82rem;
-  color: var(--color-text-primary);
-  font-family: var(--font-inter);
-  outline: none;
-  margin-bottom: 10px;
-}
-.toast-input:focus {
-  border-color: var(--color-accent);
-}
 .toast-download-link {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
   margin-top: 10px;
-  font-size: 0.7rem;
+  font-size: 12px;
   color: var(--color-text-muted);
   text-decoration: underline;
   font-family: var(--font-inter);
-}
-.toast-success-text {
-  font-size: 0.85rem;
-  color: #1a7a40;
-  line-height: 1.5;
 }
 
 /* Mobile docs-search entry (polish arc PR 3) — button reset to match the

--- a/apps/website/src/styles/forms.css
+++ b/apps/website/src/styles/forms.css
@@ -130,6 +130,10 @@ select[data-ui="form-control"] {
   flex: 1 1 160px;
   min-width: 0;
 }
+/* A row button matches the control height so the pair sits flush. */
+[data-ui="form-row"] [data-ui="button"] {
+  height: var(--form-control-height);
+}
 /* A compact form's row button matches the compact control height. */
 [data-ui="form"][data-compact] [data-ui="form-row"] [data-ui="button"] {
   height: var(--form-control-height-compact);

--- a/apps/website/src/styles/forms.css
+++ b/apps/website/src/styles/forms.css
@@ -131,6 +131,7 @@ select[data-ui="form-control"] {
   min-width: 0;
 }
 /* A row button matches the control height so the pair sits flush. */
+/* Ties on specificity with [data-ui="button"][data-size="lg"] in ui.css; wins only because forms.css is imported after ui.css in global.css. */
 [data-ui="form-row"] [data-ui="button"] {
   height: var(--form-control-height);
 }

--- a/apps/website/src/styles/landing.css
+++ b/apps/website/src/styles/landing.css
@@ -269,47 +269,16 @@
     gap: 2px;
   }
 }
-.wp-success {
-  font-family: var(--font-inter);
-  font-size: var(--text-body);
-  color: #1a7a40;
-  margin-bottom: 16px;
-}
-.wp-success-link {
-  color: var(--color-accent);
-}
 .wp-form {
-  display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
-  max-width: 480px;
-}
-.wp-email-input {
-  flex: 1 1 240px;
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  padding: 12px 14px;
-  font-family: var(--font-inter);
-  font-size: var(--text-body);
-  color: var(--color-text-primary);
-  outline: none;
-}
-.wp-error {
-  margin-top: 12px;
-  color: var(--color-angular-red);
-  font-size: 14px;
-}
-.wp-error-link {
-  color: var(--color-accent);
+  max-width: 520px;
 }
 .wp-already {
-  margin-top: 12px;
+  margin-top: 4px;
   font-size: 13px;
   color: var(--color-text-muted);
   font-family: var(--font-inter);
 }
-.wp-already-link {
+.wp-already a {
   color: var(--color-accent);
   text-decoration: underline;
 }


### PR DESCRIPTION
PR 3 of 3 for `docs/superpowers/specs/2026-09-03-lead-forms-system-design.md`. The whitepaper signup and the announcement toast compose the form kit; the last of the per-surface form CSS is deleted.

## Summary

- `WhitePaperForm` (the shared component #1024 extracted, used by the homepage teams block and by `WhitePaperBlock` on the library pages) rebuilds on the kit: label above the field, inline submit button matching the control height, validation on blur, focus on the field after an invalid submit, failures reported in a failure block, and the direct PDF download link kept. `WhitePaperBlock` is unchanged from main and keeps rendering the shared form.
- `AnnouncementToast` composes the same kit in a compact row with the same copy; failures are now reported instead of swallowed.
- `chrome.css` and `landing.css` lose the old per-surface form rules; `forms.css` documents the row-button specificity tie with `ui.css` (forms.css wins only by import order).
- Specs: an invalid submit never posts; the toast spec proves focus on invalid submit; the teams block spec follows the kit's "Work email" label.

Rebased onto main after #1024 (homepage restructure). The only conflict was `WhitePaperBlock.tsx`; resolved by taking main's block and porting the kit form into the shared `WhitePaperForm` with its `surface`, `sourceSection`, and `idPrefix` props, so both call sites get it.

## Gates (Task 16, rerun after the rebase)

- Sweep for old form CSS, components, and copy (`wp-email-input`, `Download (free)`, `Email address` label): clean. The only earlier hit was the `contact-form-growth-disclosure` element id inside the kit-based `ContactForm` from #995, which is an id, not retired CSS.
- `npx nx lint website`: 0 errors, pre-existing warnings only.
- `npx nx test website` (as CI runs it, from the repo root): pass.
- `GROWTH_FORM_POLICY=growth_v1 npx nx build website`: pass.
- `WEBSITE_E2E_MODE=production GROWTH_FORM_POLICY=growth_v1 npx nx e2e website --grep "whitepaper|landing page|contact page|pricing|footer newsletter|privacy policy|public copy boundary|canonical policy surface"`: see the latest comment for the rerun result.
- Visual pass before the rebase (dev server, measured via DOM): label above the field, input and button both 44px on one row, error text and focus on invalid submit; contact enterprise intent shows Company and Timeline; pricing renders the enterprise band with no lead form and no overflow; footer input 183px with 36px controls. The toast could not be triggered in the hidden browser pane because its scroll check runs on requestAnimationFrame; it is covered by `AnnouncementToast.spec.tsx`.

Task 16 Step 5 (manual production gate: one real submission per changed surface, confirm in Neon and PostHog, then delete the synthetic contact) remains after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
