### PR TITLE
chore(deployments): pin threadplane-middleware 0.1.0

### DIFF
--- a/cockpit/ag-ui/client-tools/python/requirements.txt
+++ b/cockpit/ag-ui/client-tools/python/requirements.txt
@@ -140,7 +140,7 @@ starlette==1.2.1
     # via fastapi
 tenacity==9.1.4
     # via langchain-core
-threadplane-middleware==0.0.1
+threadplane-middleware==0.1.0
     # via cockpit-ag-ui-client-tools
 tiktoken==0.13.0
     # via langchain-openai

--- a/cockpit/ag-ui/client-tools/python/uv.lock
+++ b/cockpit/ag-ui/client-tools/python/uv.lock
@@ -952,15 +952,15 @@ wheels = [
 
 [[package]]
 name = "threadplane-middleware"
-version = "0.0.1"
+version = "0.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/01/5f/fee360e3547bede9388bb72a9ad20ca811935582b989c78dafeaae57558a/threadplane_middleware-0.0.1.tar.gz", hash = "sha256:60c931d0248ed2e701a3aa1330c6fd647e611a949500269c5ba82f3607102cef", size = 95505, upload-time = "2026-06-16T20:55:18.335Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/87/1b8f5bfbc8144847133ff8e30084546b37607d148a8ace9c5a171354a10e/threadplane_middleware-0.1.0.tar.gz", hash = "sha256:66d550d267b38301e24e0e2eab4df1b83af533272e0b276f6757b13fed184ec7", size = 99030, upload-time = "2026-09-08T19:54:04.607Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/55/28e6b752f3f53f2c5d2c2fa3ef27ac62a255a3b29376384f2dfc96d8acb0/threadplane_middleware-0.0.1-py3-none-any.whl", hash = "sha256:c14e49d506e8bd3078f54df381c150d390f2d129f844694d8f5154a2cd8710ea", size = 4315, upload-time = "2026-06-16T20:55:19.044Z" },
+    { url = "https://files.pythonhosted.org/packages/da/c3/e29d9e4d56beb2c8745725b620b7bcb4841469cf7f5014bff3589da5702f/threadplane_middleware-0.1.0-py3-none-any.whl", hash = "sha256:c5682ec2a380a19ec9bfc408f808b031b37acf3a87488988493c0ecbb3f3f602", size = 6872, upload-time = "2026-09-08T19:54:03.149Z" },
 ]
 
 [[package]]

--- a/cockpit/langgraph/client-tools/python/requirements.txt
+++ b/cockpit/langgraph/client-tools/python/requirements.txt
@@ -222,7 +222,7 @@ tenacity==9.1.4
     # via
     #   langchain-core
     #   langgraph-api
-threadplane-middleware==0.0.1
+threadplane-middleware==0.1.0
     # via cockpit-langgraph-client-tools
 tiktoken==0.13.0
     # via langchain-openai

--- a/cockpit/langgraph/client-tools/python/uv.lock
+++ b/cockpit/langgraph/client-tools/python/uv.lock
@@ -1427,15 +1427,15 @@ wheels = [
 
 [[package]]
 name = "threadplane-middleware"
-version = "0.0.1"
+version = "0.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/01/5f/fee360e3547bede9388bb72a9ad20ca811935582b989c78dafeaae57558a/threadplane_middleware-0.0.1.tar.gz", hash = "sha256:60c931d0248ed2e701a3aa1330c6fd647e611a949500269c5ba82f3607102cef", size = 95505, upload-time = "2026-06-16T20:55:18.335Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/87/1b8f5bfbc8144847133ff8e30084546b37607d148a8ace9c5a171354a10e/threadplane_middleware-0.1.0.tar.gz", hash = "sha256:66d550d267b38301e24e0e2eab4df1b83af533272e0b276f6757b13fed184ec7", size = 99030, upload-time = "2026-09-08T19:54:04.607Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/55/28e6b752f3f53f2c5d2c2fa3ef27ac62a255a3b29376384f2dfc96d8acb0/threadplane_middleware-0.0.1-py3-none-any.whl", hash = "sha256:c14e49d506e8bd3078f54df381c150d390f2d129f844694d8f5154a2cd8710ea", size = 4315, upload-time = "2026-06-16T20:55:19.044Z" },
+    { url = "https://files.pythonhosted.org/packages/da/c3/e29d9e4d56beb2c8745725b620b7bcb4841469cf7f5014bff3589da5702f/threadplane_middleware-0.1.0-py3-none-any.whl", hash = "sha256:c5682ec2a380a19ec9bfc408f808b031b37acf3a87488988493c0ecbb3f3f602", size = 6872, upload-time = "2026-09-08T19:54:03.149Z" },
 ]
 
 [[package]]

