### PR TITLE
fix(tsconfig): stop four library tsconfigs from shadowing the workspace baseUrl

### DIFF
--- a/libs/cockpit-registry/tsconfig.json
+++ b/libs/cockpit-registry/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "composite": false,
-    "emitDeclarationOnly": false,
-    "baseUrl": "."
+    "emitDeclarationOnly": false
   },
   "files": [],
   "include": [],

--- a/libs/cockpit-runtime-bridge/tsconfig.json
+++ b/libs/cockpit-runtime-bridge/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "composite": false,
-    "emitDeclarationOnly": false,
-    "baseUrl": "."
+    "emitDeclarationOnly": false
   },
   "files": [],
   "include": [],

--- a/libs/example-layouts/tsconfig.json
+++ b/libs/example-layouts/tsconfig.json
@@ -5,8 +5,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "module": "preserve",
     "emitDeclarationOnly": false,
-    "composite": false,
-    "baseUrl": "."
+    "composite": false
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,

--- a/libs/growth/tsconfig.json
+++ b/libs/growth/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "composite": false,
     "emitDeclarationOnly": false
   },

--- a/scripts/tsconfig-path-inheritance.spec.mjs
+++ b/scripts/tsconfig-path-inheritance.spec.mjs
@@ -1,0 +1,107 @@
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+// Guard for a latent module-resolution defect.
+//
+// `tsconfig.base.json` declares the workspace `paths` map with entries that are
+// relative to the workspace root (`libs/design-tokens/src/index.ts`). A project
+// tsconfig that extends the base and re-declares `"baseUrl": "."` overrides the
+// inherited base directory, because `baseUrl` outranks the implicit
+// `pathsBasePath`. Every inherited substitution is then probed under the
+// *library* folder (`libs/<lib>/libs/design-tokens/src/index.ts`), misses, and
+// only resolves because the npm workspace symlink in `node_modules` happens to
+// land on the same source file. Builds stay green, so nothing catches it.
+//
+// A project that declares its own `paths` (including an empty `{}`) is exempt:
+// there `baseUrl` does real directory-resolution work and shadows nothing.
+
+const workspaceRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const baseConfigPath = join(workspaceRoot, 'tsconfig.base.json');
+
+function readConfig(configPath) {
+  const parsed = ts.parseConfigFileTextToJson(configPath, readFileSync(configPath, 'utf8'));
+  expect(parsed.error, `failed to parse ${relative(workspaceRoot, configPath)}`).toBeUndefined();
+  return parsed.config ?? {};
+}
+
+/**
+ * Walk the `extends` chain from `configPath` upwards, stopping at (and
+ * excluding) `tsconfig.base.json`. Returns null when the chain never reaches
+ * the base config — such a project does not inherit the workspace `paths`.
+ */
+function chainBelowBase(configPath) {
+  const chain = [];
+  let current = configPath;
+  for (let hop = 0; hop < 10; hop += 1) {
+    if (current === baseConfigPath) return chain;
+    const config = readConfig(current);
+    chain.push({ path: current, config });
+    if (typeof config.extends !== 'string') return null;
+    const next = resolve(dirname(current), config.extends);
+    current = existsSync(next) ? next : `${next}.json`;
+    if (!existsSync(current)) return null;
+  }
+  return null;
+}
+
+function libraryTsconfigs() {
+  const found = [];
+  for (const entry of readdirSync(join(workspaceRoot, 'libs'), { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const libDir = join(workspaceRoot, 'libs', entry.name);
+    for (const file of readdirSync(libDir)) {
+      if (file.startsWith('tsconfig') && file.endsWith('.json')) found.push(join(libDir, file));
+    }
+  }
+  return found.sort();
+}
+
+describe('library tsconfig path inheritance', () => {
+  it('never shadows the workspace baseUrl the inherited paths map resolves against', () => {
+    const offenders = [];
+    for (const configPath of libraryTsconfigs()) {
+      const chain = chainBelowBase(configPath);
+      if (chain === null) continue;
+      const declaresOwnPaths = chain.some((link) => link.config.compilerOptions?.paths !== undefined);
+      if (declaresOwnPaths) continue;
+      const shadowing = chain.find((link) => link.config.compilerOptions?.baseUrl !== undefined);
+      if (shadowing) offenders.push(relative(workspaceRoot, shadowing.path));
+    }
+    expect([...new Set(offenders)]).toEqual([]);
+  });
+
+  it.each([
+    'libs/cockpit-runtime-bridge',
+    'libs/growth',
+    'libs/example-layouts',
+    'libs/cockpit-registry',
+  ])('resolves @threadplane/design-tokens through the paths map from %s', (libDir) => {
+    const configPath = join(workspaceRoot, libDir, 'tsconfig.json');
+    const parsed = ts.getParsedCommandLineOfConfigFile(configPath, {}, {
+      ...ts.sys,
+      onUnRecoverableConfigFileDiagnostic: (diagnostic) => {
+        throw new Error(ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n'));
+      },
+      getCurrentDirectory: () => workspaceRoot,
+      useCaseSensitiveFileNames: true,
+    });
+    expect(parsed, `could not parse ${libDir}/tsconfig.json`).toBeDefined();
+
+    const containingFile = join(workspaceRoot, libDir, 'src', 'index.ts');
+    const resolved = ts.resolveModuleName(
+      '@threadplane/design-tokens',
+      containingFile,
+      parsed.options,
+      ts.sys,
+    ).resolvedModule;
+
+    expect(resolved?.resolvedFileName).toBe(join(workspaceRoot, 'libs/design-tokens/src/index.ts'));
+    // A `packageId` means TypeScript fell through the `paths` substitution and
+    // found the source only via the npm workspace symlink under node_modules.
+    expect(resolved?.packageId, 'resolved via node_modules symlink, not the paths map').toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What changed

`libs/cockpit-runtime-bridge`, `libs/growth`, `libs/example-layouts` and `libs/cockpit-registry` each re-declared `"baseUrl": "."` in their own `tsconfig.json` while extending `tsconfig.base.json` and declaring **no `paths` of their own**. `baseUrl` outranks the implicit `pathsBasePath`, so every inherited substitution from the base `paths` map — which is workspace-root-relative, e.g. `libs/design-tokens/src/index.ts` — was probed under the *library* folder instead of the repo root. This PR removes those four `baseUrl` lines so the libraries inherit the base config's `baseUrl` (the repo root).

## Why it matters (the evidence)

The build passes either way, so a trace is the only proof the change does something real. `npx tsc --traceResolution` on a probe file importing `@threadplane/design-tokens` from each library.

**Before** (identical shape in all four; `example-layouts` shown):

```
'baseUrl' option is set to '<root>/libs/example-layouts', using this value to resolve non-relative module name '@threadplane/design-tokens'.
'paths' option is specified, looking for a pattern to match module name '@threadplane/design-tokens'.
Module name '@threadplane/design-tokens', matched pattern '@threadplane/design-tokens'.
Trying substitution 'libs/design-tokens/src/index.ts', candidate module location: 'libs/design-tokens/src/index.ts'.
File '<root>/libs/example-layouts/libs/design-tokens/src/index.ts' does not exist.
Loading module '@threadplane/design-tokens' from 'node_modules' folder, target file types: TypeScript, JavaScript, Declaration, JSON.
File '<root>/node_modules/@threadplane/design-tokens/src/index.ts' exists - use it as a name resolution result.
Resolving real path for '<root>/node_modules/@threadplane/design-tokens/src/index.ts', result '<root>/libs/design-tokens/src/index.ts'.
======== Module name '@threadplane/design-tokens' was successfully resolved to '<root>/libs/design-tokens/src/index.ts' with Package ID '@threadplane/design-tokens/src/index.ts@0.0.35'. ========
```

The paths substitution **missed**. Resolution only landed on the right file because the npm workspace symlink under `node_modules/@threadplane/` happens to point at the same source. The `Package ID` on the last line is the tell: TypeScript treated the library as an installed package, not a workspace path mapping.

**After** (again identical in all four):

```
'baseUrl' option is set to '<root>', using this value to resolve non-relative module name '@threadplane/design-tokens'.
Trying substitution 'libs/design-tokens/src/index.ts', candidate module location: 'libs/design-tokens/src/index.ts'.
File '<root>/libs/design-tokens/src/index.ts' exists - use it as a name resolution result.
======== Module name '@threadplane/design-tokens' was successfully resolved to '<root>/libs/design-tokens/src/index.ts'. ========
```

The substitution now hits on the first try, with no `node_modules` fallback and no `Package ID`.

## What was deliberately left alone

- **`tsconfig.base.json`'s own `baseUrl`** — Nx's `createTmpTsConfig` (`@nx/js/src/utils/buildable-libs-utils.js`) writes generated build tsconfigs whose `paths` carry non-relative `dist/libs/...` entries. With no `baseUrl` anywhere in the chain TypeScript raises TS5090 and discards the entire paths map, breaking `render:build:production` and `cockpit-shell:build`. The existing comment there already explains this.
- **`libs/growth-capture` and `apps/growth-research`** — both pair `baseUrl` with their own `"paths": {}`, so `baseUrl` is doing real directory-resolution work and shadows nothing.
- **`apps/website`** — declares its own complete `paths`.
- **`cockpit/**` and `examples/**` e2e/python tsconfigs** — each declares its own `paths` or does not extend the base.
- **`apps/lifecycle/tsconfig.json`** — noted as out of scope, see below.

## Guard spec

`scripts/tsconfig-path-inheritance.spec.mjs` (new, 5 tests) guards both halves of the fix:

1. A structural check: walk every `libs/*/tsconfig*.json`, follow its `extends` chain, and fail any config that reaches `tsconfig.base.json` without declaring its own `paths` yet re-declares `baseUrl`.
2. A behavioral check, one per library: parse the real tsconfig with `ts.getParsedCommandLineOfConfigFile`, call `ts.resolveModuleName('@threadplane/design-tokens', …)`, and assert both that it lands on `libs/design-tokens/src/index.ts` **and** that `resolvedModule.packageId` is `undefined` — i.e. it came through the paths map, not the node_modules symlink.

Mutation-checked: restoring `"baseUrl": "."` in `libs/growth/tsconfig.json` fails both assertions.

```
× never shadows the workspace baseUrl the inherited paths map resolves against
× resolves @threadplane/design-tokens through the paths map from libs/growth
AssertionError: expected [ 'libs/growth/tsconfig.json' ] to deeply equal []
AssertionError: resolved via node_modules symlink, not the paths map: expected { …(4) } to be undefined
Tests  2 failed | 3 passed (5)
```

## Verification

| Lane | Result |
| --- | --- |
| `nx run-many -t lint,test,build` across `cockpit-runtime-bridge, growth, example-layouts, cockpit-registry, chat, ag-ui, langgraph, render, a2ui, telemetry, cockpit-shell, scripts` | Successfully ran targets for 12 projects and 7 dependent tasks (lint: 0 errors, warnings only) |
| `nx run chat:type-tests`, `ag-ui:type-tests`, `langgraph:type-tests` | all three green |
| `nx run render:build:production` | green (TS5090 regression check) |
| `nx run cockpit-shell:build` | green (TS5090 regression check) |
| `vitest run --root apps/website` | 141 files, 1408 tests passed |
| `GROWTH_FORM_POLICY=growth_v1 nx build website` | green |
| `nx run-many -t build --projects=examples-chat-angular,cockpit-chat-debug-angular,cockpit-render-repeat-loops-angular` | green |

## Follow-up noted, not taken

`apps/lifecycle/tsconfig.json` has the same shape — it extends `apps/lifecycle/tsconfig.runtime-base.json`, which extends `tsconfig.base.json`, and it declares `"baseUrl": "."` with no `paths` of its own. It was outside this task's scope, and nothing under `apps/lifecycle` currently imports a mapped `@threadplane/*` specifier, so the shadowing is inert there today. The new guard spec is scoped to `libs/**` and therefore does not cover it. Worth cleaning up separately, alongside a decision about widening the guard to `apps/**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
