### PR TITLE
feat(website): the homepage closes on a quiet open-source strip

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -24,7 +24,7 @@
       "runtimeExecutable": "/bin/bash",
       "runtimeArgs": [
         "-c",
-        "export PATH=/Users/blove/.nvm/versions/node/v22.14.0/bin:$PATH && npx nx serve website --port $PORT"
+        "export PATH=/Users/blove/.nvm/versions/node/v22.14.0/bin:$PATH && export GROWTH_FORM_POLICY=growth_v1 && npx nx serve website --port $PORT"
       ],
       "port": 3000,
       "autoPort": true

--- a/apps/website/e2e/website.spec.ts
+++ b/apps/website/e2e/website.spec.ts
@@ -52,7 +52,7 @@ test('landing page renders the spine in order (live-stage spec §3)', async ({ p
     'proof-heading',
     'architecture-heading',
     'stage-heading',
-    'final-cta-heading',
+    'open-source-heading',
     'pilot-heading',
     'faq-heading',
   ];

--- a/apps/website/src/app/opengraph-image.tsx
+++ b/apps/website/src/app/opengraph-image.tsx
@@ -70,7 +70,12 @@ export default async function OpenGraphImage() {
               </div>
             ))}
           </div>
-          <div style={{ display: 'flex', marginTop: 20, fontSize: 24, lineHeight: 1.45, color: CARD.inkSecondary, maxWidth: 470 }}>
+          {/* Three lines. The subhead names every capability, and at 24px/470
+              it ran to four and overlapped the pills — the column is centred in
+              a fixed 630px card, so overflow collides rather than pushing. 530
+              is the widest the 600px column's 64px left padding allows, and 20px
+              is what holds three lines without orphaning the last two words. */}
+          <div style={{ display: 'flex', marginTop: 20, fontSize: 20, lineHeight: 1.45, color: CARD.inkSecondary, maxWidth: 530 }}>
             {HERO_SUBHEAD}
           </div>
           <div style={{ display: 'flex', marginTop: 26 }}>

--- a/apps/website/src/app/page.tsx
+++ b/apps/website/src/app/page.tsx
@@ -4,19 +4,16 @@ import { EnterpriseArchitecture } from '../components/landing/EnterpriseArchitec
 import { Stage } from '../components/landing/Stage';
 import { TeamsBlock } from '../components/landing/TeamsBlock';
 import { HomeFAQ } from '../components/landing/HomeFAQ';
-import { FinalCTA } from '../components/landing/FinalCTA';
+import { OpenSourceStrip } from '../components/landing/OpenSourceStrip';
 import { RecentArticles } from '../components/landing/RecentArticles';
-import { PROVE_IT_ROWS } from '../lib/positioning';
 // The homepage must stay statically rendered (no cookies()/headers()/dynamic):
 // the proof lines are read from the demo recording at build time, and the file
 // is traced into the deployment only as a safety net.
 import { STAGE_PROOF } from '../lib/stage-proof';
 import {
   createPageMetadata,
-  HERO_SECONDARY_HREF,
   HOME_DESCRIPTION,
   HOME_TITLE,
-  INSTALL_OPTIONS,
 } from '../lib/site-metadata';
 import { getFormPolicy } from '../lib/growth/form-policy';
 
@@ -41,30 +38,9 @@ export default function HomePage() {
           (live-stage spec §3, §8). Copy lives in STAGE_RAIL (positioning.ts). */}
       <Stage proof={STAGE_PROOF} />
 
