### PR TITLE
refactor(website): render both nav panel surfaces from one body

### DIFF
--- a/apps/website/src/components/shared/NavDesktop.tsx
+++ b/apps/website/src/components/shared/NavDesktop.tsx
@@ -10,103 +10,22 @@ import {
 import { Button } from '../ui/Button';
 import { GitHubIcon } from '../ui/GitHubIcon';
 import { GITHUB_REPO_URL } from '../../lib/positioning';
-import { LibraryMark } from '../docs/LibraryMark';
-import { NAV_TRIGGERS, type NavItem, type NavPanel } from './nav-config';
+import { NavPanelBody } from './NavPanelBody';
+import { NAV_TRIGGERS, type NavPanel } from './nav-config';
 
 /** Long enough to cross the gap between trigger and panel diagonally. */
 const OPEN_DELAY_MS = 100;
 const CLOSE_DELAY_MS = 150;
 
-export function trackNavItem(item: NavItem, surface: 'nav' | 'mobile_nav') {
-  const ctaId: `nav_${string}` | `mobile_nav_${string}` =
-    surface === 'nav' ? `nav_${item.ctaId}` : `mobile_nav_${item.ctaId}`;
-  if (item.external) {
-    trackExternalLinkClick(item.href, {
-      surface,
-      cta_id: ctaId,
-      cta_text: item.label,
-    });
-    return;
-  }
-  trackCtaClick({
-    surface,
-    destination_url: item.href,
-    cta_id: ctaId,
-    cta_text: item.label,
-  });
-}
-
-export function NavPanelItem({
-  item,
-  surface,
-  onNavigate,
-}: {
-  item: NavItem;
-  surface: 'nav' | 'mobile_nav';
-  onNavigate?: () => void;
-}) {
-  const Icon = item.icon;
-  const body = (
-    <>
-      <span className="nav-panel-item-chip" aria-hidden="true">
-        {item.library ? (
-          <LibraryMark library={item.library} size={20} />
-        ) : Icon ? (
-          <Icon size={16} aria-hidden={true} />
-        ) : null}
-      </span>
-      <span className="nav-panel-item-text">
-        <span className="nav-panel-item-label">{item.label}</span>
-        <span className="nav-panel-item-desc">{item.description}</span>
-      </span>
-    </>
-  );
-  const onClick = () => {
-    trackNavItem(item, surface);
-    onNavigate?.();
-  };
-
-  if (item.external) {
-    return (
-      <a
-        href={item.href}
-        target="_blank"
-        rel="noopener noreferrer"
-        onClick={onClick}
-        className="nav-panel-item"
-      >
-        {body}
-      </a>
-    );
-  }
-  return (
-    <Link href={item.href} onClick={onClick} className="nav-panel-item">
-      {body}
-    </Link>
-  );
-}
-
 function Panel({ panel, id }: { panel: NavPanel; id: string }) {
   return (
     <div id={id} className="nav-panel" data-columns={panel.columns.length}>
-      <div className="nav-panel-cols">
-        {panel.columns.map((column, index) => (
-          <div key={column.heading ?? index} className="nav-panel-col">
-            {column.heading ? (
-              <span className="nav-panel-col-head">{column.heading}</span>
-            ) : null}
-            {column.items.map((item) => (
-              <NavPanelItem key={item.ctaId} item={item} surface="nav" />
-            ))}
-          </div>
-        ))}
-      </div>
-      {panel.footer ? (
-        <div className="nav-panel-footer">
-          <span className="nav-panel-footer-lead">{panel.footer.lead}</span>
-          <NavPanelItem item={panel.footer} surface="nav" />
-        </div>
-      ) : null}
+      <NavPanelBody
+        panel={panel}
+        surface="nav"
+        columnsClassName="nav-panel-cols"
+        columnClassName="nav-panel-col"
+      />
     </div>
   );
 }

--- a/apps/website/src/components/shared/NavMobile.tsx
+++ b/apps/website/src/components/shared/NavMobile.tsx
@@ -19,7 +19,7 @@ import { Button } from '../ui/Button';
 import { GitHubIcon } from '../ui/GitHubIcon';
 import { GITHUB_REPO_URL } from '../../lib/positioning';
 import { DocsContextContent } from '../docs/DocsControlPlane';
-import { NavPanelItem } from './NavDesktop';
+import { NavPanelBody } from './NavPanelBody';
 import { NAV_TRIGGERS } from './nav-config';
 
 const toAnalyticsLibrary = (library: LibraryId | null): AnalyticsLibrary => {
@@ -436,38 +436,12 @@ export function NavMobile({
 
               {panel ? (
                 <div className="nav-mobile-panel">
-                  {panel.columns.map((column, index) => (
-                    <div
-                      key={column.heading ?? index}
-                      className="nav-mobile-group"
-                    >
-                      {column.heading ? (
-                        <span className="nav-panel-col-head">
-                          {column.heading}
-                        </span>
-                      ) : null}
-                      {column.items.map((item) => (
-                        <NavPanelItem
-                          key={item.ctaId}
-                          item={item}
-                          surface="mobile_nav"
-                          onNavigate={() => closeMobileMenu()}
-                        />
-                      ))}
-                    </div>
-                  ))}
-                  {panel.footer ? (
-                    <div className="nav-panel-footer">
-                      <span className="nav-panel-footer-lead">
-                        {panel.footer.lead}
-                      </span>
-                      <NavPanelItem
-                        item={panel.footer}
-                        surface="mobile_nav"
-                        onNavigate={() => closeMobileMenu()}
-                      />
-                    </div>
-                  ) : null}
+                  <NavPanelBody
+                    panel={panel}
+                    surface="mobile_nav"
+                    columnClassName="nav-mobile-group"
+                    onNavigate={() => closeMobileMenu()}
+                  />
                 </div>
               ) : null}
             </div>

--- a/apps/website/src/components/shared/NavPanelBody.tsx
+++ b/apps/website/src/components/shared/NavPanelBody.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import Link from 'next/link';
+import {
+  trackCtaClick,
+  trackExternalLinkClick,
+} from '../../lib/analytics/client';
+import { LibraryMark } from '../docs/LibraryMark';
+import type { NavItem, NavPanel } from './nav-config';
+
+export function trackNavItem(item: NavItem, surface: 'nav' | 'mobile_nav') {
+  const ctaId: `nav_${string}` | `mobile_nav_${string}` =
+    surface === 'nav' ? `nav_${item.ctaId}` : `mobile_nav_${item.ctaId}`;
+  if (item.external) {
+    trackExternalLinkClick(item.href, {
+      surface,
+      cta_id: ctaId,
+      cta_text: item.label,
+    });
+    return;
+  }
+  trackCtaClick({
+    surface,
+    destination_url: item.href,
+    cta_id: ctaId,
+    cta_text: item.label,
+  });
+}
+
+export function NavPanelItem({
+  item,
+  surface,
+  onNavigate,
+}: {
+  item: NavItem;
+  surface: 'nav' | 'mobile_nav';
+  onNavigate?: () => void;
+}) {
+  const Icon = item.icon;
+  const body = (
+    <>
+      <span className="nav-panel-item-chip" aria-hidden="true">
+        {item.library ? (
+          <LibraryMark library={item.library} size={20} />
+        ) : Icon ? (
+          <Icon size={16} aria-hidden={true} />
+        ) : null}
+      </span>
+      <span className="nav-panel-item-text">
+        <span className="nav-panel-item-label">{item.label}</span>
+        <span className="nav-panel-item-desc">{item.description}</span>
+      </span>
+    </>
+  );
+  const onClick = () => {
+    trackNavItem(item, surface);
+    onNavigate?.();
+  };
+
+  if (item.external) {
+    return (
+      <a
+        href={item.href}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={onClick}
+        className="nav-panel-item"
+      >
+        {body}
+      </a>
+    );
+  }
+  return (
+    <Link href={item.href} onClick={onClick} className="nav-panel-item">
+      {body}
+    </Link>
+  );
+}
+
+/**
+ * The contents of one nav panel — its columns, then its footer — shared by the
+ * desktop hover panel and the mobile drill-in stack.
+ *
+ * Only the wrapper class names and the mobile drawer's close callback differ
+ * between the two surfaces; the column/footer shape itself is the same, and
+ * writing it twice let the two drift. The caller still owns the outermost
+ * element, because that is where the surfaces genuinely diverge: desktop needs
+ * the panel's id and `data-columns`, mobile does not.
+ */
+export function NavPanelBody({
+  panel,
+  surface,
+  columnsClassName,
+  columnClassName,
+  onNavigate,
+}: {
+  panel: NavPanel;
+  surface: 'nav' | 'mobile_nav';
+  /** Desktop grids its columns inside a wrapper; the mobile stack has none. */
+  columnsClassName?: string;
+  columnClassName: string;
+  onNavigate?: () => void;
+}) {
+  const columns = panel.columns.map((column, index) => (
+    <div key={column.heading ?? index} className={columnClassName}>
+      {column.heading ? (
+        <span className="nav-panel-col-head">{column.heading}</span>
+      ) : null}
+      {column.items.map((item) => (
+        <NavPanelItem
+          key={item.ctaId}
+          item={item}
+          surface={surface}
+          onNavigate={onNavigate}
+        />
+      ))}
+    </div>
+  ));
+
+  return (
+    <>
+      {columnsClassName ? (
+        <div className={columnsClassName}>{columns}</div>
+      ) : (
+        columns
+      )}
+      {panel.footer ? (
+        <div className="nav-panel-footer">
+          <span className="nav-panel-footer-lead">{panel.footer.lead}</span>
+          <NavPanelItem
+            item={panel.footer}
+            surface={surface}
+            onNavigate={onNavigate}
+          />
+        </div>
+      ) : null}
+    </>
+  );
+}


### PR DESCRIPTION
Stacked on #1083 — base is `blove/navbar-design-brainstorm-2b6a7d`, so this diff is the single commit on top of that branch.

## The duplication

`NavDesktop`'s `Panel` and `NavMobile`'s inline panel JSX each wrote the same shape by hand: map `panel.columns` → a column wrapper → `column.items.map(NavPanelItem)`, then conditionally render `panel.footer` with the same `nav-panel-footer` / `nav-panel-footer-lead` classes plus one more `NavPanelItem`. Individual items already funnelled through the shared `NavPanelItem` — which is what has kept the analytics ids from drifting — but the column and footer shape around them was written twice and free to diverge.

## The shape

`NavPanelBody` renders columns + footer once, parameterised by the two things that genuinely differ:

- **wrapper class names**, because the layouts are not the same — desktop keeps `nav-panel-cols` / `nav-panel-col`, mobile keeps `nav-mobile-panel` / `nav-mobile-group`
- **an optional `onNavigate`**, which the mobile drawer uses to close itself and desktop omits

The caller still owns the outermost element, because that is the other real difference: desktop needs the panel `id` and `data-columns`, mobile needs neither. Desktop passes `columnsClassName`; mobile omits it, so the mobile stack keeps its columns as direct children of `.nav-mobile-panel` and the scoped `.nav-mobile-panel .nav-panel-footer` override that stacks the footer lead above the link at narrow widths still matches.

`NavPanelItem` and `trackNavItem` move into the new module with it. `NavMobile` had been importing `NavPanelItem` from `NavDesktop`, pointing the dependency the wrong way between two sibling surfaces; both now import from a shared leaf and neither imports the other.

## Rendered output is unchanged

Pure refactor. Rather than trusting the unit suite — jsdom has no layout engine, and the panel geometry bugs on this branch were all invisible to it — the `outerHTML` of all three panels was dumped on **both** surfaces before and after (6 files, 612 lines). `diff -r` reports zero differences, down to the `useId`-generated `id="_r_0_-libraries"`.

No `cta_id` changes: `trackNavItem` moved verbatim and both call sites pass the same `surface`, so desktop still emits `nav_<ctaId>` and mobile `mobile_nav_<ctaId>`.

## Verification

| Lane | Result |
|---|---|
| `nx test website -- --run` | 1462 passed, 0 failed (409 suites; `Nav.spec.tsx` collected, 28 tests) |
| `nx build website` | green, 320 pages prerendered |
| `nx e2e website -- --testFiles=e2e/nav-panels.spec.ts` | 5 passed |
| `nav-drawer` + `nav-surface` + `nav-height` e2e | 27 passed |
| `nx lint website` | 0 errors |

`nav-panels.spec.ts` is desktop-only and this touches the mobile surface too, so the mobile drawer suites were run as well rather than left unverified in a real browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)