--- a/deployments/ag-ui-dev/deps/client_tools/requirements.txt
+++ b/deployments/ag-ui-dev/deps/client_tools/requirements.txt
@@ -140,7 +140,7 @@ starlette==1.2.1
     # via fastapi
 tenacity==9.1.4
     # via langchain-core
-threadplane-middleware==0.0.1
+threadplane-middleware==0.1.0
     # via cockpit-ag-ui-client-tools
 tiktoken==0.13.0
     # via langchain-openai

--- a/deployments/ag-ui-dev/deps/client_tools/uv.lock
+++ b/deployments/ag-ui-dev/deps/client_tools/uv.lock
@@ -952,15 +952,15 @@ wheels = [
 
 [[package]]
 name = "threadplane-middleware"
-version = "0.0.1"
+version = "0.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/01/5f/fee360e3547bede9388bb72a9ad20ca811935582b989c78dafeaae57558a/threadplane_middleware-0.0.1.tar.gz", hash = "sha256:60c931d0248ed2e701a3aa1330c6fd647e611a949500269c5ba82f3607102cef", size = 95505, upload-time = "2026-06-16T20:55:18.335Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/87/1b8f5bfbc8144847133ff8e30084546b37607d148a8ace9c5a171354a10e/threadplane_middleware-0.1.0.tar.gz", hash = "sha256:66d550d267b38301e24e0e2eab4df1b83af533272e0b276f6757b13fed184ec7", size = 99030, upload-time = "2026-09-08T19:54:04.607Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/55/28e6b752f3f53f2c5d2c2fa3ef27ac62a255a3b29376384f2dfc96d8acb0/threadplane_middleware-0.0.1-py3-none-any.whl", hash = "sha256:c14e49d506e8bd3078f54df381c150d390f2d129f844694d8f5154a2cd8710ea", size = 4315, upload-time = "2026-06-16T20:55:19.044Z" },
+    { url = "https://files.pythonhosted.org/packages/da/c3/e29d9e4d56beb2c8745725b620b7bcb4841469cf7f5014bff3589da5702f/threadplane_middleware-0.1.0-py3-none-any.whl", hash = "sha256:c5682ec2a380a19ec9bfc408f808b031b37acf3a87488988493c0ecbb3f3f602", size = 6872, upload-time = "2026-09-08T19:54:03.149Z" },
 ]
 
 [[package]]

--- a/deployments/ag-ui-dev/requirements.txt
+++ b/deployments/ag-ui-dev/requirements.txt
@@ -11,5 +11,5 @@ langgraph==1.2.4
 langsmith==0.8.11
 openai==2.54.0
 strands-agents==1.54.0
-threadplane-middleware==0.0.1
+threadplane-middleware==0.1.0
 uvicorn==0.52.4

--- a/examples/ag-ui/python/requirements.txt
+++ b/examples/ag-ui/python/requirements.txt
@@ -145,7 +145,7 @@ starlette==1.2.1
     # via fastapi
 tenacity==9.1.4
     # via langchain-core
-threadplane-middleware==0.0.1
+threadplane-middleware==0.1.0
     # via examples-ag-ui-python
 tiktoken==0.13.0
     # via langchain-openai

