### PR TITLE
fix(website): remove a fabricated anecdote from the 0.1.0 post

### DIFF
--- a/apps/website/content/blog/2026-09-08-threadplane-0-1-0.mdx
+++ b/apps/website/content/blog/2026-09-08-threadplane-0-1-0.mdx
@@ -110,16 +110,15 @@ If you disagree with a decision I made, the remedy is a fork, and the license al
 Free is easy to say.
 Maintained is the part that needs numbers, so here are the ones I would want if I were the person putting this into a production Angular app.
 
-- Ranked #8 of 119 agent frameworks on the HVTracker supply-chain index.
-- 8.2 / 10 on the OpenSSF Scorecard.
-- Releases are signed, with OIDC provenance and SLSA attestations.
-- Angular 20, 21, and 22 are tested in CI, not merely claimed.
-- Model drift is checked weekly against a live provider, and the workflow diffs fresh recordings against committed fixtures.
-- There is no cloud service, no telemetry account, and no VC board seat waiting to change any of the above.
+- Ranked [#8 of 119 agent frameworks](https://hvtracker.net/categories/agent-frameworks/) on the HVTracker supply-chain index.
+- [8.2 / 10](https://scorecard.dev/viewer/?uri=github.com/cacheplane/angular-agent-framework) on the OpenSSF Scorecard.
+- Releases are [signed](https://www.npmjs.com/package/@threadplane/chat), with OIDC provenance and SLSA attestations.
+- [Angular 20, 21, and 22](https://www.npmjs.com/package/@threadplane/langgraph) are tested in CI, not merely claimed.
+- Model drift is [checked weekly](https://github.com/cacheplane/angular-agent-framework/blob/main/.github/workflows/aimock-drift.yml) against a live provider, and the workflow diffs fresh recordings against committed fixtures.
+- There is [no cloud service](/privacy), no telemetry account, and no VC board seat waiting to change any of the above.
 
-I verified every one of those before writing this sentence, which is more than I can say for the first draft of the homepage checklist.
-Three claims did not survive that pass, including one that was simply false.
-Removing them made the page better, and I would rather tell you that than pretend the list arrived correct.
+Every one of those is a link you can follow.
+Do not take my word for any of it.
 
 ## Conclusion
 


### PR DESCRIPTION
The Airworthiness section of the [live 0.1.0 post](https://threadplane.ai/blog/threadplane-0-1-0) closed on this:

> I verified every one of those before writing this sentence, which is more than I can say for the first draft of the homepage checklist. Three claims did not survive that pass, including one that was simply false.

That should not have shipped.

### Why it is wrong

**It is a fabricated first-person anecdote.** The detail came from a code comment in `apps/website/src/lib/preflight-checklist.ts` recording a verification pass. Rewriting it as Brian's own confession about his own homepage puts words in his mouth about his own work. `docs/gtm/voice.md` is explicit: *"Never fabricate a first-person anecdote. Warmth comes from opinion and directness, not from invented experiences."* The voice checklist asks for a moment of warmth, and this was warmth manufactured out of someone else's notes.

**It is inside baseball.** "The first draft of the homepage checklist" is meaningless to a reader who has never seen the homepage checklist.

**It undermines the section it closes.** Airworthiness exists to say the numbers are checkable. Following six trust claims with "my last list had a false claim in it" invites the reader to distrust the six bullets directly above it.

### The fix

Replaced with:

> Every one of those is a link you can follow.
> Do not take my word for any of it.

That sentence was false as written — the bullets had no links — so all six claims are now linked to the source that proves them: the HVTracker category page, the Scorecard viewer, the two npm package pages, the `aimock-drift.yml` workflow, and `/privacy`. The section now does what it always claimed to do, and the close is verifiable rather than confessional.

The same fabrication had propagated into the Reddit and Dev.to campaign drafts; removed there in #1074.

### Verification
- `nx test website` green.
- Numbers unchanged and **not** re-verified in this PR: rank and score drift, and `preflight-checklist.ts` records them as verified 2026-09-04. Worth a re-check before the campaign posts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)