### PR TITLE
docs(gtm): refresh the nav cta_id register and make it self-checking

### DIFF
--- a/apps/website/src/components/shared/nav-config.spec.ts
+++ b/apps/website/src/components/shared/nav-config.spec.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
@@ -7,6 +7,11 @@ import { docsConfig } from '../../lib/docs-config';
 import { getAllSolutionSlugs } from '../../lib/solutions-data';
 
 const APP_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'app');
+const TAXONOMY = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..', '..', '..', '..', '..',
+  'docs', 'gtm', 'taxonomy.md',
+);
 
 /**
  * `/docs/:library/:section/:slug` is a dynamic route, so a page file cannot
@@ -87,5 +92,25 @@ describe('nav-config', () => {
       'Solutions',
       'Pricing',
     ]);
+  });
+
+  /**
+   * The GTM taxonomy is the register analytics work reads to know which
+   * `cta_id`s exist. It is hand-maintained prose, and it had silently drifted
+   * before the navbar rebuild — it still listed `nav_get_started`, `nav_npm`
+   * and `nav_cockpit`, none of which the nav emitted any more.
+   *
+   * The nav's ids are data, so the doc can be checked against them instead of
+   * trusted. Only the `nav_` surface is asserted: `mobile_nav_` is the same
+   * list with a different prefix, applied by `trackNavItem`, and the doc says
+   * so once rather than duplicating twenty entries.
+   */
+  it('documents every nav cta_id in the GTM taxonomy', () => {
+    const taxonomy = readFileSync(TAXONOMY, 'utf8');
+    const undocumented = navItems()
+      .map((item) => `nav_${item.ctaId}`)
+      .filter((id) => !taxonomy.includes(id));
+
+    expect(undocumented).toEqual([]);
   });
 });

--- a/docs/gtm/taxonomy.md
+++ b/docs/gtm/taxonomy.md
@@ -158,7 +158,35 @@ Browser events never fire unless the consumer explicitly opts in. See `libs/tele
 
 **Nav**
 
-- `nav_get_started` `nav_docs` `nav_pricing` `nav_github` `nav_npm` `nav_cockpit`
+The navbar was rebuilt on 2026-09-08 into four triggers, three of which open panels.
+Every panel destination is data in `apps/website/src/components/shared/nav-config.ts`,
+and `trackNavItem` prefixes each item's `ctaId` with the surface — so **every id below
+also exists with a `mobile_nav_` prefix**, emitted by the same items in the mobile
+drill-in drawer. Add a destination there and its id appears on both surfaces
+automatically; there is no second list to keep in sync.
+
+- Libraries panel — `nav_libraries_langgraph` `nav_libraries_ag_ui` `nav_libraries_chat`
+  `nav_libraries_render` `nav_libraries_choosing_an_adapter`
+- Docs panel — `nav_docs_documentation` `nav_docs_quick_start`
+  `nav_docs_choosing_an_adapter` `nav_docs_guides` `nav_docs_concepts`
+  `nav_docs_api_reference`
+- Docs panel, external demos — `nav_docs_demo_langgraph` `nav_docs_demo_ag_ui`
+  (derived from `DEMOS` in `lib/demos.ts`, so a new demo adds its own id)
+- Solutions panel — `nav_solutions_customer_support` `nav_solutions_analytics`
+  `nav_solutions_compliance` `nav_solutions_pilot_to_prod` `nav_solutions_blog`
+  `nav_solutions_about`
+- Bar itself — `nav_pricing` `nav_github` `nav_talk_to_us`
+- Mobile drawer only — `mobile_nav_docs_page` (any link inside the docs tree, with the
+  page title in `cta_text` and the library in `library`)
+
+- retired 2026-09-08: `nav_demo_langgraph` `nav_demo_ag_ui` (the hand-rolled `Demo ▾`
+  dropdown was absorbed into the Docs panel — the demos are now
+  `nav_docs_demo_langgraph` / `nav_docs_demo_ag_ui`); `nav_docs` (now
+  `nav_docs_documentation`); `nav_pilot_to_prod` (now `nav_solutions_pilot_to_prod`)
+- retired earlier, date unknown: `nav_get_started` `nav_npm` `nav_cockpit` — these were
+  already listed here but no longer emitted by the pre-redesign nav either, so this
+  section had drifted before the rebuild. Recorded rather than silently dropped, in case
+  a dashboard still filters them.
 
 **Footer**
 


### PR DESCRIPTION
Follow-up to the navbar rebuild (#1083). The nav's analytics ids changed; the register that documents them did not.

## What was wrong

`docs/gtm/taxonomy.md` is the register analytics work reads to know which `cta_id`s exist. Its Nav section said:

```
nav_get_started  nav_docs  nav_pricing  nav_github  nav_npm  nav_cockpit
```

Three of those — `nav_get_started`, `nav_npm`, `nav_cockpit` — **were already not emitted before the rebuild.** This section had drifted silently some time ago. The rebuild then replaced almost all of the rest.

## What it says now

The real set: twenty panel destinations plus the bar's own ids, grouped by panel, with a note that **every one also exists with a `mobile_nav_` prefix** — `trackNavItem` applies the surface, so the mobile drill-in emits the same list rather than a parallel one that could drift.

Retirements recorded following the file's existing convention:

- `nav_demo_langgraph` / `nav_demo_ag_ui` → `nav_docs_demo_langgraph` / `nav_docs_demo_ag_ui`. The hand-rolled `Demo ▾` dropdown was absorbed into the Docs panel.
- `nav_docs` → `nav_docs_documentation`
- `nav_pilot_to_prod` → `nav_solutions_pilot_to_prod`
- `nav_get_started`, `nav_npm`, `nav_cockpit` — noted as retired at an unknown earlier date rather than quietly deleted, in case a dashboard still filters them.

## The part that matters

**The register is now checked, not trusted.** `nav-config.spec.ts` asserts the taxonomy mentions every id the nav emits. The ids are data in `nav-config.ts`, so this is verifiable — and adding a nav destination without documenting it now fails a test instead of drifting for months.

Proven non-vacuous — removing one id from the doc:

```
× documents every nav cta_id in the GTM taxonomy
  AssertionError: expected [ 'nav_solutions_compliance' ] to deeply equal []
```

Only the `nav_` surface is asserted; `mobile_nav_` is the same list with a different prefix, and the doc says so once rather than duplicating twenty entries.

## Scope

No dashboards-as-code needed changing — `tools/posthog/dashboards` and `tools/posthog/insights` contain no `nav_` ids at all, and nothing in the repo referenced the retired ones. Any consumer is a PostHog-UI dashboard or saved query, which is outside version control; the retirement list above is what someone auditing those needs.

`nx build` exit 0 · **1457 unit tests pass** · `nx lint` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
