### PR TITLE
fix(website): give arch-flow console badges an on-dark palette

### DIFF
--- a/apps/website/src/styles/docs.css
+++ b/apps/website/src/styles/docs.css
@@ -1646,9 +1646,27 @@ body:has([data-website-workspace-host]) {
   animation: blink 0.6s infinite;
 }
 .arch-flow-console-panel {
+  /* Hardcoded dark ground. This is NOT a [data-ui="section"][data-surface="dark"]
+   * scope, so nothing inside inherits that scope's re-pointed --color-* values
+   * and the light-surface tokens land here unchanged — which is how the source
+   * badges ended up carrying near-black scope navy on near-black. The badges
+   * below read from this local on-dark palette instead of the global tokens.
+   * Every ratio quoted is measured against the composited badge ground (tint
+   * over #1a1b26), never against white: aviation yellow is INK on this ground
+   * at 7.0:1, where on white it is a fill only at 1.84:1. */
+  --console-ground: #1a1b26;
+  --console-ink-angular: #ff9e9e;
+  --console-fill-angular: rgba(221, 0, 49, 0.14);
+  --console-ink-transport: #c3b0ff;
+  --console-fill-transport: rgba(139, 123, 232, 0.14);
+  --console-ink-langgraph: var(--color-signal);
+  --console-fill-langgraph: rgba(255, 175, 0, 0.14);
+  --console-ink-signal: #5fe3b0;
+  --console-fill-signal: rgba(16, 185, 129, 0.14);
+
   flex: 1;
   padding: 12px;
-  background: #1a1b26;
+  background: var(--console-ground);
   overflow: auto;
   font-family: var(--font-mono);
   font-size: 10px;
@@ -1683,21 +1701,22 @@ body:has([data-website-workspace-host]) {
   min-width: 62px;
   text-align: center;
 }
+/* 8px bold on a dark ground, so each variant clears 4.5:1 with margin. */
 .arch-flow-log-source[data-source="angular"] {
-  background: rgba(221, 0, 49, 0.08);
-  color: #c62828;
+  background: var(--console-fill-angular);
+  color: var(--console-ink-angular); /* 8.14:1 */
 }
 .arch-flow-log-source[data-source="transport"] {
-  background: rgba(100, 80, 200, 0.08);
-  color: #5e35b1;
+  background: var(--console-fill-transport);
+  color: var(--console-ink-transport); /* 7.40:1 */
 }
 .arch-flow-log-source[data-source="langgraph"] {
-  background: rgba(255, 175, 0, 0.12);
-  color: var(--color-accent);
+  background: var(--console-fill-langgraph);
+  color: var(--console-ink-langgraph); /* 7.03:1 */
 }
 .arch-flow-log-source[data-source="signal"] {
-  background: rgba(16, 185, 129, 0.08);
-  color: #059669;
+  background: var(--console-fill-signal);
+  color: var(--console-ink-signal); /* 8.57:1 */
 }
 .arch-flow-log-message {
   color: #a9b1d6;


### PR DESCRIPTION
## What

The developer-console panel in `ArchFlowDiagram` paints a hardcoded `#1a1b26` ground. It is **not** a `[data-ui="section"][data-surface="dark"]` scope, so it never inherits that scope's re-pointed `--color-*` values — the light-surface tokens landed on it unchanged. All four `.arch-flow-log-source` badges failed contrast against it.

Measured against the composited badge ground (tint over `#1a1b26`), before this change:

| variant | ink | ratio |
|---|---|---|
| `langgraph` | `var(--color-accent)` → `#15253E` | **1.13:1** |
| `transport` | `#5e35b1` | **2.01:1** |
| `angular` | `#c62828` | **2.95:1** |
| `signal` | `#059669` | **4.03:1** |

Most of this predates the ATC retheme, but `langgraph` does not: the retheme pointed it at `--color-accent`, which resolves to scope navy `#15253E` at `:root`, so that badge renders near-black on near-black.

## Approach

Section-scoping the panel was a non-starter — `[data-surface="dark"]` carries section padding, a navy gradient background and a `::before` accent seam, and its surfaces are neutral greys rather than `#1a1b26`. Instead the panel declares a **local on-dark palette** in its own rule block and the badges read from it. Each keeps its hue identity (Angular red, transport purple, aviation yellow, render green) as a light ink over a 0.14-alpha tint of the same hue.

## Verification

Ratios read off the **rendered page** via `getComputedStyle`, compositing every background layer up to the first opaque ancestor — not against white:

| variant | ink | composited ground | ratio |
|---|---|---|---|
| `angular` | `#ff9e9e` | `rgb(53, 23, 40)` | **8.14:1** |
| `transport` | `#c3b0ff` | `rgb(42, 40, 65)` | **7.40:1** |
| `langgraph` | `#FFAF00` | `rgb(58, 48, 33)` | **7.03:1** |
| `signal` | `#5fe3b0` | `rgb(25, 49, 51)` | **8.57:1** |

All clear 4.5:1 with margin, which the 8px/600 type needs. Aviation yellow works as ink here — 9.27:1 bare, 7.03:1 once its own tint lightens the ground — where on white it is a fill only at 1.84:1.

Also verified: all four variants render legibly and stay distinguishable by hue; `style-contracts.spec.ts` + `font-vars.spec.ts` pass (97 tests); no console errors; no test or guard asserted the old hexes.

## Not included

`.arch-flow-console-title` and `.arch-flow-log-time` use `#4A527A` on the same panel at **2.26:1** — same defect class, same component, but outside the scope of this fix. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)