### PR TITLE
fix(libs): make the type-tests targets runnable again

### DIFF
--- a/libs/ag-ui/tsconfig.type-tests.json
+++ b/libs/ag-ui/tsconfig.type-tests.json
@@ -2,6 +2,12 @@
   "extends": "./tsconfig.lib.json",
   "compilerOptions": {
     "noEmit": true,
+    // This target runs the workspace `tsc` (newer than the build compilers),
+    // which errors on the inherited baseUrl unless deprecations are ignored.
+    "ignoreDeprecations": "6.0",
+    // Type-specs import sibling libraries through tsconfig paths; with noEmit
+    // the rootDir only has to be wide enough to contain them.
+    "rootDir": "../..",
     "strict": true,
     "strictFunctionTypes": true,
     "skipLibCheck": true,

--- a/libs/chat/tsconfig.type-tests.json
+++ b/libs/chat/tsconfig.type-tests.json
@@ -3,6 +3,12 @@
   "compilerOptions": {
     "outDir": "../../dist/out-tsc/type-tests",
     "noEmit": true,
+    // This target runs the workspace `tsc` (newer than the build compilers),
+    // which errors on the inherited baseUrl unless deprecations are ignored.
+    "ignoreDeprecations": "6.0",
+    // Type-specs import sibling libraries through tsconfig paths; with noEmit
+    // the rootDir only has to be wide enough to contain them.
+    "rootDir": "../..",
     "composite": false,
     "declarationMap": false,
     "emitDeclarationOnly": false,

--- a/libs/langgraph/tsconfig.type-tests.json
+++ b/libs/langgraph/tsconfig.type-tests.json
@@ -2,6 +2,12 @@
   "extends": "./tsconfig.lib.json",
   "compilerOptions": {
     "noEmit": true,
+    // This target runs the workspace `tsc` (newer than the build compilers),
+    // which errors on the inherited baseUrl unless deprecations are ignored.
+    "ignoreDeprecations": "6.0",
+    // Type-specs import sibling libraries through tsconfig paths; with noEmit
+    // the rootDir only has to be wide enough to contain them.
+    "rootDir": "../..",
     "strict": true,
     "strictFunctionTypes": true,
     "skipLibCheck": true,


### PR DESCRIPTION
All three `type-tests` targets (`chat`, `ag-ui`, `langgraph`) have been failing on main, so the type-level assertions they exist to enforce were not being checked. Three separate agents hit this last week and had to verify their type assertions by hand.

Two inherited causes, both fixed only inside the type-tests configs:

- **`TS5101`** — `tsconfig.base.json` sets `baseUrl`, which TypeScript 6 reports as deprecated. These targets invoke the workspace `tsc` (6.0.2), newer than the compilers the library builds use. Putting `ignoreDeprecations` in `tsconfig.base.json` instead **breaks every library build** with `TS5103: Invalid value for '--ignoreDeprecations'`, so it is scoped to the three configs that need it.
- **`TS6059`** — each library's `rootDir` is its own directory, but type-specs import sibling libraries through `tsconfig` path mappings. With `noEmit`, `rootDir` only has to be wide enough to contain what is checked.

Dropping `baseUrl` altogether is the real migration before TypeScript 7, but it changes resolution for every project in the workspace and does not belong in this fix.

**Verification**: `chat:type-tests`, `ag-ui:type-tests`, `langgraph:type-tests` all exit 0 (each failed before); `nx run-many -t build,lint --projects=chat,ag-ui,langgraph,render` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)