-      <FinalCTA
-        variant="dark"
-        rows={PROVE_IT_ROWS}
-        headline="Prove the Angular UI before you connect the backend."
-        subtext="Start with a fake agent, render a real Threadplane surface, then swap in LangGraph or AG-UI when the integration is ready."
-        primary={{
-          label: 'Start the quickstart',
-          href: INSTALL_OPTIONS[0].quickstartHref,
-          ctaId: 'hero_quickstart',
-        }}
-        secondary={{
-          label: 'Run live examples',
-          href: HERO_SECONDARY_HREF,
-          ctaId: 'hero_live_demo',
-        }}
-        caption="MIT · no account, no cloud"
-        captionLink={{ label: 'Talk to an engineer', href: '/contact' }}
-        captionLinks={[
-          {
-            label: 'Setup prompt for coding agents',
-            href: '/docs/chat/getting-started/coding-agents',
-          },
-        ]}
-      />
+      {/* The open-source beat: a slim dark strip, not a second CTA. Copy lives
+          in OPEN_SOURCE_STRIP (positioning.ts). */}
+      <OpenSourceStrip />
       <TeamsBlock formPolicy={formPolicy} />
       <HomeFAQ />
       <RecentArticles />

--- a/apps/website/src/components/landing/FinalCTA.spec.tsx
+++ b/apps/website/src/components/landing/FinalCTA.spec.tsx
@@ -91,29 +91,6 @@ describe('FinalCTA', () => {
     expect(screen.getByRole('link', { name: 'Talk to an engineer' }).getAttribute('href')).toBe('/contact');
   });
 