--- a/examples/ag-ui/python/uv.lock
+++ b/examples/ag-ui/python/uv.lock
@@ -986,15 +986,15 @@ wheels = [
 
 [[package]]
 name = "threadplane-middleware"
-version = "0.0.1"
+version = "0.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/01/5f/fee360e3547bede9388bb72a9ad20ca811935582b989c78dafeaae57558a/threadplane_middleware-0.0.1.tar.gz", hash = "sha256:60c931d0248ed2e701a3aa1330c6fd647e611a949500269c5ba82f3607102cef", size = 95505, upload-time = "2026-06-16T20:55:18.335Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/87/1b8f5bfbc8144847133ff8e30084546b37607d148a8ace9c5a171354a10e/threadplane_middleware-0.1.0.tar.gz", hash = "sha256:66d550d267b38301e24e0e2eab4df1b83af533272e0b276f6757b13fed184ec7", size = 99030, upload-time = "2026-09-08T19:54:04.607Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/55/28e6b752f3f53f2c5d2c2fa3ef27ac62a255a3b29376384f2dfc96d8acb0/threadplane_middleware-0.0.1-py3-none-any.whl", hash = "sha256:c14e49d506e8bd3078f54df381c150d390f2d129f844694d8f5154a2cd8710ea", size = 4315, upload-time = "2026-06-16T20:55:19.044Z" },
+    { url = "https://files.pythonhosted.org/packages/da/c3/e29d9e4d56beb2c8745725b620b7bcb4841469cf7f5014bff3589da5702f/threadplane_middleware-0.1.0-py3-none-any.whl", hash = "sha256:c5682ec2a380a19ec9bfc408f808b031b37acf3a87488988493c0ecbb3f3f602", size = 6872, upload-time = "2026-09-08T19:54:03.149Z" },
 ]
 
 [[package]]

--- a/examples/chat/python/uv.lock
+++ b/examples/chat/python/uv.lock
@@ -1492,15 +1492,15 @@ wheels = [
 
 [[package]]
 name = "threadplane-middleware"
-version = "0.0.2"
+version = "0.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/f6/4f5bce0536c584677f191223821c74d0617bde36d45640008e8adf123c79/threadplane_middleware-0.0.2.tar.gz", hash = "sha256:964925aef5cc5ed8a9a9bb1c7ea7f740ee010291b6ad0bec35f50ac3f41d9809", size = 97651, upload-time = "2026-08-30T18:35:45.87Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/87/1b8f5bfbc8144847133ff8e30084546b37607d148a8ace9c5a171354a10e/threadplane_middleware-0.1.0.tar.gz", hash = "sha256:66d550d267b38301e24e0e2eab4df1b83af533272e0b276f6757b13fed184ec7", size = 99030, upload-time = "2026-09-08T19:54:04.607Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/a4/0bc72be56ee222a15e151a8eb99decb749acf44c964ef12c240ec6a8f76f/threadplane_middleware-0.0.2-py3-none-any.whl", hash = "sha256:3bf42291b06b49f6e59eb92672fa88d9f14467a5222fec806531714d4349f17b", size = 5517, upload-time = "2026-08-30T18:35:45.074Z" },
+    { url = "https://files.pythonhosted.org/packages/da/c3/e29d9e4d56beb2c8745725b620b7bcb4841469cf7f5014bff3589da5702f/threadplane_middleware-0.1.0-py3-none-any.whl", hash = "sha256:c5682ec2a380a19ec9bfc408f808b031b37acf3a87488988493c0ecbb3f3f602", size = 6872, upload-time = "2026-09-08T19:54:03.149Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`threadplane-middleware@0.1.0` is [live on PyPI](https://pypi.org/project/threadplane-middleware/0.1.0/) with attestations on both files, so the Railway lanes can finally move off the `0.0.1` pin.

This closes the ordering gap from the release: `emit_custom_event` has been in the repository since #1052, but the deployed images install from the exported requirements, which pinned `0.0.1` — so the helper was not importable where it matters. The pin could only be bumped after the package was published, or the image build would fail on a version that did not exist.

**How it was bumped.** These files carry `GENERATED`/`autogenerated by uv` headers, so nothing was hand-edited: each project's `uv.lock` was upgraded with `uv lock --upgrade-package threadplane-middleware`, requirements re-exported with `uv export --no-hashes`, and `deployments/ag-ui-dev` regenerated through `scripts/generate-ag-ui-deployment-config.ts`. The declared constraints (`>=0.0.1` / `>=0.0.2`) already admitted 0.1.0 and are unchanged.

**Verification**
- The diff contains nothing but the middleware pin, its file URLs and hashes.
- Downloaded the published wheel and confirmed it carries `custom_events.py`, that the helper wraps `adispatch_custom_event`, and that it is exported from the package.
- `nx test scripts` green (it guards the generator's output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)