### PR TITLE
feat(website): the reliability band becomes a preflight checklist

### DIFF
--- a/apps/website/e2e/website.spec.ts
+++ b/apps/website/e2e/website.spec.ts
@@ -50,6 +50,7 @@ test('landing page renders the spine in order (live-stage spec §3)', async ({ p
   const ids = [
     'hero-heading',
     'proof-heading',
+    'compatibility-heading',
     'architecture-heading',
     'stage-heading',
     'open-source-heading',

--- a/apps/website/src/app/page.tsx
+++ b/apps/website/src/app/page.tsx
@@ -1,5 +1,6 @@
 import { Hero } from '../components/landing/Hero';
 import { Reliability } from '../components/landing/Reliability';
+import { Compatibility } from '../components/landing/Compatibility';
 import { EnterpriseArchitecture } from '../components/landing/EnterpriseArchitecture';
 import { Stage } from '../components/landing/Stage';
 import { TeamsBlock } from '../components/landing/TeamsBlock';
@@ -31,6 +32,7 @@ export default function HomePage() {
     <>
       <Hero />
       <Reliability />
+      <Compatibility />
       <EnterpriseArchitecture />
 
       {/* The four capability beats (stream, persist, approve, render): stills

--- a/apps/website/src/components/landing/Compatibility.spec.tsx
+++ b/apps/website/src/components/landing/Compatibility.spec.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Compatibility, COMPATIBILITY_GROUPS, COMPATIBILITY_MORE_COUNT } from './Compatibility';
+
+describe('Compatibility', () => {
+  it('renders a light section with a stable id', () => {
+    const { container } = render(<Compatibility />);
+    const section = container.querySelector('[data-ui="section"]');
+    expect(section?.getAttribute('data-surface')).toBe('tinted');
+    expect(section?.getAttribute('id')).toBe('compatibility');
+  });
+
+  it('groups every item under a labelled heading', () => {
+    render(<Compatibility />);
+    for (const group of COMPATIBILITY_GROUPS) {
+      expect(screen.getByText(group.label)).toBeTruthy();
+      for (const item of group.items) expect(screen.getByText(item.name)).toBeTruthy();
+    }
+    expect(screen.getByText(`+ ${COMPATIBILITY_MORE_COUNT} more`)).toBeTruthy();
+  });
+
+  it('states compatibility in words and never implies a customer', () => {
+    const { container } = render(<Compatibility />);
+    // The claim used to exist only as alt="" plus a spec comment. A reader
+    // could not see it. Now it is on the page.
+    expect(screen.getByText(/Compatibility, not endorsement/)).toBeTruthy();
+    expect(container.textContent).not.toMatch(/trusted by|customers|our clients|powered by/i);
+  });
+
+  it('marks every logo decorative, since the visible name carries the meaning', () => {
+    const { container } = render(<Compatibility />);
+    const logos = container.querySelectorAll('img.compatibility-logo');
+    const withLogos = COMPATIBILITY_GROUPS.flatMap((g) => g.items).filter((i) => i.logoSrc);
+    expect(logos).toHaveLength(withLogos.length);
+    for (const img of Array.from(logos)) {
+      expect(img.getAttribute('aria-hidden')).toBe('true');
+      expect(img.getAttribute('alt')).toBe('');
+    }
+  });
+
+  it('links to the adapter guide', () => {
+    render(<Compatibility />);
+    expect(
+      screen.getByRole('link', { name: 'Choose an adapter →' }).getAttribute('href'),
+    ).toBe('/docs/choosing-an-adapter');
+  });
+});

--- a/apps/website/src/components/landing/Compatibility.spec.tsx
+++ b/apps/website/src/components/landing/Compatibility.spec.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
-import { Compatibility, COMPATIBILITY_GROUPS, COMPATIBILITY_MORE_COUNT } from './Compatibility';
+import { Compatibility, COMPATIBILITY_GROUPS } from './Compatibility';
 
 describe('Compatibility', () => {
   it('renders a light section with a stable id', () => {
@@ -10,13 +10,35 @@ describe('Compatibility', () => {
     expect(section?.getAttribute('id')).toBe('compatibility');
   });
 
+  it('lists twelve integrations across three groups', () => {
+    render(<Compatibility />);
+    // The suite otherwise iterates the same constant the component renders
+    // from, so it cannot see content disappear: a reviewer deleted the whole
+    // Protocols group — LangGraph and AG-UI, the two with first-party
+    // adapters — and every other test stayed green.
+    expect(COMPATIBILITY_GROUPS).toHaveLength(3);
+    expect(COMPATIBILITY_GROUPS.map((g) => g.label)).toEqual([
+      'Model providers',
+      'Agent runtimes',
+      'Protocols',
+    ]);
+    expect(COMPATIBILITY_GROUPS.flatMap((g) => g.items)).toHaveLength(12);
+    for (const name of ['LangGraph', 'AG-UI', 'OpenAI', 'Anthropic']) {
+      expect(screen.getByText(name)).toBeTruthy();
+    }
+  });
+
   it('groups every item under a labelled heading', () => {
     render(<Compatibility />);
     for (const group of COMPATIBILITY_GROUPS) {
       expect(screen.getByText(group.label)).toBeTruthy();
       for (const item of group.items) expect(screen.getByText(item.name)).toBeTruthy();
     }
-    expect(screen.getByText(`+ ${COMPATIBILITY_MORE_COUNT} more`)).toBeTruthy();
+    // The label is a bare <p>, so the list only carries an accessible name if
+    // aria-labelledby actually points at it.
+    for (const group of COMPATIBILITY_GROUPS) {
+      expect(screen.getByRole('list', { name: group.label })).toBeTruthy();
+    }
   });
 
   it('states compatibility in words and never implies a customer', () => {

--- a/apps/website/src/components/landing/Compatibility.spec.tsx
+++ b/apps/website/src/components/landing/Compatibility.spec.tsx
@@ -8,6 +8,7 @@ describe('Compatibility', () => {
     const section = container.querySelector('[data-ui="section"]');
     expect(section?.getAttribute('data-surface')).toBe('tinted');
     expect(section?.getAttribute('id')).toBe('compatibility');
+    expect(section?.getAttribute('aria-labelledby')).toBe('compatibility-heading');
   });
 
   it('lists twelve integrations across three groups', () => {

--- a/apps/website/src/components/landing/Compatibility.tsx
+++ b/apps/website/src/components/landing/Compatibility.tsx
@@ -19,6 +19,16 @@ interface CompatibilityGroup {
  * beside a protocol as though they were the same kind of thing, which is not
  * the information someone evaluating this needs.
  *
+ * This list is COMPLETE — every integration is named. It used to stop at nine
+ * and close the runtimes group with a "+ 3 more" badge, which mis-filed Azure
+ * OpenAI (a model provider) as a runtime and left a count that only stayed
+ * honest if an editor remembered to decrement it. There is no hidden count to
+ * keep in step now; add an entry to the group it actually belongs to.
+ *
+ * "Works with" is a compatibility claim, never a customer claim: logos are
+ * `alt="" aria-hidden` beside visible names, and no wording may imply these
+ * companies use Threadplane. Compatibility.spec.tsx guards both halves.
+ *
  * This section is LIGHT on purpose. These marks are drawn for light grounds —
  * Anthropic's is #181818 — and on the dark band they were invisible. Moving
  * them here is the fix; no CSS filter is involved.
@@ -31,6 +41,7 @@ export const COMPATIBILITY_GROUPS: readonly CompatibilityGroup[] = [
       { name: 'Anthropic', logoSrc: '/logos/providers/anthropic.svg' },
       { name: 'Gemini', logoSrc: '/logos/providers/google.svg' },
       { name: 'Bedrock', logoSrc: '/logos/providers/bedrock.svg' },
+      { name: 'Azure OpenAI', logoSrc: '/logos/providers/azure.svg' },
     ],
   },
   {
@@ -38,6 +49,8 @@ export const COMPATIBILITY_GROUPS: readonly CompatibilityGroup[] = [
     items: [
       { name: 'Mastra', logoSrc: '/logos/runtimes/mastra.svg' },
       { name: 'CrewAI', logoSrc: '/logos/runtimes/crewai.svg' },
+      { name: 'Pydantic AI', logoSrc: '/logos/runtimes/pydantic.svg' },
+      { name: 'Microsoft Agent Framework', logoSrc: '/logos/runtimes/microsoft.svg' },
       { name: 'AWS Strands', logoSrc: null },
     ],
   },
@@ -51,13 +64,11 @@ export const COMPATIBILITY_GROUPS: readonly CompatibilityGroup[] = [
 ];
 
 /**
- * Azure OpenAI, Pydantic AI, Microsoft Agent Framework.
- *
- * Was 4 and included AWS Strands, which is now named above — it is already
- * named twice elsewhere on the page (a reliability receipt cites it), so
- * hiding it in a count was odd. Decrement this if another is promoted.
+ * Derived, never hand-written: each group's `<ul>` takes its accessible name
+ * from the sibling label through this id, so rewording a label cannot leave
+ * the list unnamed.
  */
-export const COMPATIBILITY_MORE_COUNT = 3;
+const groupId = (label: string) => `compatibility-${label.toLowerCase().replace(/\s+/g, '-')}`;
 
 export function Compatibility() {
   return (
@@ -73,8 +84,14 @@ export function Compatibility() {
         <div className="compatibility-groups">
           {COMPATIBILITY_GROUPS.map((group) => (
             <div className="compatibility-group" key={group.label}>
-              <p className="compatibility-group-label">{group.label}</p>
-              <ul className="compatibility-items" role="list">
+              <p className="compatibility-group-label" id={groupId(group.label)}>
+                {group.label}
+              </p>
+              <ul
+                className="compatibility-items"
+                role="list"
+                aria-labelledby={groupId(group.label)}
+              >
                 {group.items.map((item) => (
                   <li className="compatibility-item" key={item.name}>
                     {item.logoSrc ? (
@@ -90,9 +107,6 @@ export function Compatibility() {
                     <span className="compatibility-name">{item.name}</span>
                   </li>
                 ))}
-                {group.label === 'Agent runtimes' ? (
-                  <li className="compatibility-more">+ {COMPATIBILITY_MORE_COUNT} more</li>
-                ) : null}
               </ul>
             </div>
           ))}

--- a/apps/website/src/components/landing/Compatibility.tsx
+++ b/apps/website/src/components/landing/Compatibility.tsx
@@ -1,0 +1,109 @@
+import { Container } from '../ui/Container';
+import { Section } from '../ui/Section';
+import { SectionHeader } from '../ui/SectionHeader';
+import { AdapterGuideLink } from './AdapterGuideLink';
+
+interface CompatibilityItem {
+  readonly name: string;
+  /** null for an entry we support but have no mark for. */
+  readonly logoSrc: string | null;
+}
+
+interface CompatibilityGroup {
+  readonly label: string;
+  readonly items: readonly CompatibilityItem[];
+}
+
+/**
+ * Grouped rather than a flat run: the previous single row put a model provider
+ * beside a protocol as though they were the same kind of thing, which is not
+ * the information someone evaluating this needs.
+ *
+ * This section is LIGHT on purpose. These marks are drawn for light grounds —
+ * Anthropic's is #181818 — and on the dark band they were invisible. Moving
+ * them here is the fix; no CSS filter is involved.
+ */
+export const COMPATIBILITY_GROUPS: readonly CompatibilityGroup[] = [
+  {
+    label: 'Model providers',
+    items: [
+      { name: 'OpenAI', logoSrc: '/logos/providers/openai.svg' },
+      { name: 'Anthropic', logoSrc: '/logos/providers/anthropic.svg' },
+      { name: 'Gemini', logoSrc: '/logos/providers/google.svg' },
+      { name: 'Bedrock', logoSrc: '/logos/providers/bedrock.svg' },
+    ],
+  },
+  {
+    label: 'Agent runtimes',
+    items: [
+      { name: 'Mastra', logoSrc: '/logos/runtimes/mastra.svg' },
+      { name: 'CrewAI', logoSrc: '/logos/runtimes/crewai.svg' },
+      { name: 'AWS Strands', logoSrc: null },
+    ],
+  },
+  {
+    label: 'Protocols',
+    items: [
+      { name: 'LangGraph', logoSrc: '/logos/langgraph.svg' },
+      { name: 'AG-UI', logoSrc: '/logos/ag-ui.svg' },
+    ],
+  },
+];
+
+/**
+ * Azure OpenAI, Pydantic AI, Microsoft Agent Framework.
+ *
+ * Was 4 and included AWS Strands, which is now named above — it is already
+ * named twice elsewhere on the page (a reliability receipt cites it), so
+ * hiding it in a count was odd. Decrement this if another is promoted.
+ */
+export const COMPATIBILITY_MORE_COUNT = 3;
+
+export function Compatibility() {
+  return (
+    <Section surface="tinted" id="compatibility" ariaLabelledBy="compatibility-heading">
+      <Container>
+        <SectionHeader
+          variant="rail"
+          eyebrow="Compatibility"
+          heading="Your backend, your models, your runtime."
+          headingId="compatibility-heading"
+          aside="Threadplane is the UI layer. What it talks to is your choice — and swapping any of it does not mean rewriting the interface."
+        />
+        <div className="compatibility-groups">
+          {COMPATIBILITY_GROUPS.map((group) => (
+            <div className="compatibility-group" key={group.label}>
+              <p className="compatibility-group-label">{group.label}</p>
+              <ul className="compatibility-items" role="list">
+                {group.items.map((item) => (
+                  <li className="compatibility-item" key={item.name}>
+                    {item.logoSrc ? (
+                      <img
+                        src={item.logoSrc}
+                        alt=""
+                        aria-hidden="true"
+                        loading="lazy"
+                        decoding="async"
+                        className="compatibility-logo"
+                      />
+                    ) : null}
+                    <span className="compatibility-name">{item.name}</span>
+                  </li>
+                ))}
+                {group.label === 'Agent runtimes' ? (
+                  <li className="compatibility-more">+ {COMPATIBILITY_MORE_COUNT} more</li>
+                ) : null}
+              </ul>
+            </div>
+          ))}
+        </div>
+        <div className="compatibility-footer">
+          <AdapterGuideLink className="compatibility-link" />
+          <p className="compatibility-disclaimer">
+            Compatibility, not endorsement — no company here is claimed as a customer.
+          </p>
+        </div>
+      </Container>
+    </Section>
+  );
+}

--- a/apps/website/src/components/landing/Compatibility.tsx
+++ b/apps/website/src/components/landing/Compatibility.tsx
@@ -104,7 +104,7 @@ export function Compatibility() {
                         className="compatibility-logo"
                       />
                     ) : null}
-                    <span className="compatibility-name">{item.name}</span>
+                    <span>{item.name}</span>
                   </li>
                 ))}
               </ul>

--- a/apps/website/src/components/landing/Hero.spec.tsx
+++ b/apps/website/src/components/landing/Hero.spec.tsx
@@ -7,7 +7,6 @@ import {
   HERO_H1,
   HERO_SECONDARY_HREF,
   HERO_SUBHEAD,
-  HERO_TRUST_LINE,
 } from '../../lib/positioning';
 
 const trackMock = vi.hoisted(() => vi.fn());
@@ -62,7 +61,6 @@ describe('Hero', () => {
       'Your backend stays where it is.',
     );
     expect(document.querySelectorAll('.hero-subhead .marker-highlight')).toHaveLength(1);
-    expect(document.querySelector('.hero-trust')?.textContent).toBe(HERO_TRUST_LINE);
     expect(document.querySelector('.hero-chip-row')).toBeNull();
     expect(screen.queryByText(/six months/)).toBeNull();
     expect(screen.queryByRole('link', { name: /Talk to our engineers/ })).toBeNull();

--- a/apps/website/src/components/landing/Hero.tsx
+++ b/apps/website/src/components/landing/Hero.tsx
@@ -13,7 +13,6 @@ import {
   HERO_SECONDARY_HREF,
   HERO_SECONDARY_LABEL,
   HERO_SUBHEAD_SEGMENTS,
-  HERO_TRUST_LINE,
 } from '../../lib/positioning';
 import { HeroDemo } from './HeroDemo';
 import { InstallDialog } from './InstallDialog';
@@ -59,7 +58,6 @@ export function Hero() {
             </a>
           </div>
           <HeroDemo />
-          <p className="hero-trust hero-strip">{HERO_TRUST_LINE}</p>
         </div>
       </Container>
       <InstallDialog open={installOpen} onClose={closeInstall} />

--- a/apps/website/src/components/landing/PreflightChecklist.spec.tsx
+++ b/apps/website/src/components/landing/PreflightChecklist.spec.tsx
@@ -1,0 +1,62 @@
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { PreflightChecklist } from './PreflightChecklist';
+import { PREFLIGHT_OURS, PREFLIGHT_YOURS, AIRWORTHINESS } from '../../lib/preflight-checklist';
+
+describe('PreflightChecklist', () => {
+  it('renders one row per data row', () => {
+    const { container } = render(<PreflightChecklist />);
+    expect(container.querySelectorAll('.preflight-row')).toHaveLength(
+      PREFLIGHT_OURS.length + PREFLIGHT_YOURS.length + AIRWORTHINESS.length,
+    );
+  });
+
+  it('links every ticked row and none of the Yours rows', () => {
+    const { container } = render(<PreflightChecklist />);
+    expect(container.querySelectorAll('a.preflight-row')).toHaveLength(
+      PREFLIGHT_OURS.length + AIRWORTHINESS.length,
+    );
+    for (const a of Array.from(container.querySelectorAll('a.preflight-row'))) {
+      expect(a.getAttribute('href')).toBeTruthy();
+    }
+  });
+
+  it('draws the boxes rather than using form controls', () => {
+    // Nothing here is interactive. An <input type="checkbox"> would tell a
+    // screen reader it can be toggled, which is a lie.
+    const { container } = render(<PreflightChecklist />);
+    expect(container.querySelectorAll('input')).toHaveLength(0);
+    expect(container.querySelectorAll('.preflight-box')).toHaveLength(
+      PREFLIGHT_OURS.length + PREFLIGHT_YOURS.length + AIRWORTHINESS.length,
+    );
+  });
+
+  it('names each column list so two adjacent lists are distinguishable', () => {
+    const { container } = render(<PreflightChecklist />);
+    const lists = Array.from(container.querySelectorAll('ul[aria-labelledby]'));
+    expect(lists).toHaveLength(3);
+    for (const ul of lists) {
+      const label = container.querySelector(`#${ul.getAttribute('aria-labelledby')}`);
+      expect(label?.textContent).toBeTruthy();
+    }
+  });
+
+  it('keeps the HVTrust grade a live badge with real alt text', () => {
+    const { container } = render(<PreflightChecklist />);
+    const badge = container.querySelector('img.preflight-badge');
+    expect(badge?.getAttribute('src')).toBe('https://hvtracker.net/badge/threadplane.svg');
+    // Not decorative: it carries the grade, so it needs a real description.
+    expect(badge?.getAttribute('alt')).toBeTruthy();
+    expect(badge?.getAttribute('alt')).not.toBe('');
+  });
+
+  it('opens off-site sources safely in a new tab', () => {
+    const { container } = render(<PreflightChecklist />);
+    for (const a of Array.from(container.querySelectorAll('a.preflight-row'))) {
+      const href = a.getAttribute('href')!;
+      if (!href.startsWith('http')) continue;
+      expect(a.getAttribute('target')).toBe('_blank');
+      expect(a.getAttribute('rel')).toBe('noopener noreferrer');
+    }
+  });
+});

--- a/apps/website/src/components/landing/PreflightChecklist.tsx
+++ b/apps/website/src/components/landing/PreflightChecklist.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import {
+  AIRWORTHINESS,
+  PREFLIGHT_OURS,
+  PREFLIGHT_YOURS,
+  type ChecklistRow,
+} from '../../lib/preflight-checklist';
+
+/** Milliseconds between ticks. Fast enough not to read as a loading bar. */
+const TICK_MS = 180;
+
+function Box() {
+  return (
+    <span className="preflight-box" aria-hidden="true">
+      <svg viewBox="0 0 10 10" focusable="false">
+        <path d="M1 5.2 3.8 8 9 2.2" fill="none" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    </span>
+  );
+}
+
+function Row({ row, done }: { row: ChecklistRow; done: boolean }) {
+  const body = (
+    <>
+      <Box />
+      <span className="preflight-challenge">{row.challenge}</span>
+      <span className="preflight-dots" aria-hidden="true" />
+      {row.badgeSrc ? (
+        <img
+          className="preflight-badge"
+          src={row.badgeSrc}
+          alt="HVTrust supply-chain grade for Threadplane (live badge)"
+          width={91}
+          height={20}
+          loading="lazy"
+          referrerPolicy="no-referrer"
+        />
+      ) : (
+        <span className="preflight-response">
+          {row.response}
+          {row.unit ? <span className="preflight-unit"> {row.unit}</span> : null}
+        </span>
+      )}
+    </>
+  );
+
+  const className = `preflight-row${done ? ' is-done' : ''}`;
+  if (!row.href) return <li className={className}>{body}</li>;
+
+  const external = row.href.startsWith('http');
+  return (
+    <li>
+      <a
+        className={className}
+        href={row.href}
+        {...(external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+      >
+        {body}
+      </a>
+    </li>
+  );
+}
+
+/**
+ * The band's argument in checklist form. The Yours boxes never fill — that is
+ * deliberate, and it is the half that makes the section honest.
+ *
+ * The tick sequence is decorative: `is-done` also changes the response colour,
+ * so a reader who never sees the animation still sees the state. Under
+ * reduced motion every row is done from the first paint.
+ */
+export function PreflightChecklist() {
+  const ref = useRef<HTMLDivElement>(null);
+  const [ticked, setTicked] = useState(0);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || typeof IntersectionObserver === 'undefined') return;
+    const total = PREFLIGHT_OURS.length + AIRWORTHINESS.length;
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      setTicked(total);
+      return;
+    }
+    const timers: ReturnType<typeof setTimeout>[] = [];
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (!entries.some((e) => e.isIntersecting)) return;
+        io.disconnect();
+        for (let i = 1; i <= total; i += 1) {
+          timers.push(setTimeout(() => setTicked(i), TICK_MS * i));
+        }
+      },
+      { threshold: 0.25 },
+    );
+    io.observe(el);
+    return () => {
+      io.disconnect();
+      timers.forEach(clearTimeout);
+    };
+  }, []);
+
+  // One counter across both ticked groups, so Airworthiness continues the
+  // sequence rather than restarting it.
+  const doneAt = (index: number) => index < ticked;
+
+  return (
+    <div className="preflight" ref={ref}>
+      <div className="preflight-cols">
+        <div>
+          <p className="preflight-col-head is-ours" id="preflight-ours-label">Threadplane</p>
+          <ul className="preflight-rows" aria-labelledby="preflight-ours-label">
+            {PREFLIGHT_OURS.map((row, i) => (
+              <Row key={row.challenge} row={row} done={doneAt(i)} />
+            ))}
+          </ul>
+        </div>
+        <div className="preflight-yours">
+          <p className="preflight-col-head is-yours" id="preflight-yours-label">Yours</p>
+          <ul className="preflight-rows" aria-labelledby="preflight-yours-label">
+            {PREFLIGHT_YOURS.map((row) => (
+              <Row key={row.challenge} row={row} done={false} />
+            ))}
+          </ul>
+        </div>
+      </div>
+
+      <p className="preflight-col-head is-ours" id="preflight-air-label">Airworthiness</p>
+      <ul className="preflight-rows preflight-air" aria-labelledby="preflight-air-label">
+        {AIRWORTHINESS.map((row, i) => (
+          <Row key={row.challenge} row={row} done={doneAt(PREFLIGHT_OURS.length + i)} />
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/website/src/components/landing/Reliability.spec.tsx
+++ b/apps/website/src/components/landing/Reliability.spec.tsx
@@ -3,9 +3,19 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import { Reliability, PROOF_CELLS, RIBBON_ITEMS, RIBBON_MORE_COUNT } from './Reliability';
-import { RELIABILITY_RECEIPTS } from '../../lib/positioning';
+import { HERO_TRUST_LINE, RELIABILITY_RECEIPTS } from '../../lib/positioning';
 
 describe('Reliability', () => {
+  it('opens with the trust masthead, so the yellow block closes into the dark band', () => {
+    const { container } = render(<Reliability />);
+    const mast = container.querySelector('.proof-masthead');
+    expect(mast?.textContent).toBe(HERO_TRUST_LINE);
+    // It must be the section's first child: it is the seam between the hero's
+    // yellow and this band, not a line floating inside the content.
+    const section = container.querySelector('[data-ui="section"]');
+    expect(section?.firstElementChild).toBe(mast);
+  });
+
   it('renders four cells, each with a source link', () => {
     render(<Reliability />);
     expect(PROOF_CELLS).toHaveLength(4);

--- a/apps/website/src/components/landing/Reliability.spec.tsx
+++ b/apps/website/src/components/landing/Reliability.spec.tsx
@@ -56,6 +56,9 @@ describe('Reliability', () => {
     expect(mark?.textContent).toBe('');
     expect(screen.getByText('Climb performance')).toBeTruthy();
     expect(screen.getByRole('heading', { name: 'Audited, scored, published.' }).id).toBe('proof-heading');
+    // The public-copy contract scan reads only content/**, so component copy is
+    // guarded here alone: a sourced score is not a customer claim.
+    expect(container.textContent).not.toMatch(/trusted by|customers|our clients|powered by/i);
   });
 
   it('frames the section as a climb and hides the instrument from assistive tech', () => {

--- a/apps/website/src/components/landing/Reliability.spec.tsx
+++ b/apps/website/src/components/landing/Reliability.spec.tsx
@@ -54,8 +54,19 @@ describe('Reliability', () => {
     expect(mark?.getAttribute('aria-hidden')).toBe('true');
     expect(mark?.getAttribute('data-watermark-text')).toBe('Proof');
     expect(mark?.textContent).toBe('');
-    expect(screen.getByText('Reliable to the core')).toBeTruthy();
+    expect(screen.getByText('Climb performance')).toBeTruthy();
     expect(screen.getByRole('heading', { name: 'Audited, scored, published.' }).id).toBe('proof-heading');
+  });
+
+  it('frames the section as a climb and hides the instrument from assistive tech', () => {
+    const { container } = render(<Reliability />);
+    expect(
+      screen.getByText(/Vx clears today’s obstacle; Vy gets you to altitude\./),
+    ).toBeTruthy();
+    const ladder = container.querySelector('.proof-ladder');
+    expect(ladder?.getAttribute('aria-hidden')).toBe('true');
+    // The words carry the argument; the drawing carries none of it.
+    expect(ladder?.textContent).toBe('');
   });
 
   it('carries the works-with line as a compatibility claim with an adapter link', () => {
@@ -75,12 +86,12 @@ describe('Reliability', () => {
     expect(screen.getByRole('list', { name: 'Works with' })).toBeTruthy();
   });
 
-  it('orders cells, receipts, then the works-with line', () => {
+  it('orders the ladder, cells, then receipts', () => {
     const { container } = render(<Reliability />);
     const children = container.querySelector('.proof-strip-grid')!.children;
-    expect(children[1].className).toBe('proof-strip-cells');
-    expect(children[2].className).toBe('reliability-receipts');
-    expect(children[3].className).toBe('reliability-works-with');
+    expect(children[1].getAttribute('class')).toBe('proof-ladder');
+    expect(children[2].className).toBe('proof-strip-cells');
+    expect(children[3].className).toBe('reliability-receipts');
   });
 
   it('links every number and receipt to a human-readable page, never a raw API', () => {

--- a/apps/website/src/components/landing/Reliability.spec.tsx
+++ b/apps/website/src/components/landing/Reliability.spec.tsx
@@ -2,8 +2,8 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
-import { Reliability, PROOF_CELLS } from './Reliability';
-import { HERO_TRUST_LINE, RELIABILITY_RECEIPTS } from '../../lib/positioning';
+import { Reliability } from './Reliability';
+import { HERO_TRUST_LINE } from '../../lib/positioning';
 
 describe('Reliability', () => {
   it('opens with the trust masthead, so the yellow block closes into the dark band', () => {
@@ -14,35 +14,6 @@ describe('Reliability', () => {
     // yellow and this band, not a line floating inside the content.
     const section = container.querySelector('[data-ui="section"]');
     expect(section?.firstElementChild).toBe(mast);
-  });
-
-  it('renders four cells, each with a source link', () => {
-    render(<Reliability />);
-    expect(PROOF_CELLS).toHaveLength(4);
-    for (const cell of PROOF_CELLS) {
-      expect(screen.getByText(cell.caption)).toBeTruthy();
-      expect(screen.getByRole('link', { name: cell.sourceLabel }).getAttribute('href')).toBe(cell.sourceHref);
-    }
-  });
-
-  it('renders the HVTrust grade as a live badge image, not text', () => {
-    render(<Reliability />);
-    expect(screen.getByAltText(/HVTrust grade/i).getAttribute('src')).toBe('https://hvtracker.net/badge/threadplane.svg');
-  });
-
-  it('renders three receipts under the cells, each with a source link', () => {
-    render(<Reliability />);
-    const list = screen.getByRole('list', { name: 'Receipts' });
-    expect(list.querySelectorAll('li')).toHaveLength(3);
-    for (const r of RELIABILITY_RECEIPTS) {
-      expect(screen.getByText(r.claim)).toBeTruthy();
-      expect(screen.getByText(r.detail)).toBeTruthy();
-      const link = screen.getByRole('link', { name: r.sourceLabel });
-      expect(link.getAttribute('href')).toBe(r.sourceHref);
-      const external = r.sourceHref.startsWith('http');
-      expect(link.getAttribute('target')).toBe(external ? '_blank' : null);
-      expect(link.getAttribute('rel')).toBe(external ? 'noopener noreferrer' : null);
-    }
   });
 
   it('keeps the dark band, the id the e2e pins, the watermark, and the framing', () => {
@@ -61,31 +32,13 @@ describe('Reliability', () => {
     expect(container.textContent).not.toMatch(/trusted by|customers|our clients|powered by/i);
   });
 
-  it('frames the section as a climb and hides the instrument from assistive tech', () => {
+  it('carries the checklist and keeps the framing above it', () => {
     const { container } = render(<Reliability />);
-    expect(
-      screen.getByText(/Vx clears today’s obstacle; Vy gets you to altitude\./),
-    ).toBeTruthy();
-    const ladder = container.querySelector('.proof-ladder');
-    expect(ladder?.getAttribute('aria-hidden')).toBe('true');
-    // The words carry the argument; the drawing carries none of it.
-    expect(ladder?.textContent).toBe('');
-  });
-
-  it('orders the ladder, cells, then receipts', () => {
-    const { container } = render(<Reliability />);
-    const children = container.querySelector('.proof-strip-grid')!.children;
-    expect(children[1].getAttribute('class')).toBe('proof-ladder');
-    expect(children[2].className).toBe('proof-strip-cells');
-    expect(children[3].className).toBe('reliability-receipts');
-    expect(children).toHaveLength(4);
-  });
-
-  it('links every number and receipt to a human-readable page, never a raw API', () => {
-    for (const href of [...PROOF_CELLS.map((c) => c.sourceHref), ...RELIABILITY_RECEIPTS.map((r) => r.sourceHref)]) {
-      const { hostname, pathname } = new URL(href, 'https://threadplane.ai');
-      expect(hostname.startsWith('api.'), href).toBe(false);
-      expect(pathname.startsWith('/api/'), href).toBe(false);
-    }
+    // The eyebrow and aside still frame the band; the checklist is what
+    // replaced the figure cards beneath them.
+    expect(screen.getByText('Climb performance')).toBeTruthy();
+    expect(container.querySelector('.preflight')).toBeTruthy();
+    expect(container.querySelector('.proof-ladder')).toBeNull();
+    expect(container.querySelector('.proof-strip-cells')).toBeNull();
   });
 });

--- a/apps/website/src/components/landing/Reliability.spec.tsx
+++ b/apps/website/src/components/landing/Reliability.spec.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
-import { Reliability, PROOF_CELLS, RIBBON_ITEMS, RIBBON_MORE_COUNT } from './Reliability';
+import { Reliability, PROOF_CELLS } from './Reliability';
 import { HERO_TRUST_LINE, RELIABILITY_RECEIPTS } from '../../lib/positioning';
 
 describe('Reliability', () => {
@@ -69,29 +69,13 @@ describe('Reliability', () => {
     expect(ladder?.textContent).toBe('');
   });
 
-  it('carries the works-with line as a compatibility claim with an adapter link', () => {
-    const { container } = render(<Reliability />);
-    expect(RIBBON_ITEMS).toHaveLength(8);
-    expect(screen.getByText('Works with')).toBeTruthy();
-    for (const item of RIBBON_ITEMS) expect(screen.getByText(item.name)).toBeTruthy();
-    expect(screen.getByText(`+ ${RIBBON_MORE_COUNT} more`)).toBeTruthy();
-    const logos = container.querySelectorAll('img.reliability-logo');
-    expect(logos).toHaveLength(RIBBON_ITEMS.length);
-    for (const img of Array.from(logos)) {
-      expect(img.getAttribute('aria-hidden')).toBe('true');
-      expect(img.getAttribute('alt')).toBe('');
-    }
-    expect(container.textContent).not.toMatch(/trusted by|customers|our clients|powered by/i);
-    expect(screen.getByRole('link', { name: 'Choose an adapter →' }).getAttribute('href')).toBe('/docs/choosing-an-adapter');
-    expect(screen.getByRole('list', { name: 'Works with' })).toBeTruthy();
-  });
-
   it('orders the ladder, cells, then receipts', () => {
     const { container } = render(<Reliability />);
     const children = container.querySelector('.proof-strip-grid')!.children;
     expect(children[1].getAttribute('class')).toBe('proof-ladder');
     expect(children[2].className).toBe('proof-strip-cells');
     expect(children[3].className).toBe('reliability-receipts');
+    expect(children).toHaveLength(4);
   });
 
   it('links every number and receipt to a human-readable page, never a raw API', () => {

--- a/apps/website/src/components/landing/Reliability.tsx
+++ b/apps/website/src/components/landing/Reliability.tsx
@@ -96,9 +96,9 @@ export function Reliability() {
               aside="Vx clears today’s obstacle; Vy gets you to altitude. Not self-reported — every number links to its source."
             />
             {/* Attitude indicator: pitch ladder either side of an amber
-              * waterline, nose above the horizon. A divider that happens to
-              * mean something — it pays off the Vx/Vy line above it. Purely
-              * decorative, so aria-hidden. */}
+              * waterline. A divider that happens to mean something — it pays
+              * off the Vx/Vy line above it. Purely decorative, so
+              * aria-hidden. */}
             <svg
               className="proof-ladder"
               viewBox="0 0 700 46"

--- a/apps/website/src/components/landing/Reliability.tsx
+++ b/apps/website/src/components/landing/Reliability.tsx
@@ -2,7 +2,7 @@ import { Container } from '../ui/Container';
 import { Section } from '../ui/Section';
 import { SectionHeader } from '../ui/SectionHeader';
 import { WEBSITE_SUPPORTED_ANGULAR_MAJORS } from '../pricing/angular-support.mjs';
-import { RELIABILITY_RECEIPTS } from '../../lib/positioning';
+import { HERO_TRUST_LINE, RELIABILITY_RECEIPTS } from '../../lib/positioning';
 import { AdapterGuideLink } from './AdapterGuideLink';
 
 interface ProofCell {
@@ -91,6 +91,11 @@ export const RIBBON_MORE_COUNT = 4;
 export function Reliability() {
   return (
     <Section surface="dark" id="proof" ariaLabelledBy="proof-heading">
+      {/* The seam. The hero's yellow block ends, this marks the boundary, the
+        * scope band begins — which is where the ATC app puts its frequency
+        * bar. It lived inside the hero until 2026-09-08, where it read as a
+        * stray navy bar 78px above a much larger band of the same colour. */}
+      <p className="proof-masthead">{HERO_TRUST_LINE}</p>
       <Container>
         <div className="proof-strip">
           {/* Garamond watermark; the glyph comes from the data attribute so no

--- a/apps/website/src/components/landing/Reliability.tsx
+++ b/apps/website/src/components/landing/Reliability.tsx
@@ -111,11 +111,33 @@ export function Reliability() {
           <div className="proof-strip-grid">
             <SectionHeader
               variant="rail"
-              eyebrow="Reliable to the core"
+              eyebrow="Climb performance"
               heading="Audited, scored, published."
               headingId="proof-heading"
-              aside="Not self-reported — every number links to its source."
+              aside="Vx clears today’s obstacle; Vy gets you to altitude. Not self-reported — every number links to its source."
             />
+            {/* Attitude indicator: pitch ladder either side of an amber
+              * waterline, nose above the horizon. A divider that happens to
+              * mean something — it pays off the Vx/Vy line above it. Purely
+              * decorative, so aria-hidden. */}
+            <svg
+              className="proof-ladder"
+              viewBox="0 0 700 46"
+              aria-hidden="true"
+              focusable="false"
+            >
+              <g className="proof-ladder-rungs">
+                <line x1="150" y1="34" x2="245" y2="34" />
+                <line x1="455" y1="34" x2="550" y2="34" />
+                <line x1="196" y1="16" x2="245" y2="16" />
+                <line x1="455" y1="16" x2="504" y2="16" />
+              </g>
+              <g className="proof-ladder-wing">
+                <line x1="290" y1="26" x2="330" y2="26" />
+                <line x1="370" y1="26" x2="410" y2="26" />
+              </g>
+              <circle className="proof-ladder-dot" cx="350" cy="26" r="2.5" />
+            </svg>
             <ul className="proof-strip-cells" role="list">
               {PROOF_CELLS.map((cell) => (
                 <li className="proof-strip-cell" key={cell.caption}>

--- a/apps/website/src/components/landing/Reliability.tsx
+++ b/apps/website/src/components/landing/Reliability.tsx
@@ -74,9 +74,10 @@ export function Reliability() {
         * scope band begins — which is where the ATC app puts its frequency
         * bar. It lived inside the hero until 2026-09-08, when it read as a
         * stray navy bar 78px above a much larger band of near-identical navy.
-        * Keep the two colours distinct: the bar is --color-scope flat, the band
-        * is a gradient that only reaches that value at its bottom, and that
-        * difference is what stops the bar dissolving into it. */}
+        * Keep the two colours distinct: the bar is --color-scope #15253E; the
+        * band is a darker gradient (#0B1622 → #0F1C2E) that never reaches it,
+        * so the bar sits lighter against the band below, and that difference
+        * is what stops the bar dissolving into it. */}
       <p className="proof-masthead">{HERO_TRUST_LINE}</p>
       <Container>
         <div className="proof-strip">
@@ -117,7 +118,7 @@ export function Reliability() {
               </g>
               <circle className="proof-ladder-dot" cx="350" cy="26" r="2.5" />
             </svg>
-            <ul className="proof-strip-cells" role="list">
+            <ul className="proof-strip-cells" role="list" aria-label="Published scores">
               {PROOF_CELLS.map((cell) => (
                 <li className="proof-strip-cell" key={cell.caption}>
                   {cell.value ? (

--- a/apps/website/src/components/landing/Reliability.tsx
+++ b/apps/website/src/components/landing/Reliability.tsx
@@ -1,67 +1,18 @@
 import { Container } from '../ui/Container';
 import { Section } from '../ui/Section';
 import { SectionHeader } from '../ui/SectionHeader';
-import { WEBSITE_SUPPORTED_ANGULAR_MAJORS } from '../pricing/angular-support.mjs';
-import { HERO_TRUST_LINE, RELIABILITY_RECEIPTS } from '../../lib/positioning';
-
-interface ProofCell {
-  /** Big Garamond numeral, or null when the cell renders a live badge. */
-  value: string | null;
-  /** Small suffix set beside the numeral (e.g. "of 119"). */
-  suffix?: string;
-  caption: string;
-  sourceLabel: string;
-  sourceHref: string;
-}
-
-/**
- * Verified 2026-09-04 against live sources (see the homepage design spec,
- * "Verification results"). The rank and score drift over time — re-verify on
- * touch, and never "round up". The HVTrust grade is deliberately a LIVE badge:
- * it sits at 84.3 against an A-band floor of 80 and has flipped grade several
- * times in a month; a hardcoded letter would be wrong on some days.
- *
- * Every href must be a page a human can read. The Scorecard number comes from
- * api.securityscorecards.dev, but the LINK goes to the scorecard.dev viewer —
- * the API URL renders as raw JSON.
- */
-export const PROOF_CELLS: readonly ProofCell[] = [
-  {
-    value: '#8',
-    suffix: 'of 119',
-    caption: 'Of all agent frameworks ranked',
-    sourceLabel: 'hvtracker.net',
-    sourceHref: 'https://hvtracker.net/categories/agent-frameworks/',
-  },
-  {
-    value: '8.2',
-    suffix: '/10',
-    caption: 'OpenSSF Scorecard, official scan',
-    sourceLabel: 'scorecard.dev',
-    sourceHref:
-      'https://scorecard.dev/viewer/?uri=github.com/cacheplane/angular-agent-framework',
-  },
-  {
-    value: null,
-    caption: 'HVTrust supply-chain grade, live',
-    sourceLabel: 'hvtracker.net/agents',
-    sourceHref: 'https://hvtracker.net/agents/threadplane/',
-  },
-  {
-    // Derived from the published peer range, never hardcoded.
-    value: `${WEBSITE_SUPPORTED_ANGULAR_MAJORS[0]}–${WEBSITE_SUPPORTED_ANGULAR_MAJORS.at(-1)}`,
-    caption: 'Angular majors supported, CI-tested',
-    sourceLabel: 'npmjs.com',
-    sourceHref: 'https://www.npmjs.com/package/@threadplane/langgraph',
-  },
-];
+import { HERO_TRUST_LINE } from '../../lib/positioning';
+import { PreflightChecklist } from './PreflightChecklist';
 
 /**
  * The reliability section (homepage design spec §3, block 2): the sourced
- * proof band and a second line of receipts in the same grammar.
+ * proof band, now argued as a preflight checklist.
  *
  * Replaces ProofStrip and LogoRibbon, both deleted with the homepage
- * restructure.
+ * restructure. The figure cards, the prose receipts and the pitch ladder came
+ * out in favour of the checklist: every row states a challenge, the response
+ * it gets, and links the page that proves it — and the unticked Yours column
+ * is the half that makes the section honest.
  *
  * The works-with line used to close this section. It now has its own LIGHT
  * section (Compatibility.tsx): the vendor marks are drawn for light grounds
@@ -96,79 +47,7 @@ export function Reliability() {
               headingId="proof-heading"
               aside="Vx clears today’s obstacle; Vy gets you to altitude. Not self-reported — every number links to its source."
             />
-            {/* Attitude indicator: pitch ladder either side of an amber
-              * waterline. A divider that happens to mean something — it pays
-              * off the Vx/Vy line above it. Purely decorative, so
-              * aria-hidden. */}
-            <svg
-              className="proof-ladder"
-              viewBox="0 0 700 46"
-              aria-hidden="true"
-              focusable="false"
-            >
-              <g className="proof-ladder-rungs">
-                <line x1="150" y1="34" x2="245" y2="34" />
-                <line x1="455" y1="34" x2="550" y2="34" />
-                <line x1="196" y1="16" x2="245" y2="16" />
-                <line x1="455" y1="16" x2="504" y2="16" />
-              </g>
-              <g className="proof-ladder-wing">
-                <line x1="290" y1="26" x2="330" y2="26" />
-                <line x1="370" y1="26" x2="410" y2="26" />
-              </g>
-              <circle className="proof-ladder-dot" cx="350" cy="26" r="2.5" />
-            </svg>
-            <ul className="proof-strip-cells" role="list" aria-label="Published scores">
-              {PROOF_CELLS.map((cell) => (
-                <li className="proof-strip-cell" key={cell.caption}>
-                  {cell.value ? (
-                    <p className="proof-strip-value">
-                      {cell.value}
-                      {cell.suffix ? (
-                        <span className="proof-strip-suffix"> {cell.suffix}</span>
-                      ) : null}
-                    </p>
-                  ) : (
-                    <img
-                      className="proof-strip-badge"
-                      src="https://hvtracker.net/badge/threadplane.svg"
-                      alt="HVTrust grade for Threadplane (live badge)"
-                      width={91}
-                      height={20}
-                      loading="lazy"
-                      referrerPolicy="no-referrer"
-                    />
-                  )}
-                  <p className="proof-strip-caption">{cell.caption}</p>
-                  <a
-                    className="proof-strip-source"
-                    href={cell.sourceHref}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    {cell.sourceLabel}
-                  </a>
-                </li>
-              ))}
-            </ul>
-            <ul className="reliability-receipts" role="list" aria-label="Receipts">
-              {RELIABILITY_RECEIPTS.map((r) => {
-                const external = r.sourceHref.startsWith('http');
-                return (
-                  <li className="reliability-receipt" key={r.claim}>
-                    <p className="reliability-receipt-claim">{r.claim}</p>
-                    <p className="reliability-receipt-detail">{r.detail}</p>
-                    <a
-                      className="proof-strip-source"
-                      href={r.sourceHref}
-                      {...(external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
-                    >
-                      {r.sourceLabel}
-                    </a>
-                  </li>
-                );
-              })}
-            </ul>
+            <PreflightChecklist />
           </div>
         </div>
       </Container>

--- a/apps/website/src/components/landing/Reliability.tsx
+++ b/apps/website/src/components/landing/Reliability.tsx
@@ -3,7 +3,6 @@ import { Section } from '../ui/Section';
 import { SectionHeader } from '../ui/SectionHeader';
 import { WEBSITE_SUPPORTED_ANGULAR_MAJORS } from '../pricing/angular-support.mjs';
 import { HERO_TRUST_LINE, RELIABILITY_RECEIPTS } from '../../lib/positioning';
-import { AdapterGuideLink } from './AdapterGuideLink';
 
 interface ProofCell {
   /** Big Garamond numeral, or null when the cell renders a live badge. */
@@ -57,36 +56,16 @@ export const PROOF_CELLS: readonly ProofCell[] = [
   },
 ];
 
-interface RibbonItem {
-  name: string;
-  logoSrc: string;
-}
-
-export const RIBBON_ITEMS: readonly RibbonItem[] = [
-  { name: 'OpenAI', logoSrc: '/logos/providers/openai.svg' },
-  { name: 'Anthropic', logoSrc: '/logos/providers/anthropic.svg' },
-  { name: 'Gemini', logoSrc: '/logos/providers/google.svg' },
-  { name: 'Bedrock', logoSrc: '/logos/providers/bedrock.svg' },
-  { name: 'LangGraph', logoSrc: '/logos/langgraph.svg' },
-  { name: 'AG-UI', logoSrc: '/logos/ag-ui.svg' },
-  { name: 'CrewAI', logoSrc: '/logos/runtimes/crewai.svg' },
-  { name: 'Mastra', logoSrc: '/logos/runtimes/mastra.svg' },
-];
-/** Azure OpenAI, Pydantic AI, Microsoft Agent Framework, AWS Strands. */
-export const RIBBON_MORE_COUNT = 4;
-
 /**
  * The reliability section (homepage design spec §3, block 2): the sourced
- * proof band, a second line of receipts in the same grammar, and the
- * works-with line as its footer, so the multi-runtime claim sits inside the
- * trust argument instead of floating above it as a separate strip.
+ * proof band and a second line of receipts in the same grammar.
  *
  * Replaces ProofStrip and LogoRibbon, both deleted with the homepage
  * restructure.
  *
- * "Works with" is a compatibility claim, never a customer claim: logos are
- * `alt="" aria-hidden` beside visible names, and no wording may imply these
- * companies use Threadplane. Reliability.spec.tsx guards that.
+ * The works-with line used to close this section. It now has its own LIGHT
+ * section (Compatibility.tsx): the vendor marks are drawn for light grounds
+ * and were invisible here, and the section was carrying two arguments at once.
  */
 export function Reliability() {
   return (
@@ -188,32 +167,6 @@ export function Reliability() {
                   </li>
                 );
               })}
-            </ul>
-            <ul
-              className="reliability-works-with"
-              role="list"
-              aria-labelledby="reliability-works-with-label"
-            >
-              <li className="reliability-works-with-label" id="reliability-works-with-label">
-                Works with
-              </li>
-              {RIBBON_ITEMS.map((item) => (
-                <li className="reliability-works-with-item" key={item.name}>
-                  <img
-                    src={item.logoSrc}
-                    alt=""
-                    aria-hidden="true"
-                    loading="lazy"
-                    decoding="async"
-                    className="reliability-logo"
-                  />
-                  <span className="reliability-works-with-name">{item.name}</span>
-                </li>
-              ))}
-              <li className="reliability-works-with-more">+ {RIBBON_MORE_COUNT} more</li>
-              <li className="reliability-works-with-cta">
-                <AdapterGuideLink className="reliability-works-with-link" />
-              </li>
             </ul>
           </div>
         </div>

--- a/apps/website/src/components/landing/Reliability.tsx
+++ b/apps/website/src/components/landing/Reliability.tsx
@@ -93,8 +93,11 @@ export function Reliability() {
     <Section surface="dark" id="proof" ariaLabelledBy="proof-heading">
       {/* The seam. The hero's yellow block ends, this marks the boundary, the
         * scope band begins — which is where the ATC app puts its frequency
-        * bar. It lived inside the hero until 2026-09-08, where it read as a
-        * stray navy bar 78px above a much larger band of the same colour. */}
+        * bar. It lived inside the hero until 2026-09-08, when it read as a
+        * stray navy bar 78px above a much larger band of near-identical navy.
+        * Keep the two colours distinct: the bar is --color-scope flat, the band
+        * is a gradient that only reaches that value at its bottom, and that
+        * difference is what stops the bar dissolving into it. */}
       <p className="proof-masthead">{HERO_TRUST_LINE}</p>
       <Container>
         <div className="proof-strip">

--- a/apps/website/src/lib/positioning.spec.ts
+++ b/apps/website/src/lib/positioning.spec.ts
@@ -157,36 +157,6 @@ describe('positioning: coding-agent prompt', () => {
 });
 
 describe('homepage restructure copy (live-stage spec §3)', () => {
-
-  it('carries three reliability receipts, each linking a human-readable page', async () => {
-    const { RELIABILITY_RECEIPTS } = await import('./positioning');
-    expect(RELIABILITY_RECEIPTS.map((r) => r.claim)).toEqual([
-      'Signed provenance on every release',
-      'Three runtimes exercised end to end',
-      'No content telemetry, no cloud',
-    ]);
-    for (const r of RELIABILITY_RECEIPTS) {
-      expect(r.sourceLabel.length).toBeGreaterThan(0);
-      const { hostname, pathname } = new URL(r.sourceHref, 'https://threadplane.ai');
-      expect(hostname.startsWith('api.'), r.sourceHref).toBe(false);
-      expect(pathname.startsWith('/api/'), r.sourceHref).toBe(false);
-
-      if (r.sourceHref.startsWith('/docs/')) {
-        const slug = pathname.replace(/^\/docs\//, '');
-        const candidates = [
-          path.join(resolveWebsiteDir(), 'content', 'docs', `${slug}.mdx`),
-          path.join(resolveWebsiteDir(), 'content', 'docs', slug, 'index.mdx'),
-        ];
-        expect(candidates.some((p) => fs.existsSync(p)), r.sourceHref).toBe(true);
-      } else if (r.sourceHref.startsWith('/')) {
-        expect(
-          fs.existsSync(path.join(resolveWebsiteDir(), 'src', 'app', r.sourceHref.slice(1), 'page.tsx')),
-          r.sourceHref,
-        ).toBe(true);
-      }
-    }
-  });
-
   it('closes on the open-source offer: one sentence, the licence, the fork CTA', async () => {
     const { OPEN_SOURCE_STRIP } = await import('./positioning');
     expect(`${OPEN_SOURCE_STRIP.lead} ${OPEN_SOURCE_STRIP.emphasis}`).toBe(

--- a/apps/website/src/lib/positioning.ts
+++ b/apps/website/src/lib/positioning.ts
@@ -52,35 +52,6 @@ export const HERO_TRUST_LINE = `MIT · ${formatAngularRange(WEBSITE_SUPPORTED_AN
 
 // ── The final mile (live-stage spec §3, block 3) ─────────────────────────────
 
-// ── Reliability receipts (spec §3, block 2). Each links a page a human can read;
-// the sourced numbers stay in Reliability.tsx beside them. ───────────────────
-export interface ReliabilityReceipt {
-  readonly claim: string;
-  readonly detail: string;
-  readonly sourceLabel: string;
-  readonly sourceHref: string;
-}
-export const RELIABILITY_RECEIPTS: readonly ReliabilityReceipt[] = [
-  {
-    claim: 'Signed provenance on every release',
-    detail: 'npm provenance attestations from OIDC trusted publishing, and a SLSA provenance file on each GitHub release.',
-    sourceLabel: 'npmjs.com · provenance',
-    sourceHref: 'https://www.npmjs.com/package/@threadplane/chat',
-  },
-  {
-    claim: 'Three runtimes exercised end to end',
-    detail: 'LangGraph, Mastra and AWS Strands backends, each driven by browser tests on every merge against one Angular contract.',
-    sourceLabel: 'runtime portability matrix',
-    sourceHref: '/docs/choosing-an-adapter#measured-runtime-support',
-  },
-  {
-    claim: 'No content telemetry, no cloud',
-    detail: 'Operational facts about how the product runs, never prompts, messages or tool data. MIT, self-hosted, no account.',
-    sourceLabel: 'privacy policy',
-    sourceHref: '/privacy',
-  },
-];
-
 /**
  * The public source repository.
  *

--- a/apps/website/src/lib/preflight-checklist.spec.ts
+++ b/apps/website/src/lib/preflight-checklist.spec.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import {
+  PREFLIGHT_OURS,
+  PREFLIGHT_YOURS,
+  AIRWORTHINESS,
+} from './preflight-checklist';
+
+describe('preflight checklist data', () => {
+  it('has the shape the section argues for', () => {
+    // The unticked half is the argument, not an oversight — if Yours ever
+    // empties out, the section stops making its point.
+    expect(PREFLIGHT_OURS).toHaveLength(11);
+    expect(PREFLIGHT_YOURS).toHaveLength(8);
+    expect(AIRWORTHINESS).toHaveLength(8);
+  });
+
+  it('proves every claim it ticks', () => {
+    // "Not self-reported" is the section's own aside. A ticked row with no
+    // link is a claim with no source.
+    for (const row of [...PREFLIGHT_OURS, ...AIRWORTHINESS]) {
+      expect(row.href, row.challenge).toBeTruthy();
+    }
+  });
+
+  it('claims nothing in the Yours column', () => {
+    // Nothing proves that YOU set a cost ceiling, so these carry no link.
+    for (const row of PREFLIGHT_YOURS) {
+      expect(row.href, row.challenge).toBeNull();
+    }
+  });
+
+  it('links pages a human can read, never a raw API', () => {
+    for (const row of [...PREFLIGHT_OURS, ...AIRWORTHINESS]) {
+      const { hostname, pathname } = new URL(row.href!, 'https://threadplane.ai');
+      expect(hostname.startsWith('api.'), row.href!).toBe(false);
+      expect(pathname.startsWith('/api/'), row.href!).toBe(false);
+    }
+  });
+
+  it('keeps the HVTrust grade live rather than hardcoding it', () => {
+    // It has flipped grade several times in a month against an A-band floor
+    // of 80; a hardcoded number would be wrong on some days.
+    const grade = AIRWORTHINESS.find((r) => r.challenge === 'Supply-chain grade');
+    expect(grade?.badgeSrc).toBe('https://hvtracker.net/badge/threadplane.svg');
+    expect(grade?.response).toBe('');
+  });
+
+  it('gives every response an outcome, not a feature name', () => {
+    // Responses are states you could verify. Lowercase would mean someone
+    // wrote a sentence instead of a checklist response.
+    for (const row of [...PREFLIGHT_OURS, ...PREFLIGHT_YOURS]) {
+      expect(row.response, row.challenge).toBe(row.response.toUpperCase());
+    }
+  });
+});

--- a/apps/website/src/lib/preflight-checklist.spec.ts
+++ b/apps/website/src/lib/preflight-checklist.spec.ts
@@ -52,4 +52,13 @@ describe('preflight checklist data', () => {
       expect(row.response, row.challenge).toBe(row.response.toUpperCase());
     }
   });
+
+  it('derives the Angular range rather than hardcoding it', async () => {
+    const { WEBSITE_SUPPORTED_ANGULAR_MAJORS } = await import(
+      '../components/pricing/angular-support.mjs'
+    );
+    const row = AIRWORTHINESS.find((r) => r.challenge === 'Angular support');
+    expect(row?.response).toContain(String(WEBSITE_SUPPORTED_ANGULAR_MAJORS[0]));
+    expect(row?.response).toContain(String(WEBSITE_SUPPORTED_ANGULAR_MAJORS.at(-1)));
+  });
 });

--- a/apps/website/src/lib/preflight-checklist.spec.ts
+++ b/apps/website/src/lib/preflight-checklist.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   PREFLIGHT_OURS,
   PREFLIGHT_YOURS,
@@ -60,5 +60,19 @@ describe('preflight checklist data', () => {
     const row = AIRWORTHINESS.find((r) => r.challenge === 'Angular support');
     expect(row?.response).toContain(String(WEBSITE_SUPPORTED_ANGULAR_MAJORS[0]));
     expect(row?.response).toContain(String(WEBSITE_SUPPORTED_ANGULAR_MAJORS.at(-1)));
+
+    // The assertions above cannot tell a derived "20-22" from a typed one —
+    // they agree until someone bumps a major, and by then the homepage has
+    // been wrong for a release. So move the dependency and check the value
+    // follows it. A hardcoded string will not.
+    vi.resetModules();
+    vi.doMock('../components/pricing/angular-support.mjs', () => ({
+      WEBSITE_SUPPORTED_ANGULAR_MAJORS: Object.freeze([41, 42, 43]),
+    }));
+    const { AIRWORTHINESS: moved } = await import('./preflight-checklist');
+    vi.doUnmock('../components/pricing/angular-support.mjs');
+    vi.resetModules();
+
+    expect(moved.find((r) => r.challenge === 'Angular support')?.response).toBe('41–43');
   });
 });

--- a/apps/website/src/lib/preflight-checklist.ts
+++ b/apps/website/src/lib/preflight-checklist.ts
@@ -1,3 +1,5 @@
+import { WEBSITE_SUPPORTED_ANGULAR_MAJORS } from '../components/pricing/angular-support.mjs';
+
 /**
  * The homepage preflight checklist.
  *
@@ -84,7 +86,14 @@ export const AIRWORTHINESS: readonly ChecklistRow[] = [
     badgeSrc: 'https://hvtracker.net/badge/threadplane.svg',
     href: 'https://hvtracker.net/agents/threadplane/',
   },
-  { challenge: 'Angular support', response: '20–22', unit: 'CI-TESTED', href: 'https://www.npmjs.com/package/@threadplane/langgraph' },
+  {
+    challenge: 'Angular support',
+    // Derived, not typed: bumping a supported major must update the homepage
+    // without anyone remembering to edit this file.
+    response: `${WEBSITE_SUPPORTED_ANGULAR_MAJORS[0]}–${WEBSITE_SUPPORTED_ANGULAR_MAJORS.at(-1)}`,
+    unit: 'CI-TESTED',
+    href: 'https://www.npmjs.com/package/@threadplane/langgraph',
+  },
   { challenge: 'Release provenance', response: 'SIGNED', unit: 'OIDC · SLSA', href: 'https://www.npmjs.com/package/@threadplane/chat' },
   { challenge: 'Cloud', response: 'NONE', unit: 'SELF-HOSTED', href: '/privacy' },
   { challenge: 'Signup', response: 'NONE', unit: 'npm i', href: '/docs/chat/getting-started/installation' },

--- a/apps/website/src/lib/preflight-checklist.ts
+++ b/apps/website/src/lib/preflight-checklist.ts
@@ -1,0 +1,92 @@
+/**
+ * The homepage preflight checklist.
+ *
+ * Every row in OURS and AIRWORTHINESS was verified against the docs rather
+ * than written from memory, and that caught three errors worth remembering:
+ *
+ *  - "Destructive actions — HELD FOR APPROVAL" was FALSE. `<chat>` does not
+ *    render the interrupt panel; the docs say "Interrupt UI is not part of it
+ *    — compose <chat-interrupt-panel> yourself." It is two YOURS rows now.
+ *  - "Errors & retry" had been held back as unverified and is in fact the
+ *    strongest line: zero-config retry across five classified error kinds.
+ *  - Keyboard and screen reader stay OFF. Four components document a11y,
+ *    there is no overview page and no audit, and reduced motion exists only
+ *    in code with nothing to link. A tick would overclaim.
+ *
+ * Before adding a row: find the page that proves it. If there is no page, it
+ * is not a tick.
+ */
+export interface ChecklistRow {
+  /** Left side of the line. 1–3 words. */
+  readonly challenge: string;
+  /** Right side. An outcome you could verify, never a feature name. */
+  readonly response: string;
+  /** The page that proves it. `null` only in YOURS. */
+  readonly href: string | null;
+  /** Small trailing unit, AIRWORTHINESS only. */
+  readonly unit?: string;
+  /** Live badge rendered instead of `response` text. */
+  readonly badgeSrc?: string;
+}
+
+export const PREFLIGHT_OURS: readonly ChecklistRow[] = [
+  { challenge: 'A run fails', response: 'RETRY, BUILT IN', href: '/docs/chat/guides/error-handling' },
+  { challenge: 'Tool calls', response: 'LIVE STATUS CARDS', href: '/docs/chat/components/chat-tool-call-card' },
+  { challenge: 'Durable threads', response: 'SURVIVE RESTARTS', href: '/docs/langgraph/guides/persistence' },
+  { challenge: 'Reader scrolls up', response: 'STREAM STAYS PUT', href: '/docs/chat/components/chat' },
+  { challenge: 'Model output', response: 'SANITIZED, 26 NODES', href: '/docs/chat/guides/markdown' },
+  { challenge: 'Shared link', response: 'URL IS THE TRUTH', href: '/docs/chat/guides/thread-routing' },
+  { challenge: 'Your design system', response: 'CSS VARS, NO !IMPORTANT', href: '/docs/chat/guides/theming' },
+  { challenge: 'Your tests', response: 'RUN WITHOUT A MODEL', href: '/docs/chat/getting-started/try-without-a-backend' },
+  { challenge: 'Swapping backend', response: 'ONE IMPORT CHANGES', href: '/docs/choosing-an-adapter' },
+  {
+    challenge: 'Model drift',
+    response: 'CHECKED WEEKLY, LIVE',
+    // No doc page for this one. The workflow IS the source: it runs the
+    // @drift e2e subset against the live provider every Monday and diffs
+    // fresh recordings against the committed fixtures.
+    href: 'https://github.com/cacheplane/angular-agent-framework/blob/main/.github/workflows/aimock-drift.yml',
+  },
+  { challenge: 'Debug panel', response: 'TREE-SHAKEN OUT', href: '/docs/chat/components/chat-debug' },
+];
+
+/**
+ * The product's own words, not ours. Every response here is a paraphrase of a
+ * sentence in the docs — "Never generate a thread ID client-side", "never
+ * expose a LangSmith API key in client-side code", "you must configure CORS".
+ *
+ * These boxes never fill. That is the argument.
+ */
+export const PREFLIGHT_YOURS: readonly ChecklistRow[] = [
+  { challenge: 'Agent endpoint', response: 'BEHIND YOUR PROXY', href: null },
+  { challenge: 'API keys', response: 'NEVER IN THE BUNDLE', href: null },
+  { challenge: 'Thread IDs', response: 'SERVER-GENERATED', href: null },
+  { challenge: 'CORS', response: 'YOURS TO CONFIGURE', href: null },
+  { challenge: 'Interrupt panel', response: 'YOU COMPOSE IT', href: null },
+  { challenge: 'Resume payload', response: 'YOURS TO CHOOSE', href: null },
+  { challenge: 'Runs', response: 'TRACED', href: null },
+  { challenge: 'Regressions', response: 'EVALUATED', href: null },
+];
+
+/**
+ * Verified 2026-09-04 against live sources. The rank and score drift — re-verify
+ * on touch, and never "round up".
+ */
+export const AIRWORTHINESS: readonly ChecklistRow[] = [
+  { challenge: 'Framework rank', response: '#8', unit: 'OF 119', href: 'https://hvtracker.net/categories/agent-frameworks/' },
+  { challenge: 'OpenSSF Scorecard', response: '8.2', unit: '/ 10', href: 'https://scorecard.dev/viewer/?uri=github.com/cacheplane/angular-agent-framework' },
+  {
+    challenge: 'Supply-chain grade',
+    // Deliberately empty: the badge is the response. It sits near an A-band
+    // floor of 80 and has flipped grade several times in a month, so a
+    // hardcoded number would be wrong on some days.
+    response: '',
+    badgeSrc: 'https://hvtracker.net/badge/threadplane.svg',
+    href: 'https://hvtracker.net/agents/threadplane/',
+  },
+  { challenge: 'Angular support', response: '20–22', unit: 'CI-TESTED', href: 'https://www.npmjs.com/package/@threadplane/langgraph' },
+  { challenge: 'Release provenance', response: 'SIGNED', unit: 'OIDC · SLSA', href: 'https://www.npmjs.com/package/@threadplane/chat' },
+  { challenge: 'Cloud', response: 'NONE', unit: 'SELF-HOSTED', href: '/privacy' },
+  { challenge: 'Signup', response: 'NONE', unit: 'npm i', href: '/docs/chat/getting-started/installation' },
+  { challenge: 'VC board', response: 'NONE', href: '/about' },
+];

--- a/apps/website/src/styles/landing.css
+++ b/apps/website/src/styles/landing.css
@@ -1094,7 +1094,6 @@
   padding: 0;
 }
 .proof-strip-cell {
-  position: relative;
   /* Grid items default to min-width:auto; the long mono source URLs would then
    * push the columns past the container. */
   min-width: 0;
@@ -1179,7 +1178,11 @@
 }
 @media (max-width: 900px) {
   .proof-strip-grid {
-    gap: 32px;
+    /* Has to stay clear of the cells' 44px row gutter. At the old 32px the gap
+     * between two ROWS of figures beat the gap between the figures block and
+     * the receipts block — the same grouping inversion .proof-strip-cells
+     * above argues against, just one level up. */
+    gap: 48px;
   }
   .proof-strip-cells {
     grid-template-columns: repeat(2, 1fr);

--- a/apps/website/src/styles/landing.css
+++ b/apps/website/src/styles/landing.css
@@ -2189,18 +2189,16 @@
   text-decoration: none;
 }
 
-/* The frequency strip — the ATC player's bottom bar. Full-bleed scope navy
- * closing the yellow block, set in mono because the instrument-panel cue is
- * doing as much work here as the colour is. */
-.hero-strip {
-  margin: 32px calc(50% - 50vw) 0;
-  width: 100vw;
+/* The seam between the yellow hero and the scope band. Full width by virtue of
+ * sitting outside the Container, so no calc(50% - 50vw) breakout is needed. */
+.proof-masthead {
+  /* [data-ui="section"] sets padding-top: var(--spacing-section-y), so a first
+   * child would otherwise sit BELOW that padding with a navy gap above it —
+   * which defeats the whole point. Pull it back up to the section's top edge
+   * so it is flush against the hero's yellow. */
+  margin: calc(-1 * var(--spacing-section-y)) 0 0;
   padding: 10px var(--spacing-container-x);
   background: var(--color-scope);
-  /* Literal rather than a token on purpose: the strip sits inside the signal
-     scope, which re-points --color-text-inverted (and every surface token) to
-     the yellow. The strip declares its own ground, so it declares its own ink
-     too. */
   color: #ffffff;
   font-family: var(--font-mono);
   font-size: 11px;

--- a/apps/website/src/styles/landing.css
+++ b/apps/website/src/styles/landing.css
@@ -2195,8 +2195,16 @@
   /* [data-ui="section"] sets padding-top: var(--spacing-section-y), so a first
    * child would otherwise sit BELOW that padding with a navy gap above it —
    * which defeats the whole point. Pull it back up to the section's top edge
-   * so it is flush against the hero's yellow. */
-  margin: calc(-1 * var(--spacing-section-y)) 0 0;
+   * so it is flush against the hero's yellow.
+   *
+   * The matching bottom margin is not symmetry for its own sake: a negative
+   * margin-top on an in-flow first child drags every following sibling up too,
+   * so without it the band loses its whole top padding and the eyebrow sits
+   * flush against this bar. Give back exactly what the top pulled away.
+   *
+   * Both halves assume this Section is not `tight` — that variant swaps in
+   * --spacing-section-y-tight and the cancellation would no longer balance. */
+  margin: calc(-1 * var(--spacing-section-y)) 0 var(--spacing-section-y);
   padding: 10px var(--spacing-container-x);
   background: var(--color-scope);
   color: #ffffff;

--- a/apps/website/src/styles/landing.css
+++ b/apps/website/src/styles/landing.css
@@ -2108,8 +2108,12 @@
   margin: 0;
   padding: 0;
 }
-.preflight-air {
-  margin-top: 22px;
+/* The Airworthiness heading follows the two columns, so it — not its list —
+ * is what needs the separation. Putting the margin on the list instead left
+ * the heading butted flat against the last Threadplane row (measured: 0px)
+ * while pushing it away from the rows it labels. */
+.preflight-cols + .preflight-col-head {
+  margin-top: 38px;
 }
 .preflight-row {
   display: flex;

--- a/apps/website/src/styles/landing.css
+++ b/apps/website/src/styles/landing.css
@@ -1081,7 +1081,14 @@
 .proof-strip-cells {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  gap: 20px;
+  /* Asymmetric on purpose. With the cards gone, whitespace is the ONLY grouping
+   * cue, and a symmetric 20px made the gap between one cell's source link and
+   * the next cell's numeral no larger than the gaps inside a cell — so the
+   * rhythm argued for the wrong grouping wherever the grid stacks (≤900px and
+   * ≤560px). The row gutter has to beat the intra-cell spacing; the column
+   * gutter is the old card padding expressed as a gap, which is what
+   * column-gap is for. */
+  gap: 44px 40px;
   list-style: none;
   margin: 0;
   padding: 0;
@@ -1091,7 +1098,6 @@
   /* Grid items default to min-width:auto; the long mono source URLs would then
    * push the columns past the container. */
   min-width: 0;
-  padding: 0 20px 0 0;
 }
 .proof-strip-value {
   font-family: var(--font-display);

--- a/apps/website/src/styles/landing.css
+++ b/apps/website/src/styles/landing.css
@@ -2174,3 +2174,25 @@
   text-transform: uppercase;
   text-align: center;
 }
+
+/* Attitude indicator between the framing copy and the figures. Hairlines only:
+ * it is a divider first and an instrument second, and the section's problem
+ * was too many competing layers. */
+.proof-ladder {
+  display: block;
+  width: 100%;
+  height: auto;
+  max-width: 700px;
+  margin: 4px 0 26px;
+}
+.proof-ladder-rungs line {
+  stroke: rgba(255, 255, 255, 0.3);
+  stroke-width: 1;
+}
+.proof-ladder-wing line {
+  stroke: var(--color-signal);
+  stroke-width: 2.5;
+}
+.proof-ladder-dot {
+  fill: var(--color-signal);
+}

--- a/apps/website/src/styles/landing.css
+++ b/apps/website/src/styles/landing.css
@@ -2119,9 +2119,13 @@
  * was too many competing layers. */
 .proof-ladder {
   display: block;
+  /* Spans the full content width rather than a capped 700px. Capped and
+   * left-aligned, the instrument's waterline landed well left of the band's
+   * centre and the whole thing read as stray marks; full width makes it a
+   * divider whose waterline is centred, which is what it is for. The strokes
+   * hold their weight at any scale via vector-effect below. */
   width: 100%;
   height: auto;
-  max-width: 700px;
   margin: 4px 0 26px;
 }
 /* The svg is width:100% over a 700-wide viewBox, so below 700px the whole

--- a/apps/website/src/styles/landing.css
+++ b/apps/website/src/styles/landing.css
@@ -1177,64 +1177,6 @@
   color: var(--color-text-secondary);
   margin: 6px 0 0;
 }
-/* Works-with footer line, inside the dark band. */
-.reliability-works-with {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 10px 22px;
-  padding-top: 22px;
-  border-top: 1px solid var(--color-border);
-  list-style: none;
-  margin: 0;
-  padding-left: 0;
-}
-.reliability-works-with-label {
-  font-family: var(--font-mono);
-  font-size: 10.5px;
-  font-weight: 700;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: var(--color-text-muted);
-}
-.reliability-works-with-more {
-  font-family: var(--font-mono);
-  font-size: 10.5px;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--color-text-muted);
-}
-.reliability-works-with-cta {
-  margin-left: auto;
-}
-.reliability-works-with-item {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  white-space: nowrap;
-}
-.reliability-logo {
-  width: 16px;
-  height: 16px;
-  object-fit: contain;
-}
-.reliability-works-with-name {
-  font-family: var(--font-sans);
-  font-size: 13px;
-  font-weight: 500;
-  color: var(--color-text-secondary);
-}
-.reliability-works-with-link {
-  font-family: var(--font-mono);
-  font-size: 11px;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-  color: var(--color-accent);
-}
-[data-ui="section"][data-surface="dark"] .reliability-works-with-link:hover {
-  color: var(--color-accent-hover);
-  text-decoration-color: currentColor;
-}
 @media (max-width: 900px) {
   .proof-strip-grid {
     gap: 32px;
@@ -1249,9 +1191,6 @@
   }
   .reliability-receipts {
     grid-template-columns: repeat(2, 1fr);
-  }
-  .reliability-works-with-cta {
-    margin-left: 0;
   }
 }
 @media (max-width: 640px) {
@@ -2195,4 +2134,75 @@
 }
 .proof-ladder-dot {
   fill: var(--color-signal);
+}
+
+/* Compatibility — light ground on purpose: these marks are drawn for light
+ * backgrounds and were invisible on the dark band. */
+.compatibility-groups {
+  margin-top: 26px;
+}
+.compatibility-group {
+  padding: 16px 0;
+  border-top: 1px solid var(--color-border);
+}
+.compatibility-group-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  margin: 0;
+}
+.compatibility-items {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 26px;
+  list-style: none;
+  margin: 10px 0 0;
+  padding: 0;
+}
+.compatibility-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  white-space: nowrap;
+  font-family: var(--font-sans);
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--color-text-primary);
+}
+.compatibility-logo {
+  width: 17px;
+  height: 17px;
+  object-fit: contain;
+}
+.compatibility-more {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  color: var(--color-text-muted);
+  align-self: center;
+}
+.compatibility-footer {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  flex-wrap: wrap;
+  border-top: 1px solid var(--color-border);
+  padding-top: 18px;
+}
+/* The adapter link carries the same mono-uppercase treatment the works-with
+ * line gave it on the dark band, so the CTA still reads as a CTA here. */
+.compatibility-link {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-accent);
+}
+.compatibility-disclaimer {
+  font-size: 12.5px;
+  color: var(--color-text-muted);
+  margin: 0;
 }

--- a/apps/website/src/styles/landing.css
+++ b/apps/website/src/styles/landing.css
@@ -1068,8 +1068,8 @@
   );
   pointer-events: none;
 }
-/* The rail header stacks ABOVE the cells here: four big Garamond numerals need
- * the full container width to stay on one line. */
+/* The rail header stacks ABOVE the checklist here: the checklist's two columns
+ * need the full container width to keep every row on one line. */
 .proof-strip-grid {
   position: relative;
   display: grid;
@@ -1078,132 +1078,17 @@
 .proof-strip-grid > [data-ui="section-header"] {
   max-width: 620px;
 }
-.proof-strip-cells {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  /* Asymmetric on purpose. With the cards gone, whitespace is the ONLY grouping
-   * cue, and a symmetric 20px made the gap between one cell's source link and
-   * the next cell's numeral no larger than the gaps inside a cell — so the
-   * rhythm argued for the wrong grouping wherever the grid stacks (≤900px and
-   * ≤560px). The row gutter has to beat the intra-cell spacing; the column
-   * gutter is the old card padding expressed as a gap, which is what
-   * column-gap is for. */
-  gap: 44px 40px;
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-.proof-strip-cell {
-  /* Grid items default to min-width:auto; the long mono source URLs would then
-   * push the columns past the container. */
-  min-width: 0;
-}
-.proof-strip-value {
-  font-family: var(--font-display);
-  font-size: 58px;
-  line-height: 0.9;
-  letter-spacing: -0.028em;
-  color: var(--color-text-primary);
-  margin: 0;
-}
-.proof-strip-suffix {
-  font-size: 18px;
-  font-weight: 500;
-  letter-spacing: 0;
-  color: var(--color-text-muted);
-}
-.proof-strip-badge {
-  height: 52px;
-  width: auto;
-  display: block;
-}
-.proof-strip-caption {
-  font-family: var(--font-sans);
-  font-size: 14px;
-  line-height: 1.5;
-  color: var(--color-text-secondary);
-  margin: 12px 0 0;
-}
-.proof-strip-source {
-  display: inline-block;
-  max-width: 100%;
-  font-family: var(--font-mono);
-  font-size: 11px;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-  color: var(--color-text-muted);
-  margin-top: 9px;
-  overflow-wrap: anywhere;
-}
-[data-ui="section"][data-surface="dark"] .proof-strip-source {
-  color: var(--color-accent);
-  text-decoration: underline;
-  text-underline-offset: 3px;
-  text-decoration-color: var(--color-accent-border-hover);
-}
-[data-ui="section"][data-surface="dark"] .proof-strip-source:hover {
-  color: var(--color-accent-hover);
-  text-decoration-color: currentColor;
-}
-/* Reliability receipts: a second line under the four cells, same grammar,
- * smaller type. Reliability.tsx. Always rendered inside the dark #proof
- * band, so --color-text-* and --color-accent already resolve to the dark
- * re-scope from ui.css without any extra [data-surface="dark"] scoping. */
-.reliability-receipts {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 20px;
-  list-style: none;
-  margin: 0;
-  padding: 24px 0 0;
-  border-top: 1px solid var(--color-border);
-}
-.reliability-receipt {
-  min-width: 0;
-}
-.reliability-receipt-claim {
-  font-family: var(--font-sans);
-  font-size: 15px;
-  font-weight: 600;
-  line-height: 1.4;
-  color: var(--color-text-primary);
-  margin: 0;
-}
-.reliability-receipt-detail {
-  font-family: var(--font-sans);
-  font-size: 13px;
-  line-height: 1.5;
-  color: var(--color-text-secondary);
-  margin: 6px 0 0;
-}
 @media (max-width: 900px) {
   .proof-strip-grid {
-    /* Has to stay clear of the cells' 44px row gutter. At the old 32px the gap
-     * between two ROWS of figures beat the gap between the figures block and
-     * the receipts block — the same grouping inversion .proof-strip-cells
-     * above argues against, just one level up. */
+    /* Above the usual 32px on purpose: the gap between the framing copy and
+     * the block beneath it has to beat the spacing inside that block, or the
+     * rhythm argues for the wrong grouping once the grid stacks. */
     gap: 48px;
-  }
-  .proof-strip-cells {
-    grid-template-columns: repeat(2, 1fr);
   }
   .proof-strip-watermark {
     font-size: 130px;
     right: -16px;
     top: -46px;
-  }
-  .reliability-receipts {
-    grid-template-columns: repeat(2, 1fr);
-  }
-}
-@media (max-width: 640px) {
-  .reliability-receipts {
-    grid-template-columns: 1fr;
-  }
-}
-@media (max-width: 560px) {
-  .proof-strip-cells {
-    grid-template-columns: 1fr;
   }
 }
 
@@ -2117,40 +2002,6 @@
   text-align: center;
 }
 
-/* Attitude indicator between the framing copy and the figures. Hairlines only:
- * it is a divider first and an instrument second, and the section's problem
- * was too many competing layers. */
-.proof-ladder {
-  display: block;
-  /* Spans the full content width rather than a capped 700px. Capped and
-   * left-aligned, the instrument's waterline landed well left of the band's
-   * centre and the whole thing read as stray marks; full width makes it a
-   * divider whose waterline is centred, which is what it is for. The strokes
-   * hold their weight at any scale via vector-effect below. */
-  width: 100%;
-  height: auto;
-  margin: 4px 0 26px;
-}
-/* The svg is width:100% over a 700-wide viewBox, so below 700px the whole
- * drawing scales down — and the stroke would scale with it, putting the rungs
- * at roughly 0.5 CSS px at 375, which at 30% white is effectively invisible.
- * non-scaling-stroke holds the hairline at any scale. It has to live on the
- * lines, not the <g>: vector-effect is not an inherited property, so setting
- * it on the group is a no-op for the children. */
-.proof-ladder-rungs line {
-  stroke: rgba(255, 255, 255, 0.3);
-  stroke-width: 1;
-  vector-effect: non-scaling-stroke;
-}
-.proof-ladder-wing line {
-  stroke: var(--color-signal);
-  stroke-width: 2.5;
-  vector-effect: non-scaling-stroke;
-}
-.proof-ladder-dot {
-  fill: var(--color-signal);
-}
-
 /* Compatibility — light ground on purpose: these marks are drawn for light
  * backgrounds and were invisible on the dark band. */
 .compatibility-groups {
@@ -2221,4 +2072,147 @@
   font-size: 12.5px;
   color: var(--color-text-muted);
   margin: 0;
+}
+
+/* Preflight checklist.
+ *
+ * Plain flex rows: every row starts at its column's left edge and its first
+ * child is a fixed 16px box, so the boxes share one edge by construction. Do
+ * NOT reach for `display: contents` here — it breaks the moment one row is an
+ * <li> rather than an <a>, and it weakens the link's semantics. */
+.preflight {
+  margin-top: 26px;
+}
+.preflight-cols {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0 48px;
+}
+.preflight-col-head {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  margin: 0;
+  padding-bottom: 12px;
+}
+.preflight-col-head.is-ours {
+  color: var(--color-signal);
+}
+.preflight-col-head.is-yours {
+  color: var(--color-text-muted);
+}
+.preflight-rows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.preflight-air {
+  margin-top: 22px;
+}
+.preflight-row {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  height: 33px;
+  text-decoration: none;
+}
+.preflight-box {
+  flex: 0 0 16px;
+  height: 16px;
+  box-sizing: border-box;
+  /* Deliberately NOT var(--color-border-strong): that resolves to
+   * rgba(255,255,255,.2) in the dark scope, and the empty Yours boxes are the
+   * section's whole argument — they cannot be the faintest thing on the band.
+   * .35 is the value the approved prototype was reviewed at. */
+  border: 1.5px solid rgba(255, 255, 255, 0.35);
+  border-radius: 3px;
+  display: grid;
+  place-items: center;
+  transition: border-color 180ms ease, background-color 180ms ease;
+}
+.preflight-box svg {
+  width: 10px;
+  height: 10px;
+  display: block;
+  opacity: 0;
+  transform: scale(0.5);
+  stroke: var(--color-ink);
+  transition: opacity 150ms ease, transform 200ms cubic-bezier(0.2, 1.5, 0.4, 1);
+}
+.preflight-row.is-done .preflight-box {
+  border-color: var(--color-signal);
+  background-color: var(--color-signal);
+}
+.preflight-row.is-done .preflight-box svg {
+  opacity: 1;
+  transform: scale(1);
+}
+.preflight-challenge {
+  flex: 0 0 auto;
+  font-family: var(--font-sans);
+  font-size: 13px;
+  color: var(--color-text-primary);
+  white-space: nowrap;
+}
+.preflight-dots {
+  flex: 1 1 auto;
+  min-width: 12px;
+  border-bottom: 1px dotted var(--color-border);
+  margin-bottom: 4px;
+}
+.preflight-response {
+  flex: 0 0 auto;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  white-space: nowrap;
+  color: var(--color-text-muted);
+  transition: color 180ms ease;
+}
+.preflight-row.is-done .preflight-response {
+  color: var(--color-signal);
+}
+.preflight-yours .preflight-response {
+  font-weight: 400;
+}
+/* Airworthiness responses are figures, so they take the display face and a
+ * larger size; the unit stays mono beside them. */
+.preflight-air .preflight-response {
+  font-family: var(--font-display);
+  font-size: 15px;
+  font-weight: 400;
+  letter-spacing: -0.01em;
+  color: var(--color-text-muted);
+}
+.preflight-air .preflight-row.is-done .preflight-response {
+  color: var(--color-text-primary);
+}
+.preflight-unit {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  color: var(--color-text-muted);
+}
+.preflight-badge {
+  flex: 0 0 auto;
+  display: block;
+}
+a.preflight-row:hover .preflight-challenge {
+  color: #ffffff;
+}
+@media (prefers-reduced-motion: reduce) {
+  .preflight-box,
+  .preflight-box svg,
+  .preflight-response {
+    transition: none;
+  }
+}
+@media (max-width: 820px) {
+  .preflight-cols {
+    grid-template-columns: 1fr;
+    gap: 24px;
+  }
 }

--- a/apps/website/src/styles/landing.css
+++ b/apps/website/src/styles/landing.css
@@ -1089,56 +1089,9 @@
 .proof-strip-cell {
   position: relative;
   /* Grid items default to min-width:auto; the long mono source URLs would then
-   * push the four columns past the container. */
+   * push the columns past the container. */
   min-width: 0;
-  background: var(--color-surface);
-  background-image: linear-gradient(
-    180deg,
-    rgba(255, 255, 255, 0.9),
-    rgba(251, 251, 251, 0.4)
-  );
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  padding: 26px 24px 22px;
-  box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.04),
-    0 12px 28px -12px rgba(28, 28, 28, 0.14);
-}
-/* On the dark band the paper gradient inverts: a faint lift off the surface
- * token rather than a white sheet. The token re-scope in ui.css handles the
- * rest (background, border, text). */
-[data-ui="section"][data-surface="dark"] .proof-strip-cell {
-  background-image: linear-gradient(
-    180deg,
-    rgba(255, 255, 255, 0.05),
-    rgba(255, 255, 255, 0.01)
-  );
-  border-color: var(--color-border-strong);
-  box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.35),
-    0 16px 34px -16px rgba(0, 0, 0, 0.6);
-}
-/* 1px top highlight so the card reads as paper, not an outline. */
-.proof-strip-cell::before {
-  content: '';
-  position: absolute;
-  inset: 0 0 auto 0;
-  height: 1px;
-  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
-  background: linear-gradient(
-    90deg,
-    transparent,
-    rgba(255, 255, 255, 0.9),
-    transparent
-  );
-}
-[data-ui="section"][data-surface="dark"] .proof-strip-cell::before {
-  background: linear-gradient(
-    90deg,
-    transparent,
-    rgba(255, 255, 255, 0.16),
-    transparent
-  );
+  padding: 0 20px 0 0;
 }
 .proof-strip-value {
   font-family: var(--font-display);

--- a/apps/website/src/styles/landing.css
+++ b/apps/website/src/styles/landing.css
@@ -2124,13 +2124,21 @@
   max-width: 700px;
   margin: 4px 0 26px;
 }
+/* The svg is width:100% over a 700-wide viewBox, so below 700px the whole
+ * drawing scales down — and the stroke would scale with it, putting the rungs
+ * at roughly 0.5 CSS px at 375, which at 30% white is effectively invisible.
+ * non-scaling-stroke holds the hairline at any scale. It has to live on the
+ * lines, not the <g>: vector-effect is not an inherited property, so setting
+ * it on the group is a no-op for the children. */
 .proof-ladder-rungs line {
   stroke: rgba(255, 255, 255, 0.3);
   stroke-width: 1;
+  vector-effect: non-scaling-stroke;
 }
 .proof-ladder-wing line {
   stroke: var(--color-signal);
   stroke-width: 2.5;
+  vector-effect: non-scaling-stroke;
 }
 .proof-ladder-dot {
   fill: var(--color-signal);
@@ -2167,7 +2175,6 @@
   align-items: center;
   gap: 8px;
   white-space: nowrap;
-  font-family: var(--font-sans);
   font-size: 14px;
   font-weight: 500;
   color: var(--color-text-primary);
@@ -2177,13 +2184,6 @@
   height: 17px;
   object-fit: contain;
 }
-.compatibility-more {
-  font-family: var(--font-mono);
-  font-size: 11px;
-  letter-spacing: 0.06em;
-  color: var(--color-text-muted);
-  align-self: center;
-}
 .compatibility-footer {
   display: flex;
   align-items: center;
@@ -2192,14 +2192,23 @@
   border-top: 1px solid var(--color-border);
   padding-top: 18px;
 }
-/* The adapter link carries the same mono-uppercase treatment the works-with
- * line gave it on the dark band, so the CTA still reads as a CTA here. */
+/* AdapterGuideLink REPLACES its className rather than appending, so without a
+ * rule here the anchor renders as plain body text. The mono-uppercase
+ * treatment came from the dark band, where --color-accent was amber against
+ * white; on this light ground it resolves to navy against near-black ink — a
+ * very small hue step at 11px. The weight bump and the hover colour are what
+ * make it read as a CTA, not the case and tracking alone. */
 .compatibility-link {
   font-family: var(--font-mono);
   font-size: 11px;
+  font-weight: 600;
   letter-spacing: 0.05em;
   text-transform: uppercase;
   color: var(--color-accent);
+}
+.compatibility-link:hover,
+.compatibility-link:focus-visible {
+  color: var(--color-accent-hover);
 }
 .compatibility-disclaimer {
   font-size: 12.5px;

--- a/apps/website/src/styles/ui.css
+++ b/apps/website/src/styles/ui.css
@@ -169,14 +169,18 @@
  * deliberately do not: this band is website-only and takes the ATC scope
  * navy, while dark.ts stays neutral because @threadplane/chat and the cockpit
  * consume it and a navy ground there would seam against embedded chat.
- * 2026-09-08: the surfaces moved to the navy family as well, because leaving
- * --color-surface neutral put grey-black cards on a navy ground.
+ * 2026-09-08: the surfaces moved to the navy family as well. The proof cards
+ * that first exposed this are gone, but --color-surface still dresses the
+ * secondary Button and the focus halo in this band, and a neutral
+ * rgb(28,28,28) left those grey-black on a navy ground.
  * Treatment B (spec): vertical gradient canvas, 1px accent seam at the
  * light→dark boundary. */
 [data-ui="section"][data-surface="dark"] {
   /* Navy-family surfaces. The ground goes DARKER and the surfaces go LIGHTER,
-   * which is the hierarchy that was missing: before this, cards were neutral
-   * rgb(28,28,28) floating on a navy ground — two unrelated darks. */
+   * which is the hierarchy that was missing — before, the two darks were
+   * unrelated. --color-surface is consumed here by the secondary Button and
+   * the focus halo; -tinted and -dim complete the ladder for nested surfaces
+   * and currently have no consumer in this band. */
   --color-canvas: #0B1622;
   --color-surface: #15253E;
   --color-surface-tinted: #1B2E4D;
@@ -307,7 +311,7 @@
  * fill. The inner `--color-surface` halo is what separates ring from fill in
  * the two cases where both land in the same colour family — yellow ring on
  * yellow fill in the dark band, ink ring on ink fill in the signal scope —
- * because `--color-surface` re-points with the scope too (dark grey, then the
+ * because `--color-surface` re-points with the scope too (navy, then the
  * signal yellow). Held by a style contract. */
 [data-ui="button"]:focus-visible {
   outline: 2px solid var(--color-accent);

--- a/apps/website/src/styles/ui.css
+++ b/apps/website/src/styles/ui.css
@@ -169,15 +169,20 @@
  * deliberately do not: this band is website-only and takes the ATC scope
  * navy, while dark.ts stays neutral because @threadplane/chat and the cockpit
  * consume it and a navy ground there would seam against embedded chat.
+ * 2026-09-08: the surfaces moved to the navy family as well, because leaving
+ * --color-surface neutral put grey-black cards on a navy ground.
  * Treatment B (spec): vertical gradient canvas, 1px accent seam at the
  * light→dark boundary. */
 [data-ui="section"][data-surface="dark"] {
-  --color-canvas: rgb(17, 17, 17);
-  --color-surface: rgb(28, 28, 28);
-  --color-surface-tinted: rgb(44, 44, 44);
-  --color-surface-dim: rgb(10, 10, 10);
-  --color-border: rgb(45, 45, 45);
-  --color-border-strong: rgb(60, 60, 60);
+  /* Navy-family surfaces. The ground goes DARKER and the surfaces go LIGHTER,
+   * which is the hierarchy that was missing: before this, cards were neutral
+   * rgb(28,28,28) floating on a navy ground — two unrelated darks. */
+  --color-canvas: #0B1622;
+  --color-surface: #15253E;
+  --color-surface-tinted: #1B2E4D;
+  --color-surface-dim: #08111B;
+  --color-border: rgba(255, 255, 255, 0.12);
+  --color-border-strong: rgba(255, 255, 255, 0.2);
   --color-text-primary: rgb(245, 245, 245);
   --color-text-secondary: rgb(200, 200, 200);
   --color-text-muted: rgb(160, 160, 160);
@@ -189,7 +194,7 @@
   --color-accent-border-hover: rgba(255, 175, 0, 0.4);
   --color-accent-surface: rgba(255, 175, 0, 0.1);
 
-  background: linear-gradient(180deg, #1b2e4d 0%, #15253e 100%);
+  background: linear-gradient(180deg, #0b1622 0%, #0f1c2e 100%);
   color: var(--color-text-primary);
   position: relative;
 }

--- a/docs/superpowers/plans/2026-09-08-preflight-checklist.md
+++ b/docs/superpowers/plans/2026-09-08-preflight-checklist.md
@@ -1,0 +1,878 @@
+# Preflight Checklist Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the homepage proof band's figure cards, receipts and pitch ladder with a two-column preflight checklist (Threadplane / Yours) plus an Airworthiness block, where every ticked row links to the page that proves it.
+
+**Architecture:** The 27 rows live in a data module so the component stays a renderer and the guards can assert the data directly. The checklist is a **client** component because the tick sequence runs off an IntersectionObserver; `Reliability` stays a server component and composes it. The boxes are drawn spans, not form controls — nothing here is interactive.
+
+**Tech Stack:** Next.js 15 App Router, React, plain CSS in `apps/website/src/styles/landing.css`, Vitest + Testing Library, Playwright.
+
+**Spec:** `docs/superpowers/specs/2026-09-08-preflight-checklist-design.md`
+
+---
+
+## Background an engineer needs before starting
+
+**Run the commands CI runs**: `npx nx test website`, `npx nx lint website`, `npx nx build website` — NOT `npx vitest run --root apps/website`. They are not equivalent; the nx executor swallows output on a hard failure, and `nx test` does not type-check while `nx build` does.
+
+**Two things the spec did not know, found while reading the code. Both are binding:**
+
+1. **The HVTrust grade must stay a live badge image.** `Reliability.tsx`'s comment is emphatic: *"The HVTrust grade is deliberately a LIVE badge: it sits at 84.3 against an A-band floor of 80 and has flipped grade several times in a month; a hardcoded letter would be wrong on some days."* The spec's Airworthiness table shows `84.8 HVTRUST` as text. **Do not hardcode it** — that row renders the badge `<img>` as its response.
+
+2. **`RELIABILITY_RECEIPTS` is guarded outside this component.** `apps/website/src/lib/positioning.spec.ts:162-168` asserts its exact claim strings. Two of the three receipts are being dropped, so that spec must be updated in the same change or it fails.
+
+**`#proof`, `#proof-heading` and `data-surface="dark"` do not change.** `apps/website/e2e/website.spec.ts` pins all three, and it must stay green untouched. If it goes red, something drifted that was not meant to.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+| --- | --- | --- |
+| `apps/website/src/lib/preflight-checklist.ts` | The 27 rows and their proof links | **Create** |
+| `apps/website/src/lib/preflight-checklist.spec.ts` | Data guards — counts, links, no raw APIs | **Create** |
+| `apps/website/src/components/landing/PreflightChecklist.tsx` | Renders the rows, runs the tick sequence | **Create** (client) |
+| `apps/website/src/components/landing/PreflightChecklist.spec.tsx` | Render guards — boxes, links, a11y | **Create** |
+| `apps/website/src/components/landing/Reliability.tsx` | The band | Loses cells, receipts, ladder; composes the checklist |
+| `apps/website/src/components/landing/Reliability.spec.tsx` | Band guards | Cell/receipt/ladder tests move or go |
+| `apps/website/src/lib/positioning.ts` | Copy | `RELIABILITY_RECEIPTS` trimmed to the one surviving receipt |
+| `apps/website/src/lib/positioning.spec.ts` | Copy guard | Follows that trim |
+| `apps/website/src/styles/landing.css` | Styles | Checklist styles in; cells/receipts/ladder styles out |
+
+---
+
+## Task 1: The data module
+
+**Files:**
+- Create: `apps/website/src/lib/preflight-checklist.ts`
+- Create: `apps/website/src/lib/preflight-checklist.spec.ts`
+
+- [ ] **Step 1: Write the failing spec**
+
+Create `apps/website/src/lib/preflight-checklist.spec.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import {
+  PREFLIGHT_OURS,
+  PREFLIGHT_YOURS,
+  AIRWORTHINESS,
+} from './preflight-checklist';
+
+describe('preflight checklist data', () => {
+  it('has the shape the section argues for', () => {
+    // The unticked half is the argument, not an oversight — if Yours ever
+    // empties out, the section stops making its point.
+    expect(PREFLIGHT_OURS).toHaveLength(11);
+    expect(PREFLIGHT_YOURS).toHaveLength(8);
+    expect(AIRWORTHINESS).toHaveLength(8);
+  });
+
+  it('proves every claim it ticks', () => {
+    // "Not self-reported" is the section's own aside. A ticked row with no
+    // link is a claim with no source.
+    for (const row of [...PREFLIGHT_OURS, ...AIRWORTHINESS]) {
+      expect(row.href, row.challenge).toBeTruthy();
+    }
+  });
+
+  it('claims nothing in the Yours column', () => {
+    // Nothing proves that YOU set a cost ceiling, so these carry no link.
+    for (const row of PREFLIGHT_YOURS) {
+      expect(row.href, row.challenge).toBeNull();
+    }
+  });
+
+  it('links pages a human can read, never a raw API', () => {
+    for (const row of [...PREFLIGHT_OURS, ...AIRWORTHINESS]) {
+      const { hostname, pathname } = new URL(row.href!, 'https://threadplane.ai');
+      expect(hostname.startsWith('api.'), row.href!).toBe(false);
+      expect(pathname.startsWith('/api/'), row.href!).toBe(false);
+    }
+  });
+
+  it('keeps the HVTrust grade live rather than hardcoding it', () => {
+    // It has flipped grade several times in a month against an A-band floor
+    // of 80; a hardcoded number would be wrong on some days.
+    const grade = AIRWORTHINESS.find((r) => r.challenge === 'Supply-chain grade');
+    expect(grade?.badgeSrc).toBe('https://hvtracker.net/badge/threadplane.svg');
+    expect(grade?.response).toBe('');
+  });
+
+  it('gives every response an outcome, not a feature name', () => {
+    // Responses are states you could verify. Lowercase would mean someone
+    // wrote a sentence instead of a checklist response.
+    for (const row of [...PREFLIGHT_OURS, ...PREFLIGHT_YOURS]) {
+      expect(row.response, row.challenge).toBe(row.response.toUpperCase());
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+npx nx test website
+```
+
+Expected: FAIL — `./preflight-checklist` does not exist.
+
+- [ ] **Step 3: Create the data module**
+
+Create `apps/website/src/lib/preflight-checklist.ts`:
+
+```ts
+/**
+ * The homepage preflight checklist.
+ *
+ * Every row in OURS and AIRWORTHINESS was verified against the docs rather
+ * than written from memory, and that caught three errors worth remembering:
+ *
+ *  - "Destructive actions — HELD FOR APPROVAL" was FALSE. `<chat>` does not
+ *    render the interrupt panel; the docs say "Interrupt UI is not part of it
+ *    — compose <chat-interrupt-panel> yourself." It is two YOURS rows now.
+ *  - "Errors & retry" had been held back as unverified and is in fact the
+ *    strongest line: zero-config retry across five classified error kinds.
+ *  - Keyboard and screen reader stay OFF. Four components document a11y,
+ *    there is no overview page and no audit, and reduced motion exists only
+ *    in code with nothing to link. A tick would overclaim.
+ *
+ * Before adding a row: find the page that proves it. If there is no page, it
+ * is not a tick.
+ */
+export interface ChecklistRow {
+  /** Left side of the line. 1–3 words. */
+  readonly challenge: string;
+  /** Right side. An outcome you could verify, never a feature name. */
+  readonly response: string;
+  /** The page that proves it. `null` only in YOURS. */
+  readonly href: string | null;
+  /** Small trailing unit, AIRWORTHINESS only. */
+  readonly unit?: string;
+  /** Live badge rendered instead of `response` text. */
+  readonly badgeSrc?: string;
+}
+
+export const PREFLIGHT_OURS: readonly ChecklistRow[] = [
+  { challenge: 'A run fails', response: 'RETRY, BUILT IN', href: '/docs/chat/guides/error-handling' },
+  { challenge: 'Tool calls', response: 'LIVE STATUS CARDS', href: '/docs/chat/components/chat-tool-call-card' },
+  { challenge: 'Durable threads', response: 'SURVIVE RESTARTS', href: '/docs/langgraph/guides/persistence' },
+  { challenge: 'Reader scrolls up', response: 'STREAM STAYS PUT', href: '/docs/chat/components/chat' },
+  { challenge: 'Model output', response: 'SANITIZED, 26 NODES', href: '/docs/chat/guides/markdown' },
+  { challenge: 'Shared link', response: 'URL IS THE TRUTH', href: '/docs/chat/guides/thread-routing' },
+  { challenge: 'Your design system', response: 'CSS VARS, NO !IMPORTANT', href: '/docs/chat/guides/theming' },
+  { challenge: 'Your tests', response: 'RUN WITHOUT A MODEL', href: '/docs/chat/getting-started/try-without-a-backend' },
+  { challenge: 'Swapping backend', response: 'ONE IMPORT CHANGES', href: '/docs/choosing-an-adapter' },
+  {
+    challenge: 'Model drift',
+    response: 'CHECKED WEEKLY, LIVE',
+    // No doc page for this one. The workflow IS the source: it runs the
+    // @drift e2e subset against the live provider every Monday and diffs
+    // fresh recordings against the committed fixtures.
+    href: 'https://github.com/cacheplane/angular-agent-framework/blob/main/.github/workflows/aimock-drift.yml',
+  },
+  { challenge: 'Debug panel', response: 'TREE-SHAKEN OUT', href: '/docs/chat/components/chat-debug' },
+];
+
+/**
+ * The product's own words, not ours. Every response here is a paraphrase of a
+ * sentence in the docs — "Never generate a thread ID client-side", "never
+ * expose a LangSmith API key in client-side code", "you must configure CORS".
+ *
+ * These boxes never fill. That is the argument.
+ */
+export const PREFLIGHT_YOURS: readonly ChecklistRow[] = [
+  { challenge: 'Agent endpoint', response: 'BEHIND YOUR PROXY', href: null },
+  { challenge: 'API keys', response: 'NEVER IN THE BUNDLE', href: null },
+  { challenge: 'Thread IDs', response: 'SERVER-GENERATED', href: null },
+  { challenge: 'CORS', response: 'YOURS TO CONFIGURE', href: null },
+  { challenge: 'Interrupt panel', response: 'YOU COMPOSE IT', href: null },
+  { challenge: 'Resume payload', response: 'YOURS TO CHOOSE', href: null },
+  { challenge: 'Runs', response: 'TRACED', href: null },
+  { challenge: 'Regressions', response: 'EVALUATED', href: null },
+];
+
+/**
+ * Verified 2026-09-04 against live sources. The rank and score drift — re-verify
+ * on touch, and never "round up".
+ */
+export const AIRWORTHINESS: readonly ChecklistRow[] = [
+  { challenge: 'Framework rank', response: '#8', unit: 'OF 119', href: 'https://hvtracker.net/categories/agent-frameworks/' },
+  { challenge: 'OpenSSF Scorecard', response: '8.2', unit: '/ 10', href: 'https://scorecard.dev/viewer/?uri=github.com/cacheplane/angular-agent-framework' },
+  {
+    challenge: 'Supply-chain grade',
+    // Deliberately empty: the badge is the response. It sits near an A-band
+    // floor of 80 and has flipped grade several times in a month, so a
+    // hardcoded number would be wrong on some days.
+    response: '',
+    badgeSrc: 'https://hvtracker.net/badge/threadplane.svg',
+    href: 'https://hvtracker.net/agents/threadplane/',
+  },
+  { challenge: 'Angular support', response: '20–22', unit: 'CI-TESTED', href: 'https://www.npmjs.com/package/@threadplane/langgraph' },
+  { challenge: 'Release provenance', response: 'SIGNED', unit: 'OIDC · SLSA', href: 'https://www.npmjs.com/package/@threadplane/chat' },
+  { challenge: 'Cloud', response: 'NONE', unit: 'SELF-HOSTED', href: '/privacy' },
+  { challenge: 'Signup', response: 'NONE', unit: 'npm i', href: '/docs/chat/getting-started/installation' },
+  { challenge: 'VC board', response: 'NONE', href: '/about' },
+];
+```
+
+- [ ] **Step 4: Run it**
+
+```bash
+npx nx test website
+```
+
+Expected: PASS.
+
+Note the `Angular support` response is hardcoded `20–22` here while `Reliability.tsx` derived it from `WEBSITE_SUPPORTED_ANGULAR_MAJORS`. That regression is fixed in Task 5 Step 2 — leave it for now so this task stays one concern.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/website/src/lib/preflight-checklist.ts apps/website/src/lib/preflight-checklist.spec.ts
+git commit -m "feat(website): the preflight checklist rows, with a proof link each"
+```
+
+---
+
+## Task 2: The component
+
+**Files:**
+- Create: `apps/website/src/components/landing/PreflightChecklist.tsx`
+- Create: `apps/website/src/components/landing/PreflightChecklist.spec.tsx`
+
+- [ ] **Step 1: Write the failing spec**
+
+Create `apps/website/src/components/landing/PreflightChecklist.spec.tsx`:
+
+```tsx
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { PreflightChecklist } from './PreflightChecklist';
+import { PREFLIGHT_OURS, PREFLIGHT_YOURS, AIRWORTHINESS } from '../../lib/preflight-checklist';
+
+describe('PreflightChecklist', () => {
+  it('renders one row per data row', () => {
+    const { container } = render(<PreflightChecklist />);
+    expect(container.querySelectorAll('.preflight-row')).toHaveLength(
+      PREFLIGHT_OURS.length + PREFLIGHT_YOURS.length + AIRWORTHINESS.length,
+    );
+  });
+
+  it('links every ticked row and none of the Yours rows', () => {
+    const { container } = render(<PreflightChecklist />);
+    expect(container.querySelectorAll('a.preflight-row')).toHaveLength(
+      PREFLIGHT_OURS.length + AIRWORTHINESS.length,
+    );
+    for (const a of Array.from(container.querySelectorAll('a.preflight-row'))) {
+      expect(a.getAttribute('href')).toBeTruthy();
+    }
+  });
+
+  it('draws the boxes rather than using form controls', () => {
+    // Nothing here is interactive. An <input type="checkbox"> would tell a
+    // screen reader it can be toggled, which is a lie.
+    const { container } = render(<PreflightChecklist />);
+    expect(container.querySelectorAll('input')).toHaveLength(0);
+    expect(container.querySelectorAll('.preflight-box')).toHaveLength(
+      PREFLIGHT_OURS.length + PREFLIGHT_YOURS.length + AIRWORTHINESS.length,
+    );
+  });
+
+  it('names each column list so two adjacent lists are distinguishable', () => {
+    const { container } = render(<PreflightChecklist />);
+    const lists = Array.from(container.querySelectorAll('ul[aria-labelledby]'));
+    expect(lists).toHaveLength(3);
+    for (const ul of lists) {
+      const label = container.querySelector(`#${ul.getAttribute('aria-labelledby')}`);
+      expect(label?.textContent).toBeTruthy();
+    }
+  });
+
+  it('keeps the HVTrust grade a live badge with real alt text', () => {
+    const { container } = render(<PreflightChecklist />);
+    const badge = container.querySelector('img.preflight-badge');
+    expect(badge?.getAttribute('src')).toBe('https://hvtracker.net/badge/threadplane.svg');
+    // Not decorative: it carries the grade, so it needs a real description.
+    expect(badge?.getAttribute('alt')).toBeTruthy();
+    expect(badge?.getAttribute('alt')).not.toBe('');
+  });
+
+  it('opens off-site sources safely in a new tab', () => {
+    const { container } = render(<PreflightChecklist />);
+    for (const a of Array.from(container.querySelectorAll('a.preflight-row'))) {
+      const href = a.getAttribute('href')!;
+      if (!href.startsWith('http')) continue;
+      expect(a.getAttribute('target')).toBe('_blank');
+      expect(a.getAttribute('rel')).toBe('noopener noreferrer');
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run and watch it fail**
+
+```bash
+npx nx test website
+```
+
+Expected: FAIL — `./PreflightChecklist` does not exist.
+
+- [ ] **Step 3: Create the component**
+
+Create `apps/website/src/components/landing/PreflightChecklist.tsx`:
+
+```tsx
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import {
+  AIRWORTHINESS,
+  PREFLIGHT_OURS,
+  PREFLIGHT_YOURS,
+  type ChecklistRow,
+} from '../../lib/preflight-checklist';
+
+/** Milliseconds between ticks. Fast enough not to read as a loading bar. */
+const TICK_MS = 180;
+
+function Box() {
+  return (
+    <span className="preflight-box" aria-hidden="true">
+      <svg viewBox="0 0 10 10" focusable="false">
+        <path d="M1 5.2 3.8 8 9 2.2" fill="none" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    </span>
+  );
+}
+
+function Row({ row, done }: { row: ChecklistRow; done: boolean }) {
+  const body = (
+    <>
+      <Box />
+      <span className="preflight-challenge">{row.challenge}</span>
+      <span className="preflight-dots" aria-hidden="true" />
+      {row.badgeSrc ? (
+        <img
+          className="preflight-badge"
+          src={row.badgeSrc}
+          alt="HVTrust supply-chain grade for Threadplane (live badge)"
+          width={91}
+          height={20}
+          loading="lazy"
+          referrerPolicy="no-referrer"
+        />
+      ) : (
+        <span className="preflight-response">
+          {row.response}
+          {row.unit ? <span className="preflight-unit"> {row.unit}</span> : null}
+        </span>
+      )}
+    </>
+  );
+
+  const className = `preflight-row${done ? ' is-done' : ''}`;
+  if (!row.href) return <li className={className}>{body}</li>;
+
+  const external = row.href.startsWith('http');
+  return (
+    <li>
+      <a
+        className={className}
+        href={row.href}
+        {...(external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+      >
+        {body}
+      </a>
+    </li>
+  );
+}
+
+/**
+ * The band's argument in checklist form. The Yours boxes never fill — that is
+ * deliberate, and it is the half that makes the section honest.
+ *
+ * The tick sequence is decorative: `is-done` also changes the response colour,
+ * so a reader who never sees the animation still sees the state. Under
+ * reduced motion every row is done from the first paint.
+ */
+export function PreflightChecklist() {
+  const ref = useRef<HTMLDivElement>(null);
+  const [ticked, setTicked] = useState(0);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || typeof IntersectionObserver === 'undefined') return;
+    const total = PREFLIGHT_OURS.length + AIRWORTHINESS.length;
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      setTicked(total);
+      return;
+    }
+    const timers: ReturnType<typeof setTimeout>[] = [];
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (!entries.some((e) => e.isIntersecting)) return;
+        io.disconnect();
+        for (let i = 1; i <= total; i += 1) {
+          timers.push(setTimeout(() => setTicked(i), TICK_MS * i));
+        }
+      },
+      { threshold: 0.25 },
+    );
+    io.observe(el);
+    return () => {
+      io.disconnect();
+      timers.forEach(clearTimeout);
+    };
+  }, []);
+
+  // One counter across both ticked groups, so Airworthiness continues the
+  // sequence rather than restarting it.
+  const doneAt = (index: number) => index < ticked;
+
+  return (
+    <div className="preflight" ref={ref}>
+      <div className="preflight-cols">
+        <div>
+          <p className="preflight-col-head is-ours" id="preflight-ours-label">Threadplane</p>
+          <ul className="preflight-rows" aria-labelledby="preflight-ours-label">
+            {PREFLIGHT_OURS.map((row, i) => (
+              <Row key={row.challenge} row={row} done={doneAt(i)} />
+            ))}
+          </ul>
+        </div>
+        <div className="preflight-yours">
+          <p className="preflight-col-head is-yours" id="preflight-yours-label">Yours</p>
+          <ul className="preflight-rows" aria-labelledby="preflight-yours-label">
+            {PREFLIGHT_YOURS.map((row) => (
+              <Row key={row.challenge} row={row} done={false} />
+            ))}
+          </ul>
+        </div>
+      </div>
+
+      <p className="preflight-col-head is-ours" id="preflight-air-label">Airworthiness</p>
+      <ul className="preflight-rows preflight-air" aria-labelledby="preflight-air-label">
+        {AIRWORTHINESS.map((row, i) => (
+          <Row key={row.challenge} row={row} done={doneAt(PREFLIGHT_OURS.length + i)} />
+        ))}
+      </ul>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run it**
+
+```bash
+npx nx test website
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/website/src/components/landing/PreflightChecklist.tsx apps/website/src/components/landing/PreflightChecklist.spec.tsx
+git commit -m "feat(website): the preflight checklist component"
+```
+
+---
+
+## Task 3: The styles
+
+**Files:**
+- Modify: `apps/website/src/styles/landing.css`
+
+- [ ] **Step 1: Add the checklist styles**
+
+Append to `landing.css`:
+
+```css
+/* Preflight checklist.
+ *
+ * Plain flex rows: every row starts at its column's left edge and its first
+ * child is a fixed 16px box, so the boxes share one edge by construction. Do
+ * NOT reach for `display: contents` here — it breaks the moment one row is an
+ * <li> rather than an <a>, and it weakens the link's semantics. */
+.preflight {
+  margin-top: 26px;
+}
+.preflight-cols {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0 48px;
+}
+.preflight-col-head {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  margin: 0;
+  padding-bottom: 12px;
+}
+.preflight-col-head.is-ours {
+  color: var(--color-signal);
+}
+.preflight-col-head.is-yours {
+  color: var(--color-text-muted);
+}
+.preflight-rows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.preflight-air {
+  margin-top: 22px;
+}
+.preflight-row {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  height: 33px;
+  text-decoration: none;
+}
+.preflight-box {
+  flex: 0 0 16px;
+  height: 16px;
+  box-sizing: border-box;
+  /* Deliberately NOT var(--color-border-strong): that resolves to
+   * rgba(255,255,255,.2) in the dark scope, and the empty Yours boxes are the
+   * section's whole argument — they cannot be the faintest thing on the band.
+   * .35 is the value the approved prototype was reviewed at. */
+  border: 1.5px solid rgba(255, 255, 255, 0.35);
+  border-radius: 3px;
+  display: grid;
+  place-items: center;
+  transition: border-color 180ms ease, background-color 180ms ease;
+}
+.preflight-box svg {
+  width: 10px;
+  height: 10px;
+  display: block;
+  opacity: 0;
+  transform: scale(0.5);
+  stroke: var(--color-ink);
+  transition: opacity 150ms ease, transform 200ms cubic-bezier(0.2, 1.5, 0.4, 1);
+}
+.preflight-row.is-done .preflight-box {
+  border-color: var(--color-signal);
+  background-color: var(--color-signal);
+}
+.preflight-row.is-done .preflight-box svg {
+  opacity: 1;
+  transform: scale(1);
+}
+.preflight-challenge {
+  flex: 0 0 auto;
+  font-family: var(--font-sans);
+  font-size: 13px;
+  color: var(--color-text-primary);
+  white-space: nowrap;
+}
+.preflight-dots {
+  flex: 1 1 auto;
+  min-width: 12px;
+  border-bottom: 1px dotted var(--color-border);
+  margin-bottom: 4px;
+}
+.preflight-response {
+  flex: 0 0 auto;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  white-space: nowrap;
+  color: var(--color-text-muted);
+  transition: color 180ms ease;
+}
+.preflight-row.is-done .preflight-response {
+  color: var(--color-signal);
+}
+.preflight-yours .preflight-response {
+  font-weight: 400;
+}
+/* Airworthiness responses are figures, so they take the display face and a
+ * larger size; the unit stays mono beside them. */
+.preflight-air .preflight-response {
+  font-family: var(--font-display);
+  font-size: 15px;
+  font-weight: 400;
+  letter-spacing: -0.01em;
+  color: var(--color-text-muted);
+}
+.preflight-air .preflight-row.is-done .preflight-response {
+  color: var(--color-text-primary);
+}
+.preflight-unit {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  color: var(--color-text-muted);
+}
+.preflight-badge {
+  flex: 0 0 auto;
+  display: block;
+}
+a.preflight-row:hover .preflight-challenge {
+  color: #ffffff;
+}
+@media (prefers-reduced-motion: reduce) {
+  .preflight-box,
+  .preflight-box svg,
+  .preflight-response {
+    transition: none;
+  }
+}
+@media (max-width: 820px) {
+  .preflight-cols {
+    grid-template-columns: 1fr;
+    gap: 24px;
+  }
+}
+```
+
+- [ ] **Step 2: Remove the styles the checklist replaces**
+
+Delete these rules from `landing.css` entirely:
+
+- `.proof-strip-cells`, `.proof-strip-cell`, `.proof-strip-value`, `.proof-strip-suffix`, `.proof-strip-caption`, `.proof-strip-badge`
+- `.proof-strip-source` and its `[data-surface="dark"]` variants
+- `.reliability-receipts`, `.reliability-receipt`, `.reliability-receipt-claim`, `.reliability-receipt-detail`
+- `.proof-ladder`, `.proof-ladder-rungs line`, `.proof-ladder-wing line`, `.proof-ladder-dot`
+- Any `@media` block that only adjusts `.proof-strip-cells` columns
+
+Keep `.proof-strip`, `.proof-strip-grid` and `.proof-strip-watermark` — the band's frame and its guarded watermark.
+
+Then confirm nothing dangles:
+
+```bash
+grep -n "proof-strip-cell\|proof-strip-value\|proof-strip-caption\|proof-strip-source\|proof-strip-badge\|reliability-receipt\|proof-ladder" apps/website/src/styles/landing.css || echo "clean"
+```
+
+Expected: `clean`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/website/src/styles/landing.css
+git commit -m "feat(website): checklist styles in, figure-card and ladder styles out"
+```
+
+---
+
+## Task 4: Wire it into the band
+
+**Files:**
+- Modify: `apps/website/src/components/landing/Reliability.tsx`
+- Modify: `apps/website/src/components/landing/Reliability.spec.tsx`
+
+- [ ] **Step 1: Update the band's spec first**
+
+In `Reliability.spec.tsx`:
+
+Note the Yours rows are `<li>` here, not the `<div>` the spec's §6 names — `<div>` children of a `<ul>` are invalid, and the point that spec section was making (no `<a>`, because no page proves you set a cost ceiling) is preserved.
+
+- **Delete** `it('renders four cells, each with a source link', …)`, `it('renders the HVTrust grade as a live badge image, not text', …)`, `it('renders three receipts under the cells, each with a source link', …)`, `it('orders the ladder, cells, then receipts', …)` and `it('frames the section as a climb and hides the instrument from assistive tech', …)`. Their coverage now lives in `PreflightChecklist.spec.tsx` and `preflight-checklist.spec.ts`.
+- **Delete** `it('links every number and receipt to a human-readable page, never a raw API', …)` — the same assertion is in `preflight-checklist.spec.ts`, against the data rather than the render.
+- **Remove** the now-unused `PROOF_CELLS` and `RELIABILITY_RECEIPTS` imports.
+- **Keep** the masthead test and the dark-band/watermark/framing test exactly as they are.
+
+Then add:
+
+```tsx
+  it('carries the checklist and keeps the framing above it', () => {
+    const { container } = render(<Reliability />);
+    // The eyebrow and aside still frame the band; the checklist is what
+    // replaced the figure cards beneath them.
+    expect(screen.getByText('Climb performance')).toBeTruthy();
+    expect(container.querySelector('.preflight')).toBeTruthy();
+    expect(container.querySelector('.proof-ladder')).toBeNull();
+    expect(container.querySelector('.proof-strip-cells')).toBeNull();
+  });
+```
+
+- [ ] **Step 2: Run and watch it fail**
+
+```bash
+npx nx test website
+```
+
+Expected: FAIL — `.preflight` is not rendered and `.proof-ladder` still is.
+
+- [ ] **Step 3: Rewrite the band's body**
+
+In `Reliability.tsx`:
+
+- Delete the `ProofCell` interface, the `PROOF_CELLS` export and its docblock.
+- Delete the entire `<svg className="proof-ladder">` block.
+- Delete the entire `<ul className="proof-strip-cells">` block.
+- Delete the entire `<ul className="reliability-receipts">` block.
+- Remove the now-unused imports: `RELIABILITY_RECEIPTS`, `WEBSITE_SUPPORTED_ANGULAR_MAJORS`.
+- Add `import { PreflightChecklist } from './PreflightChecklist';`
+- Render `<PreflightChecklist />` as the last child of `.proof-strip-grid`, directly after `<SectionHeader />`.
+
+The `<Section>`, the masthead `<p className="proof-masthead">`, the `.proof-strip` wrapper, the watermark `<div>`, `.proof-strip-grid` and the whole `<SectionHeader>` (eyebrow, heading, headingId, aside) are **unchanged**.
+
+- [ ] **Step 4: Run it**
+
+```bash
+npx nx test website
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/website/src/components/landing/Reliability.tsx apps/website/src/components/landing/Reliability.spec.tsx
+git commit -m "feat(website): the proof band is a preflight checklist"
+```
+
+---
+
+## Task 5: The two data regressions the rewrite creates
+
+Both are consequences of Task 1 that would otherwise ship silently.
+
+**Files:**
+- Modify: `apps/website/src/lib/positioning.ts`
+- Modify: `apps/website/src/lib/positioning.spec.ts`
+- Modify: `apps/website/src/lib/preflight-checklist.ts`
+
+- [ ] **Step 1: Trim the receipts to the one that survived**
+
+Two of the three receipts are gone from the page — "Three runtimes exercised end to end" and "No content telemetry, no cloud" — and provenance is now an Airworthiness row rather than a receipt. So `RELIABILITY_RECEIPTS` has no consumer.
+
+Delete the `ReliabilityReceipt` interface and the `RELIABILITY_RECEIPTS` export from `positioning.ts`, then delete the test at `positioning.spec.ts` that asserts their claim strings (it imports `RELIABILITY_RECEIPTS` and checks `.map((r) => r.claim)`).
+
+Confirm:
+
+```bash
+grep -rn "RELIABILITY_RECEIPTS\|ReliabilityReceipt" apps/website/src || echo "clean"
+```
+
+Expected: `clean`
+
+- [ ] **Step 2: Restore the derived Angular range**
+
+`Reliability.tsx` derived the Angular row from `WEBSITE_SUPPORTED_ANGULAR_MAJORS`, so bumping a major updated the homepage. Task 1 hardcoded `20–22`, which will silently go stale.
+
+In `preflight-checklist.ts`, add at the top:
+
+```ts
+import { WEBSITE_SUPPORTED_ANGULAR_MAJORS } from '../components/pricing/angular-support.mjs';
+```
+
+and change that row's response to:
+
+```ts
+  {
+    challenge: 'Angular support',
+    // Derived, not typed: bumping a supported major must update the homepage
+    // without anyone remembering to edit this file.
+    response: `${WEBSITE_SUPPORTED_ANGULAR_MAJORS[0]}–${WEBSITE_SUPPORTED_ANGULAR_MAJORS.at(-1)}`,
+    unit: 'CI-TESTED',
+    href: 'https://www.npmjs.com/package/@threadplane/langgraph',
+  },
+```
+
+- [ ] **Step 3: Guard the derivation so it cannot be re-hardcoded**
+
+Add to `preflight-checklist.spec.ts`:
+
+```ts
+  it('derives the Angular range rather than hardcoding it', async () => {
+    const { WEBSITE_SUPPORTED_ANGULAR_MAJORS } = await import(
+      '../components/pricing/angular-support.mjs'
+    );
+    const row = AIRWORTHINESS.find((r) => r.challenge === 'Angular support');
+    expect(row?.response).toContain(String(WEBSITE_SUPPORTED_ANGULAR_MAJORS[0]));
+    expect(row?.response).toContain(String(WEBSITE_SUPPORTED_ANGULAR_MAJORS.at(-1)));
+  });
+```
+
+- [ ] **Step 4: Test, lint, build**
+
+```bash
+npx nx test website && npx nx lint website && npx nx build website
+```
+
+Expected: all pass, lint 0 errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/website/src/lib
+git commit -m "fix(website): retire the orphaned receipts and re-derive the Angular range"
+```
+
+---
+
+## Task 6: Verification
+
+- [ ] **Step 1: The CI commands**
+
+```bash
+npx nx test website
+npx nx lint website
+npx nx build website
+```
+
+All pass; lint 0 errors (65 pre-existing warnings expected).
+
+- [ ] **Step 2: The guard that must not move**
+
+```bash
+npx nx e2e website
+```
+
+Free port 3000 first if a dev server holds it. `e2e/website.spec.ts` pins `#proof-heading` and `#proof[data-surface="dark"]`, and the spine order test now includes `compatibility-heading`. All must pass **unchanged** — if any fails, something drifted that was not meant to.
+
+- [ ] **Step 3: Every proof link must resolve**
+
+A checklist whose proof 404s is worse than no checklist. With the dev server running:
+
+```bash
+for p in /docs/chat/guides/error-handling /docs/chat/components/chat-tool-call-card \
+  /docs/langgraph/guides/persistence /docs/chat/components/chat /docs/chat/guides/markdown \
+  /docs/chat/guides/thread-routing /docs/chat/guides/theming \
+  /docs/chat/getting-started/try-without-a-backend /docs/choosing-an-adapter \
+  /docs/chat/components/chat-debug /docs/chat/getting-started/installation /privacy /about; do
+  printf "%-52s %s\n" "$p" "$(curl -sS -o /dev/null -w '%{http_code}' "http://localhost:3000$p")"
+done
+```
+
+Expected: `200` for every one.
+
+- [ ] **Step 4: Look at it, and measure the alignment**
+
+Start the dev server through the Browser pane preview tools (`website-dev` in `.claude/launch.json`), then in the console:
+
+```javascript
+const boxes = [...document.querySelectorAll('#proof .preflight-box')].map(b => b.getBoundingClientRect());
+({ count: boxes.length,
+   lefts: [...new Set(boxes.map(b => Math.round(b.left)))].sort((a,b) => a-b),
+   sizes: [...new Set(boxes.map(b => `${Math.round(b.width)}x${Math.round(b.height)}`))] })
+```
+
+Expected: 27 boxes, **exactly two distinct left edges** above 820px (one per column) and all `16x16`. More than two means a row escaped its column — that happened once already with `display: contents`.
+
+Then confirm by eye: the Yours boxes stay empty after the sequence finishes, the ticks read as a sequence rather than a flicker, and at 390px the columns stack with each row still on one line.
+
+- [ ] **Step 5: Commit any fixes**
+
+```bash
+git add -A
+git commit -m "fix(website): preflight checklist verification pass"
+```
+
+---
+
+## Out of scope
+
+- The **masthead** keeps `MIT · ANGULAR 20–22 · NO ACCOUNT · NO CLOUD` even though Cloud and Signup now appear as rows ~200px below. The duplication is recorded in spec §5 as accepted; do not fix it here.
+- The **"no content telemetry" claim** leaves the homepage with the dropped receipt. That is the decision, not an oversight.
+- The **nine unused STRONG items** (multiple threads, subagents, generative UI, four layouts, conformance suite, dark mode, lifecycle timestamps, scriptable fake-agent events, MIT with no runtime key) stay on the bench.

--- a/docs/superpowers/plans/2026-09-08-reliability-scope-redesign.md
+++ b/docs/superpowers/plans/2026-09-08-reliability-scope-redesign.md
@@ -1,0 +1,819 @@
+# Reliability Scope Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn the homepage's dark Reliability band into a legible scope band with a Vx/Vy frame and one pitch-ladder device, and move the works-with logos into their own light compatibility section.
+
+**Architecture:** Almost every change is subtractive. The hero's navy strip moves to become the dark section's masthead so there is one navy moment instead of two. The website's `[data-surface="dark"]` scope re-points its surface tokens to the navy family. The proof cells lose all card chrome. The logo row leaves the section entirely for a new light `Compatibility` component — which is what makes the logos legible, since they are dark marks drawn for light grounds.
+
+**Tech Stack:** Next.js 15 App Router, React, Tailwind v4 `@theme` tokens, plain CSS in `apps/website/src/styles/`, Vitest + Testing Library, Playwright.
+
+**Spec:** `docs/superpowers/specs/2026-09-08-reliability-scope-redesign-design.md`
+
+---
+
+## Background an engineer needs before starting
+
+**Run the commands CI runs.** `npx nx test website` and `npx nx lint website` — NOT `npx vitest run --root apps/website`. They are not equivalent: the nx executor crashes on module-scope imports that vitest tolerates, and it swallows the output when it does, so a failure shows as a bare "target test failed" with no assertion. `nx test` also does not type-check; `npx nx build website` does.
+
+**The colours.** `--color-signal` `#FFAF00` is a FILL, never text or an icon colour on a light ground (1.84:1 on white). `--color-ink` `#0A0A0A` goes on top of it (10.73:1). `--color-scope` `#15253E` is the interactive ink on light and the ground on dark.
+
+**`Section` surfaces** live in `apps/website/src/components/ui/Section.tsx` as a union: `'canvas' | 'tinted' | 'white' | 'dark' | 'signal'`. The scopes that re-point `--color-*` per band are in `apps/website/src/styles/ui.css`.
+
+**Two guards must stay green untouched.** `apps/website/e2e/website.spec.ts` asserts `#proof-heading` is visible and `#proof[data-surface="dark"]` exists. This design keeps the id, the heading text and the dark surface, so if that spec goes red something drifted that was not meant to.
+
+**Checked already, so you do not have to:** `style-contracts.spec.ts` pins nothing on `.proof-strip-cell` or any `.reliability-*` class, so removing the card chrome breaks no style contract.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+| --- | --- | --- |
+| `apps/website/src/components/landing/Hero.tsx` | Homepage hero | Loses the trust strip |
+| `apps/website/src/components/landing/Hero.spec.tsx` | Hero guard | Trust-line assertion moves out |
+| `apps/website/src/components/landing/Reliability.tsx` | The proof band | Gains the masthead + pitch ladder; loses the works-with row and the ribbon data |
+| `apps/website/src/components/landing/Reliability.spec.tsx` | Proof-band guard | Works-with assertions leave; ordering indices shift |
+| `apps/website/src/components/landing/Compatibility.tsx` | **New** — the grouped works-with section | Created |
+| `apps/website/src/components/landing/Compatibility.spec.tsx` | **New** — its guard | Created |
+| `apps/website/src/app/page.tsx` | Homepage composition | Mounts `<Compatibility />` between Reliability and EnterpriseArchitecture |
+| `apps/website/src/styles/ui.css` | Surface scopes | Dark scope surface tokens go navy |
+| `apps/website/src/styles/landing.css` | Landing styles | Masthead rename, card chrome removed, ladder + compatibility styles |
+
+---
+
+## Task 1: The strip becomes the masthead
+
+The hero's navy strip and the dark section start 78px apart in the same colour. Moving the strip to the section's top edge makes the sequence yellow → strip → scope, contiguous.
+
+The class is renamed from `.hero-strip` / `.hero-trust` to `.proof-masthead`: after the move a `hero-` prefix would lie about where the element lives. (`.hero-trust` already has no CSS rule — it was removed as dead in #1059 — but the class is still in the markup and `Hero.spec.tsx` queries it.)
+
+**Files:**
+- Modify: `apps/website/src/components/landing/Hero.tsx`
+- Modify: `apps/website/src/components/landing/Reliability.tsx`
+- Modify: `apps/website/src/styles/landing.css`
+- Test: `apps/website/src/components/landing/Hero.spec.tsx`
+- Test: `apps/website/src/components/landing/Reliability.spec.tsx`
+
+- [ ] **Step 1: Move the assertion between the two specs**
+
+In `Hero.spec.tsx`, delete this line:
+
+```tsx
+    expect(document.querySelector('.hero-trust')?.textContent).toBe(HERO_TRUST_LINE);
+```
+
+Then remove `HERO_TRUST_LINE` from that file's import list from `'../../lib/positioning'` if nothing else in the file uses it — check with a grep before deleting, since removing a still-used import is a compile error.
+
+In `Reliability.spec.tsx`, add inside the top-level `describe`:
+
+```tsx
+  it('opens with the trust masthead, so the yellow block closes into the dark band', () => {
+    const { container } = render(<Reliability />);
+    const mast = container.querySelector('.proof-masthead');
+    expect(mast?.textContent).toBe(HERO_TRUST_LINE);
+    // It must be the section's first child: it is the seam between the hero's
+    // yellow and this band, not a line floating inside the content.
+    const section = container.querySelector('[data-ui="section"]');
+    expect(section?.firstElementChild).toBe(mast);
+  });
+```
+
+Add `HERO_TRUST_LINE` to the existing `'../../lib/positioning'` import in `Reliability.spec.tsx`.
+
+- [ ] **Step 2: Run and watch it fail**
+
+```bash
+npx nx test website
+```
+
+Expected: FAIL — `.proof-masthead` does not exist, so `mast?.textContent` is `undefined`.
+
+- [ ] **Step 3: Remove the strip from the hero**
+
+In `Hero.tsx`, delete this line entirely:
+
+```tsx
+          <p className="hero-trust hero-strip">{HERO_TRUST_LINE}</p>
+```
+
+Remove `HERO_TRUST_LINE` from its import from `'../../lib/positioning'`.
+
+- [ ] **Step 4: Render it as the section's masthead**
+
+In `Reliability.tsx`, add `HERO_TRUST_LINE` to the existing import from `'../../lib/positioning'`, then make it the first child of `<Section>`, before `<Container>`:
+
+```tsx
+    <Section surface="dark" id="proof" ariaLabelledBy="proof-heading">
+      {/* The seam. The hero's yellow block ends, this marks the boundary, the
+        * scope band begins — which is where the ATC app puts its frequency
+        * bar. It lived inside the hero until 2026-09-08, where it read as a
+        * stray navy bar 78px above a much larger band of the same colour. */}
+      <p className="proof-masthead">{HERO_TRUST_LINE}</p>
+      <Container>
+```
+
+- [ ] **Step 5: Move the CSS**
+
+In `landing.css`, rename the `.hero-strip` rule to `.proof-masthead` and drop the full-bleed maths — it is now the first child of a full-width section, so it does not need to break out of a container:
+
+```css
+/* The seam between the yellow hero and the scope band. Full width by virtue of
+ * sitting outside the Container, so no calc(50% - 50vw) breakout is needed. */
+.proof-masthead {
+  /* [data-ui="section"] sets padding-top: var(--spacing-section-y), so a first
+   * child would otherwise sit BELOW that padding with a navy gap above it —
+   * which defeats the whole point. Pull it back up to the section's top edge
+   * so it is flush against the hero's yellow. */
+  margin: calc(-1 * var(--spacing-section-y)) 0 0;
+  padding: 10px var(--spacing-container-x);
+  background: var(--color-scope);
+  color: #ffffff;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  text-align: center;
+}
+```
+
+Then confirm no `.hero-strip` or `.hero-trust` reference survives anywhere:
+
+```bash
+grep -rn "hero-strip\|hero-trust" apps/website/src || echo "clean"
+```
+
+Expected: `clean`
+
+- [ ] **Step 6: Run the tests**
+
+```bash
+npx nx test website
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/website/src/components/landing/Hero.tsx apps/website/src/components/landing/Hero.spec.tsx apps/website/src/components/landing/Reliability.tsx apps/website/src/components/landing/Reliability.spec.tsx apps/website/src/styles/landing.css
+git commit -m "feat(website): the hero's trust strip becomes the proof band's masthead"
+```
+
+---
+
+## Task 2: The dark scope stops fighting itself
+
+`[data-surface="dark"] .proof-strip-cell` overrides the cell's `background-image` but not its `background`, which stays `var(--color-surface)` — neutral `rgb(28,28,28)` — on a navy ground. Fix the tokens, not the card.
+
+**Files:**
+- Modify: `apps/website/src/styles/ui.css` (inside `[data-ui="section"][data-surface="dark"]`)
+
+- [ ] **Step 1: Re-point the surface tokens**
+
+In `ui.css`, inside the `[data-ui="section"][data-surface="dark"]` rule, replace the six surface/border lines. Leave the accent lines and the `::before` seam alone — they were set correctly by the ATC retheme:
+
+```css
+  /* Navy-family surfaces. The ground goes DARKER and the surfaces go LIGHTER,
+   * which is the hierarchy that was missing: before this, cards were neutral
+   * rgb(28,28,28) floating on a navy ground — two unrelated darks. */
+  --color-canvas: #0B1622;
+  --color-surface: #15253E;
+  --color-surface-tinted: #1B2E4D;
+  --color-surface-dim: #08111B;
+  --color-border: rgba(255, 255, 255, 0.12);
+  --color-border-strong: rgba(255, 255, 255, 0.2);
+```
+
+And change the rule's own `background` to the deeper ground:
+
+```css
+  background: linear-gradient(180deg, #0b1622 0%, #0f1c2e 100%);
+```
+
+- [ ] **Step 2: Update the comment above the rule**
+
+That comment says the accents mirror `dark.ts` while the surfaces deliberately do not. That is still true and now more so — extend it so the reason survives:
+
+```css
+/* Dark section scope (homepage proof band + FinalCTA dark variant).
+ * The ACCENTS mirror libs/design-tokens/src/lib/dark.ts. The SURFACES
+ * deliberately do not: this band is website-only and takes the ATC scope
+ * navy, while dark.ts stays neutral because @threadplane/chat and the cockpit
+ * consume it and a navy ground there would seam against embedded chat.
+ * 2026-09-08: the surfaces moved to the navy family as well, because leaving
+ * --color-surface neutral put grey-black cards on a navy ground.
+ * Treatment B (spec): vertical gradient canvas, 1px accent seam at the
+ * light→dark boundary. */
+```
+
+- [ ] **Step 3: Test and build**
+
+```bash
+npx nx test website && npx nx build website
+```
+
+Expected: both pass. These are token changes with no markup change, so nothing should move.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/website/src/styles/ui.css
+git commit -m "fix(website): the dark band's surfaces join its ground in the navy family"
+```
+
+---
+
+## Task 3: The figures lose their card chrome
+
+`.proof-strip-cell` carries a background, a gradient, a border, a radius, a 1px top highlight and two shadows. On a plate, figures sit on the ground under a rule. This is most of the busy-ness fix.
+
+**Files:**
+- Modify: `apps/website/src/styles/landing.css` (`.proof-strip-cell`, its `::before`, and both dark-scope overrides)
+
+- [ ] **Step 1: Strip the chrome**
+
+Replace the `.proof-strip-cell` rule with:
+
+```css
+.proof-strip-cell {
+  position: relative;
+  /* Grid items default to min-width:auto; the long mono source URLs would then
+   * push the columns past the container. */
+  min-width: 0;
+  padding: 0 20px 0 0;
+}
+```
+
+- [ ] **Step 2: Delete the rules that no longer have anything to style**
+
+Remove all three of these blocks entirely — the base `::before` highlight, and both dark-scope overrides, which existed only to make the box read as paper:
+
+- `.proof-strip-cell::before { ... }`
+- `[data-ui="section"][data-surface="dark"] .proof-strip-cell { ... }`
+- `[data-ui="section"][data-surface="dark"] .proof-strip-cell::before { ... }`
+
+Then confirm nothing else referenced them:
+
+```bash
+grep -n "proof-strip-cell" apps/website/src/styles/landing.css
+```
+
+Expected: only the single rule from Step 1, plus the `.proof-strip-cells` container rules and any `@media` blocks that adjust the grid — those stay.
+
+- [ ] **Step 3: Leave the watermark alone**
+
+`.proof-strip-watermark` sits in the same area of `landing.css` and is NOT part of this change. `Reliability.spec.tsx` guards that it exists, is `aria-hidden`, carries `data-watermark-text="Proof"` and renders no text. With the radar grid and sweep rejected during design it no longer competes with anything, so it stays exactly as it is. Do not tidy it away while you are in this file.
+
+- [ ] **Step 4: Test**
+
+```bash
+npx nx test website
+```
+
+Expected: PASS. (jsdom does not apply CSS, so this proves only that nothing structural broke — the visual check is Task 6.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/website/src/styles/landing.css
+git commit -m "feat(website): proof figures sit on the ground, not in cards"
+```
+
+---
+
+## Task 4: The Vx/Vy frame and the pitch ladder
+
+**Files:**
+- Modify: `apps/website/src/components/landing/Reliability.tsx`
+- Modify: `apps/website/src/styles/landing.css`
+- Test: `apps/website/src/components/landing/Reliability.spec.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+`Reliability.spec.tsx` currently asserts `screen.getByText('Reliable to the core')` inside the "keeps the dark band…" test. Change that string to `'Climb performance'`, then add:
+
+```tsx
+  it('frames the section as a climb and hides the instrument from assistive tech', () => {
+    const { container } = render(<Reliability />);
+    expect(
+      screen.getByText(/Vx clears today’s obstacle; Vy gets you to altitude\./),
+    ).toBeTruthy();
+    const ladder = container.querySelector('.proof-ladder');
+    expect(ladder?.getAttribute('aria-hidden')).toBe('true');
+    // The words carry the argument; the drawing carries none of it.
+    expect(ladder?.textContent).toBe('');
+  });
+```
+
+Note the curly apostrophe in `today’s` — the aside uses a typographic apostrophe, and a straight one will not match.
+
+- [ ] **Step 2: Run and watch it fail**
+
+```bash
+npx nx test website
+```
+
+Expected: FAIL — the eyebrow still reads "Reliable to the core" and `.proof-ladder` does not exist.
+
+- [ ] **Step 3: Change the eyebrow and the aside**
+
+In `Reliability.tsx`, in the `<SectionHeader>` props, change `eyebrow` and `aside`. The `heading` and `headingId` do NOT change — `e2e/website.spec.ts` pins `#proof-heading`, and the heading is a working claim:
+
+```tsx
+              eyebrow="Climb performance"
+              heading="Audited, scored, published."
+              headingId="proof-heading"
+              aside="Vx clears today’s obstacle; Vy gets you to altitude. Not self-reported — every number links to its source."
+```
+
+- [ ] **Step 4: Add the pitch ladder**
+
+In `Reliability.tsx`, between `<SectionHeader />` and the `<ul className="proof-strip-cells">`, add:
+
+```tsx
+            {/* Attitude indicator: pitch ladder either side of an amber
+              * waterline, nose above the horizon. A divider that happens to
+              * mean something — it pays off the Vx/Vy line above it. Purely
+              * decorative, so aria-hidden. */}
+            <svg
+              className="proof-ladder"
+              viewBox="0 0 700 46"
+              aria-hidden="true"
+              focusable="false"
+            >
+              <g className="proof-ladder-rungs">
+                <line x1="150" y1="34" x2="245" y2="34" />
+                <line x1="455" y1="34" x2="550" y2="34" />
+                <line x1="196" y1="16" x2="245" y2="16" />
+                <line x1="455" y1="16" x2="504" y2="16" />
+              </g>
+              <g className="proof-ladder-wing">
+                <line x1="290" y1="26" x2="330" y2="26" />
+                <line x1="370" y1="26" x2="410" y2="26" />
+              </g>
+              <circle className="proof-ladder-dot" cx="350" cy="26" r="2.5" />
+            </svg>
+```
+
+- [ ] **Step 5: Style it**
+
+Append to `landing.css`:
+
+```css
+/* Attitude indicator between the framing copy and the figures. Hairlines only:
+ * it is a divider first and an instrument second, and the section's problem
+ * was too many competing layers. */
+.proof-ladder {
+  display: block;
+  width: 100%;
+  height: auto;
+  max-width: 700px;
+  margin: 4px 0 26px;
+}
+.proof-ladder-rungs line {
+  stroke: rgba(255, 255, 255, 0.3);
+  stroke-width: 1;
+}
+.proof-ladder-wing line {
+  stroke: var(--color-signal);
+  stroke-width: 2.5;
+}
+.proof-ladder-dot {
+  fill: var(--color-signal);
+}
+```
+
+- [ ] **Step 6: Fix the ordering assertion the new element shifts**
+
+`Reliability.spec.tsx` has:
+
+```tsx
+    const children = container.querySelector('.proof-strip-grid')!.children;
+    expect(children[1].className).toBe('proof-strip-cells');
+    expect(children[2].className).toBe('reliability-receipts');
+    expect(children[3].className).toBe('reliability-works-with');
+```
+
+The ladder is inserted at index 1, so cells and receipts shift by one. The works-with row leaves in Task 5, so drop that line here and let Task 5 own the final shape. Rename the test to `'orders the ladder, cells, then receipts'` at the same time — leaving the old name would have it claiming to check a row it no longer checks. Replace the body with:
+
+```tsx
+    const children = container.querySelector('.proof-strip-grid')!.children;
+    expect(children[1].getAttribute('class')).toBe('proof-ladder');
+    expect(children[2].className).toBe('proof-strip-cells');
+    expect(children[3].className).toBe('reliability-receipts');
+```
+
+`className` on an SVG element is an `SVGAnimatedString`, not a string — that is why this line uses `getAttribute('class')` while the others do not. Using `.className` there silently compares an object to a string and fails in a confusing way.
+
+- [ ] **Step 7: Test**
+
+```bash
+npx nx test website
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/website/src/components/landing/Reliability.tsx apps/website/src/components/landing/Reliability.spec.tsx apps/website/src/styles/landing.css
+git commit -m "feat(website): the proof band is framed as a climb, with a pitch ladder"
+```
+
+---
+
+## Task 5: Compatibility becomes its own section
+
+The logo row leaves the dark band. This is what makes the logos legible — they are dark marks drawn for light grounds, so on a light section they need no treatment at all and there is no filter to guard.
+
+**Files:**
+- Create: `apps/website/src/components/landing/Compatibility.tsx`
+- Create: `apps/website/src/components/landing/Compatibility.spec.tsx`
+- Modify: `apps/website/src/components/landing/Reliability.tsx`
+- Modify: `apps/website/src/components/landing/Reliability.spec.tsx`
+- Modify: `apps/website/src/app/page.tsx`
+- Modify: `apps/website/src/styles/landing.css`
+
+- [ ] **Step 1: Write the new component's spec first**
+
+Create `apps/website/src/components/landing/Compatibility.spec.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Compatibility, COMPATIBILITY_GROUPS, COMPATIBILITY_MORE_COUNT } from './Compatibility';
+
+describe('Compatibility', () => {
+  it('renders a light section with a stable id', () => {
+    const { container } = render(<Compatibility />);
+    const section = container.querySelector('[data-ui="section"]');
+    expect(section?.getAttribute('data-surface')).toBe('tinted');
+    expect(section?.getAttribute('id')).toBe('compatibility');
+  });
+
+  it('groups every item under a labelled heading', () => {
+    render(<Compatibility />);
+    for (const group of COMPATIBILITY_GROUPS) {
+      expect(screen.getByText(group.label)).toBeTruthy();
+      for (const item of group.items) expect(screen.getByText(item.name)).toBeTruthy();
+    }
+    expect(screen.getByText(`+ ${COMPATIBILITY_MORE_COUNT} more`)).toBeTruthy();
+  });
+
+  it('states compatibility in words and never implies a customer', () => {
+    const { container } = render(<Compatibility />);
+    // The claim used to exist only as alt="" plus a spec comment. A reader
+    // could not see it. Now it is on the page.
+    expect(screen.getByText(/Compatibility, not endorsement/)).toBeTruthy();
+    expect(container.textContent).not.toMatch(/trusted by|customers|our clients|powered by/i);
+  });
+
+  it('marks every logo decorative, since the visible name carries the meaning', () => {
+    const { container } = render(<Compatibility />);
+    const logos = container.querySelectorAll('img.compatibility-logo');
+    const withLogos = COMPATIBILITY_GROUPS.flatMap((g) => g.items).filter((i) => i.logoSrc);
+    expect(logos).toHaveLength(withLogos.length);
+    for (const img of Array.from(logos)) {
+      expect(img.getAttribute('aria-hidden')).toBe('true');
+      expect(img.getAttribute('alt')).toBe('');
+    }
+  });
+
+  it('links to the adapter guide', () => {
+    render(<Compatibility />);
+    expect(
+      screen.getByRole('link', { name: 'Choose an adapter →' }).getAttribute('href'),
+    ).toBe('/docs/choosing-an-adapter');
+  });
+});
+```
+
+- [ ] **Step 2: Run and watch it fail**
+
+```bash
+npx nx test website
+```
+
+Expected: FAIL — `./Compatibility` does not exist.
+
+- [ ] **Step 3: Create the component**
+
+Create `apps/website/src/components/landing/Compatibility.tsx`:
+
+```tsx
+import { Container } from '../ui/Container';
+import { Section } from '../ui/Section';
+import { SectionHeader } from '../ui/SectionHeader';
+import { AdapterGuideLink } from './AdapterGuideLink';
+
+interface CompatibilityItem {
+  readonly name: string;
+  /** null for an entry we support but have no mark for. */
+  readonly logoSrc: string | null;
+}
+
+interface CompatibilityGroup {
+  readonly label: string;
+  readonly items: readonly CompatibilityItem[];
+}
+
+/**
+ * Grouped rather than a flat run: the previous single row put a model provider
+ * beside a protocol as though they were the same kind of thing, which is not
+ * the information someone evaluating this needs.
+ *
+ * This section is LIGHT on purpose. These marks are drawn for light grounds —
+ * Anthropic's is #181818 — and on the dark band they were invisible. Moving
+ * them here is the fix; no CSS filter is involved.
+ */
+export const COMPATIBILITY_GROUPS: readonly CompatibilityGroup[] = [
+  {
+    label: 'Model providers',
+    items: [
+      { name: 'OpenAI', logoSrc: '/logos/providers/openai.svg' },
+      { name: 'Anthropic', logoSrc: '/logos/providers/anthropic.svg' },
+      { name: 'Gemini', logoSrc: '/logos/providers/google.svg' },
+      { name: 'Bedrock', logoSrc: '/logos/providers/bedrock.svg' },
+    ],
+  },
+  {
+    label: 'Agent runtimes',
+    items: [
+      { name: 'Mastra', logoSrc: '/logos/runtimes/mastra.svg' },
+      { name: 'CrewAI', logoSrc: '/logos/runtimes/crewai.svg' },
+      { name: 'AWS Strands', logoSrc: null },
+    ],
+  },
+  {
+    label: 'Protocols',
+    items: [
+      { name: 'LangGraph', logoSrc: '/logos/langgraph.svg' },
+      { name: 'AG-UI', logoSrc: '/logos/ag-ui.svg' },
+    ],
+  },
+];
+
+/**
+ * Azure OpenAI, Pydantic AI, Microsoft Agent Framework.
+ *
+ * Was 4 and included AWS Strands, which is now named above — it is already
+ * named twice elsewhere on the page (a reliability receipt cites it), so
+ * hiding it in a count was odd. Decrement this if another is promoted.
+ */
+export const COMPATIBILITY_MORE_COUNT = 3;
+
+export function Compatibility() {
+  return (
+    <Section surface="tinted" id="compatibility" ariaLabelledBy="compatibility-heading">
+      <Container>
+        <SectionHeader
+          variant="rail"
+          eyebrow="Compatibility"
+          heading="Your backend, your models, your runtime."
+          headingId="compatibility-heading"
+          aside="Threadplane is the UI layer. What it talks to is your choice — and swapping any of it does not mean rewriting the interface."
+        />
+        <div className="compatibility-groups">
+          {COMPATIBILITY_GROUPS.map((group) => (
+            <div className="compatibility-group" key={group.label}>
+              <p className="compatibility-group-label">{group.label}</p>
+              <ul className="compatibility-items" role="list">
+                {group.items.map((item) => (
+                  <li className="compatibility-item" key={item.name}>
+                    {item.logoSrc ? (
+                      <img
+                        src={item.logoSrc}
+                        alt=""
+                        aria-hidden="true"
+                        loading="lazy"
+                        decoding="async"
+                        className="compatibility-logo"
+                      />
+                    ) : null}
+                    <span className="compatibility-name">{item.name}</span>
+                  </li>
+                ))}
+                {group.label === 'Agent runtimes' ? (
+                  <li className="compatibility-more">+ {COMPATIBILITY_MORE_COUNT} more</li>
+                ) : null}
+              </ul>
+            </div>
+          ))}
+        </div>
+        <div className="compatibility-footer">
+          <AdapterGuideLink className="compatibility-link" />
+          <p className="compatibility-disclaimer">
+            Compatibility, not endorsement — no company here is claimed as a customer.
+          </p>
+        </div>
+      </Container>
+    </Section>
+  );
+}
+```
+
+- [ ] **Step 4: Style it**
+
+Append to `landing.css`:
+
+```css
+/* Compatibility — light ground on purpose: these marks are drawn for light
+ * backgrounds and were invisible on the dark band. */
+.compatibility-groups {
+  margin-top: 26px;
+}
+.compatibility-group {
+  padding: 16px 0;
+  border-top: 1px solid var(--color-border);
+}
+.compatibility-group-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  margin: 0;
+}
+.compatibility-items {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 26px;
+  list-style: none;
+  margin: 10px 0 0;
+  padding: 0;
+}
+.compatibility-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  white-space: nowrap;
+  font-family: var(--font-sans);
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--color-text-primary);
+}
+.compatibility-logo {
+  width: 17px;
+  height: 17px;
+  object-fit: contain;
+}
+.compatibility-more {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  color: var(--color-text-muted);
+  align-self: center;
+}
+.compatibility-footer {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  flex-wrap: wrap;
+  border-top: 1px solid var(--color-border);
+  padding-top: 18px;
+}
+.compatibility-disclaimer {
+  font-size: 12.5px;
+  color: var(--color-text-muted);
+  margin: 0;
+}
+```
+
+- [ ] **Step 5: Remove the row from Reliability**
+
+In `Reliability.tsx`, delete the whole `<ul className="reliability-works-with"> … </ul>` block, and delete the now-unused `RIBBON_ITEMS` / `RibbonItem` / `RIBBON_MORE_COUNT` declarations and the `AdapterGuideLink` import.
+
+Then confirm nothing still imports them:
+
+```bash
+grep -rn "RIBBON_ITEMS\|RIBBON_MORE_COUNT" apps/website/src || echo "clean"
+```
+
+Expected: `clean`
+
+Remove the now-dead `.reliability-works-with*` and `.reliability-logo` rules from `landing.css`:
+
+```bash
+grep -n "reliability-works-with\|reliability-logo" apps/website/src/styles/landing.css
+```
+
+Delete every rule that grep lists.
+
+- [ ] **Step 6: Update Reliability's spec**
+
+Delete the whole `it('carries the works-with line as a compatibility claim with an adapter link', …)` test — it now belongs to `Compatibility.spec.tsx`. Remove `RIBBON_ITEMS` / `RIBBON_MORE_COUNT` from that file's imports.
+
+The ordering test loses its last row, since works-with is gone:
+
+```tsx
+  it('orders the ladder, cells, then receipts', () => {
+    const { container } = render(<Reliability />);
+    const children = container.querySelector('.proof-strip-grid')!.children;
+    expect(children[1].getAttribute('class')).toBe('proof-ladder');
+    expect(children[2].className).toBe('proof-strip-cells');
+    expect(children[3].className).toBe('reliability-receipts');
+    expect(children).toHaveLength(4);
+  });
+```
+
+- [ ] **Step 7: Mount it on the homepage**
+
+In `apps/website/src/app/page.tsx`, add the import beside the others:
+
+```tsx
+import { Compatibility } from '../components/landing/Compatibility';
+```
+
+and mount it between the two existing sections:
+
+```tsx
+      <Reliability />
+      <Compatibility />
+      <EnterpriseArchitecture />
+```
+
+- [ ] **Step 8: Test and build**
+
+```bash
+npx nx test website && npx nx lint website && npx nx build website
+```
+
+Expected: all pass, `nx lint` with 0 errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/website/src/components/landing apps/website/src/app/page.tsx apps/website/src/styles/landing.css
+git commit -m "feat(website): compatibility becomes its own light section, grouped"
+```
+
+---
+
+## Task 6: Verification
+
+- [ ] **Step 1: The suites CI runs**
+
+```bash
+npx nx test website
+npx nx lint website
+npx nx build website
+```
+
+All three must pass; lint with 0 errors (65 pre-existing warnings are expected).
+
+- [ ] **Step 2: The guard that should not have moved**
+
+```bash
+npx nx e2e website -- --grep "landing page"
+```
+
+`e2e/website.spec.ts` asserts `#proof-heading` is visible and `#proof[data-surface="dark"]` exists. This design keeps all three, so it must pass **unchanged**. If it fails, something drifted that was not meant to — do not edit the spec to match, find what moved.
+
+- [ ] **Step 3: Full e2e**
+
+```bash
+npx nx e2e website
+```
+
+Free port 3000 first if a dev server is running — the Playwright config starts its own and will fail with "Process from config.webServer was not able to start" if the port is taken.
+
+- [ ] **Step 4: Look at it**
+
+Start the dev server through the Browser pane preview tools (`website-dev` already exists in `.claude/launch.json`), then check the homepage at desktop and at 390px:
+
+- Every logo in `#compatibility` is legible. This is the headline fix — Anthropic and Mastra were the invisible ones.
+- The seam has no sliver of yellow: the masthead sits directly against the hero's yellow above and the scope band below, with nothing between.
+- The figures read against the ground now that the cards are gone, and nothing looks like it lost a background it needed.
+- The pitch ladder reads as a divider, not as clip art.
+
+- [ ] **Step 5: Sample contrast from the rendered page**
+
+In the Browser pane console:
+
+```javascript
+const s = document.querySelector('#proof');
+const cell = document.querySelector('.proof-strip-value');
+({ ground: getComputedStyle(s).backgroundImage,
+   figure: getComputedStyle(cell).color,
+   surface: getComputedStyle(s).getPropertyValue('--color-surface') })
+```
+
+Expected: ground is the `#0b1622 → #0f1c2e` gradient, `--color-surface` is `#15253E`, and the figure colour is a near-white.
+
+- [ ] **Step 6: Commit any fixes**
+
+```bash
+git add -A
+git commit -m "fix(website): reliability redesign verification pass"
+```
+
+---
+
+## Out of scope
+
+- `libs/design-tokens/src/lib/dark.ts` and the cockpit's neutral dark surfaces. The divergence is deliberate and documented in `ui.css`.
+- The second, 97px `[data-surface="dark"]` band further down the homepage. It inherits Task 2's token change; look at it during Task 6 Step 4, but do not redesign it here.
+- The `.arch-flow-log-source` badge contrast issue in the docs, tracked separately.

--- a/docs/superpowers/plans/2026-09-08-reliability-scope-redesign.md
+++ b/docs/superpowers/plans/2026-09-08-reliability-scope-redesign.md
@@ -248,13 +248,18 @@ Replace the `.proof-strip-cell` rule with:
 
 ```css
 .proof-strip-cell {
-  position: relative;
   /* Grid items default to min-width:auto; the long mono source URLs would then
    * push the columns past the container. */
   min-width: 0;
-  padding: 0 20px 0 0;
 }
 ```
+
+> **Superseded during execution (2026-09-08).** This step originally added
+> `padding: 0 20px 0 0;` to the cell. Do not re-introduce it: the column gutter
+> is now the grid's own `column-gap` — `.proof-strip-cells` carries
+> `gap: 44px 40px` — and a cell padding on top of that is double spacing.
+> `position: relative` also went: it was the containing block for the `::before`
+> highlight that Step 2 deletes, and nothing inside a cell is positioned now.
 
 - [ ] **Step 2: Delete the rules that no longer have anything to style**
 
@@ -368,6 +373,17 @@ In `Reliability.tsx`, between `<SectionHeader />` and the `<ul className="proof-
 ```
 
 - [ ] **Step 5: Style it**
+
+> **Superseded during execution (2026-09-08).** Two changes to the block below.
+> The `max-width: 700px` cap is gone: capped and left-aligned inside a wider
+> container, the waterline sat roughly 210px left of the band's centre and the
+> instrument read as stray marks rather than a divider. It spans the full
+> content width instead, which centres the waterline.
+> With the cap gone the svg is `width: 100%` over a 700-wide viewBox, so below
+> 700px the whole drawing scales down and the strokes would scale with it —
+> the rungs go sub-pixel at 375px. Both stroke rules therefore also carry
+> `vector-effect: non-scaling-stroke`, which holds the hairline weight at any
+> scale. Take the shipped rules in `landing.css` as authoritative.
 
 Append to `landing.css`:
 

--- a/docs/superpowers/plans/2026-09-08-reliability-scope-redesign.md
+++ b/docs/superpowers/plans/2026-09-08-reliability-scope-redesign.md
@@ -124,8 +124,16 @@ In `landing.css`, rename the `.hero-strip` rule to `.proof-masthead` and drop th
   /* [data-ui="section"] sets padding-top: var(--spacing-section-y), so a first
    * child would otherwise sit BELOW that padding with a navy gap above it —
    * which defeats the whole point. Pull it back up to the section's top edge
-   * so it is flush against the hero's yellow. */
-  margin: calc(-1 * var(--spacing-section-y)) 0 0;
+   * so it is flush against the hero's yellow.
+   *
+   * The matching bottom margin is not symmetry for its own sake: a negative
+   * margin-top on an in-flow first child drags every following sibling up too,
+   * so without it the band loses its whole top padding and the eyebrow sits
+   * flush against this bar. Give back exactly what the top pulled away.
+   *
+   * Both halves assume this Section is not `tight` — that variant swaps in
+   * --spacing-section-y-tight and the cancellation would no longer balance. */
+  margin: calc(-1 * var(--spacing-section-y)) 0 var(--spacing-section-y);
   padding: 10px var(--spacing-container-x);
   background: var(--color-scope);
   color: #ffffff;
@@ -145,6 +153,8 @@ grep -rn "hero-strip\|hero-trust" apps/website/src || echo "clean"
 ```
 
 Expected: `clean`
+
+**Neither margin is checkable by a unit test** — jsdom applies no CSS. Verify in a real browser: the masthead's top must be flush with both the hero's bottom and the section's top (gap 0 on each), and the heading below it must keep roughly `--spacing-section-y` of clearance. Measured on the real page at 1280px after this change: 0, 0 and 143px.
 
 - [ ] **Step 6: Run the tests**
 

--- a/docs/superpowers/plans/2026-09-08-reliability-scope-redesign.md
+++ b/docs/superpowers/plans/2026-09-08-reliability-scope-redesign.md
@@ -436,6 +436,27 @@ git commit -m "feat(website): the proof band is framed as a climb, with a pitch 
 
 ## Task 5: Compatibility becomes its own section
 
+> **Superseded during execution (2026-09-08).** This task as written keeps a
+> `COMPATIBILITY_MORE_COUNT = 3` badge. Review found that impossible to state
+> honestly: the badge renders only inside the Agent runtimes group, but one of
+> the three hidden entries — Azure OpenAI — is a model provider, so the section
+> claimed three more *runtimes* and one was not. Its trigger was also a string
+> comparison against display copy, so rewording a label would have silently
+> removed it.
+>
+> All three hidden marks already existed on disk (`providers/azure.svg`,
+> `runtimes/pydantic.svg`, `runtimes/microsoft.svg`), so the shipped version
+> names all twelve and deletes the count entirely. Read the steps below for the
+> structure; ignore every reference to `COMPATIBILITY_MORE_COUNT` and
+> `.compatibility-more`.
+>
+> Two other things review caught here, both shipped: each group's `<ul>` needs
+> `aria-labelledby` pointing at its label (the old markup had it and the move
+> dropped it), and the spec must pin group and item counts independently —
+> iterating `COMPATIBILITY_GROUPS` is tautological, and deleting the whole
+> Protocols group left every test green.
+
+
 The logo row leaves the dark band. This is what makes the logos legible — they are dark marks drawn for light grounds, so on a light section they need no treatment at all and there is no filter to guard.
 
 **Files:**

--- a/docs/superpowers/specs/2026-09-08-preflight-checklist-design.md
+++ b/docs/superpowers/specs/2026-09-08-preflight-checklist-design.md
@@ -1,0 +1,113 @@
+# The proof band becomes a preflight checklist
+
+**Date:** 2026-09-08
+**Status:** Approved, ready for planning
+**Branch:** `blove/reliability-dark-redesign`
+**Supersedes:** the pitch-ladder device in `2026-09-08-reliability-scope-redesign-design.md` §4.4
+
+## 1. Why
+
+Pilots run checklists. The homepage's dark proof band argues that Threadplane is trustworthy, but it argues it as a set of scores — which is a certificate, not a preflight. A preflight lists what *you* verify before you go, and its most useful half is the part still outstanding.
+
+Recasting the band as a checklist does three things at once: it gives the aviation frame something structural to do rather than decorative, it states the product boundary as work you still own rather than as a feature, and it forces every claim to be checkable.
+
+## 2. Shape
+
+Two columns, no group headers, no footer.
+
+**Threadplane** — 11 ticked rows, each linking to the doc page that proves it.
+**Yours** — 8 unticked rows, phrased in the docs' own words.
+
+Beneath, without a divider, an **Airworthiness** block: 8 rows where the response *is* the figure, each linking to its source.
+
+Each row is `[box] [challenge] · · · · · [response]`. Responses are outcomes you could verify, never feature names: `SURVIVES RELOAD`, not "persistence".
+
+The boxes tick in sequence on scroll-into-view, ~180ms apart, Threadplane column then Airworthiness. The **Yours boxes never fill** — that is the argument, not an oversight.
+
+### 2.1 The rows
+
+**Threadplane**
+
+| Challenge | Response | Proof |
+| --- | --- | --- |
+| A run fails | RETRY, BUILT IN | `/docs/chat/guides/error-handling` |
+| Tool calls | LIVE STATUS CARDS | `/docs/chat/components/chat-tool-call-card` |
+| Durable threads | SURVIVE RESTARTS | `/docs/langgraph/guides/persistence` |
+| Reader scrolls up | STREAM STAYS PUT | `/docs/chat/components/chat` |
+| Model output | SANITIZED, 26 NODES | `/docs/chat/guides/markdown` |
+| Shared link | URL IS THE TRUTH | `/docs/chat/guides/thread-routing` |
+| Your design system | CSS VARS, NO !IMPORTANT | `/docs/chat/guides/theming` |
+| Your tests | RUN WITHOUT A MODEL | `/docs/chat/getting-started/try-without-a-backend` |
+| Swapping backend | ONE IMPORT CHANGES | `/docs/choosing-an-adapter` |
+| Model drift | CHECKED WEEKLY, LIVE | `.github/workflows/aimock-drift.yml` on GitHub |
+| Debug panel | TREE-SHAKEN OUT | `/docs/chat/components/chat-debug` |
+
+**Yours**
+
+| Challenge | Response |
+| --- | --- |
+| Agent endpoint | BEHIND YOUR PROXY |
+| API keys | NEVER IN THE BUNDLE |
+| Thread IDs | SERVER-GENERATED |
+| CORS | YOURS TO CONFIGURE |
+| Interrupt panel | YOU COMPOSE IT |
+| Resume payload | YOURS TO CHOOSE |
+| Runs | TRACED |
+| Regressions | EVALUATED |
+
+**Airworthiness**
+
+| Challenge | Response | Source |
+| --- | --- | --- |
+| Framework rank | #8 OF 119 | hvtracker.net categories |
+| OpenSSF Scorecard | 8.2 / 10 | scorecard.dev |
+| Supply-chain grade | 84.8 HVTRUST | hvtracker.net/agents |
+| Angular support | 20–22 CI-TESTED | npmjs.com |
+| Release provenance | SIGNED · OIDC · SLSA | npmjs.com |
+| Cloud | NONE · SELF-HOSTED | `/privacy` |
+| Signup | NONE · npm i | `/docs/chat/getting-started/installation` |
+| VC board | NONE | `/about` |
+
+## 3. Every claim is sourced, and three were wrong
+
+The section's existing aside says "not self-reported". A checklist makes that harder, not easier, so the rows were verified against the docs rather than written from memory. Three items that appeared in earlier drafts came out:
+
+- **"Destructive actions — HELD FOR APPROVAL"** was false. `<chat>` does not render the interrupt panel: *"Interrupt UI is not part of it — compose `<chat-interrupt-panel>` yourself."* It became two Yours rows, which is the stronger claim anyway.
+- **"Errors & retry"** had been held back as unverified. It is the opposite — `<chat>` renders `<chat-error>` with per-kind copy and a Retry button with zero configuration, across five classified error kinds. It is now the first row.
+- **Keyboard & screen reader** stays off the list. Four components document accessibility; there is no overview page, no audit, no conformance claim. Reduced motion is genuinely implemented with a WCAG citation but only in code, so there is nothing to link. A tick would overclaim.
+
+**Durable threads is LangGraph-only.** `persistence.mdx` says conversations survive "page refreshes, browser restarts, and server deployments", and also that event-stream adapters like `@threadplane/ag-ui` "typically cannot offer it". The row links to the LangGraph page so a reader lands on that context; the tick itself does not carry the caveat.
+
+**The drift check is advisory.** `aimock-drift.yml` runs weekly against the live provider and is explicitly "never a merge gate". `CHECKED WEEKLY, LIVE` states frequency without implying it blocks releases.
+
+## 4. What this replaces
+
+- The **pitch ladder** from the previous spec. The checklist is the aviation device now; two would be one too many.
+- The four **proof cells** as figures-with-captions. They become Airworthiness rows.
+- The three **receipts** as a prose block. Provenance becomes a row; **runtimes** and **content telemetry** are dropped.
+
+The **masthead**, **eyebrow**, **heading** and the **Vx/Vy aside** all stay. `#proof`, `#proof-heading` and `data-surface="dark"` are unchanged, so `e2e/website.spec.ts` stays green untouched.
+
+## 5. Known, accepted
+
+Recorded so they read as decisions rather than oversights:
+
+- **Cloud and Signup duplicate the masthead**, which reads `MIT · ANGULAR 20–22 · NO ACCOUNT · NO CLOUD` about 200px above. Shipping as-is; the cleaner fix later is for the masthead to shed those and keep MIT.
+- **The "no content telemetry" claim leaves the homepage.** It was a real differentiator for enterprise readers and now appears nowhere on the page.
+- **The receipts' detail sentences are cut** — for example provenance's "npm attestations from OIDC trusted publishing, and a SLSA file on each release". A row cannot carry it.
+- **Nine more STRONG items were available and did not fit**: multiple threads, subagents, generative UI, four layouts, the adapter conformance suite, dark mode, lifecycle timestamps, scriptable fake-agent events, MIT with no runtime key. The constraint is column length, not availability.
+
+## 6. Accessibility
+
+- The boxes are drawn `<span>`s, not `<input type="checkbox">`. Nothing here is a form control and none of it is interactive; presenting it as a form would mislead assistive tech into offering to toggle it.
+- Ticked rows are `<a>`; Yours rows are `<div>` with no link, because no page proves that you set a cost ceiling.
+- The animation is decorative. Under `prefers-reduced-motion: reduce` every tick applies at once with no transition.
+- The tick sequence must not be the only signal that a row is ticked — the response colour changes too, so the state survives a user who never sees the animation.
+
+## 7. Verification
+
+- `npx nx test website`, `npx nx lint website`, `npx nx build website` — the CI commands.
+- `npx nx e2e website`, with `#proof` assertions passing **unchanged**.
+- Every `href` in the section resolves — including the two off-site registry links and the GitHub workflow link. A checklist whose proof 404s is worse than no checklist.
+- Measured in a browser, not eyeballed: every box in a column shares one left edge, every response shares one right edge, and the row count matches the spec.
+- At 390px the columns stack and the rows stay on one line each.

--- a/docs/superpowers/specs/2026-09-08-reliability-scope-redesign-design.md
+++ b/docs/superpowers/specs/2026-09-08-reliability-scope-redesign-design.md
@@ -121,6 +121,15 @@ Each of these pins something this design deliberately changes, and must be updat
 - The small second `[data-surface="dark"]` band further down the homepage (97px, in the stage area). It inherits the §4.2 token change and should be looked at during verification, but is not redesigned here.
 - The `.arch-flow-log-source` badge contrast issue in the docs, already tracked separately.
 
+**Checked, not redesigned (2026-09-08).** The `[data-surface="dark"]` token
+change also re-grounds the `FinalCTA` dark variant on `/langgraph`, `/ag-ui`,
+`/chat` and `/render`, which share one component. Verified on the rendered
+`/langgraph`: ground `#0B1622 → #0F1C2E`, primary button ink-on-signal,
+secondary now `#15253E` with an `rgba(255,255,255,.2)` edge and a near-white
+label, ghost in amber, no horizontal overflow. The secondary button is the one
+element that visibly improves — it was the same grey-black-on-navy mismatch the
+proof cards had, and unlike the cards it still exists.
+
 ## 8. Verification
 
 - `npx nx test website` and `npx nx lint website` — the CI commands, not `vitest --root`.

--- a/docs/superpowers/specs/2026-09-08-reliability-scope-redesign-design.md
+++ b/docs/superpowers/specs/2026-09-08-reliability-scope-redesign-design.md
@@ -1,0 +1,127 @@
+# Reliability as a scope band, and compatibility as its own section
+
+**Date:** 2026-09-08
+**Status:** Approved, ready for planning
+**Branch:** `blove/reliability-dark-redesign`
+
+## 1. Goal
+
+The homepage's dark Reliability band came out of the ATC retheme visually broken in three specific ways. Fix those, give the section a genuine aviation frame rather than a decorative one, and move the works-with logos into a compatibility section of their own.
+
+## 2. What is actually wrong
+
+Measured on the live page, not inferred.
+
+**The logos are invisible.** `.reliability-logo` sets only `width`, `height` and `object-fit` — no colour treatment at all — so each mark keeps whatever fill its own SVG ships with. Anthropic's is `#181818` on a `#15253E` ground. Google's is the only one that reads, because it is full-colour, which makes it the loudest thing in a band meant to be quiet.
+
+**The cards are a different dark from the ground.** Introduced by #1058. `[data-surface="dark"] .proof-strip-cell` overrides the cell's `background-image` but not its `background`, which stays `var(--color-surface)` — neutral `rgb(28,28,28)` — while the section's ground moved to scope navy. Two unrelated darks with no hierarchy between them.
+
+**The hero strip and the section are the same navy, 78px apart.** The strip sits at document y 1072, the hero block ends at 1180, and the dark section begins at 1180. The strip was designed to *close* the yellow block; it cannot, while a larger band of the same colour starts a moment later.
+
+A fourth problem is editorial rather than visual: the section was carrying four background layers (grid-less ground, a 150–300px `Proof` watermark, card chrome, and a logo ribbon) plus two separate arguments — "we are trustworthy" and "we are compatible with things". It was too busy, and the two arguments were competing.
+
+## 3. The frame: Vx and Vy
+
+Vx is best *angle* of climb — most altitude per unit of ground distance, flown to clear an obstacle. Vy is best *rate* — most altitude per unit of time, which is what actually gets you to altitude. Vx has the steeper deck angle, so it looks more impressive, and leaves you lower ten minutes later.
+
+That is the section's argument: other approaches may look steeper today; we are optimising for rate of climb, and publishing the numbers that say so.
+
+The frame lands in the **aside line**, not the heading. The heading stays "Audited, scored, published."
+
+```
+eyebrow:  Climb performance
+heading:  Audited, scored, published.
+aside:    Vx clears today's obstacle; Vy gets you to altitude.
+          Not self-reported — every number links to its source.
+```
+
+Rejected: rewriting the heading around the climb frame (strongest, but rebuilds an argument that is working and touches the copy guard and three specs), and a plotted climb chart (a real altitude-against-time plate with deck-angle glyphs — accurate, and too much drawing for a section whose problem was busy-ness).
+
+## 4. The Reliability section
+
+### 4.1 The strip becomes the masthead
+
+`.hero-strip` moves out of `Hero.tsx` and becomes the dark section's top edge, so the page reads yellow → strip → scope, contiguous. One navy moment instead of two. This is where the ATC app puts its frequency bar: at the boundary, not floating inside a block.
+
+`HERO_TRUST_LINE` stays in `positioning.ts` — it is still the same words — but is rendered by the Reliability section. `Hero.spec.tsx` asserts `.hero-trust` textContent and will need to follow it.
+
+### 4.2 The surfaces stop fighting
+
+Fix the cause rather than the card. The website's `[data-ui="section"][data-surface="dark"]` scope re-points its surface tokens to the navy family. That scope is website-local — `dark.ts` stays neutral because `@threadplane/chat` and the cockpit consume it, and a navy ground there would seam against embedded chat — so this is safe, and it corrects every element in the band rather than one class.
+
+| | now | becomes |
+| --- | --- | --- |
+| section ground | `#1b2e4d → #15253e` | `#0B1622 → #0F1C2E` |
+| `--color-surface` | `rgb(28,28,28)` | `#15253E` |
+| `--color-surface-tinted` | `rgb(44,44,44)` | `#1B2E4D` |
+| `--color-border` | `rgb(45,45,45)` | `rgba(255,255,255,.12)` |
+| `--color-border-strong` | `rgb(60,60,60)` | `rgba(255,255,255,.20)` |
+
+The ground gets *darker* and the surfaces get *lighter*, which is the hierarchy that was missing.
+
+### 4.3 The numbers lose their card chrome
+
+`.proof-strip-cell` currently carries a background, a gradient, a border, a radius, a 1px top highlight and two shadows. On a plate, figures sit on the ground under a rule. The cells become plain: figure, caption, source link, no box.
+
+One of the four cells is not a figure: the HVTrust cell renders a live external badge image from `hvtracker.net`. It keeps the badge — it is a grey-and-green pill that already reads on dark — and simply loses the box around it like the others.
+
+This is most of the busy-ness fix, and it is why §4.2's surface re-point matters less than it appears — with the boxes gone there is little left to mismatch. The re-point still lands, because other elements in the band use those tokens.
+
+### 4.4 One device: a pitch ladder
+
+Between the aside and the figures, a single inline SVG: the pitch ladder and amber waterline of an attitude indicator, nose above the horizon. It is a divider that happens to mean something, and it pays off "attitude and pitch" literally.
+
+- `aria-hidden="true"` — it carries no information a screen reader needs; the words carry the argument.
+- Hairline strokes at `rgba(255,255,255,.30)`, waterline in `--color-signal`.
+- No animation. Static.
+
+Rejected: a radar grid with a rotating or static sweep (three background layers competing with the watermark), and instrument-style field labels on every figure (`RANK`, `SCORE`, `GRADE`, `SUPPORT` — good, but it adds back chrome we just removed).
+
+### 4.5 The watermark
+
+`Reliability.spec.tsx` guards that `.proof-strip-watermark` exists, is `aria-hidden`, carries `data-watermark-text="Proof"`, and renders no text content. It stays, unchanged. It is already amber, and with the grid and sweep rejected it is no longer competing with anything.
+
+## 5. The compatibility section
+
+The works-with row leaves Reliability entirely and becomes its own section, placed in `page.tsx` between `<Reliability />` and `<EnterpriseArchitecture />` — it answers "what does it plug into" immediately after the trust argument and immediately before the diagram showing where it sits.
+
+The section takes `id="compatibility"` and `surface="tinted"`, matching the pattern of its neighbours (`#architecture`, `#teams`), so in-page anchors and any future e2e have something stable to address.
+
+**Light ground.** This is the decision that makes the logos work: they are dark marks drawn for light backgrounds. On white they need no treatment at all.
+
+**This retires the filter fix.** An earlier draft of this design normalised every mark with `filter: brightness(0) invert(1)`. Once the row is on a light section there are no logos left on dark, so the filter is unnecessary and there is nothing to guard. Fewer moving parts. (The HVTrust badge stays in the dark band, but it is a grey-and-green pill that already reads there.)
+
+**Grouped, not a flat run.** The eight marks currently sit in one row where a model provider is adjacent to a protocol as though they were the same kind of thing:
+
+- **Model providers** — OpenAI, Anthropic, Gemini, Bedrock
+- **Agent runtimes** — Mastra, CrewAI, AWS Strands, + 4 more
+- **Protocols** — LangGraph, AG-UI
+
+Grouping is the actual information. It also gives "+ 4 more" an honest home inside the group it belongs to, and lets a name-only entry read as normal rather than as a broken image.
+
+**The compatibility claim becomes visible.** Today it lives only as `alt=""` / `aria-hidden` plus a spec comment: `Reliability.spec.tsx` guards that no wording implies these companies are customers. On its own section the claim can be stated in words — "Compatibility, not endorsement — no company here is claimed as a customer" — which is a stronger guarantee than a hidden attribute. The existing guard moves with the component and keeps asserting the attributes.
+
+`RIBBON_ITEMS`, `RIBBON_MORE_COUNT` and the `AdapterGuideLink` usage move out of `Reliability.tsx` into the new component.
+
+## 6. Guards this touches
+
+Each of these pins something this design deliberately changes, and must be updated as part of the work — not worked around:
+
+- `apps/website/e2e/website.spec.ts` asserts `#proof-heading` is visible and `#proof[data-surface="dark"]` exists. Both survive: the id, the heading and the dark surface are all unchanged. **This should stay green untouched**; if it goes red, something has drifted that was not meant to.
+- `Reliability.spec.tsx` — "carries the works-with line as a compatibility claim with an adapter link" and "orders cells, receipts, then the works-with line" both assert a row that is leaving. They move to the new component's spec, rewritten for the grouped structure.
+- `Reliability.spec.tsx` — the watermark, dark-band, id and heading assertions stay exactly as they are.
+- `Hero.spec.tsx` asserts `.hero-trust` textContent; the trust line moves to the Reliability masthead.
+- `style-contracts.spec.ts` — **checked: it pins nothing on `.proof-strip-cell` or any `.reliability-*` class**, so removing the card chrome breaks no style contract. Noted so the next person does not re-derive it.
+
+## 7. Out of scope
+
+- `dark.ts` and the cockpit's neutral dark surfaces. The divergence is deliberate and documented in `ui.css`.
+- The small second `[data-surface="dark"]` band further down the homepage (97px, in the stage area). It inherits the §4.2 token change and should be looked at during verification, but is not redesigned here.
+- The `.arch-flow-log-source` badge contrast issue in the docs, already tracked separately.
+
+## 8. Verification
+
+- `npx nx test website` and `npx nx lint website` — the CI commands, not `vitest --root`.
+- `npx nx e2e website` — in particular `website.spec.ts`'s `#proof` assertions, which should pass unchanged.
+- In the browser at desktop and 390px: confirm every logo in the new section is legible, that the yellow → strip → scope seam has no sliver of yellow between the strip and the band, and that the figures read against the ground with the card chrome gone.
+- Contrast sampled from the rendered page, not from this document.

--- a/docs/superpowers/specs/2026-09-08-reliability-scope-redesign-design.md
+++ b/docs/superpowers/specs/2026-09-08-reliability-scope-redesign-design.md
@@ -91,17 +91,19 @@ The section takes `id="compatibility"` and `surface="tinted"`, matching the patt
 
 **This retires the filter fix.** An earlier draft of this design normalised every mark with `filter: brightness(0) invert(1)`. Once the row is on a light section there are no logos left on dark, so the filter is unnecessary and there is nothing to guard. Fewer moving parts. (The HVTrust badge stays in the dark band, but it is a grey-and-green pill that already reads there.)
 
-**Grouped, not a flat run.** The eight marks currently sit in one row where a model provider is adjacent to a protocol as though they were the same kind of thing:
+**Grouped, not a flat run.** The marks currently sit in one row where a model provider is adjacent to a protocol as though they were the same kind of thing. Grouped, and with every integration named:
 
-- **Model providers** — OpenAI, Anthropic, Gemini, Bedrock
-- **Agent runtimes** — Mastra, CrewAI, AWS Strands, + 4 more
+- **Model providers** — OpenAI, Anthropic, Gemini, Bedrock, Azure OpenAI
+- **Agent runtimes** — Mastra, CrewAI, Pydantic AI, Microsoft Agent Framework, AWS Strands
 - **Protocols** — LangGraph, AG-UI
 
-Grouping is the actual information. It also gives "+ 4 more" an honest home inside the group it belongs to, and lets a name-only entry read as normal rather than as a broken image.
+Grouping is the actual information, and it lets a name-only entry read as normal rather than as a broken image.
+
+**No hidden count.** An earlier draft closed the runtimes group with a "+ 4 more" badge. Grouping is what killed it rather than housing it: the badge could only render inside one group, and the hidden entries did not all belong to that group — Azure OpenAI is a model provider, so "+ N more runtimes" could not be stated honestly under any count. All of the previously hidden marks already existed on disk, so naming the full twelve costs nothing and removes a number that only stayed correct if an editor remembered to decrement it.
 
 **The compatibility claim becomes visible.** Today it lives only as `alt=""` / `aria-hidden` plus a spec comment: `Reliability.spec.tsx` guards that no wording implies these companies are customers. On its own section the claim can be stated in words — "Compatibility, not endorsement — no company here is claimed as a customer" — which is a stronger guarantee than a hidden attribute. The existing guard moves with the component and keeps asserting the attributes.
 
-`RIBBON_ITEMS`, `RIBBON_MORE_COUNT` and the `AdapterGuideLink` usage move out of `Reliability.tsx` into the new component.
+`RIBBON_ITEMS` and the `AdapterGuideLink` usage move out of `Reliability.tsx` into the new component; the items land as `COMPATIBILITY_GROUPS`. `RIBBON_MORE_COUNT` does not move — per "No hidden count" above, it is deleted.
 
 ## 6. Guards this touches
 


### PR DESCRIPTION
## Summary

Two connected changes to the homepage's dark proof band, on the aviation theme the site now uses.

**Compatibility moved out.** The band was arguing two things at once, and the partner logos were invisible on the dark ground. `<Compatibility />` is now its own light section that names all twelve integrations instead of hiding three behind a "+3 more" badge.

**The band became a preflight checklist.** It previously argued trustworthiness as four big figures and three prose receipts — a certificate, not a preflight. Pilots run checklists, and the useful half of a checklist is the part still outstanding. So:

- **Threadplane** — 11 ticked rows, each linking to the doc page that proves it.
- **Yours** — 8 rows, phrased in the docs' own words. **These boxes never fill.** That is the argument, not an oversight.
- **Airworthiness** — 8 rows where the response is the figure, each linking to its source.

The framing stays: the "Climb performance" eyebrow and the Vx/Vy aside (Vx clears today's obstacle; Vy gets you to altitude).

## Three claims were wrong, and the docs caught them

The rows were verified against the docs rather than written from memory, which is the only reason the band can keep saying "not self-reported":

- **"Destructive actions — HELD FOR APPROVAL" was false.** `<chat>` does not render the interrupt panel; the docs say to compose `<chat-interrupt-panel>` yourself. It is two *Yours* rows now, which is the stronger claim anyway. This had appeared in every mockup.
- **"Errors & retry" had been held back as unverified** and is in fact the strongest line on the list — zero-config retry across five classified error kinds. It leads the column.
- **Keyboard & screen reader stays off.** Four components document accessibility; there is no overview, no audit, nothing to link. A tick would overclaim.

## Notes

- `#proof`, `#proof-heading` and `data-surface="dark"` are unchanged, so `e2e/website.spec.ts` passes **without being edited**.
- The HVTrust grade stays a live badge image rather than becoming text — it sits near an A-band floor of 80 and has flipped grade several times in a month.
- The Angular range is derived from `WEBSITE_SUPPORTED_ANGULAR_MAJORS`, not typed, so bumping a major updates the homepage. The guard for this is mutation-verified: hardcoding the string fails with `expected '20-22' to be '41-43'`.
- `compatibility-heading` was added to the e2e spine — the new section could otherwise have been deleted from `page.tsx` with all 128 tests green.

## Test Plan

- [x] `npx nx test website` — green
- [x] `npx nx lint website` — 0 errors
- [x] `npx nx build website` — green
- [x] `npx nx e2e website` — 128 passed, 1 skipped, `#proof` assertions unedited
- [x] All 13 internal proof links return 200; all off-site sources resolve (npmjs.com 403s to curl via Cloudflare bot-blocking — both packages confirmed present via the registry API, and that link is already live in production)
- [x] Measured in a real browser at 1440px: 27 boxes, **exactly two** left edges, all 16x16; 19 links, 8 unlinked; 19 ticked, **0 in Yours**
- [x] At 390px: columns stack, all boxes on one left edge, no row wraps, no horizontal overflow
- [ ] Verify on production after merge

Spec: `docs/superpowers/specs/2026-09-08-preflight-checklist-design.md`
Plan: `docs/superpowers/plans/2026-09-08-preflight-checklist.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)