-  it('renders optional rows above the headline in the claim/api grammar', () => {
-    render(
-      <FinalCTA
-        rows={[
-          { claim: 'No key, no server, no network', api: 'provideFakeAgent()' },
-          { claim: 'Same UI code in test and production', api: 'Agent' },
-        ]}
-      />,
-    );
-    const list = screen.getByRole('list', { name: 'What you can prove first' });
-    expect(list.querySelectorAll('li')).toHaveLength(2);
-    expect(screen.getByText('provideFakeAgent()')).toBeTruthy();
-    const heading = screen.getByRole('heading', { level: 2 });
-    expect(list.compareDocumentPosition(heading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-    expect(list.querySelector('.final-cta-prove-row-claim')?.textContent).toBe('No key, no server, no network');
-    expect(list.querySelector('.final-cta-prove-row-api')?.textContent).toBe('provideFakeAgent()');
-  });
-
-  it('renders no rows list when rows are omitted', () => {
-    render(<FinalCTA />);
-    expect(screen.queryByRole('list', { name: 'What you can prove first' })).toBeNull();
-  });
-
   it('renders extra caption links after the first, separated by " · "', () => {
     render(
       <FinalCTA

--- a/apps/website/src/components/landing/FinalCTA.tsx
+++ b/apps/website/src/components/landing/FinalCTA.tsx
@@ -8,7 +8,7 @@ import { trackCtaClick } from '../../lib/analytics/client';
 import type { CtaId } from '../../lib/analytics/events';
 
 interface FinalCTAProps {
-  /** Headline. Defaults to the homepage closer. */
+  /** Headline. Defaults to the product closer. */
   headline?: string;
   /** Sub-headline. Defaults to the homepage closer. */
   subtext?: string;
@@ -24,9 +24,6 @@ interface FinalCTAProps {
   caption?: string | null;
   /** Optional link rendered after the caption text (e.g. "Talk to an engineer"). */
   captionLink?: { label: string; href: string } | null;
-  /** Optional claim/api rows rendered above the headline (the homepage's
-   *  "prove it without a backend" moment). Omitted everywhere else. */
-  rows?: readonly { readonly claim: string; readonly api: string }[];
   /** Further caption links, rendered after `captionLink`. */
   captionLinks?: readonly { label: string; href: string }[];
   /**
@@ -49,7 +46,6 @@ export function FinalCTA({
   secondary = DEFAULT_SECONDARY,
   caption = null,
   captionLink = null,
-  rows = [],
   captionLinks = [],
   variant = 'default',
 }: FinalCTAProps = {}) {
@@ -65,16 +61,6 @@ export function FinalCTA({
             <div className="final-cta-mark" aria-hidden="true">
               →
             </div>
-          ) : null}
-          {rows.length > 0 ? (
-            <ul className="final-cta-rows" role="list" aria-label="What you can prove first">
-              {rows.map((row) => (
-                <li className="final-cta-prove-row" key={row.claim}>
-                  <span className="final-cta-prove-row-claim">{row.claim}</span>
-                  <span className="final-cta-prove-row-api">{row.api}</span>
-                </li>
-              ))}
-            </ul>
           ) : null}
           <h2 id="final-cta-heading" className="final-cta-heading">
             {headline}

--- a/apps/website/src/components/landing/OpenSourceStrip.spec.tsx
+++ b/apps/website/src/components/landing/OpenSourceStrip.spec.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { OpenSourceStrip } from './OpenSourceStrip';
+import { GITHUB_REPO_URL, OPEN_SOURCE_STRIP } from '../../lib/positioning';
+
+const trackCtaClickMock = vi.hoisted(() => vi.fn());
+vi.mock('../../lib/analytics/client', () => ({
+  track: vi.fn(),
+  trackCtaClick: trackCtaClickMock,
+  trackExternalLinkClick: vi.fn(),
+}));
+
+beforeEach(() => trackCtaClickMock.mockClear());
+
+describe('OpenSourceStrip', () => {
+  it('renders the whole sentence as the section heading, emphasis included', () => {
+    render(<OpenSourceStrip />);
+    const heading = screen.getByRole('heading', { level: 2 });
+    expect(heading.textContent).toBe(
+      `${OPEN_SOURCE_STRIP.lead} ${OPEN_SOURCE_STRIP.emphasis}`,
+    );
+    expect(heading.querySelector('em')?.textContent).toBe(OPEN_SOURCE_STRIP.emphasis);
+  });
+
+  it('names the section by that heading', () => {
+    const { container } = render(<OpenSourceStrip />);
+    const section = container.querySelector('[data-ui="section"]');
+    expect(section?.getAttribute('aria-labelledby')).toBe('open-source-heading');
+    expect(container.querySelector('#open-source-heading')).toBeTruthy();
+  });
+
+  it('sits on the dark surface at the tight rhythm', () => {
+    const { container } = render(<OpenSourceStrip />);
+    const section = container.querySelector('[data-ui="section"]');
+    expect(section?.getAttribute('data-surface')).toBe('dark');
+    // The strip's own padding override keys off [data-tight]; dropping the
+    // prop silently restores the full 48-80px band this replaced.
+    expect(section?.getAttribute('data-tight')).toBe('true');
+    expect(section?.classList.contains('open-source-strip')).toBe(true);
+  });
+
+  it('links the repo in a new tab, with the mark beside the label', () => {
+    const { container } = render(<OpenSourceStrip />);
+    const link = screen.getByRole('link', { name: OPEN_SOURCE_STRIP.cta });
+    expect(link.getAttribute('href')).toBe(GITHUB_REPO_URL);
+    expect(link.getAttribute('target')).toBe('_blank');
+    expect(link.getAttribute('rel')).toBe('noopener noreferrer');
+    // The mark is decorative: the accessible name above must stay the label
+    // alone, so the svg has to be hidden rather than merely unlabelled.
+    const svg = link.querySelector('svg');
+    expect(svg).toBeTruthy();
+    expect(svg?.getAttribute('aria-hidden')).toBe('true');
+    expect(container.querySelector('.open-source-strip-licence')?.textContent).toBe(
+      OPEN_SOURCE_STRIP.licence,
+    );
+  });
+
+  it('is the page’s quiet beat: one action, no second CTA', () => {
+    const { container } = render(<OpenSourceStrip />);
+    expect(container.querySelectorAll('a').length).toBe(1);
+  });
+
+  it('reports the fork click as a homepage CTA', () => {
+    render(<OpenSourceStrip />);
+    fireEvent.click(screen.getByRole('link', { name: OPEN_SOURCE_STRIP.cta }));
+    expect(trackCtaClickMock).toHaveBeenCalledWith({
+      cta_id: 'hero_github',
+      track: 'developer',
+      surface: 'home',
+      destination_url: GITHUB_REPO_URL,
+    });
+  });
+});

--- a/apps/website/src/components/landing/OpenSourceStrip.tsx
+++ b/apps/website/src/components/landing/OpenSourceStrip.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { Container } from '../ui/Container';
+import { Section } from '../ui/Section';
+import { Button } from '../ui/Button';
+import { GitHubIcon } from '../ui/GitHubIcon';
+import { trackCtaClick } from '../../lib/analytics/client';
+import { GITHUB_REPO_URL, OPEN_SOURCE_STRIP } from '../../lib/positioning';
+
+/**
+ * The homepage's open-source beat: one dark strip between the stage and the
+ * teams block.
+ *
+ * It replaced a full dark `FinalCTA` (the "prove the Angular UI" closer). The
+ * point of the section is that there is no catch and no upsell, so it is
+ * deliberately the quietest band on the page: one sentence at the left edge of
+ * the page container, the licence and the repo at the right, and no second
+ * pitch. The four library pages still close on `FinalCTA variant="dark"` —
+ * that component is untouched.
+ */
+export function OpenSourceStrip() {
+  return (
+    <Section
+      surface="dark"
+      tight
+      ariaLabelledBy="open-source-heading"
+      className="open-source-strip"
+    >
+      <Container>
+        <div className="open-source-strip-inner">
+          <h2 id="open-source-heading" className="open-source-strip-line">
+            {OPEN_SOURCE_STRIP.lead}{' '}
+            <em>{OPEN_SOURCE_STRIP.emphasis}</em>
+          </h2>
+          <div className="open-source-strip-actions">
+            <span className="open-source-strip-licence">
+              {OPEN_SOURCE_STRIP.licence}
+            </span>
+            <Button
+              variant="secondary"
+              size="md"
+              href={GITHUB_REPO_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              leadingIcon={<GitHubIcon />}
+              onClick={() =>
+                trackCtaClick({
+                  cta_id: 'hero_github',
+                  track: 'developer',
+                  surface: 'home',
+                  destination_url: GITHUB_REPO_URL,
+                })
+              }
+            >
+              {OPEN_SOURCE_STRIP.cta}
+            </Button>
+          </div>
+        </div>
+      </Container>
+    </Section>
+  );
+}

--- a/apps/website/src/components/shared/Footer.tsx
+++ b/apps/website/src/components/shared/Footer.tsx
@@ -8,16 +8,11 @@ import { trackCtaClick, trackExternalLinkClick } from '../../lib/analytics/clien
 import { DEMOS, demoCtaSuffix } from '../../lib/demos';
 import { LogoMark } from '../ui/LogoMark';
 import { Button } from '../ui/Button';
+import { GitHubIcon } from '../ui/GitHubIcon';
+import { GITHUB_REPO_URL } from '../../lib/positioning';
 import { Eyebrow } from '../ui/Eyebrow';
 import { Field, FormStatus, SubmitButton, TextInput, emailError, useGrowthForm } from '../form';
 
-function GitHubIcon() {
-  return (
-    <svg width="18" height="18" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
-    </svg>
-  );
-}
 
 function NpmIcon() {
   return (
@@ -146,17 +141,17 @@ export function Footer({
             {showNewsletter ? <NewsletterForm formPolicy={formPolicy} /> : null}
             {/* Social links */}
             <div className="flex items-center gap-4">
-              <a href="https://github.com/cacheplane/angular-agent-framework"
+              <a href={GITHUB_REPO_URL}
                 target="_blank"
                 rel="noopener noreferrer"
-                onClick={() => trackExternalLinkClick('https://github.com/cacheplane/angular-agent-framework', {
+                onClick={() => trackExternalLinkClick(GITHUB_REPO_URL, {
                   surface: 'footer',
                   cta_id: 'footer_github_icon',
                   cta_text: 'GitHub',
                 })}
                 className="transition-colors footer-social-link"
                 aria-label="GitHub">
-                <GitHubIcon />
+                <GitHubIcon size={18} />
               </a>
               <a href="https://www.npmjs.com/package/@threadplane/langgraph"
                 target="_blank"
@@ -198,10 +193,10 @@ export function Footer({
               onClick={() => trackFooterCta('Pricing', '/pricing')}>
               Pricing
             </Link>
-            <a href="https://github.com/cacheplane/angular-agent-framework"
+            <a href={GITHUB_REPO_URL}
               target="_blank" rel="noopener noreferrer"
               className="transition-colors footer-link"
-              onClick={() => trackExternalLinkClick('https://github.com/cacheplane/angular-agent-framework', {
+              onClick={() => trackExternalLinkClick(GITHUB_REPO_URL, {
                 surface: 'footer',
                 cta_id: 'footer_github',
                 cta_text: 'GitHub',

--- a/apps/website/src/components/shared/Nav.tsx
+++ b/apps/website/src/components/shared/Nav.tsx
@@ -10,6 +10,8 @@ import {
 import type { AnalyticsLibrary } from '../../lib/analytics/events';
 import { LogoMark } from '../ui/LogoMark';
 import { Button } from '../ui/Button';
+import { GitHubIcon } from '../ui/GitHubIcon';
+import { GITHUB_REPO_URL } from '../../lib/positioning';
 import { DEMOS, demoCtaSuffix } from '../../lib/demos';
 import { DocsContextContent } from '../docs/DocsControlPlane';
 
@@ -31,19 +33,6 @@ const toAnalyticsLibrary = (library: LibraryId | null): AnalyticsLibrary => {
   }
 };
 
-function GitHubIcon() {
-  return (
-    <svg
-      width="16"
-      height="16"
-      viewBox="0 0 16 16"
-      fill="currentColor"
-      aria-hidden="true"
-    >
-      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
-    </svg>
-  );
-}
 
 function MenuIcon() {
   return (
@@ -319,12 +308,12 @@ export function Nav() {
             )}
             <DemoDropdown />
             <a
-              href="https://github.com/cacheplane/angular-agent-framework"
+              href={GITHUB_REPO_URL}
               target="_blank"
               rel="noopener noreferrer"
               onClick={() =>
                 trackExternalLinkClick(
-                  'https://github.com/cacheplane/angular-agent-framework',
+                  GITHUB_REPO_URL,
                   {
                     surface: 'nav',
                     cta_id: 'nav_github',
@@ -481,12 +470,12 @@ export function Nav() {
                   </a>
                 ))}
                 <a
-                  href="https://github.com/cacheplane/angular-agent-framework"
+                  href={GITHUB_REPO_URL}
                   target="_blank"
                   rel="noopener noreferrer"
                   onClick={() => {
                     trackExternalLinkClick(
-                      'https://github.com/cacheplane/angular-agent-framework',
+                      GITHUB_REPO_URL,
                       {
                         surface: 'mobile_nav',
                         cta_id: 'mobile_nav_github',

--- a/apps/website/src/components/ui/Button.tsx
+++ b/apps/website/src/components/ui/Button.tsx
@@ -14,6 +14,8 @@ interface CommonProps {
   size?: Size;
   /** Optional right-side icon — typically an arrow for ghost links. */
   trailingIcon?: ReactNode;
+  /** Optional left-side icon — typically a brand mark (e.g. the GitHub logo). */
+  leadingIcon?: ReactNode;
 }
 
 type AnchorButtonProps = CommonProps &
@@ -34,12 +36,14 @@ export function Button(props: ButtonProps) {
     variant = 'primary',
     size = 'md',
     trailingIcon,
+    leadingIcon,
     className,
     style,
   } = props;
 
   const content = (
     <>
+      {leadingIcon ? <span aria-hidden="true">{leadingIcon}</span> : null}
       <span>{children}</span>
       {trailingIcon ? <span aria-hidden="true">{trailingIcon}</span> : null}
     </>
@@ -52,6 +56,7 @@ export function Button(props: ButtonProps) {
       variant: _v,
       size: _s,
       trailingIcon: _t,
+      leadingIcon: _li,
       className: _cn,
       style: _st,
       ...anchorAttrs
@@ -76,6 +81,7 @@ export function Button(props: ButtonProps) {
     variant: _v2,
     size: _s2,
     trailingIcon: _t2,
+    leadingIcon: _li2,
     className: _cn2,
     style: _st2,
     href: _h,

--- a/apps/website/src/components/ui/GitHubIcon.tsx
+++ b/apps/website/src/components/ui/GitHubIcon.tsx
@@ -1,0 +1,22 @@
+/**
+ * The GitHub mark.
+ *
+ * One copy, three callers: the nav, the footer and the homepage's open-source
+ * strip. It was duplicated inline in the first two before the strip needed a
+ * third. `fill: currentColor` lets each caller colour it from its own scope —
+ * the dark section re-points `--color-text-primary`, so the strip's mark
+ * follows the button label without any extra rule.
+ */
+export function GitHubIcon({ size = 16 }: { size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+    </svg>
+  );
+}

--- a/apps/website/src/lib/positioning.spec.ts
+++ b/apps/website/src/lib/positioning.spec.ts
@@ -49,7 +49,9 @@ describe('positioning: hero copy', () => {
   it('names the exact category in eyebrow, H1, title and description', () => {
     expect(HERO_EYEBROW).toBe('Angular · LangGraph & AG-UI');
     expect(HERO_H1).toBe('The open-source thread-plane for agents.');
-    expect(HERO_SUBHEAD).toBe('Chat, threads, approvals, and generative UI on Signals and DI. Your backend stays where it is.');
+    expect(HERO_SUBHEAD).toBe(
+      'Chat, durable threads, persistence, human approvals, and generative UI for Angular, on LangGraph and AG-UI. Your backend stays where it is.',
+    );
     expect(HOME_TITLE).toBe('Threadplane — The open-source thread-plane for agents');
     expect(HOME_DESCRIPTION).toBe(
       'The open-source thread-plane for agents: chat, durable threads, persistence, human approvals, and generative UI for Angular, on LangGraph and AG-UI.',
@@ -185,13 +187,16 @@ describe('homepage restructure copy (live-stage spec §3)', () => {
     }
   });
 
-  it('carries the three prove-it rows the final CTA absorbs from the Test section', async () => {
-    const { PROVE_IT_ROWS } = await import('./positioning');
-    expect(PROVE_IT_ROWS).toEqual([
-      { claim: 'No key, no server, no network', api: 'provideFakeAgent()' },
-      { claim: 'Script tool calls and interrupts', api: 'mockLangGraphAgent()' },
-      { claim: 'Same UI code in test and production', api: 'Agent' },
-    ]);
+  it('closes on the open-source offer: one sentence, the licence, the fork CTA', async () => {
+    const { OPEN_SOURCE_STRIP } = await import('./positioning');
+    expect(`${OPEN_SOURCE_STRIP.lead} ${OPEN_SOURCE_STRIP.emphasis}`).toBe(
+      'Yes, this is all free. Don’t like something? Fork us.',
+    );
+    // The strip is one line on a wide viewport; long copy would wrap into the
+    // action group and undo the whole point of the shape.
+    expect(`${OPEN_SOURCE_STRIP.lead} ${OPEN_SOURCE_STRIP.emphasis}`.length).toBeLessThanOrEqual(60);
+    expect(OPEN_SOURCE_STRIP.licence).toBe('MIT');
+    expect(OPEN_SOURCE_STRIP.cta).toBe('Fork on GitHub');
   });
 });
 

--- a/apps/website/src/lib/positioning.ts
+++ b/apps/website/src/lib/positioning.ts
@@ -12,7 +12,7 @@ export const HERO_H1 = 'The open-source thread-plane for agents.';
  */
 export const HERO_H1_LINES: readonly string[] = ['The open-source', 'thread-plane', 'for agents.'];
 export const HERO_SUBHEAD =
-  'Chat, threads, approvals, and generative UI on Signals and DI. Your backend stays where it is.';
+  'Chat, durable threads, persistence, human approvals, and generative UI for Angular, on LangGraph and AG-UI. Your backend stays where it is.';
 
 /**
  * The subhead, split so Hero.tsx can marker-highlight the boundary claim.
@@ -26,7 +26,7 @@ export interface HeroSubheadSegment {
   highlight?: boolean;
 }
 export const HERO_SUBHEAD_SEGMENTS: readonly HeroSubheadSegment[] = [
-  { text: 'Chat, threads, approvals, and generative UI on Signals and DI. ' },
+  { text: 'Chat, durable threads, persistence, human approvals, and generative UI for Angular, on LangGraph and AG-UI. ' },
   { text: 'Your backend stays where it is.', highlight: true },
 ];
 
@@ -81,13 +81,29 @@ export const RELIABILITY_RECEIPTS: readonly ReliabilityReceipt[] = [
   },
 ];
 
-// ── Prove it without a backend (spec §3, block 5): the Test rows the final CTA
-// absorbs. ────────────────────────────────────────────────────────────────────
-export const PROVE_IT_ROWS = [
-  { claim: 'No key, no server, no network', api: 'provideFakeAgent()' },
-  { claim: 'Script tool calls and interrupts', api: 'mockLangGraphAgent()' },
-  { claim: 'Same UI code in test and production', api: 'Agent' },
-] as const;
+/**
+ * The public source repository.
+ *
+ * It lives here, not in site-metadata.ts: that module reaches node:fs through
+ * blog.ts, so importing it from a client component drags the filesystem into
+ * the browser bundle and the page 500s. positioning.ts is client-safe — the
+ * hero already imports it.
+ */
+export const GITHUB_REPO_URL = 'https://github.com/cacheplane/angular-agent-framework';
+
+// ── The open-source strip (the slim dark band after the stage). One sentence,
+// the licence, the repo. Bold in what it says, quiet in how it looks: the
+// point is that there is no catch, and the remedy for disagreeing with us is
+// a fork — so it must not read as another sales pitch. ──────────────────────
+export const OPEN_SOURCE_STRIP = {
+  /** The sentence, up to the part that carries the emphasis. */
+  lead: 'Yes, this is all free. Don’t like something?',
+  /** Rendered italic at the end of the same line. */
+  emphasis: 'Fork us.',
+  /** The licence tag beside the action. */
+  licence: 'MIT',
+  cta: 'Fork on GitHub',
+} as const;
 
 // ── The stage rail (stage-rail spec §3–5): the four-claim ledger beside the
 // pinned demo. One label, one claim and one docs link per beat; the still

--- a/apps/website/src/lib/site-metadata.spec.ts
+++ b/apps/website/src/lib/site-metadata.spec.ts
@@ -22,7 +22,7 @@ describe('site positioning copy', () => {
     expect(LONG_SUBHEAD).toContain('open-source thread-plane for agents');
     expect(LONG_SUBHEAD).toContain('LangGraph and AG-UI');
     expect(HERO_SUBHEAD).toBe(
-      'Chat, threads, approvals, and generative UI on Signals and DI. Your backend stays where it is.',
+      'Chat, durable threads, persistence, human approvals, and generative UI for Angular, on LangGraph and AG-UI. Your backend stays where it is.',
     );
     expect(POSITIONING_PROOF_POINTS.map((p) => p.label)).toEqual([
       'LangGraph + AG-UI',

--- a/apps/website/src/styles/landing.css
+++ b/apps/website/src/styles/landing.css
@@ -585,33 +585,6 @@
   margin: 0;
 }
 
-/* Prove-it rows above the closing headline. FinalCTA.tsx `rows`. */
-.final-cta-rows {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
-  gap: 12px 24px;
-  list-style: none;
-  margin: 0 0 28px;
-  padding: 0;
-  text-align: left;
-}
-.final-cta-prove-row {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  min-width: 0;
-}
-.final-cta-prove-row-claim {
-  font-family: var(--font-inter);
-  font-size: 14px;
-  color: var(--color-text-secondary);
-}
-.final-cta-prove-row-api {
-  font-family: var(--font-mono);
-  font-size: 12px;
-  color: var(--color-accent);
-  overflow-wrap: anywhere;
-}
 /* FinalCTA dark variant — the Yes wall's partner section. */
 [data-surface="dark"] .final-cta-inner {
   position: relative;
@@ -643,6 +616,59 @@
 @media (max-width: 640px) {
   .final-cta-mark {
     font-size: 140px;
+  }
+}
+
+/* OpenSourceStrip — components/landing/OpenSourceStrip.tsx
+ *
+ * A strip, not a section: the sentence sits at the left edge of the page
+ * container and the action at the right, so it reads as an aside between the
+ * stage and the teams block. It deliberately undercuts the tight section
+ * rhythm (48–80px) — at that height the band still reads as a full closing
+ * beat, which is the volume this replaced. The [data-tight] selector is two
+ * attributes, so the override has to carry both to win. */
+[data-ui="section"][data-tight].open-source-strip {
+  padding-top: clamp(28px, 3.2vw, 44px);
+  padding-bottom: clamp(28px, 3.2vw, 44px);
+}
+.open-source-strip-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px 32px;
+  flex-wrap: wrap;
+}
+.open-source-strip-line {
+  font-family: var(--font-garamond);
+  font-size: 23px;
+  line-height: 1.35;
+  font-weight: 400;
+  letter-spacing: -0.005em;
+  color: var(--color-text-primary);
+  margin: 0;
+}
+.open-source-strip-line em {
+  font-style: italic;
+}
+.open-source-strip-actions {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  flex: none;
+}
+.open-source-strip-licence {
+  font-family: var(--font-inter);
+  font-size: 12px;
+  letter-spacing: 0.02em;
+  color: var(--color-text-muted);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-pill, 999px);
+  padding: 4px 10px;
+  white-space: nowrap;
+}
+@media (max-width: 640px) {
+  .open-source-strip-line {
+    font-size: 21px;
   }
 }
 


### PR DESCRIPTION
The dark band after the stage was a second full CTA — "Prove the Angular UI before you connect the backend", three prove-it rows, two buttons and a row of caption links. The point of that beat is that the project is free and forkable, and a billboard is the wrong volume for saying so. It read as another pitch immediately before the teams block.

It is now a strip: one sentence at the left edge of the page container, an MIT tag and an outlined **Fork on GitHub** button at the right, on the same dark surface at roughly a third of the height. It stacks left-aligned on phones.

`OpenSourceStrip` is a new component rather than another `FinalCTA` variant, because the four library pages still close on `FinalCTA variant="dark"` and that shape is deliberately unchanged. The now-unused `rows` prop and its CSS came out with it.

### Also here

- **One GitHub mark, one repo URL.** The mark was inlined twice (nav, footer) and the URL five times. `Button` grew a `leadingIcon` slot beside the trailing one it already had. `GITHUB_REPO_URL` lives in `positioning.ts`, not `site-metadata.ts` — that module reaches `node:fs` through `blog.ts`, so a client component importing it drags the filesystem into the browser bundle and the page 500s.
- **Hero subhead** now names what the site description names: chat, durable threads, persistence, human approvals and generative UI, on LangGraph and AG-UI. The highlighted boundary claim after it is unchanged.
- **Social card.** That subhead renders there too. The longer copy ran to four lines and overlapped the pills — the left column is centred in a fixed 630px card, so overflow collides rather than pushing. The subhead now sits at 20px in a 530px measure, which holds three lines.
- **Dev server.** The website needs `GROWTH_FORM_POLICY` to render at all locally; the launch config now sets the value CI uses. Unrelated to the copy work — happy to drop it if you would rather.

### Verification

Website unit suite, plus the `website`, `home-hero`, `home-stage`, `nav-height` and `solutions` Playwright suites. Lint clean of errors, types clean. The social card and the strip were rendered and inspected at desktop, tablet and phone widths. I confirmed the taller hero does not push the demo frame past its IntersectionObserver threshold, which has broken that spec before.

### Known nit

On phones, and on line two of the card, "AG-UI" breaks across lines at its hyphen. A non-breaking hyphen fixes it but would stop the string matching the site description character for character.

🤖 Generated with [Claude Code](https://claude.com/claude-code)