### PR TITLE
fix(libs): pin the type-tests compiler; document the tsconfig baseUrl blocker

### DIFF
--- a/libs/ag-ui/project.json
+++ b/libs/ag-ui/project.json
@@ -57,7 +57,7 @@
     "type-tests": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "npx tsc --noEmit -p libs/ag-ui/tsconfig.type-tests.json"
+        "command": "node ./node_modules/typescript/bin/tsc --noEmit -p libs/ag-ui/tsconfig.type-tests.json"
       }
     },
     "prepare-install": {

--- a/libs/ag-ui/tsconfig.type-tests.json
+++ b/libs/ag-ui/tsconfig.type-tests.json
@@ -2,9 +2,6 @@
   "extends": "./tsconfig.lib.json",
   "compilerOptions": {
     "noEmit": true,
-    // This target runs the workspace `tsc` (newer than the build compilers),
-    // which errors on the inherited baseUrl unless deprecations are ignored.
-    "ignoreDeprecations": "6.0",
     // Type-specs import sibling libraries through tsconfig paths; with noEmit
     // the rootDir only has to be wide enough to contain them.
     "rootDir": "../..",

--- a/libs/chat/project.json
+++ b/libs/chat/project.json
@@ -57,7 +57,7 @@
     "type-tests": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "npx tsc --project libs/chat/tsconfig.type-tests.json --noEmit"
+        "command": "node ./node_modules/typescript/bin/tsc --project libs/chat/tsconfig.type-tests.json --noEmit"
       }
     },
     "prepare-install": {

--- a/libs/chat/tsconfig.type-tests.json
+++ b/libs/chat/tsconfig.type-tests.json
@@ -3,9 +3,6 @@
   "compilerOptions": {
     "outDir": "../../dist/out-tsc/type-tests",
     "noEmit": true,
-    // This target runs the workspace `tsc` (newer than the build compilers),
-    // which errors on the inherited baseUrl unless deprecations are ignored.
-    "ignoreDeprecations": "6.0",
     // Type-specs import sibling libraries through tsconfig paths; with noEmit
     // the rootDir only has to be wide enough to contain them.
     "rootDir": "../..",

--- a/libs/langgraph/project.json
+++ b/libs/langgraph/project.json
@@ -57,7 +57,7 @@
     "type-tests": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "npx tsc --noEmit -p libs/langgraph/tsconfig.type-tests.json"
+        "command": "node ./node_modules/typescript/bin/tsc --noEmit -p libs/langgraph/tsconfig.type-tests.json"
       }
     },
     "prepare-install": {

--- a/libs/langgraph/tsconfig.type-tests.json
+++ b/libs/langgraph/tsconfig.type-tests.json
@@ -2,9 +2,6 @@
   "extends": "./tsconfig.lib.json",
   "compilerOptions": {
     "noEmit": true,
-    // This target runs the workspace `tsc` (newer than the build compilers),
-    // which errors on the inherited baseUrl unless deprecations are ignored.
-    "ignoreDeprecations": "6.0",
     // Type-specs import sibling libraries through tsconfig paths; with noEmit
     // the rootDir only has to be wide enough to contain them.
     "rootDir": "../..",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,6 +15,15 @@
     "noImplicitOverride": true,
     "noImplicitReturns": true,
     "noUnusedLocals": true,
+    // TypeScript 7 drops `baseUrl`, and since TypeScript 5.0 the `paths` below
+    // no longer need it (they resolve against this file's directory). It cannot
+    // go yet: Nx's buildable-library executors (`@nx/angular:package`,
+    // `@nx/js:tsc`) write a generated tsconfig under `tmp/<projectRoot>/build/`
+    // that re-declares `paths` with workspace-root-relative dist outputs such as
+    // `dist/libs/telemetry/browser`. Those entries are non-relative, so without a
+    // `baseUrl` TypeScript reports TS5090 and discards the whole `paths` map,
+    // and every library that depends on another library fails to compile.
+    // Removing this needs an Nx fix (or the Nx TS-solution setup) first.
     "baseUrl": ".",
     "paths": {
       "@threadplane/design-tokens": ["libs/design-tokens/src/index.ts"],


### PR DESCRIPTION
## What changed

Two things, both downstream of trying to remove `baseUrl` from `tsconfig.base.json`.

**1. The `type-tests` targets now run the workspace TypeScript.**

They invoked `npx tsc`, which does not resolve to the workspace compiler here. `@dawn-ai/core` depends on `@typescript/typescript6`, which depends on `@typescript/old` (`npm:typescript@6.0.2`); that package's `tsc` bin wins the hoist at `node_modules/.bin/tsc`. So `npx tsc` is TypeScript **6.0.2** while every other target compiles with the declared **5.9.3**:

```
$ npx tsc --version
Version 6.0.2
$ node -e "console.log(require('typescript/package.json').version)"
5.9.3
```

That mismatch is what raised `TS5101` on the inherited `baseUrl`, which #1064 silenced with `"ignoreDeprecations": "6.0"`. The targets now invoke `node ./node_modules/typescript/bin/tsc`, so they type-check the public API with the compiler the workspace actually declares, and the `ignoreDeprecations` holding action is gone from all three configs.

The `"rootDir": "../.."` lines stay — they solve the unrelated problem of type-specs importing sibling libraries through path mappings.

**2. `baseUrl` stays in `tsconfig.base.json`, with the reason recorded next to it.**

## Why `baseUrl` could not be removed

The premise checks out: since TypeScript 5.0 the `paths` entries resolve against the directory of the tsconfig that declares them, and `--traceResolution` confirms it against the installed compilers — with `baseUrl` gone, `@threadplane/chat` still resolves to `libs/chat/src/public-api.ts`, now via `pathsBasePath` rather than `baseUrl`. No source file relies on `baseUrl` for bare-specifier resolution either (there are no `from 'libs/…'`-style imports anywhere in the repo).

What breaks is Nx. `@nx/angular:package` and `@nx/js:tsc` call `createTmpTsConfig`, which writes a generated tsconfig to `tmp/<projectRoot>/build/` that re-declares the whole `paths` map with dependency entries remapped to their dist outputs:

```json
"@threadplane/telemetry/browser": [
  "dist/libs/telemetry/browser",
  "./dist/libs/telemetry/src/browser/public-api",
  "./dist/libs/telemetry/src/browser/public-api.ts"
]
```

The first entry comes from `dep.outputs` and is workspace-root-relative, i.e. non-relative. With no `baseUrl` anywhere in the chain, TypeScript raises `TS5090` and **discards the entire `paths` map**, and the generated config's directory is the wrong base for the remaining entries regardless. Every library with a workspace library dependency then fails:

```
error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set.
libs/render/src/lib/render-element.component.ts:24:73 - error TS2307:
  Cannot find module '@threadplane/telemetry/browser'
libs/cockpit-shell/src/lib/workspace-presentation.ts:9:8 - error TS2307:
  Cannot find module '@threadplane/cockpit-registry'
```

`render:build:production` (ng-packagr) and `cockpit-shell:build` (`@nx/js:tsc`) both fail this way; `chat`, `ag-ui` and `langgraph` builds are then skipped as dependents. `createTmpTsConfig` does take a `useWorkspaceAsBaseUrl` flag that would fix it, but the executors call it with the default `false` and it is not reachable from `project.json`. Prefixing the base `paths` values with `./` does not help — Nx's own injected `dist/…` entry is still non-relative.

So this needs an Nx-side fix (or migrating to the Nx TS-solution setup, which drops `paths` for project references) before `baseUrl` can go. The comment in `tsconfig.base.json` records that so the next attempt starts there.

## Other `baseUrl` declarations, and why they are left alone

- **`libs/{cockpit-runtime-bridge,growth,example-layouts,cockpit-registry}/tsconfig.json`** set `"baseUrl": "."` (the library directory). Because `baseUrl` outranks `pathsBasePath`, these already redirect the *inherited* base `paths` into the library folder — `@threadplane/design-tokens` in `example-layouts` tries `libs/example-layouts/libs/design-tokens/src/index.ts`, misses, and only resolves because the npm workspace symlink under `node_modules` happens to point at the same source. That is a pre-existing latent bug, unchanged by this PR, and removing those lines changes resolution for those builds — worth its own change rather than riding along here.
- **`libs/growth-capture`, `apps/growth-research`** pair `"baseUrl": "."` with `"paths": {}`, so `baseUrl` is doing real directory-resolution work for those NodeNext projects. Not redundant.
- **`apps/website`** declares its own complete `paths` (including the Next.js `@/*` convention) alongside `baseUrl`. Self-contained and a separate decision.
- **The `cockpit/**/{python,angular/e2e}` and `examples/**/e2e` configs** either declare `baseUrl` plus their own `paths` together, or do not extend `tsconfig.base.json` at all. Unaffected by this change.

## Verification

- `npx nx run-many -t lint,test,build --projects=chat,ag-ui,langgraph,render,a2ui,telemetry,middleware,cockpit-registry,cockpit-shell,scripts --skip-nx-cache` — green (0 lint errors; warnings only)
- `chat:type-tests`, `ag-ui:type-tests`, `langgraph:type-tests` — all green on TypeScript 5.9.3 with no `ignoreDeprecations`
- Mutation-checked the pinned compiler: appending `const x: number = "s"` to `libs/ag-ui/src/lib/provide-agent.type-spec.ts` fails the target with `TS2322`, so it is not passing vacuously
- `npx vitest run --root apps/website --reporter=dot` — 138 files, 1394 tests passed
- `GROWTH_FORM_POLICY=growth_v1 npx nx build website` — green
- `npx nx run-many -t build --projects=examples-chat-angular,cockpit-render-repeat-loops-angular,cockpit-chat-debug-angular` — green
- `npx nx run e2e-harness:lint` (the one other bare-`tsc` target) — green; its tsconfig is standalone and declares no `baseUrl`
- `npx tsc --noEmit -p tsconfig.base.json` is not meaningful here: the file has no `include`/`files`, so it would sweep every `.ts` in the workspace. The equivalent editor-facing surfaces are covered by the website build (Next.js) and the library builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
