### PR TITLE
chore(release): 0.1.0 — first minor release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,64 @@
+## 0.1.0 (2026-09-08)
+
+### 🚀 Features
+
+- one route family — every capability is a docs page ([#1010](https://github.com/cacheplane/angular-agent-framework/pull/1010))
+- **ag-ui:** scriptable provideFakeAgent() and a duplicate-AgentRef warning ([#1053](https://github.com/cacheplane/angular-agent-framework/pull/1053))
+- **chat:** public scrollToBottom() on ChatComponent; the stage pins through it ([#1045](https://github.com/cacheplane/angular-agent-framework/pull/1045))
+- ⚠️  **chat:** remove provideChat(), fix app-level markdown registry overrides, and three API cleanups ([#1055](https://github.com/cacheplane/angular-agent-framework/pull/1055))
+- **docs:** ExampleCode include + guards; retire the walkthrough renderer ([#1025](https://github.com/cacheplane/angular-agent-framework/pull/1025))
+- **examples/chat:** executable approval tools behind the hero's pause ([#1011](https://github.com/cacheplane/angular-agent-framework/pull/1011))
+- **examples/chat:** /stage — the real chat beside the real devtools, seekable to any recorded time (live-stage plan 2 of 3) ([#1030](https://github.com/cacheplane/angular-agent-framework/pull/1030))
+- **growth:** add inspectable company research pilot ([#1009](https://github.com/cacheplane/angular-agent-framework/pull/1009))
+- **growth:** explain company capture failures ([#1015](https://github.com/cacheplane/angular-agent-framework/pull/1015))
+- **growth:** attribute campaign sends per template with a bounded Resend tag ([#1020](https://github.com/cacheplane/angular-agent-framework/pull/1020))
+- **growth:** enrich install activations and report developer journeys ([#1027](https://github.com/cacheplane/angular-agent-framework/pull/1027))
+- **growth:** integrate gated Dawn company enrichment ([#1028](https://github.com/cacheplane/angular-agent-framework/pull/1028))
+- **growth:** cut over company enrichment to Dawn ([#1041](https://github.com/cacheplane/angular-agent-framework/pull/1041))
+- **growth:** schedule founder emails on Pacific business mornings ([#1044](https://github.com/cacheplane/angular-agent-framework/pull/1044))
+- **lifecycle:** founder session offer as step one, one-word unsubscribe link ([#1012](https://github.com/cacheplane/angular-agent-framework/pull/1012))
+- **lifecycle:** add optional bounded Firecrawl company capture ([#1017](https://github.com/cacheplane/angular-agent-framework/pull/1017))
+- **lifecycle:** integrate self-hosted Firecrawl browser scraper ([#1019](https://github.com/cacheplane/angular-agent-framework/pull/1019))
+- **lifecycle:** fulfillment mail in the campaign register ([#1018](https://github.com/cacheplane/angular-agent-framework/pull/1018))
+- **lifecycle:** print the business postal address in every email footer ([#1021](https://github.com/cacheplane/angular-agent-framework/pull/1021))
+- **website:** homepage restructure (live-stage plan 1 of 3) ([#1024](https://github.com/cacheplane/angular-agent-framework/pull/1024))
+- **website:** whitepaper block and toast on the form kit; old form CSS removed ([#1026](https://github.com/cacheplane/angular-agent-framework/pull/1026))
+- **website:** the stage on the homepage — one real run, scrubbed by scroll (live-stage plan 3 of 3) ([#1032](https://github.com/cacheplane/angular-agent-framework/pull/1032))
+- **website:** the stage rail is a completeness ledger ([#1043](https://github.com/cacheplane/angular-agent-framework/pull/1043))
+- **website:** the social card shows the product, and the brand gets a real mark ([#1047](https://github.com/cacheplane/angular-agent-framework/pull/1047))
+- **website:** retire the last stale positioning from the brand assets ([#1051](https://github.com/cacheplane/angular-agent-framework/pull/1051))
+- **website:** architecture diagram — the UI layer between your users and your agents ([#1048](https://github.com/cacheplane/angular-agent-framework/pull/1048))
+- **website:** the homepage closes on a quiet open-source strip ([#1057](https://github.com/cacheplane/angular-agent-framework/pull/1057))
+- **website:** ATC theme spike — aviation yellow, Archivo Black, scope navy ([#1058](https://github.com/cacheplane/angular-agent-framework/pull/1058), [#15253](https://github.com/cacheplane/angular-agent-framework/issues/15253), [#004090](https://github.com/cacheplane/angular-agent-framework/issues/004090), [#1048](https://github.com/cacheplane/angular-agent-framework/issues/1048), [#963](https://github.com/cacheplane/angular-agent-framework/issues/963), [#1057](https://github.com/cacheplane/angular-agent-framework/issues/1057))
+
+### 🩹 Fixes
+
+- **growth:** validate telemetry and align PostHog dashboards ([#1050](https://github.com/cacheplane/angular-agent-framework/pull/1050))
+- **langgraph:** lifecycle token, error kind, root registry, required interrupt, awaitable mock transport ([#1054](https://github.com/cacheplane/angular-agent-framework/pull/1054))
+- **libs:** make the type-tests targets runnable again ([#1064](https://github.com/cacheplane/angular-agent-framework/pull/1064))
+- **lifecycle:** ground company research in substantive evidence ([add9e6801](https://github.com/cacheplane/angular-agent-framework/commit/add9e6801))
+- ⚠️  **middleware:** server_tools router default; Python emit_custom_event helper ([#1052](https://github.com/cacheplane/angular-agent-framework/pull/1052))
+- **render:** honor every ActionBinding field, per-item visible, real element lifecycle and state paths ([#1056](https://github.com/cacheplane/angular-agent-framework/pull/1056))
+- **render:** resolve repeated element readiness and props in the row's own scope ([#1062](https://github.com/cacheplane/angular-agent-framework/pull/1062))
+- **website:** pin the stage hold one millisecond inside it so the frame reports pause ([#1034](https://github.com/cacheplane/angular-agent-framework/pull/1034), [#1032](https://github.com/cacheplane/angular-agent-framework/issues/1032))
+- **website:** ATC theme follow-ups — favicon, social cards, whitepapers ([#1059](https://github.com/cacheplane/angular-agent-framework/pull/1059), [#004090](https://github.com/cacheplane/angular-agent-framework/issues/004090), [#15253](https://github.com/cacheplane/angular-agent-framework/issues/15253))
+- **website:** give arch-flow console badges an on-dark palette ([#1060](https://github.com/cacheplane/angular-agent-framework/pull/1060), [#1](https://github.com/cacheplane/angular-agent-framework/issues/1), [#15253](https://github.com/cacheplane/angular-agent-framework/issues/15253))
+
+### ⚠️  Breaking Changes
+
+- **chat:** remove provideChat(), fix app-level markdown registry overrides, and three API cleanups  ([#1055](https://github.com/cacheplane/angular-agent-framework/pull/1055))
+- **middleware:** server_tools router default; Python emit_custom_event helper  ([#1052](https://github.com/cacheplane/angular-agent-framework/pull/1052))
+  the default is now 'server_tools'. Rename your server tool
+  node to server_tools and drop the override, or keep the override pointing at
+  whatever name your node uses. There is no shim. The Python package's
+  route_after_agent() keeps tools_node="tools"; Python LangGraph has no such
+  namespace collision.
+  Two integration specs record the behavior: one invokes a graph whose ToolNode
+  is named server_tools with no override and asserts the tool actually ran (it
+  failed with "Branch condition returned unknown or null destination" before the
+  fix), and one pins the addNode('tools', …) throw so the reason is written down.
+  Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
+
 ## 0.0.66 (2026-09-05)
 
 ### 🚀 Features

--- a/apps/website/public/AGENTS.md
+++ b/apps/website/public/AGENTS.md
@@ -1,4 +1,4 @@
-# Threadplane v0.0.66
+# Threadplane v0.1.0
 
 Production-ready chat, thread/history/branch UI, interrupts, subagents, planning, memory, and generative UI for Angular agent apps.
 

--- a/apps/website/public/CLAUDE.md
+++ b/apps/website/public/CLAUDE.md
@@ -1,4 +1,4 @@
-# Threadplane v0.0.66
+# Threadplane v0.1.0
 
 Production-ready chat, thread/history/branch UI, interrupts, subagents, planning, memory, and generative UI for Angular agent apps.
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,6 +1,6 @@
 # Release Process
 
-The six publishable libraries (`@threadplane/chat`, `@threadplane/langgraph`, `@threadplane/ag-ui`, `@threadplane/render`, `@threadplane/a2ui`, `@threadplane/telemetry`) ship together at a synchronized version via Nx Release. During the `0.0.x` exploratory phase, only patch bumps are used.
+The six publishable libraries (`@threadplane/chat`, `@threadplane/langgraph`, `@threadplane/ag-ui`, `@threadplane/render`, `@threadplane/a2ui`, `@threadplane/telemetry`) ship together at a synchronized version via Nx Release. Releases use **minor** bumps (`0.1.0` → `0.2.0` → …). **Never cut `1.0.0` without explicit approval from the repository owner, every time.**
 
 Nx updates internal dependency and peer ranges with the synchronized release. `preserveMatchingDependencyRanges` is disabled so a prior `^0.0.x` peer range cannot block the next patch or leave companion packages on incompatible versions. External dependency ranges remain unchanged.
 
@@ -25,7 +25,7 @@ git checkout main && git pull
 
 # 1. Version bump. Runs preVersionCommand (builds all six projects), rewrites every
 #    package.json, updates package-lock.json, and stages the result.
-npx nx release version --specifier=patch
+npx nx release version --specifier=minor
 
 # 2. Regenerate the public agent-context files. They embed the release
 #    version, and the Website unit suite fails the release commit until
@@ -110,7 +110,7 @@ Always sanity-check before a real release. Dry-run each subcommand — the
 one-shot `nx release patch --dry-run` fails the same way the real command does:
 
 ```bash
-npx nx release version --specifier=patch --dry-run
+npx nx release version --specifier=minor --dry-run
 npx nx release changelog 0.0.57 --dry-run   # bare version; check the printed tag URL
 ```
 
@@ -132,11 +132,13 @@ Anything above `0` means main has unpublished commits.
 
 `Publish` workflow accepts `workflow_dispatch` with a `dry-run` input (default `true`). Trigger from the GitHub Actions UI to verify CI's publish path without actually shipping.
 
-## Why patch-only during 0.0.x
+## Versioning policy
 
-While the API is still settling we bump only the patch component (`0.0.1` → `0.0.2` → `0.0.3`). This signals to consumers that breaking changes can land in any release; lock to an exact version.
+Releases bump the **minor** component (`0.1.0` → `0.2.0` → …). Breaking changes can still land in any release while the major is `0`, so consumers should lock to an exact version; the changelog names the breaking entries.
 
-When the API stabilizes enough to make compatibility promises, transition to `0.1.0` and start using minor/major bumps with conventional-commit-driven semver.
+`1.0.0` is a deliberate gate, not something to infer from scope or stability: **ask the repository owner and wait for an explicit yes before cutting it.**
+
+Through `v0.0.66` the project used patch-only bumps. That ended on 2026-09-08, when a backlog of breaking changes made the patch counter actively misleading.
 
 ## Internal peer dependencies
 

--- a/libs/a2ui/package.json
+++ b/libs/a2ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/a2ui",
-  "version": "0.0.66",
+  "version": "0.1.0",
   "description": "A2UI protocol types, streaming parser, and dynamic-value resolver for agent-generated UI. Pure TypeScript.",
   "license": "MIT",
   "repository": {

--- a/libs/ag-ui/package.json
+++ b/libs/ag-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/ag-ui",
-  "version": "0.0.66",
+  "version": "0.1.0",
   "description": "AG-UI adapter for the Angular AI agent UI — connect any AG-UI-compatible backend to the same chat surface.",
   "keywords": [
     "angular",
@@ -10,8 +10,8 @@
     "threadplane"
   ],
   "peerDependencies": {
-    "@threadplane/chat": "0.0.66",
-    "@threadplane/telemetry": "^0.0.66",
+    "@threadplane/chat": "0.1.0",
+    "@threadplane/telemetry": "^0.1.0",
     "@angular/core": "^20.0.0 || ^21.0.0 || ^22.0.0",
     "@ag-ui/client": "*",
     "@ag-ui/core": "*",

--- a/libs/chat/package.json
+++ b/libs/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/chat",
-  "version": "0.0.66",
+  "version": "0.1.0",
   "description": "The Angular AI agent chat UI: <chat>, headless primitives, interrupts, subagents, and generative UI on Signals.",
   "exports": {
     "./chat.css": "./chat.css",
@@ -18,14 +18,14 @@
     "@cacheplane/partial-markdown": "0.5.8"
   },
   "peerDependencies": {
-    "@threadplane/telemetry": "^0.0.66",
+    "@threadplane/telemetry": "^0.1.0",
     "zod": "^3.25.0",
     "@angular/core": "^20.0.0 || ^21.0.0 || ^22.0.0",
     "@angular/common": "^20.0.0 || ^21.0.0 || ^22.0.0",
     "@angular/platform-browser": "^20.0.0 || ^21.0.0 || ^22.0.0",
     "@angular/router": "^20.0.0 || ^21.0.0 || ^22.0.0",
-    "@threadplane/render": "0.0.66",
-    "@threadplane/a2ui": "0.0.66",
+    "@threadplane/render": "0.1.0",
+    "@threadplane/a2ui": "0.1.0",
     "@json-render/core": "^0.16.0",
     "rxjs": "~7.8.0",
     "marked": "^15.0.0 || ^16.0.0",

--- a/libs/langgraph/package.json
+++ b/libs/langgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/langgraph",
-  "version": "0.0.66",
+  "version": "0.1.0",
   "description": "LangGraph adapter for the Angular AI agent UI — provideAgent()/injectAgent() expose a run as Angular Signals.",
   "keywords": [
     "angular",
@@ -11,8 +11,8 @@
     "threadplane"
   ],
   "peerDependencies": {
-    "@threadplane/chat": "0.0.66",
-    "@threadplane/telemetry": "^0.0.66",
+    "@threadplane/chat": "0.1.0",
+    "@threadplane/telemetry": "^0.1.0",
     "@angular/core": "^20.0.0 || ^21.0.0 || ^22.0.0",
     "@langchain/core": "^1.1.33",
     "@langchain/langgraph-sdk": "^1.7.4",

--- a/libs/render/package.json
+++ b/libs/render/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@threadplane/render",
-  "version": "0.0.66",
+  "version": "0.1.0",
   "description": "Angular render engine for agent-generated UI: maps JSON specs onto your own design-system components.",
   "peerDependencies": {
-    "@threadplane/telemetry": "^0.0.66",
+    "@threadplane/telemetry": "^0.1.0",
     "@angular/core": "^20.0.0 || ^21.0.0 || ^22.0.0",
     "@angular/common": "^20.0.0 || ^21.0.0 || ^22.0.0",
     "@json-render/core": "^0.16.0"

--- a/libs/telemetry/package.json
+++ b/libs/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threadplane/telemetry",
-  "version": "0.0.66",
+  "version": "0.1.0",
   "description": "Explicit Node and browser capture helpers for Angular AI agent applications that choose to send events.",
   "license": "MIT",
   "publishConfig": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -401,26 +401,26 @@
     },
     "libs/a2ui": {
       "name": "@threadplane/a2ui",
-      "version": "0.0.66",
+      "version": "0.1.0",
       "license": "MIT"
     },
     "libs/ag-ui": {
       "name": "@threadplane/ag-ui",
-      "version": "0.0.66",
+      "version": "0.1.0",
       "hasInstallScript": true,
       "license": "MIT",
       "peerDependencies": {
         "@ag-ui/client": "*",
         "@ag-ui/core": "*",
         "@angular/core": "^20.0.0 || ^21.0.0 || ^22.0.0",
-        "@threadplane/chat": "0.0.66",
-        "@threadplane/telemetry": "^0.0.66",
+        "@threadplane/chat": "0.1.0",
+        "@threadplane/telemetry": "^0.1.0",
         "rxjs": "~7.8.0"
       }
     },
     "libs/chat": {
       "name": "@threadplane/chat",
-      "version": "0.0.66",
+      "version": "0.1.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -433,10 +433,9 @@
         "@angular/platform-browser": "^20.0.0 || ^21.0.0 || ^22.0.0",
         "@angular/router": "^20.0.0 || ^21.0.0 || ^22.0.0",
         "@json-render/core": "^0.16.0",
-        "@langchain/core": "^1.1.33",
-        "@threadplane/a2ui": "0.0.66",
-        "@threadplane/render": "0.0.66",
-        "@threadplane/telemetry": "^0.0.66",
+        "@threadplane/a2ui": "0.1.0",
+        "@threadplane/render": "0.1.0",
+        "@threadplane/telemetry": "^0.1.0",
         "katex": "^0.16.0 || ^0.17.0",
         "marked": "^15.0.0 || ^16.0.0",
         "rxjs": "~7.8.0",
@@ -590,15 +589,15 @@
     },
     "libs/langgraph": {
       "name": "@threadplane/langgraph",
-      "version": "0.0.66",
+      "version": "0.1.0",
       "hasInstallScript": true,
       "license": "MIT",
       "peerDependencies": {
         "@angular/core": "^20.0.0 || ^21.0.0 || ^22.0.0",
         "@langchain/core": "^1.1.33",
         "@langchain/langgraph-sdk": "^1.7.4",
-        "@threadplane/chat": "0.0.66",
-        "@threadplane/telemetry": "^0.0.66",
+        "@threadplane/chat": "0.1.0",
+        "@threadplane/telemetry": "^0.1.0",
         "rxjs": "~7.8.0"
       }
     },
@@ -613,19 +612,19 @@
     },
     "libs/render": {
       "name": "@threadplane/render",
-      "version": "0.0.66",
+      "version": "0.1.0",
       "hasInstallScript": true,
       "license": "MIT",
       "peerDependencies": {
         "@angular/common": "^20.0.0 || ^21.0.0 || ^22.0.0",
         "@angular/core": "^20.0.0 || ^21.0.0 || ^22.0.0",
         "@json-render/core": "^0.16.0",
-        "@threadplane/telemetry": "^0.0.66"
+        "@threadplane/telemetry": "^0.1.0"
       }
     },
     "libs/telemetry": {
       "name": "@threadplane/telemetry",
-      "version": "0.0.66",
+      "version": "0.1.0",
       "license": "MIT",
       "peerDependencies": {
         "@angular/core": "^20.0.0 || ^21.0.0 || ^22.0.0",
@@ -10992,6 +10991,7 @@
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/@json-render/core/-/core-0.16.0.tgz",
       "integrity": "sha512-qQp8BB/3pWYapTGXBDSBMXRCdrC05VJPLL3drXMPX/QbUB3nuvtyXUGmAZFUz8eLUy7JImODvb3GNIq38dGzhQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^4.3.6"
@@ -11004,6 +11004,7 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -17530,6 +17531,7 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
       "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -17569,6 +17571,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -17589,6 +17592,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -17609,6 +17613,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -17629,6 +17634,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -17649,6 +17655,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -17669,6 +17676,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -17689,6 +17697,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -17709,6 +17718,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -17729,6 +17739,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -17749,6 +17760,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -17769,6 +17781,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -17789,6 +17802,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -17809,6 +17823,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -17826,6 +17841,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -18019,7 +18035,7 @@
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
       "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.58.2"
@@ -22000,6 +22016,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -22009,7 +22026,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -27154,6 +27171,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cuint": {
@@ -31206,7 +31224,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
       "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -31427,7 +31445,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -31447,7 +31465,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -32453,7 +32471,7 @@
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/katex/-/katex-0.17.0.tgz",
       "integrity": "sha512-Vdw0ATsQ9V+LuegM/BTwQqV/6cTl5lbGcIrU+BCgLxyf6bo38ybOr372tuSIxir3CN720flu1meYR6XzNMwQnw==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         "https://opencollective.com/katex",
         "https://github.com/sponsors/katex"
@@ -32470,7 +32488,7 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
       "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -33873,6 +33891,7 @@
       "version": "15.0.12",
       "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
@@ -36113,6 +36132,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -37863,7 +37883,7 @@
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
       "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.58.2"
@@ -37882,7 +37902,7 @@
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
       "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -37895,6 +37915,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -39369,17 +39390,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/react-refresh": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
-      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -40354,7 +40364,7 @@
       "version": "1.98.0",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.98.0.tgz",
       "integrity": "sha512-+4N/u9dZ4PrgzGgPlKnaaRQx64RO0JBKs9sDhQ2pLgN6JQZ25uPQZKQYaBJU48Kd5BxgXoJ4e09Dq7nMcOUW3A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.0",
@@ -40780,7 +40790,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -40796,7 +40806,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -42279,6 +42289,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
       "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tapable": {
@@ -43287,7 +43298,7 @@
       "version": "7.24.4",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
       "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -44743,7 +44754,7 @@
       "version": "8.21.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
       "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/packages/threadplane-middleware/pyproject.toml
+++ b/packages/threadplane-middleware/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "threadplane-middleware"
-version = "0.0.3"
+version = "0.1.0"
 description = "LangGraph middleware for binding client-declared tool stubs and routing client tool calls to END so the browser executes them."
 readme = "README.md"
 license = { text = "MIT" }

--- a/packages/threadplane-middleware/uv.lock
+++ b/packages/threadplane-middleware/uv.lock
@@ -763,7 +763,7 @@ wheels = [
 
 [[package]]
 name = "threadplane-middleware"
-version = "0.0.3"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "langchain-core" },


### PR DESCRIPTION
Cuts **v0.1.0**, the first minor release. Through `v0.0.66` the project bumped only the patch component; 55 commits of accumulated breaking changes made that counter actively misleading, and the published packages now contradict the documentation on production. `1.0.0` stays gated on explicit owner approval, and `docs/RELEASE.md` records both rules.

### Breaking changes
- **chat**: `provideChat()`, `ChatConfig` and `CHAT_CONFIG` removed. No component ever read the token, so it configured nothing; `<chat>` is configured through its inputs.
- **chat**: `@langchain/core` is no longer a peer — nothing in the published package imports it. It remains a peer of `@threadplane/langgraph`.
- **middleware**: the JS router's default `toolsNode` is now `server_tools`; `tools` cannot be a node name on a graph using `clientToolsChannel()`.
- **langgraph**: `streamErrorAt().classification` → `.kind`, carrying the `AgentError` kind rather than the constructor name.
- **langgraph**: `LangGraphAgent.interrupt` is required; the adapter always provides it.

### What ships
All six libraries move together to `0.1.0` with internal peer ranges rewritten. `threadplane-middleware` goes to `0.1.0` too, picking up `emit_custom_event` — its only change since `0.0.3`.

### Release mechanics
This PR carries the version bump, regenerated agent-context files, and the changelog **without the tag**, because `main` requires pull requests while the runbook assumed a direct push. The tag is created on the squashed commit after merge, which is what fires the Publish workflow.

**Not in this PR, and order-dependent**: `deployments/ag-ui-dev/requirements.txt` and its `deps/` exports pin `threadplane-middleware==0.0.1`, so `emit_custom_event` is still not importable in the Railway images. Those pins can only be bumped once `0.1.0` is live on PyPI, or the image build breaks.

### Verification
- `nx release version --specifier=minor` dry-run reviewed before applying; all six manifests and internal ranges correct.
- Lockfile checked per the runbook: **0** platform bindings dropped. The remaining non-version diff is npm re-deriving four build-only packages from `devOptional` to `dev` after the LangChain peer removal.
- `scripts/verify-release-versions.mjs`: release group atomic at `0.1.0`.
- Website suite **1394/1394** (it gates the release commit until the agent-context files carry the new version).
- `nx run-many -t lint,test,build --projects=middleware` green; middleware pytest **43 passed**.
- Confirmed no `v0.1.0` tag or GitHub Release was created prematurely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)